### PR TITLE
Add Libuv to Microsoft.NETCore.App

### DIFF
--- a/pkg/projects/Microsoft.NETCore.App/project.json
+++ b/pkg/projects/Microsoft.NETCore.App/project.json
@@ -38,7 +38,8 @@
     "System.Threading.Tasks.Extensions": "4.0.0-rc3-24131-00",
     "System.Threading.Tasks.Parallel": "4.0.1-rc3-24131-00",
     "System.Threading.Thread": "4.0.0-rc3-24131-00",
-    "System.Threading.ThreadPool": "4.0.10-rc3-24131-00"
+    "System.Threading.ThreadPool": "4.0.10-rc3-24131-00",
+    "Libuv": "1.9.0-rc2-21014"
   },
   "frameworks": {
     "netstandard1.5": {}


### PR DESCRIPTION
Fixes https://github.com/dotnet/cli/issues/2277

Adds Libuv to Microsoft.NETCore.App (aka Shared framework).

cc @muratg @davidfowl @moozzyk @Petermarcu @piotrpMSFT 
