### PR TITLE
Don't delete mscorlib.dll from Shared FX

### DIFF
--- a/build_projects/shared-build-targets-utils/Utils/SharedFrameworkPublisher.cs
+++ b/build_projects/shared-build-targets-utils/Utils/SharedFrameworkPublisher.cs
@@ -121,13 +121,6 @@ namespace Microsoft.DotNet.Cli.Build
 
             CopyHostArtifactsToSharedFramework(sharedFrameworkNameAndVersionRoot);
             
-            if (File.Exists(Path.Combine(sharedFrameworkNameAndVersionRoot, "mscorlib.ni.dll")))
-            {
-                // Publish already places the crossgen'd version of mscorlib into the output, so we can
-                // remove the IL version
-                File.Delete(Path.Combine(sharedFrameworkNameAndVersionRoot, "mscorlib.dll"));
-            }
-
             _crossgenUtil.CrossgenDirectory(sharedFrameworkNameAndVersionRoot, sharedFrameworkNameAndVersionRoot);
 
             // Generate .version file for sharedfx


### PR DESCRIPTION
@gkhanna79 @eerhardt PTAL. Because the meaning of mscorlib.dll has changed with the renaming and facade, this needs to be present in the Shared FX. Once you guys agree, I will port this to release/1.0.0 -- this will be a problem with rc4 packages we would eventually ship out of.