### PR TITLE
Overwrite path_helper file on install.

### DIFF
--- a/packaging/osx/sharedhost/scripts/postinstall
+++ b/packaging/osx/sharedhost/scripts/postinstall
@@ -11,6 +11,6 @@ INSTALL_DESTINATION=$2
 chmod 755 $INSTALL_DESTINATION/dotnet
 
 # Add the installation directory to the system-wide paths
-echo $INSTALL_DESTINATION | tee -a /etc/paths.d/dotnet
+echo $INSTALL_DESTINATION > /etc/paths.d/dotnet
 
 exit 0


### PR DESCRIPTION
If the package's installer is run multiple times, the installation
path would be appended for every time the package had been run. This
change overwrites the file initially, and if subsequent paths need
to be added, then those can be appended. This ensures the "dotnet"
path helper file is clean for each install.

Fixes #18.