### PR TITLE
Fix x86 build by setting ExecutionPolicy for packaging scripts.

### DIFF
--- a/build_projects/dotnet-host-build/MsiTargets.cs
+++ b/build_projects/dotnet-host-build/MsiTargets.cs
@@ -122,7 +122,7 @@ namespace Microsoft.DotNet.Host.Build
             }
             Directory.CreateDirectory(wixObjRoot);
 
-            Cmd("powershell", "-NoProfile", "-NoLogo",
+            Cmd("powershell", "-ExecutionPolicy", "Unrestricted", "-NoProfile", "-NoLogo",
                 Path.Combine(Dirs.RepoRoot, "packaging", "windows", "host", "generatemsi.ps1"),
                 inputDir, SharedHostMsi, WixRoot, sharedHostBrandName, hostMsiVersion, hostNugetVersion, Arch, wixObjRoot)
                     .Execute()
@@ -148,7 +148,7 @@ namespace Microsoft.DotNet.Host.Build
             }
             Directory.CreateDirectory(wixObjRoot);
 
-            Cmd("powershell", "-NoProfile", "-NoLogo",
+            Cmd("powershell", "-ExecutionPolicy", "Unrestricted", "-NoProfile", "-NoLogo",
                 Path.Combine(Dirs.RepoRoot, "packaging", "windows", "sharedframework", "generatemsi.ps1"),
                 inputDir, SharedFrameworkMsi, WixRoot, sharedFxBrandName, msiVerison, sharedFrameworkNuGetName, sharedFrameworkNuGetVersion, upgradeCode, Arch, wixObjRoot)
                     .Execute()
@@ -165,7 +165,7 @@ namespace Microsoft.DotNet.Host.Build
             var upgradeCode = Utils.GenerateGuidFromName(SharedFrameworkBundle).ToString().ToUpper();
             var sharedFxBrandName = $"'{Monikers.SharedFxBrandName}'";
 
-            Cmd("powershell", "-NoProfile", "-NoLogo",
+            Cmd("powershell", "-ExecutionPolicy", "Unrestricted", "-NoProfile", "-NoLogo",
                 Path.Combine(Dirs.RepoRoot, "packaging", "windows", "sharedframework", "generatebundle.ps1"),
                 SharedFrameworkMsi, SharedHostMsi, SharedFrameworkBundle, WixRoot, sharedFxBrandName, MsiVersion, DisplayVersion, sharedFrameworkNuGetName, sharedFrameworkNuGetVersion, upgradeCode, Arch)
                     .Execute()


### PR DESCRIPTION
Error message was: "File packaging\windows\host\generatemsi.ps1 cannot be loaded because running scripts is disabled on this system."
This error only happened when I did the x86 build.