### PR TITLE
Add update-dependencies to core-setup.

### DIFF
--- a/Microsoft.DotNet.CoreSetup.sln
+++ b/Microsoft.DotNet.CoreSetup.sln
@@ -21,6 +21,8 @@ Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "dotnet-host-build", "build_
 EndProject
 Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "RuntimeGraphGenerator", "tools\independent\RuntimeGraphGenerator\RuntimeGraphGenerator.xproj", "{EFC4FE68-83EB-40E4-BFA8-61D0B4626F25}"
 EndProject
+Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "update-dependencies", "build_projects\update-dependencies\update-dependencies.xproj", "{A28BD8AC-DF15-4F58-8299-98A9AE2B8726}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -97,6 +99,22 @@ Global
 		{EFC4FE68-83EB-40E4-BFA8-61D0B4626F25}.RelWithDebInfo|Any CPU.Build.0 = Release|Any CPU
 		{EFC4FE68-83EB-40E4-BFA8-61D0B4626F25}.RelWithDebInfo|x64.ActiveCfg = Release|Any CPU
 		{EFC4FE68-83EB-40E4-BFA8-61D0B4626F25}.RelWithDebInfo|x64.Build.0 = Release|Any CPU
+		{A28BD8AC-DF15-4F58-8299-98A9AE2B8726}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A28BD8AC-DF15-4F58-8299-98A9AE2B8726}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A28BD8AC-DF15-4F58-8299-98A9AE2B8726}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{A28BD8AC-DF15-4F58-8299-98A9AE2B8726}.Debug|x64.Build.0 = Debug|Any CPU
+		{A28BD8AC-DF15-4F58-8299-98A9AE2B8726}.MinSizeRel|Any CPU.ActiveCfg = Debug|Any CPU
+		{A28BD8AC-DF15-4F58-8299-98A9AE2B8726}.MinSizeRel|Any CPU.Build.0 = Debug|Any CPU
+		{A28BD8AC-DF15-4F58-8299-98A9AE2B8726}.MinSizeRel|x64.ActiveCfg = Debug|Any CPU
+		{A28BD8AC-DF15-4F58-8299-98A9AE2B8726}.MinSizeRel|x64.Build.0 = Debug|Any CPU
+		{A28BD8AC-DF15-4F58-8299-98A9AE2B8726}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A28BD8AC-DF15-4F58-8299-98A9AE2B8726}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A28BD8AC-DF15-4F58-8299-98A9AE2B8726}.Release|x64.ActiveCfg = Release|Any CPU
+		{A28BD8AC-DF15-4F58-8299-98A9AE2B8726}.Release|x64.Build.0 = Release|Any CPU
+		{A28BD8AC-DF15-4F58-8299-98A9AE2B8726}.RelWithDebInfo|Any CPU.ActiveCfg = Release|Any CPU
+		{A28BD8AC-DF15-4F58-8299-98A9AE2B8726}.RelWithDebInfo|Any CPU.Build.0 = Release|Any CPU
+		{A28BD8AC-DF15-4F58-8299-98A9AE2B8726}.RelWithDebInfo|x64.ActiveCfg = Release|Any CPU
+		{A28BD8AC-DF15-4F58-8299-98A9AE2B8726}.RelWithDebInfo|x64.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -106,5 +124,6 @@ Global
 		{B768BD29-12BF-4C7C-B093-03193FE244D1} = {88278B81-7649-45DC-8A6A-D3A645C5AFC3}
 		{1DBB7542-0345-4F4B-A84B-3B00B185D416} = {88278B81-7649-45DC-8A6A-D3A645C5AFC3}
 		{EFC4FE68-83EB-40E4-BFA8-61D0B4626F25} = {0722D325-24C8-4E83-B5AF-0A083E7F0749}
+		{A28BD8AC-DF15-4F58-8299-98A9AE2B8726} = {88278B81-7649-45DC-8A6A-D3A645C5AFC3}
 	EndGlobalSection
 EndGlobal

--- a/build_projects/dotnet-host-build/build.sh
+++ b/build_projects/dotnet-host-build/build.sh
@@ -29,6 +29,10 @@ while [[ $# > 0 ]]; do
             IFS=',' read -r -a targets <<< $2
             shift
             ;;
+        --env-vars)
+            IFS=',' read -r -a envVars <<< $2
+            shift
+            ;;
         --nopackage)
             export DOTNET_BUILD_SKIP_PACKAGING=1
             ;;
@@ -40,13 +44,14 @@ while [[ $# > 0 ]]; do
             echo "Usage: $0 [--configuration <CONFIGURATION>] [--skip-prereqs] [--nopackage] [--docker <IMAGENAME>] [--help] [--targets <TARGETS...>]"
             echo ""
             echo "Options:"
-            echo "  --configuration <CONFIGURATION>     Build the specified Configuration (Debug or Release, default: Debug)"
-            echo "  --targets <TARGETS...>              Comma separated build targets to run (Init, Compile, Publish, etc.; Default is a full build and publish)"
-            echo "  --nopackage                         Skip packaging targets"
-            echo "  --skip-prereqs                      Skip checks for pre-reqs in dotnet_install"
-            echo "  --docker <IMAGENAME>                Build in Docker using the Dockerfile located in scripts/docker/IMAGENAME"
-            echo "  --help                              Display this help message"
-            echo "  <TARGETS...>                        The build targets to run (Init, Compile, Publish, etc.; Default is a full build and publish)"
+            echo "  --configuration <CONFIGURATION>      Build the specified Configuration (Debug or Release, default: Debug)"
+            echo "  --targets <TARGETS...>               Comma separated build targets to run (Init, Compile, Publish, etc.; Default is a full build and publish)"
+            echo "  --env-vars <'V1=val1','V2=val2'...>  Comma separated list of environment variables"
+            echo "  --nopackage                          Skip packaging targets"
+            echo "  --skip-prereqs                       Skip checks for pre-reqs in dotnet_install"
+            echo "  --docker <IMAGENAME>                 Build in Docker using the Dockerfile located in scripts/docker/IMAGENAME"
+            echo "  --help                               Display this help message"
+            echo "  <TARGETS...>                         The build targets to run (Init, Compile, Publish, etc.; Default is a full build and publish)"
             exit 0
             ;;
         *)
@@ -116,5 +121,5 @@ export PATH="$OLDPATH"
 echo "Invoking Build Scripts..."
 echo "Configuration: $CONFIGURATION"
 
-$DIR/bin/dotnet-host-build ${targets[@]}
+$DIR/bin/dotnet-host-build -t ${targets[@]} -e ${envVars[@]}
 exit $?

--- a/build_projects/update-dependencies/BuildContextProperties.cs
+++ b/build_projects/update-dependencies/BuildContextProperties.cs
@@ -1,0 +1,30 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+using Microsoft.DotNet.Cli.Build.Framework;
+
+namespace Microsoft.DotNet.Scripts
+{
+    public static class BuildContextProperties
+    {
+        public static List<DependencyInfo> GetDependencyInfos(this BuildTargetContext c)
+        {
+            const string propertyName = "DependencyInfos";
+
+            List<DependencyInfo> dependencyInfos;
+            object dependencyInfosObj;
+            if (c.BuildContext.Properties.TryGetValue(propertyName, out dependencyInfosObj))
+            {
+                dependencyInfos = (List<DependencyInfo>)dependencyInfosObj;
+            }
+            else
+            {
+                dependencyInfos = new List<DependencyInfo>();
+                c.BuildContext[propertyName] = dependencyInfos;
+            }
+
+            return dependencyInfos;
+        }
+    }
+}

--- a/build_projects/update-dependencies/Config.cs
+++ b/build_projects/update-dependencies/Config.cs
@@ -1,0 +1,76 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using Microsoft.DotNet.Cli.Build.Framework;
+
+namespace Microsoft.DotNet.Scripts
+{
+    /// <summary>
+    /// Holds the configuration information for the update-dependencies script.
+    /// </summary>
+    /// <remarks>
+    /// The following Environment Variables are required by this script:
+    /// 
+    /// GITHUB_USER - The user to commit the changes as.
+    /// GITHUB_EMAIL - The user's email to commit the changes as.
+    /// GITHUB_PASSWORD - The password/personal access token of the GitHub user.
+    ///
+    /// The following Environment Variables can optionally be specified:
+    /// 
+    /// COREFX_VERSION_URL - The Url to get the current CoreFx version. (ex. "https://raw.githubusercontent.com/dotnet/versions/master/build-info/dotnet/corefx/release/1.0.0/Latest_Packages.txt")
+    /// GITHUB_ORIGIN_OWNER - The owner of the GitHub fork to push the commit and create the PR from. (ex. "dotnet-bot")
+    /// GITHUB_UPSTREAM_OWNER - The owner of the GitHub base repo to create the PR to. (ex. "dotnet")
+    /// GITHUB_PROJECT - The repo name under the ORIGIN and UPSTREAM owners. (ex. "cli")
+    /// GITHUB_UPSTREAM_BRANCH - The branch in the GitHub base repo to create the PR to. (ex. "rel/1.0.0")
+    /// GITHUB_PULL_REQUEST_NOTIFICATIONS - A semi-colon ';' separated list of GitHub users to notify on the PR.
+    /// </remarks>
+    public class Config
+    {
+        public static Config Instance { get; } = new Config();
+
+        private Lazy<string> _userName = new Lazy<string>(() => GetEnvironmentVariable("GITHUB_USER"));
+        private Lazy<string> _email = new Lazy<string>(() => GetEnvironmentVariable("GITHUB_EMAIL"));
+        private Lazy<string> _password = new Lazy<string>(() => GetEnvironmentVariable("GITHUB_PASSWORD"));
+        
+        private Lazy<string> _coreFxVersionUrl = new Lazy<string>(() => GetEnvironmentVariable("COREFX_VERSION_URL", "https://raw.githubusercontent.com/dotnet/versions/master/build-info/dotnet/corefx/release/1.0.0/Latest_Packages.txt"));
+        private Lazy<string> _gitHubOriginOwner;
+        private Lazy<string> _gitHubUpstreamOwner = new Lazy<string>(() => GetEnvironmentVariable("GITHUB_UPSTREAM_OWNER", "dotnet"));
+        private Lazy<string> _gitHubProject = new Lazy<string>(() => GetEnvironmentVariable("GITHUB_PROJECT", "core-setup"));
+        private Lazy<string> _gitHubUpstreamBranch = new Lazy<string>(() => GetEnvironmentVariable("GITHUB_UPSTREAM_BRANCH", "master"));
+        private Lazy<string[]> _gitHubPullRequestNotifications = new Lazy<string[]>(() => 
+                                                GetEnvironmentVariable("GITHUB_PULL_REQUEST_NOTIFICATIONS", "")
+                                                    .Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries));
+
+        private Config()
+        {
+            _gitHubOriginOwner = new Lazy<string>(() => GetEnvironmentVariable("GITHUB_ORIGIN_OWNER", UserName));
+        }
+
+        public string UserName => _userName.Value;
+        public string Email => _email.Value; 
+        public string Password => _password.Value;
+        public string CoreFxVersionUrl => _coreFxVersionUrl.Value;
+        public string GitHubOriginOwner => _gitHubOriginOwner.Value;
+        public string GitHubUpstreamOwner => _gitHubUpstreamOwner.Value;
+        public string GitHubProject => _gitHubProject.Value;
+        public string GitHubUpstreamBranch => _gitHubUpstreamBranch.Value;
+        public string[] GitHubPullRequestNotifications => _gitHubPullRequestNotifications.Value;
+
+        private static string GetEnvironmentVariable(string name, string defaultValue = null)
+        {
+            string value = Environment.GetEnvironmentVariable(name);
+            if (value == null)
+            {
+                value = defaultValue;
+            }
+
+            if (value == null)
+            {
+                throw new BuildFailureException($"Can't find environment variable '{name}'.");
+            }
+
+            return value;
+        }
+    }
+}

--- a/build_projects/update-dependencies/DependencyInfo.cs
+++ b/build_projects/update-dependencies/DependencyInfo.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+using NuGet.Versioning;
+
+namespace Microsoft.DotNet.Scripts
+{
+    public class DependencyInfo
+    {
+        public string Name { get; set; }
+        public List<PackageInfo> NewVersions { get; set; }
+        public string NewReleaseVersion { get; set; }
+
+        public bool IsUpdated { get; set; }
+    }
+
+    public class PackageInfo
+    {
+        public string Id { get; set; }
+        public NuGetVersion Version { get; set; }
+    }
+}

--- a/build_projects/update-dependencies/Dirs.cs
+++ b/build_projects/update-dependencies/Dirs.cs
@@ -1,0 +1,12 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.IO;
+
+namespace Microsoft.DotNet.Scripts
+{
+    public static class Dirs
+    {
+        public static readonly string RepoRoot = Directory.GetCurrentDirectory();
+    }
+}

--- a/build_projects/update-dependencies/Program.cs
+++ b/build_projects/update-dependencies/Program.cs
@@ -1,0 +1,25 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.DotNet.Cli.Build.Framework;
+
+namespace Microsoft.DotNet.Scripts
+{
+    public class Program
+    {
+        public static int Main(string[] args)
+        {
+            DebugHelper.HandleDebugSwitch(ref args);
+
+            return BuildSetup.Create(".NET core-setup Dependency Updater")
+                .UseTargets(new[]
+                {
+                    new BuildTarget("Default", "Dependency Updater Goals", new [] { "UpdateFiles", "PushPR" }),
+                    new BuildTarget("UpdateFiles", "Dependency Updater Goals"),
+                    new BuildTarget("PushPR", "Dependency Updater Goals"),
+                })
+                .UseAllTargetsFromAssembly<Program>()
+                .Run(args);
+        }
+    }
+}

--- a/build_projects/update-dependencies/PushPRTargets.cs
+++ b/build_projects/update-dependencies/PushPRTargets.cs
@@ -1,0 +1,162 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Linq;
+using Microsoft.DotNet.Cli.Build.Framework;
+using Octokit;
+
+using static Microsoft.DotNet.Cli.Build.Framework.BuildHelpers;
+
+namespace Microsoft.DotNet.Scripts
+{
+    /// <summary>
+    /// Creates a GitHub Pull Request for the current changes in the repo.
+    /// </summary>
+    public static class PushPRTargets
+    {
+        private static readonly Config s_config = Config.Instance;
+
+        [Target(nameof(CommitChanges), nameof(CreatePR))]
+        public static BuildTargetResult PushPR(BuildTargetContext c) => c.Success();
+
+        /// <summary>
+        /// Commits all the current changes in the repo and pushes the commit to a remote
+        /// so a PR can be created for it.
+        /// </summary>
+        [Target]
+        public static BuildTargetResult CommitChanges(BuildTargetContext c)
+        {
+            CommandResult statusResult = Cmd("git", "status", "--porcelain")
+                .CaptureStdOut()
+                .Execute();
+            statusResult.EnsureSuccessful();
+
+            bool hasModifiedFiles = !string.IsNullOrWhiteSpace(statusResult.StdOut);
+            bool hasUpdatedDependencies = c.GetDependencyInfos().Where(d => d.IsUpdated).Any();
+
+            if (hasModifiedFiles != hasUpdatedDependencies)
+            {
+                return c.Failed($"'git status' does not match DependencyInfo information. Git has modified files: {hasModifiedFiles}. DependencyInfo is updated: {hasUpdatedDependencies}.");
+            }
+
+            if (!hasUpdatedDependencies)
+            {
+                c.Warn("Dependencies are currently up to date");
+                return c.Success();
+            }
+
+            string userName = s_config.UserName;
+            string email = s_config.Email;
+
+            string commitMessage = GetCommitMessage(c);
+
+            Cmd("git", "commit", "-a", "-m", commitMessage, "--author", $"{userName} <{email}>")
+                .EnvironmentVariable("GIT_COMMITTER_NAME", userName)
+                .EnvironmentVariable("GIT_COMMITTER_EMAIL", email)
+                .Execute()
+                .EnsureSuccessful();
+
+            string remoteUrl = $"github.com/{s_config.GitHubOriginOwner}/{s_config.GitHubProject}.git";
+            string remoteBranchName = $"UpdateDependencies{DateTime.UtcNow.ToString("yyyyMMddhhmmss")}";
+            string refSpec = $"HEAD:refs/heads/{remoteBranchName}";
+
+            string logMessage = $"git push https://{remoteUrl} {refSpec}";
+            BuildReporter.BeginSection("EXEC", logMessage);
+
+            CommandResult pushResult =
+                Cmd("git", "push", $"https://{userName}:{s_config.Password}@{remoteUrl}", refSpec)
+                    .QuietBuildReporter()  // we don't want secrets showing up in our logs
+                    .CaptureStdErr() // git push will write to StdErr upon success, disable that
+                    .CaptureStdOut()
+                    .Execute();
+
+            var message = logMessage + $" exited with {pushResult.ExitCode}";
+            if (pushResult.ExitCode == 0)
+            {
+                BuildReporter.EndSection("EXEC", message.Green(), success: true);
+            }
+            else
+            {
+                BuildReporter.EndSection("EXEC", message.Red().Bold(), success: false);
+            }
+
+            pushResult.EnsureSuccessful(suppressOutput: true);
+
+            c.SetRemoteBranchName(remoteBranchName);
+
+            return c.Success();
+        }
+
+        /// <summary>
+        /// Creates a GitHub PR for the remote branch created above.
+        /// </summary>
+        [Target]
+        public static BuildTargetResult CreatePR(BuildTargetContext c)
+        {
+            string remoteBranchName = c.GetRemoteBranchName();
+            string commitMessage = c.GetCommitMessage();
+
+            NewPullRequest prInfo = new NewPullRequest(
+                commitMessage,
+                s_config.GitHubOriginOwner + ":" + remoteBranchName,
+                s_config.GitHubUpstreamBranch);
+
+            string[] prNotifications = s_config.GitHubPullRequestNotifications;
+            if (prNotifications.Length > 0)
+            {
+                prInfo.Body = $"/cc @{string.Join(" @", prNotifications)}";
+            }
+
+            GitHubClient gitHub = new GitHubClient(new ProductHeaderValue("dotnetDependencyUpdater"));
+
+            gitHub.Credentials = new Credentials(s_config.Password);
+
+            PullRequest createdPR = gitHub.PullRequest.Create(s_config.GitHubUpstreamOwner, s_config.GitHubProject, prInfo).Result;
+            c.Info($"Created Pull Request: {createdPR.HtmlUrl}");
+
+            return c.Success();
+        }
+
+        private static string GetRemoteBranchName(this BuildTargetContext c)
+        {
+            return (string)c.BuildContext["RemoteBranchName"];
+        }
+
+        private static void SetRemoteBranchName(this BuildTargetContext c, string value)
+        {
+            c.BuildContext["RemoteBranchName"] = value;
+        }
+
+        private static string GetCommitMessage(this BuildTargetContext c)
+        {
+            const string commitMessagePropertyName = "CommitMessage";
+
+            string message;
+            object messageObject;
+            if (c.BuildContext.Properties.TryGetValue(commitMessagePropertyName, out messageObject))
+            {
+                message = (string)messageObject;
+            }
+            else
+            {
+                DependencyInfo[] updatedDependencies = c.GetDependencyInfos()
+                    .Where(d => d.IsUpdated)
+                    .ToArray();
+
+                string updatedDependencyNames = string.Join(", ", updatedDependencies.Select(d => d.Name));
+                string updatedDependencyVersions = string.Join(", ", updatedDependencies.Select(d => d.NewReleaseVersion));
+
+                message = $"Updating {updatedDependencyNames} to {updatedDependencyVersions}";
+                if (updatedDependencies.Count() > 1)
+                {
+                    message += " respectively";
+                }
+
+                c.BuildContext[commitMessagePropertyName] = message;
+            }
+
+            return message;
+        }
+    }
+}

--- a/build_projects/update-dependencies/UpdateFilesTargets.cs
+++ b/build_projects/update-dependencies/UpdateFilesTargets.cs
@@ -1,0 +1,250 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net.Http;
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+using Microsoft.DotNet.Cli.Build.Framework;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using NuGet.Versioning;
+
+namespace Microsoft.DotNet.Scripts
+{
+    public static class UpdateFilesTargets
+    {
+        private static HttpClient s_client = new HttpClient();
+
+        [Target(nameof(GetDependencies), nameof(ReplaceVersions))]
+        public static BuildTargetResult UpdateFiles(BuildTargetContext c) => c.Success();
+
+        /// <summary>
+        /// Gets all the dependency information and puts it in the build properties.
+        /// </summary>
+        [Target]
+        public static BuildTargetResult GetDependencies(BuildTargetContext c)
+        {
+            List<DependencyInfo> dependencyInfos = c.GetDependencyInfos();
+
+            dependencyInfos.Add(CreateDependencyInfo("CoreFx", Config.Instance.CoreFxVersionUrl).Result);
+
+            return c.Success();
+        }
+
+        private static async Task<DependencyInfo> CreateDependencyInfo(string name, string packageVersionsUrl)
+        {
+            List<PackageInfo> newPackageVersions = new List<PackageInfo>();
+
+            using (Stream versionsStream = await s_client.GetStreamAsync(packageVersionsUrl))
+            using (StreamReader reader = new StreamReader(versionsStream))
+            {
+                string currentLine;
+                while ((currentLine = await reader.ReadLineAsync()) != null)
+                {
+                    int spaceIndex = currentLine.IndexOf(' ');
+
+                    newPackageVersions.Add(new PackageInfo()
+                    {
+                        Id = currentLine.Substring(0, spaceIndex),
+                        Version = new NuGetVersion(currentLine.Substring(spaceIndex + 1))
+                    });
+                }
+            }
+
+            string newReleaseVersion = newPackageVersions
+                .Where(p => p.Version.IsPrerelease)
+                .Select(p => p.Version.Release)
+                .FirstOrDefault()
+                ??
+                // if there are no prerelease versions, just grab the first version
+                newPackageVersions
+                    .Select(p => p.Version.ToNormalizedString())
+                    .FirstOrDefault();
+
+            return new DependencyInfo()
+            {
+                Name = name,
+                NewVersions = newPackageVersions,
+                NewReleaseVersion = newReleaseVersion
+            };
+        }
+
+        [Target(nameof(ReplaceProjectJson), nameof(ReplaceCrossGen), nameof(ReplaceCoreHostPackaging))]
+        public static BuildTargetResult ReplaceVersions(BuildTargetContext c) => c.Success();
+
+        /// <summary>
+        /// Replaces all the dependency versions in the project.json files.
+        /// </summary>
+        [Target]
+        public static BuildTargetResult ReplaceProjectJson(BuildTargetContext c)
+        {
+            List<DependencyInfo> dependencyInfos = c.GetDependencyInfos();
+
+            IEnumerable<string> projectJsonFiles = Directory.GetFiles(Dirs.RepoRoot, "project.json", SearchOption.AllDirectories);
+
+            JObject projectRoot;
+            foreach (string projectJsonFile in projectJsonFiles)
+            {
+                try
+                {
+                    projectRoot = ReadProject(projectJsonFile);
+                }
+                catch (Exception e)
+                {
+                    c.Warn($"Non-fatal exception occurred reading '{projectJsonFile}'. Skipping file. Exception: {e}. ");
+                    continue;
+                }
+
+                if (projectRoot == null)
+                {
+                    c.Warn($"A non valid JSON file was encountered '{projectJsonFile}'. Skipping file.");
+                    continue;
+                }
+
+                bool changedAnyPackage = FindAllDependencyProperties(projectRoot)
+                    .Select(dependencyProperty => ReplaceDependencyVersion(dependencyProperty, dependencyInfos))
+                    .ToArray()
+                    .Any(shouldWrite => shouldWrite);
+
+                if (changedAnyPackage)
+                {
+                    c.Info($"Writing changes to {projectJsonFile}");
+                    WriteProject(projectRoot, projectJsonFile);
+                }
+            }
+
+            return c.Success();
+        }
+
+        /// <summary>
+        /// Replaces the single dependency with the updated version, if it matches any of the dependencies that need to be updated.
+        /// </summary>
+        private static bool ReplaceDependencyVersion(JProperty dependencyProperty, List<DependencyInfo> dependencyInfos)
+        {
+            string id = dependencyProperty.Name;
+            foreach (DependencyInfo dependencyInfo in dependencyInfos)
+            {
+                foreach (PackageInfo packageInfo in dependencyInfo.NewVersions)
+                {
+                    if (id == packageInfo.Id)
+                    {
+                        if (dependencyProperty.Value is JObject)
+                        {
+                            dependencyProperty.Value["version"] = packageInfo.Version.ToNormalizedString();
+                        }
+                        else
+                        {
+                            dependencyProperty.Value = packageInfo.Version.ToNormalizedString();
+                        }
+
+                        // mark the DependencyInfo as updated so we can tell which dependencies were updated
+                        dependencyInfo.IsUpdated = true;
+
+                        return true;
+                    }
+                }
+            }
+
+            return false;
+        }
+
+        private static JObject ReadProject(string projectJsonPath)
+        {
+            using (TextReader projectFileReader = File.OpenText(projectJsonPath))
+            {
+                var projectJsonReader = new JsonTextReader(projectFileReader);
+
+                var serializer = new JsonSerializer();
+                return serializer.Deserialize<JObject>(projectJsonReader);
+            }
+        }
+
+        private static void WriteProject(JObject projectRoot, string projectJsonPath)
+        {
+            string projectJson = JsonConvert.SerializeObject(projectRoot, Formatting.Indented);
+
+            File.WriteAllText(projectJsonPath, projectJson + Environment.NewLine);
+        }
+
+        private static IEnumerable<JProperty> FindAllDependencyProperties(JObject projectJsonRoot)
+        {
+            return projectJsonRoot
+                .Descendants()
+                .OfType<JProperty>()
+                .Where(property => property.Name == "dependencies")
+                .Select(property => property.Value)
+                .SelectMany(o => o.Children<JProperty>());
+        }
+
+        /// <summary>
+        /// Replaces version number that is hard-coded in the CrossGen script.
+        /// </summary>
+        [Target]
+        public static BuildTargetResult ReplaceCrossGen(BuildTargetContext c)
+        {
+            ReplaceFileContents(@"build_projects\shared-build-targets-utils\DependencyVersions.cs", dependencyVersionsContent =>
+            {
+                DependencyInfo coreFXInfo = c.GetCoreFXDependency();
+                Regex regex = new Regex(@"CoreCLRVersion = ""(?<version>\d.\d.\d)-(?<release>.*)"";");
+
+                // TODO: this needs a CoreCLR DependencyInfo
+                return regex.ReplaceGroupValue(dependencyVersionsContent, "release", coreFXInfo.NewReleaseVersion);
+            });
+
+            return c.Success();
+        }
+
+        /// <summary>
+        /// Replaces version number that is hard-coded in the corehost packaging dir.props file.
+        /// </summary>
+        [Target]
+        public static BuildTargetResult ReplaceCoreHostPackaging(BuildTargetContext c)
+        {
+            ReplaceFileContents(@"pkg\dir.props", contents =>
+            {
+                DependencyInfo coreFXInfo = c.GetCoreFXDependency();
+                Regex regex = new Regex(@"Microsoft\.NETCore\.Platforms\\(?<version>\d\.\d\.\d)-(?<release>.*)\\runtime\.json");
+
+                // TODO: this needs a CoreCLR DependencyInfo
+                return regex.ReplaceGroupValue(contents, "release", coreFXInfo.NewReleaseVersion);
+            });
+
+            return c.Success();
+        }
+
+        private static DependencyInfo GetCoreFXDependency(this BuildTargetContext c)
+        {
+            return c.GetDependencyInfos().Single(d => d.Name == "CoreFx");
+        }
+
+        private static void ReplaceFileContents(string repoRelativePath, Func<string, string> replacement)
+        {
+            string fullPath = Path.Combine(Dirs.RepoRoot, repoRelativePath);
+            string contents = File.ReadAllText(fullPath);
+
+            contents = replacement(contents);
+
+            File.WriteAllText(fullPath, contents, Encoding.UTF8);
+        }
+
+        private static string ReplaceGroupValue(this Regex regex, string input, string groupName, string newValue)
+        {
+            return regex.Replace(input, m =>
+            {
+                string replacedValue = m.Value;
+                Group group = m.Groups[groupName];
+                int startIndex = group.Index - m.Index;
+
+                replacedValue = replacedValue.Remove(startIndex, group.Length);
+                replacedValue = replacedValue.Insert(startIndex, newValue);
+
+                return replacedValue;
+            });
+        }
+    }
+}

--- a/build_projects/update-dependencies/project.json
+++ b/build_projects/update-dependencies/project.json
@@ -1,0 +1,28 @@
+{
+  "version": "1.0.0-*",
+  "description": "Updates the repos dependencies",
+  "buildOptions": {
+    "emitEntryPoint": true
+  },
+  "dependencies": {
+    "NETStandard.Library": "1.5.0-rc3-24123-01",
+    "Microsoft.CSharp": "4.0.1-rc3-24123-01",
+    "Microsoft.NETCore.Runtime": "1.0.2-rc3-24123-01",
+    "System.Runtime.Serialization.Primitives": "4.1.1-rc3-24123-01",
+    "Microsoft.DotNet.Cli.Build.Framework": {
+      "target": "project"
+    },
+    "NuGet.Versioning": "3.5.0-rc-1285",
+    "Newtonsoft.Json": "7.0.1",
+    "Octokit": "0.18.0",
+    "Microsoft.Net.Http": "2.2.29"
+  },
+  "frameworks": {
+    "netcoreapp1.0": {
+      "imports": [
+        "dnxcore50",
+        "portable-net45+win"
+      ]
+    }
+  }
+}

--- a/build_projects/update-dependencies/update-dependencies.xproj
+++ b/build_projects/update-dependencies/update-dependencies.xproj
@@ -1,0 +1,18 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.Props" Condition="'$(VSToolsPath)' != ''" />
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>a28bd8ac-df15-4f58-8299-98a9ae2b8726</ProjectGuid>
+    <RootNamespace>Microsoft.DotNet.Scripts</RootNamespace>
+    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">..\..\artifacts\obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">..\..\artifacts\bin</OutputPath>
+  </PropertyGroup>
+  <PropertyGroup>
+    <SchemaVersion>2.0</SchemaVersion>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.targets" Condition="'$(VSToolsPath)' != ''" />
+</Project>


### PR DESCRIPTION
Also - add the ability to specify environment variables on the command line during our build.  This allows us to use VSO secret variables.

#### Note
This was copied from the CLI repo - however I made the following change to it:

1. In UpdateFilesTargets.cs, instead of reading the "Latest.txt" file and getting just the pre-release version, it now expects the "Latest_Packages.txt" file to be specified.  This has every package ID and full version in it, which allows us to update versions even if the major, minor, or patch has changed.  It also allows us to remove the Regexs we were using to tell if this was a "CoreFX" package. Now we only update packages that are specified in the "Latest_Packages.txt" file.

@brthor 