### PR TITLE
Add 'override' to VerInfo.ToString

### DIFF
--- a/build_projects/shared-build-targets-utils/Utils/HostVersion.cs
+++ b/build_projects/shared-build-targets-utils/Utils/HostVersion.cs
@@ -31,7 +31,7 @@ namespace Microsoft.DotNet.Cli.Build
 
             public string WithoutSuffix => $"{Major}.{Minor}.{Patch}";
 
-            public string ToString()
+            public override string ToString()
             {
                 string suffix = "";
                 foreach (var verPad in new string[] { Release, BuildMajor, BuildMinor })


### PR DESCRIPTION
This fixes the build warning.

@schellap 
