### PR TITLE
Updating UPSTREAM_BRANCH to release/1.0.0

### DIFF
--- a/build_projects/update-dependencies/Config.cs
+++ b/build_projects/update-dependencies/Config.cs
@@ -37,7 +37,7 @@ namespace Microsoft.DotNet.Scripts
         private Lazy<string> _gitHubOriginOwner;
         private Lazy<string> _gitHubUpstreamOwner = new Lazy<string>(() => GetEnvironmentVariable("GITHUB_UPSTREAM_OWNER", "dotnet"));
         private Lazy<string> _gitHubProject = new Lazy<string>(() => GetEnvironmentVariable("GITHUB_PROJECT", "core-setup"));
-        private Lazy<string> _gitHubUpstreamBranch = new Lazy<string>(() => GetEnvironmentVariable("GITHUB_UPSTREAM_BRANCH", "master"));
+        private Lazy<string> _gitHubUpstreamBranch = new Lazy<string>(() => GetEnvironmentVariable("GITHUB_UPSTREAM_BRANCH", "release/1.0.0"));
         private Lazy<string[]> _gitHubPullRequestNotifications = new Lazy<string[]>(() => 
                                                 GetEnvironmentVariable("GITHUB_PULL_REQUEST_NOTIFICATIONS", "")
                                                     .Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries));


### PR DESCRIPTION
@dotnet-bot is still making PRs in the wrong branch. Updating the update-dependencies script to the correct branch.

@brthor - maybe this would be a good reason to keep the "BRANCH_NAME" variable around in branchinfo.txt...?

