### PR TITLE
Update Roslyn to 1.3.0-beta1-20160525-03

### DIFF
--- a/pkg/projects/Microsoft.NETCore.App/project.json
+++ b/pkg/projects/Microsoft.NETCore.App/project.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
-    "Microsoft.CodeAnalysis.CSharp": "1.3.0-beta1-20160429-01",
-    "Microsoft.CodeAnalysis.VisualBasic": "1.3.0-beta1-20160429-01",
+    "Microsoft.CodeAnalysis.CSharp": "1.3.0-beta1-20160525-03",
+    "Microsoft.CodeAnalysis.VisualBasic": "1.3.0-beta1-20160525-03",
     "Microsoft.CSharp": "4.0.1-rc3-24123-01",
     "Microsoft.NETCore.Runtime": "1.0.2-rc3-24123-01",
     "Microsoft.VisualBasic": "10.0.1-rc3-24123-01",


### PR DESCRIPTION
The Shared Framework is now being built from core-setup.  So I need to update core-setup with the new Roslyn.

@brthor @gkhanna79 