### PR TITLE
Update NETCore.App meta-package dependencies to .NETcoreApp1.0

### DIFF
--- a/pkg/projects/Microsoft.NETCore.App/Microsoft.NETCore.App.pkgproj
+++ b/pkg/projects/Microsoft.NETCore.App/Microsoft.NETCore.App.pkgproj
@@ -39,6 +39,11 @@
       <Dependency Condition="'%(Dependency.Identity)' == 'System.Runtime.Loader'">
         <Exclude>Compile</Exclude>
       </Dependency>
+
+      <File Include="$(PlaceholderFile)" >
+        <SkipPackageFileCheck>true</SkipPackageFileCheck>
+        <TargetPath>lib/netcoreapp1.0</TargetPath>
+      </File>
     </ItemGroup>
 
     <PropertyGroup>

--- a/pkg/projects/Microsoft.NETCore.App/Microsoft.NETCore.App.pkgproj
+++ b/pkg/projects/Microsoft.NETCore.App/Microsoft.NETCore.App.pkgproj
@@ -9,7 +9,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.NETCore.DotNetHost\Microsoft.NETCore.DotNetHostPolicy.pkgproj">
-      <TargetFramework>.NETStandard1.0</TargetFramework>
+      <TargetFramework>.NETCoreApp1.0</TargetFramework>
     </ProjectReference>
   </ItemGroup>
 
@@ -26,7 +26,7 @@
 
       <Dependency Include="@(PackageMatch -> '%(PackageId)')" Condition="'%(PackageVersion)' != ''">
         <Version>%(PackageVersion)</Version>
-        <TargetFramework>.NETStandard1.0</TargetFramework>
+        <TargetFramework>.NETCoreApp1.0</TargetFramework>
       </Dependency>
 
       <!-- List of dependencies to mark as exclude=compile -->


### PR DESCRIPTION
Fixes https://github.com/dotnet/cli/issues/2924

This limits the dependnecies of Microsoft.NETcore.App to only
be appicable to netcoreapp1.0 and so if people try to restore
it with other tfm's like netstandard they will not get any
of the dependencies and the meta-package will essentially be empty.

cc @ericstj @davidfowl 