### PR TITLE
System.Private.CoreLib.dll IL binary is getting crossgen'd mistakenly.

### DIFF
--- a/build_projects/shared-build-targets-utils/Utils/Crossgen.cs
+++ b/build_projects/shared-build-targets-utils/Utils/Crossgen.cs
@@ -17,7 +17,7 @@ namespace Microsoft.DotNet.Cli.Build
         {
             "mscorlib.dll",
             "mscorlib.ni.dll",
-            "System.Private.CoreLib",
+            "System.Private.CoreLib.dll",
             "System.Private.CoreLib.ni.dll"
         };
 


### PR DESCRIPTION
This causes both the IL ".dll" and the native image "ni.dll" to be the same size in the Shared Framework. This is incorrect, as the IL binary is much smaller.

The fix is to add ".dll" to the excludedLibraries list in the Crossgen util.

Fix #150

This is a port of #151 from release/1.0.0 to master

@gkhanna79 @schellap @brthor 