### PR TITLE
Add project and release notes URL and serviceable attribute

### DIFF
--- a/pkg/dir.props
+++ b/pkg/dir.props
@@ -27,6 +27,9 @@
     <PackageLicenseFile>$(ProjectDir)projects/dotnet_library_license.txt</PackageLicenseFile>
     <PackageThirdPartyNoticesFile>$(ProjectDir)projects/ThirdPartyNotices.txt</PackageThirdPartyNoticesFile>
     <PackageDescriptionFile>$(ProjectDir)projects/descriptions.json</PackageDescriptionFile>
+    <!-- This link should be updated for each release milestone, currently this points to 1.0.0 -->
+    <ReleaseNotes>https://go.microsoft.com/fwlink/?LinkID=799417</ReleaseNotes>
+    <ProjectUrl>https://dot.net</ProjectUrl>
     <PackagePlatform Condition="'$(PackagePlatform)' == ''">$(Platform)</PackagePlatform>
     <PackagePlatform Condition="'$(PackagePlatform)' == 'amd64'">x64</PackagePlatform>
   </PropertyGroup>

--- a/pkg/projects/Microsoft.NETCore.DotNetHost/Microsoft.NETCore.DotNetHost.pkgproj
+++ b/pkg/projects/Microsoft.NETCore.DotNetHost/Microsoft.NETCore.DotNetHost.pkgproj
@@ -9,6 +9,7 @@
     <PackagePlatforms>x64;x86;</PackagePlatforms>
     <OutputPath>$(PackagesOutputPath)</OutputPath>
     <IncludeRuntimeJson>true</IncludeRuntimeJson>
+    <Serviceable>true</Serviceable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/pkg/projects/Microsoft.NETCore.DotNetHost/Microsoft.NETCore.DotNetHostPolicy.pkgproj
+++ b/pkg/projects/Microsoft.NETCore.DotNetHost/Microsoft.NETCore.DotNetHostPolicy.pkgproj
@@ -9,6 +9,7 @@
     <PackagePlatforms>x64;x86;</PackagePlatforms>
     <OutputPath>$(PackagesOutputPath)</OutputPath>
     <IncludeRuntimeJson>true</IncludeRuntimeJson>
+    <Serviceable>true</Serviceable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/pkg/projects/Microsoft.NETCore.DotNetHost/Microsoft.NETCore.DotNetHostResolver.pkgproj
+++ b/pkg/projects/Microsoft.NETCore.DotNetHost/Microsoft.NETCore.DotNetHostResolver.pkgproj
@@ -9,6 +9,7 @@
     <PackagePlatforms>x64;x86;</PackagePlatforms>
     <OutputPath>$(PackagesOutputPath)</OutputPath>
     <IncludeRuntimeJson>true</IncludeRuntimeJson>
+    <Serviceable>true</Serviceable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/pkg/projects/Microsoft.NETCore.DotNetHost/debian/Microsoft.NETCore.DotNetHost.pkgproj
+++ b/pkg/projects/Microsoft.NETCore.DotNetHost/debian/Microsoft.NETCore.DotNetHost.pkgproj
@@ -7,6 +7,7 @@
     <SkipPackageFileCheck>true</SkipPackageFileCheck>
     <MinOSForArch>debian.8</MinOSForArch>
     <PackageTargetRuntime>$(MinOSForArch)-$(PackagePlatform)</PackageTargetRuntime>
+    <Serviceable>true</Serviceable>
   </PropertyGroup>
   
   <ItemGroup>

--- a/pkg/projects/Microsoft.NETCore.DotNetHost/debian/Microsoft.NETCore.DotNetHostPolicy.pkgproj
+++ b/pkg/projects/Microsoft.NETCore.DotNetHost/debian/Microsoft.NETCore.DotNetHostPolicy.pkgproj
@@ -7,6 +7,7 @@
     <SkipPackageFileCheck>true</SkipPackageFileCheck>
     <MinOSForArch>debian.8</MinOSForArch>
     <PackageTargetRuntime>$(MinOSForArch)-$(PackagePlatform)</PackageTargetRuntime>
+    <Serviceable>true</Serviceable>
   </PropertyGroup>
   
   <ItemGroup>

--- a/pkg/projects/Microsoft.NETCore.DotNetHost/debian/Microsoft.NETCore.DotNetHostResolver.pkgproj
+++ b/pkg/projects/Microsoft.NETCore.DotNetHost/debian/Microsoft.NETCore.DotNetHostResolver.pkgproj
@@ -7,6 +7,7 @@
     <SkipPackageFileCheck>true</SkipPackageFileCheck>
     <MinOSForArch>debian.8</MinOSForArch>
     <PackageTargetRuntime>$(MinOSForArch)-$(PackagePlatform)</PackageTargetRuntime>
+    <Serviceable>true</Serviceable>
   </PropertyGroup>
   
   <ItemGroup>

--- a/pkg/projects/Microsoft.NETCore.DotNetHost/fedora.23/Microsoft.NETCore.DotNetHost.pkgproj
+++ b/pkg/projects/Microsoft.NETCore.DotNetHost/fedora.23/Microsoft.NETCore.DotNetHost.pkgproj
@@ -7,6 +7,7 @@
     <SkipPackageFileCheck>true</SkipPackageFileCheck>
     <MinOSForArch>fedora.23</MinOSForArch>
     <PackageTargetRuntime>$(MinOSForArch)-$(PackagePlatform)</PackageTargetRuntime>
+    <Serviceable>true</Serviceable>
   </PropertyGroup>
   
   <ItemGroup>

--- a/pkg/projects/Microsoft.NETCore.DotNetHost/fedora.23/Microsoft.NETCore.DotNetHostPolicy.pkgproj
+++ b/pkg/projects/Microsoft.NETCore.DotNetHost/fedora.23/Microsoft.NETCore.DotNetHostPolicy.pkgproj
@@ -7,6 +7,7 @@
     <SkipPackageFileCheck>true</SkipPackageFileCheck>
     <MinOSForArch>fedora.23</MinOSForArch>
     <PackageTargetRuntime>$(MinOSForArch)-$(PackagePlatform)</PackageTargetRuntime>
+    <Serviceable>true</Serviceable>
   </PropertyGroup>
   
   <ItemGroup>

--- a/pkg/projects/Microsoft.NETCore.DotNetHost/fedora.23/Microsoft.NETCore.DotNetHostResolver.pkgproj
+++ b/pkg/projects/Microsoft.NETCore.DotNetHost/fedora.23/Microsoft.NETCore.DotNetHostResolver.pkgproj
@@ -7,6 +7,7 @@
     <SkipPackageFileCheck>true</SkipPackageFileCheck>
     <MinOSForArch>fedora.23</MinOSForArch>
     <PackageTargetRuntime>$(MinOSForArch)-$(PackagePlatform)</PackageTargetRuntime>
+    <Serviceable>true</Serviceable>
   </PropertyGroup>
   
   <ItemGroup>

--- a/pkg/projects/Microsoft.NETCore.DotNetHost/opensuse.13.2/Microsoft.NETCore.DotNetHost.pkgproj
+++ b/pkg/projects/Microsoft.NETCore.DotNetHost/opensuse.13.2/Microsoft.NETCore.DotNetHost.pkgproj
@@ -7,6 +7,7 @@
     <SkipPackageFileCheck>true</SkipPackageFileCheck>
     <MinOSForArch>opensuse.13.2</MinOSForArch>
     <PackageTargetRuntime>$(MinOSForArch)-$(PackagePlatform)</PackageTargetRuntime>
+    <Serviceable>true</Serviceable>
   </PropertyGroup>
   
   <ItemGroup>

--- a/pkg/projects/Microsoft.NETCore.DotNetHost/opensuse.13.2/Microsoft.NETCore.DotNetHostPolicy.pkgproj
+++ b/pkg/projects/Microsoft.NETCore.DotNetHost/opensuse.13.2/Microsoft.NETCore.DotNetHostPolicy.pkgproj
@@ -7,6 +7,7 @@
     <SkipPackageFileCheck>true</SkipPackageFileCheck>
     <MinOSForArch>opensuse.13.2</MinOSForArch>
     <PackageTargetRuntime>$(MinOSForArch)-$(PackagePlatform)</PackageTargetRuntime>
+    <Serviceable>true</Serviceable>
   </PropertyGroup>
   
   <ItemGroup>

--- a/pkg/projects/Microsoft.NETCore.DotNetHost/opensuse.13.2/Microsoft.NETCore.DotNetHostResolver.pkgproj
+++ b/pkg/projects/Microsoft.NETCore.DotNetHost/opensuse.13.2/Microsoft.NETCore.DotNetHostResolver.pkgproj
@@ -7,6 +7,7 @@
     <SkipPackageFileCheck>true</SkipPackageFileCheck>
     <MinOSForArch>opensuse.13.2</MinOSForArch>
     <PackageTargetRuntime>$(MinOSForArch)-$(PackagePlatform)</PackageTargetRuntime>
+    <Serviceable>true</Serviceable>
   </PropertyGroup>
   
   <ItemGroup>

--- a/pkg/projects/Microsoft.NETCore.DotNetHost/osx/Microsoft.NETCore.DotNetHost.pkgproj
+++ b/pkg/projects/Microsoft.NETCore.DotNetHost/osx/Microsoft.NETCore.DotNetHost.pkgproj
@@ -7,6 +7,7 @@
     <SkipPackageFileCheck>true</SkipPackageFileCheck>
     <MinOSForArch>osx.10.10</MinOSForArch>
     <PackageTargetRuntime>$(MinOSForArch)-$(PackagePlatform)</PackageTargetRuntime>
+    <Serviceable>true</Serviceable>
   </PropertyGroup>
   
   <ItemGroup>

--- a/pkg/projects/Microsoft.NETCore.DotNetHost/osx/Microsoft.NETCore.DotNetHostPolicy.pkgproj
+++ b/pkg/projects/Microsoft.NETCore.DotNetHost/osx/Microsoft.NETCore.DotNetHostPolicy.pkgproj
@@ -7,6 +7,7 @@
     <SkipPackageFileCheck>true</SkipPackageFileCheck>
     <MinOSForArch>osx.10.10</MinOSForArch>
     <PackageTargetRuntime>$(MinOSForArch)-$(PackagePlatform)</PackageTargetRuntime>
+    <Serviceable>true</Serviceable>
   </PropertyGroup>
   
   <ItemGroup>

--- a/pkg/projects/Microsoft.NETCore.DotNetHost/osx/Microsoft.NETCore.DotNetHostResolver.pkgproj
+++ b/pkg/projects/Microsoft.NETCore.DotNetHost/osx/Microsoft.NETCore.DotNetHostResolver.pkgproj
@@ -7,6 +7,7 @@
     <SkipPackageFileCheck>true</SkipPackageFileCheck>
     <MinOSForArch>osx.10.10</MinOSForArch>
     <PackageTargetRuntime>$(MinOSForArch)-$(PackagePlatform)</PackageTargetRuntime>
+    <Serviceable>true</Serviceable>
   </PropertyGroup>
   
   <ItemGroup>

--- a/pkg/projects/Microsoft.NETCore.DotNetHost/rhel/Microsoft.NETCore.DotNetHost.pkgproj
+++ b/pkg/projects/Microsoft.NETCore.DotNetHost/rhel/Microsoft.NETCore.DotNetHost.pkgproj
@@ -7,6 +7,7 @@
     <SkipPackageFileCheck>true</SkipPackageFileCheck>
     <MinOSForArch>rhel.7</MinOSForArch>
     <PackageTargetRuntime>$(MinOSForArch)-$(PackagePlatform)</PackageTargetRuntime>
+    <Serviceable>true</Serviceable>
   </PropertyGroup>
   
   <ItemGroup>

--- a/pkg/projects/Microsoft.NETCore.DotNetHost/rhel/Microsoft.NETCore.DotNetHostPolicy.pkgproj
+++ b/pkg/projects/Microsoft.NETCore.DotNetHost/rhel/Microsoft.NETCore.DotNetHostPolicy.pkgproj
@@ -7,6 +7,7 @@
     <SkipPackageFileCheck>true</SkipPackageFileCheck>
     <MinOSForArch>rhel.7</MinOSForArch>
     <PackageTargetRuntime>$(MinOSForArch)-$(PackagePlatform)</PackageTargetRuntime>
+    <Serviceable>true</Serviceable>
   </PropertyGroup>
   
   <ItemGroup>

--- a/pkg/projects/Microsoft.NETCore.DotNetHost/rhel/Microsoft.NETCore.DotNetHostResolver.pkgproj
+++ b/pkg/projects/Microsoft.NETCore.DotNetHost/rhel/Microsoft.NETCore.DotNetHostResolver.pkgproj
@@ -7,6 +7,7 @@
     <SkipPackageFileCheck>true</SkipPackageFileCheck>
     <MinOSForArch>rhel.7</MinOSForArch>
     <PackageTargetRuntime>$(MinOSForArch)-$(PackagePlatform)</PackageTargetRuntime>
+    <Serviceable>true</Serviceable>
   </PropertyGroup>
   
   <ItemGroup>

--- a/pkg/projects/Microsoft.NETCore.DotNetHost/ubuntu.14.04/Microsoft.NETCore.DotNetHost.pkgproj
+++ b/pkg/projects/Microsoft.NETCore.DotNetHost/ubuntu.14.04/Microsoft.NETCore.DotNetHost.pkgproj
@@ -7,6 +7,7 @@
     <SkipPackageFileCheck>true</SkipPackageFileCheck>
     <MinOSForArch>ubuntu.14.04</MinOSForArch>
     <PackageTargetRuntime>$(MinOSForArch)-$(PackagePlatform)</PackageTargetRuntime>
+    <Serviceable>true</Serviceable>
   </PropertyGroup>
   
   <ItemGroup>

--- a/pkg/projects/Microsoft.NETCore.DotNetHost/ubuntu.14.04/Microsoft.NETCore.DotNetHostPolicy.pkgproj
+++ b/pkg/projects/Microsoft.NETCore.DotNetHost/ubuntu.14.04/Microsoft.NETCore.DotNetHostPolicy.pkgproj
@@ -7,6 +7,7 @@
     <SkipPackageFileCheck>true</SkipPackageFileCheck>
     <MinOSForArch>ubuntu.14.04</MinOSForArch>
     <PackageTargetRuntime>$(MinOSForArch)-$(PackagePlatform)</PackageTargetRuntime>
+    <Serviceable>true</Serviceable>
   </PropertyGroup>
   
   <ItemGroup>

--- a/pkg/projects/Microsoft.NETCore.DotNetHost/ubuntu.14.04/Microsoft.NETCore.DotNetHostResolver.pkgproj
+++ b/pkg/projects/Microsoft.NETCore.DotNetHost/ubuntu.14.04/Microsoft.NETCore.DotNetHostResolver.pkgproj
@@ -7,6 +7,7 @@
     <SkipPackageFileCheck>true</SkipPackageFileCheck>
     <MinOSForArch>ubuntu.14.04</MinOSForArch>
     <PackageTargetRuntime>$(MinOSForArch)-$(PackagePlatform)</PackageTargetRuntime>
+    <Serviceable>true</Serviceable>
   </PropertyGroup>
   
   <ItemGroup>

--- a/pkg/projects/Microsoft.NETCore.DotNetHost/ubuntu.16.04/Microsoft.NETCore.DotNetHost.pkgproj
+++ b/pkg/projects/Microsoft.NETCore.DotNetHost/ubuntu.16.04/Microsoft.NETCore.DotNetHost.pkgproj
@@ -7,6 +7,7 @@
     <SkipPackageFileCheck>true</SkipPackageFileCheck>
     <MinOSForArch>ubuntu.16.04</MinOSForArch>
     <PackageTargetRuntime>$(MinOSForArch)-$(PackagePlatform)</PackageTargetRuntime>
+    <Serviceable>true</Serviceable>
   </PropertyGroup>
   
   <ItemGroup>

--- a/pkg/projects/Microsoft.NETCore.DotNetHost/ubuntu.16.04/Microsoft.NETCore.DotNetHostPolicy.pkgproj
+++ b/pkg/projects/Microsoft.NETCore.DotNetHost/ubuntu.16.04/Microsoft.NETCore.DotNetHostPolicy.pkgproj
@@ -7,6 +7,7 @@
     <SkipPackageFileCheck>true</SkipPackageFileCheck>
     <MinOSForArch>ubuntu.16.04</MinOSForArch>
     <PackageTargetRuntime>$(MinOSForArch)-$(PackagePlatform)</PackageTargetRuntime>
+    <Serviceable>true</Serviceable>
   </PropertyGroup>
   
   <ItemGroup>

--- a/pkg/projects/Microsoft.NETCore.DotNetHost/ubuntu.16.04/Microsoft.NETCore.DotNetHostResolver.pkgproj
+++ b/pkg/projects/Microsoft.NETCore.DotNetHost/ubuntu.16.04/Microsoft.NETCore.DotNetHostResolver.pkgproj
@@ -7,6 +7,7 @@
     <SkipPackageFileCheck>true</SkipPackageFileCheck>
     <MinOSForArch>ubuntu.16.04</MinOSForArch>
     <PackageTargetRuntime>$(MinOSForArch)-$(PackagePlatform)</PackageTargetRuntime>
+    <Serviceable>true</Serviceable>
   </PropertyGroup>
   
   <ItemGroup>

--- a/pkg/projects/Microsoft.NETCore.DotNetHost/win/Microsoft.NETCore.DotNetHost.pkgproj
+++ b/pkg/projects/Microsoft.NETCore.DotNetHost/win/Microsoft.NETCore.DotNetHost.pkgproj
@@ -8,6 +8,7 @@
     <MinOSForArch>win7</MinOSForArch>
     <MinOSForArch Condition="$(PackagePlatform.StartsWith('arm'))">win8</MinOSForArch>
     <PackageTargetRuntime>$(MinOSForArch)-$(PackagePlatform)</PackageTargetRuntime>
+    <Serviceable>true</Serviceable>
   </PropertyGroup>
   
   <ItemGroup>

--- a/pkg/projects/Microsoft.NETCore.DotNetHost/win/Microsoft.NETCore.DotNetHostPolicy.pkgproj
+++ b/pkg/projects/Microsoft.NETCore.DotNetHost/win/Microsoft.NETCore.DotNetHostPolicy.pkgproj
@@ -8,6 +8,7 @@
     <MinOSForArch>win7</MinOSForArch>
     <MinOSForArch Condition="$(PackagePlatform.StartsWith('arm'))">win8</MinOSForArch>
     <PackageTargetRuntime>$(MinOSForArch)-$(PackagePlatform)</PackageTargetRuntime>
+    <Serviceable>true</Serviceable>
   </PropertyGroup>
   
   <ItemGroup>

--- a/pkg/projects/Microsoft.NETCore.DotNetHost/win/Microsoft.NETCore.DotNetHostResolver.pkgproj
+++ b/pkg/projects/Microsoft.NETCore.DotNetHost/win/Microsoft.NETCore.DotNetHostResolver.pkgproj
@@ -8,6 +8,7 @@
     <MinOSForArch>win7</MinOSForArch>
     <MinOSForArch Condition="$(PackagePlatform.StartsWith('arm'))">win8</MinOSForArch>
     <PackageTargetRuntime>$(MinOSForArch)-$(PackagePlatform)</PackageTargetRuntime>
+    <Serviceable>true</Serviceable>
   </PropertyGroup>
   
   <ItemGroup>


### PR DESCRIPTION
`Microsoft.NETCore.App` is a meta package, so no serviceable attribute.

@ericstj or @eerhardt PTAL. The release notes link should probably come from `branchinfo.txt` #102.