### PR TITLE
publish dotnet-deb-tool on ubuntu

### DIFF
--- a/build_projects/dotnet-host-build/PublishTargets.cs
+++ b/build_projects/dotnet-host-build/PublishTargets.cs
@@ -51,6 +51,17 @@ namespace Microsoft.DotNet.Host.Build
         }
 
         [Target]
+        [BuildPlatforms(BuildPlatform.Ubuntu)]
+        public static BuildTargetResult PublishDotnetDebToolPackage(BuildTargetContext c)
+        {
+            string nugetFeedUrl = EnvVars.EnsureVariable("CLI_NUGET_FEED_URL");
+            string apiKey = EnvVars.EnsureVariable("CLI_NUGET_API_KEY");
+            NuGetUtil.PushPackages(Dirs.Packages, nugetFeedUrl, apiKey);
+
+            return c.Success();
+        }
+
+        [Target]
         public static BuildTargetResult FinalizeBuild(BuildTargetContext c)
         {
             if (CheckIfAllBuildsHavePublished())


### PR DESCRIPTION
We can't publish this on windows because it doesn't retain file permissions correctly.
@eerhardt 