### PR TITLE
Remove appending to dotnet paths

### DIFF
--- a/packaging/osx/sharedhost/scripts/postinstall
+++ b/packaging/osx/sharedhost/scripts/postinstall
@@ -11,6 +11,6 @@ INSTALL_DESTINATION=$2
 chmod 755 $INSTALL_DESTINATION/dotnet
 
 # Add the installation directory to the system-wide paths
-echo $INSTALL_DESTINATION | tee -a /etc/paths.d/dotnet
+echo $INSTALL_DESTINATION | tee /etc/paths.d/dotnet
 
 exit 0


### PR DESCRIPTION
This fixes appending multiple times to the `/etc/paths.d/dotnet` file for the shared host. 

Fixes #18

/cc @brthor @eerhardt 