### PR TITLE
Switch to generating version.props instead of using env variables

### DIFF
--- a/pkg/.gitignore
+++ b/pkg/.gitignore
@@ -1,2 +1,3 @@
 /Tools/
 version.txt
+version.props

--- a/pkg/dir.props
+++ b/pkg/dir.props
@@ -21,6 +21,8 @@
     <BaseOutputPath Condition="'$(BaseOutputPath)'==''">$(BinDir)</BaseOutputPath>
   </PropertyGroup>
 
+  <Import Project="version.props" Condition="Exists('version.props')" />
+
   <PropertyGroup>
     <PackageOutputPath>$(PackagesOutDir)</PackageOutputPath>
     <RuntimeIdGraphDefinitionFile>$(ProjectDir)packages\Microsoft.NETCore.Platforms\1.0.1-rc4-24203-06\runtime.json</RuntimeIdGraphDefinitionFile>

--- a/pkg/pack.cmd
+++ b/pkg/pack.cmd
@@ -2,53 +2,6 @@
 setlocal EnableDelayedExpansion
 
 set __ProjectDir=%~dp0
-set __ThisScriptShort=%0
-set __ThisScriptFull="%~f0"
-
-::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
-:: Adding environment variables to workaround the "Argument Escape" problem with passing arguments to
-:: .cmd calls from dotnet-cli-build scripts.
-::
-set __BuildArch=%__WorkaroundCliCoreHostBuildArch%
-set __DotNetHostBinDir=%__WorkaroundCliCoreHostBinDir%
-set __HostVer=%__WorkaroundCliCoreHostVer%
-set __FxrVer=%__WorkaroundCliCoreHostFxrVer%
-set __PolicyVer=%__WorkaroundCliCoreHostPolicyVer%
-set __BuildMajor=%__WorkaroundCliCoreHostBuildMajor%
-set __BuildMinor=%__WorkaroundCliCoreHostBuildMinor%
-set __VersionTag=%__WorkaroundCliCoreHostVersionTag%
-::
-:::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
-
-:Arg_Loop
-if "%1" == "" goto ArgsDone
-
-if /i "%1" == "/?"    goto Usage
-if /i "%1" == "-?"    goto Usage
-if /i "%1" == "/h"    goto Usage
-if /i "%1" == "-h"    goto Usage
-if /i "%1" == "/help" goto Usage
-if /i "%1" == "-help" goto Usage
-
-if /i "%1" == "x64"                 (set __BuildArch=%1&shift&goto Arg_Loop)
-if /i "%1" == "x86"                 (set __BuildArch=%1&shift&goto Arg_Loop)
-if /i "%1" == "arm"                 (set __BuildArch=%1&shift&goto Arg_Loop)
-if /i "%1" == "arm64"               (set __BuildArch=%1&shift&goto Arg_Loop)
-if /i "%1" == "/hostbindir"         (set __DotNetHostBinDir=%2&shift&shift&goto Arg_Loop)
-if /i "%1" == "/hostver"            (set __HostVer=%2&shift&shift&goto Arg_Loop)
-if /i "%1" == "/fxrver"             (set __FxrVer=%2&shift&shift&goto Arg_Loop)
-if /i "%1" == "/policyver"          (set __PolicyVer=%2&shift&shift&goto Arg_Loop)
-if /i "%1" == "/buildmajor"         (set __BuildMajor=%2&shift&shift&goto Arg_Loop)
-if /i "%1" == "/buildminor"         (set __BuildMinor=%2&shift&shift&goto Arg_Loop)
-if /i "%1" == "/vertag"             (set __VersionTag=%2&shift&shift&goto Arg_Loop)
-
-echo Invalid command line argument: %1
-goto Usage
-
-:ArgsDone
-
-if [%__BuildArch%]==[] (goto Usage)
-if [%__DotNetHostBinDir%]==[] (goto Usage)
 
 :: Initialize the MSBuild Tools
 call "%__ProjectDir%\init-tools.cmd"
@@ -63,22 +16,10 @@ if exist "%__ProjectDir%\bin" (rmdir /s /q "%__ProjectDir%\bin")
 
 :: Package the assets using Tools
 
-copy /y "%__DotNetHostBinDir%\corehost.exe" "%__DotNetHostBinDir%\dotnet.exe"
-
-"%__ProjectDir%\Tools\corerun" "%__ProjectDir%\Tools\MSBuild.exe" "%__ProjectDir%\projects\packages.builds" /p:Platform=%__BuildArch% /p:DotNetHostBinDir=%__DotNetHostBinDir% /p:TargetsWindows=true /p:HostVersion=%__HostVer% /p:HostResolverVersion=%__FxrVer% /p:HostPolicyVersion=%__PolicyVer% /p:BuildNumberMajor=%__BuildMajor% /p:BuildNumberMinor=%__BuildMinor% /p:PreReleaseLabel=%__VersionTag% /p:CLIBuildVersion=%__BuildMajor% /verbosity:minimal
+"%__ProjectDir%\Tools\corerun" "%__ProjectDir%\Tools\MSBuild.exe" "%__ProjectDir%\projects\packages.builds" /p:TargetsWindows=true /verbosity:minimal
 
 if not ERRORLEVEL 0 goto :Error
-
 exit /b 0
-
-:Usage
-echo.
-echo Package the dotnet host artifacts
-echo.
-echo Usage:
-echo     %__ThisScriptShort% [x64/x86/arm]  /hostbindir path-to-binaries /hostver /fxrver /policyver /build /vertag
-echo.
-echo./? -? /h -h /help -help: view this message.
 
 :Error
 echo An error occurred during packing.

--- a/pkg/pack.sh
+++ b/pkg/pack.sh
@@ -1,11 +1,5 @@
 #!/usr/bin/env bash
 
-usage()
-{
-   echo "Usage: ${BASH_SOURCE[0]} --arch x64/x86/arm --hostbindir path-to-binaries" --hostver --fxrver --policyver --build --vertag
-   exit 1
-}
-
 init_distro_name()
 {
     if [ ! -e /etc/os-release ]; then
@@ -13,7 +7,7 @@ init_distro_name()
         export __distro_rid=""
     else
         source /etc/os-release
-        export __distro_rid="$ID.$VERSION_ID-$__build_arch"
+        export __distro_rid="$ID.$VERSION_ID-x64"
     fi
 }
 
@@ -29,69 +23,7 @@ done
 
 # initialize variables
 __project_dir="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
-__build_arch=
-__dotnet_host_bin_dir=
 __distro_rid=
-__host_ver=
-__fxr_ver=
-__policy_ver=
-__build_major=
-__build_minor=
-__version_tag=
-
-# parse arguments
-while [ "$1" != "" ]; do
-        lowerI="$(echo $1 | awk '{print tolower($0)}')"
-        case $lowerI in
-        -h|--help)
-            usage
-            exit 1
-            ;;
-        --arch)
-            shift
-            __build_arch=$1
-            ;;
-        --hostbindir)
-            shift
-            __dotnet_host_bin_dir=$1
-            ;;
-        --hostver)
-            shift
-            __host_ver=$1
-            ;;
-        --fxrver)
-            shift
-            __fxr_ver=$1
-            ;;
-        --policyver)
-            shift
-            __policy_ver=$1
-            ;;
-        --build-major)
-            shift
-            __build_major=$1
-            ;;
-        --build-minor)
-            shift
-            __build_minor=$1
-            ;;
-        --vertag)
-            shift
-            __version_tag=$1
-            ;;
-        *)
-        echo "Unknown argument to pack.sh $1"; exit 1
-    esac
-    shift
-done
-
-# validate args
-if [ -z $__dotnet_host_bin_dir ]; then
-    usage
-fi
-if [ -z $__build_arch ]; then
-    usage
-fi
 
 # setup msbuild
 "$__project_dir/init-tools.sh"
@@ -116,10 +48,8 @@ else
     init_distro_name
 fi
 
-__common_parameters="/p:Platform=$__build_arch /p:DotNetHostBinDir=$__dotnet_host_bin_dir /p:$__targets_param /p:DistroRid=$__distro_rid /p:HostVersion=$__host_ver /p:HostResolverVersion=$__fxr_ver /p:HostPolicyVersion=$__policy_ver /p:BuildNumberMajor=$__build_major /p:BuildNumberMinor=$__build_minor /p:PreReleaseLabel=$__version_tag /p:CLIBuildVersion=$__build_major /verbosity:minimal"
+__common_parameters="/p:$__targets_param /p:DistroRid=$__distro_rid /verbosity:minimal"
 
 $__corerun $__msbuild $__project_dir/projects/packages.builds $__common_parameters || exit 1
-
-cp -rf "$__project_dir/bin/packages" "$__dotnet_host_bin_dir"
 
 exit 0

--- a/pkg/projects/Microsoft.NETCore.App/Microsoft.NETCore.App.pkgproj
+++ b/pkg/projects/Microsoft.NETCore.App/Microsoft.NETCore.App.pkgproj
@@ -45,10 +45,6 @@
         <TargetPath>lib/netcoreapp1.0</TargetPath>
       </File>
     </ItemGroup>
-
-    <PropertyGroup>
-    <VersionSuffix>-$(PreReleaseLabel)-$(CLIBuildVersion)</VersionSuffix>
-    </PropertyGroup>
   </Target>
 
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />


### PR DESCRIPTION
This has the outer build system generate a verison.props so
the package builds can consume the versions from there instead
of using env variables or a crazy list of arguments.

This has the added bonus that once you build once from the root
you can easily rebuild the just the packages without a full build
by running pack.cmd/sh directly.

cc @eerhardt @schellap 

Fixes https://github.com/dotnet/core-setup/issues/20