### PR TITLE
Adding CoreClr dependency to core-setup

### DIFF
--- a/build_projects/dotnet-host-build/project.json
+++ b/build_projects/dotnet-host-build/project.json
@@ -6,7 +6,7 @@
   },
   "dependencies": {
     "NETStandard.Library": "1.6.0-rc3-24201-00",
-    "Microsoft.NETCore.Runtime": "1.0.2-rc3-24201-00",
+    "Microsoft.NETCore.Runtime.CoreCLR": "1.0.2-rc3-24201-00",
     "Microsoft.CSharp": "4.0.1-rc3-24201-00",
     "System.Dynamic.Runtime": "4.0.11-rc3-24201-00",
     "System.Reflection.Metadata": "1.3.0-rc3-24201-00",

--- a/build_projects/update-dependencies/Config.cs
+++ b/build_projects/update-dependencies/Config.cs
@@ -19,6 +19,7 @@ namespace Microsoft.DotNet.Scripts
     /// The following Environment Variables can optionally be specified:
     /// 
     /// COREFX_VERSION_URL - The Url to get the current CoreFx version. (ex. "https://raw.githubusercontent.com/dotnet/versions/master/build-info/dotnet/corefx/release/1.0.0/Latest_Packages.txt")
+    /// CORECLR_VERSION_URL - The Url to get the current CoreCLR version. (ex. "https://raw.githubusercontent.com/dotnet/versions/master/build-info/dotnet/coreclr/release/1.0.0/Latest_Packages.txt")
     /// ROSLYN_VERSION_URL - The Url to get the current Roslyn version. (ex. "https://raw.githubusercontent.com/dotnet/versions/master/build-info/dotnet/roslyn/netcore1.0/Latest_Packages.txt")
     /// GITHUB_ORIGIN_OWNER - The owner of the GitHub fork to push the commit and create the PR from. (ex. "dotnet-bot")
     /// GITHUB_UPSTREAM_OWNER - The owner of the GitHub base repo to create the PR to. (ex. "dotnet")
@@ -35,6 +36,7 @@ namespace Microsoft.DotNet.Scripts
         private Lazy<string> _password = new Lazy<string>(() => GetEnvironmentVariable("GITHUB_PASSWORD"));
 
         private Lazy<string> _coreFxVersionUrl = new Lazy<string>(() => GetEnvironmentVariable("COREFX_VERSION_URL", "https://raw.githubusercontent.com/dotnet/versions/master/build-info/dotnet/corefx/release/1.0.0/Latest_Packages.txt"));
+        private Lazy<string> _coreClrVersionUrl = new Lazy<string>(() => GetEnvironmentVariable("CORECLR_VERSION_URL", "https://raw.githubusercontent.com/dotnet/versions/master/build-info/dotnet/coreclr/release/1.0.0/Latest_Packages.txt"));
         private Lazy<string> _roslynVersionUrl = new Lazy<string>(() => GetEnvironmentVariable("ROSLYN_VERSION_URL", "https://raw.githubusercontent.com/dotnet/versions/master/build-info/dotnet/roslyn/netcore1.0/Latest_Packages.txt"));
         private Lazy<string> _gitHubOriginOwner;
         private Lazy<string> _gitHubUpstreamOwner = new Lazy<string>(() => GetEnvironmentVariable("GITHUB_UPSTREAM_OWNER", "dotnet"));
@@ -53,6 +55,7 @@ namespace Microsoft.DotNet.Scripts
         public string Email => _email.Value; 
         public string Password => _password.Value;
         public string CoreFxVersionUrl => _coreFxVersionUrl.Value;
+        public string CoreClrVersionUrl => _coreClrVersionUrl.Value;
         public string RoslynVersionUrl => _roslynVersionUrl.Value;
         public string GitHubOriginOwner => _gitHubOriginOwner.Value;
         public string GitHubUpstreamOwner => _gitHubUpstreamOwner.Value;

--- a/build_projects/update-dependencies/UpdateFilesTargets.cs
+++ b/build_projects/update-dependencies/UpdateFilesTargets.cs
@@ -32,6 +32,7 @@ namespace Microsoft.DotNet.Scripts
             List<DependencyInfo> dependencyInfos = c.GetDependencyInfos();
 
             dependencyInfos.Add(CreateDependencyInfo("CoreFx", Config.Instance.CoreFxVersionUrl).Result);
+            dependencyInfos.Add(CreateDependencyInfo("CoreClr", Config.Instance.CoreClrVersionUrl).Result);
             dependencyInfos.Add(CreateDependencyInfo("Roslyn", Config.Instance.RoslynVersionUrl).Result);
 
             return c.Success();
@@ -134,19 +135,33 @@ namespace Microsoft.DotNet.Scripts
                 {
                     if (id == packageInfo.Id)
                     {
+                        string oldVersion;
                         if (dependencyProperty.Value is JObject)
                         {
-                            dependencyProperty.Value["version"] = packageInfo.Version.ToNormalizedString();
+                            oldVersion = (string)dependencyProperty.Value["version"];
                         }
                         else
                         {
-                            dependencyProperty.Value = packageInfo.Version.ToNormalizedString();
+                            oldVersion = (string)dependencyProperty.Value;
                         }
 
-                        // mark the DependencyInfo as updated so we can tell which dependencies were updated
-                        dependencyInfo.IsUpdated = true;
+                        string newVersion = packageInfo.Version.ToNormalizedString();
+                        if (oldVersion != newVersion)
+                        {
+                            if (dependencyProperty.Value is JObject)
+                            {
+                                dependencyProperty.Value["version"] = newVersion;
+                            }
+                            else
+                            {
+                                dependencyProperty.Value = newVersion;
+                            }
 
-                        return true;
+                            // mark the DependencyInfo as updated so we can tell which dependencies were updated
+                            dependencyInfo.IsUpdated = true;
+
+                            return true;
+                        }
                     }
                 }
             }

--- a/build_projects/update-dependencies/project.json
+++ b/build_projects/update-dependencies/project.json
@@ -7,7 +7,7 @@
   "dependencies": {
     "NETStandard.Library": "1.6.0-rc3-24201-00",
     "Microsoft.CSharp": "4.0.1-rc3-24201-00",
-    "Microsoft.NETCore.Runtime": "1.0.2-rc3-24201-00",
+    "Microsoft.NETCore.Runtime.CoreCLR": "1.0.2-rc3-24201-00",
     "System.Runtime.Serialization.Primitives": "4.1.1-rc3-24201-00",
     "Microsoft.DotNet.Cli.Build.Framework": {
       "target": "project"

--- a/pkg/projects/Microsoft.NETCore.App/project.json
+++ b/pkg/projects/Microsoft.NETCore.App/project.json
@@ -3,7 +3,7 @@
     "Microsoft.CodeAnalysis.CSharp": "1.3.0-beta1-20160602-01",
     "Microsoft.CodeAnalysis.VisualBasic": "1.3.0-beta1-20160602-01",
     "Microsoft.CSharp": "4.0.1-rc3-24201-00",
-    "Microsoft.NETCore.Runtime": "1.0.2-rc3-24201-00",
+    "Microsoft.NETCore.Runtime.CoreCLR": "1.0.2-rc3-24201-00",
     "Microsoft.VisualBasic": "10.0.1-rc3-24201-00",
     "NETStandard.Library": "1.6.0-rc3-24201-00",
     "System.Buffers": "4.0.0-rc3-24201-00",

--- a/tools/independent/RuntimeGraphGenerator/project.json
+++ b/tools/independent/RuntimeGraphGenerator/project.json
@@ -10,7 +10,6 @@
     "System.Runtime.Serialization.Json": "4.0.2-rc3-24201-00",
     "Microsoft.DotNet.ProjectModel": "1.0.0-rc2-002794",
     "Microsoft.DotNet.Cli.Utils": "1.0.0-preview2-002794",
-    "Microsoft.NETCore.ConsoleHost": "1.0.0-rc3-24201-00",
     "NETStandard.Library": "1.6.0-rc3-24201-00",
     "Microsoft.NETCore.Runtime.CoreCLR": "1.0.2-rc3-24201-00"
   },

--- a/tools/independent/RuntimeGraphGenerator/project.json
+++ b/tools/independent/RuntimeGraphGenerator/project.json
@@ -12,7 +12,7 @@
     "Microsoft.DotNet.Cli.Utils": "1.0.0-preview2-002794",
     "Microsoft.NETCore.ConsoleHost": "1.0.0-rc3-24201-00",
     "NETStandard.Library": "1.6.0-rc3-24201-00",
-    "Microsoft.NETCore.Runtime": "1.0.2-rc3-24201-00"
+    "Microsoft.NETCore.Runtime.CoreCLR": "1.0.2-rc3-24201-00"
   },
   "frameworks": {
     "netcoreapp1.0": {


### PR DESCRIPTION
Also, porting a bug fix from cli. The issue is all dependencies are reported in the PR as "updated" even if the version didn't change. We now only report actual updated dependencies.

Move dependency from Microsoft.NETCore.Runtime to Microsoft.NETCore.Runtime.CoreCLR.

@brthor @dagood @weshaggard 