### PR TITLE
stop nuking latest in core-setup

### DIFF
--- a/build_projects/dotnet-host-build/PublishTargets.cs
+++ b/build_projects/dotnet-host-build/PublishTargets.cs
@@ -71,12 +71,6 @@ namespace Microsoft.DotNet.Host.Build
                 }
                 else
                 {
-                    // This is an old drop of latest so remove all old files to ensure a clean state
-                    AzurePublisherTool.ListBlobs($"{targetContainer}")
-                        .Select(s => s.Replace("/dotnet/", ""))
-                        .ToList()
-                        .ForEach(f => AzurePublisherTool.TryDeleteBlob(f));
-
                     // Drop the version file signaling such for any race-condition builds (see above comment).
                     AzurePublisherTool.DropLatestSpecifiedVersion(targetVersionFile);
                 }

--- a/build_projects/dotnet-host-build/PublishTargets.cs
+++ b/build_projects/dotnet-host-build/PublishTargets.cs
@@ -71,6 +71,15 @@ namespace Microsoft.DotNet.Host.Build
                 }
                 else
                 {
+                    Regex versionFileRegex = new Regex(@"(?<version>\d\.\d\.\d)-(?<release>.*)?");
+
+                    // Delete old version files
+                    AzurePublisherTool.ListBlobs($"{targetContainer}")
+                        .Select(s => s.Replace("/dotnet/", ""))
+                        .Where(s => versionFileRegex.IsMatch(s))
+                        .ToList()
+                        .ForEach(f => AzurePublisherTool.TryDeleteBlob(f));
+
                     // Drop the version file signaling such for any race-condition builds (see above comment).
                     AzurePublisherTool.DropLatestSpecifiedVersion(targetVersionFile);
                 }


### PR DESCRIPTION
Right now we're nuking all of the cli binaries in latest in every core-setup build.
We shouldn't need to delete these files, we can just overwrite.

cc @eerhardt @schellap @sokket 
