### PR TITLE
Clean up NuGet packages and cache at start

### DIFF
--- a/build_projects/dotnet-host-build/build.ps1
+++ b/build_projects/dotnet-host-build/build.ps1
@@ -90,6 +90,9 @@ $env:PATH = "$env:DOTNET_INSTALL_DIR;$env:PATH"
 # Ensure clean package folder and caches
 CleanNuGet
 
+# Disable first run since we want to control all package sources
+$env:DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1
+
 # Restore the build scripts
 Write-Host "Restoring Build Script projects..."
 pushd "$PSScriptRoot\.."

--- a/build_projects/dotnet-host-build/build.ps1
+++ b/build_projects/dotnet-host-build/build.ps1
@@ -11,6 +11,21 @@ param(
     [switch]$NoPackage,
     [switch]$Help)
 
+function RemoveDirectory([string] $path)
+{
+    if (Test-Path $path) 
+    {
+        Remove-Item $path -Recurse -Force
+    }
+}
+
+function CleanNuGet()
+{
+    RemoveDirectory($env:LocalAppData + "\NuGet\Cache")
+    RemoveDirectory($env:LocalAppData + "\NuGet\v3-cache")
+    RemoveDirectory($env:NUGET_PACKAGES)
+}
+
 if($Help)
 {
     Write-Host "Usage: .\build.ps1 [-Configuration <CONFIGURATION>] [-NoPackage] [-Help] [-Targets <TARGETS...>]"
@@ -71,6 +86,9 @@ if($LASTEXITCODE -ne 0) { throw "Failed to install stage0" }
 
 # Put the stage0 on the path
 $env:PATH = "$env:DOTNET_INSTALL_DIR;$env:PATH"
+
+# Ensure clean package folder and caches
+CleanNuGet
 
 # Restore the build scripts
 Write-Host "Restoring Build Script projects..."

--- a/build_projects/dotnet-host-build/build.sh
+++ b/build_projects/dotnet-host-build/build.sh
@@ -112,6 +112,9 @@ rm -rf "$HOME/.local/share/NuGet/Cache"
 rm -rf "$HOME/.local/share/NuGet/v3-cache"
 rm -rf "$NUGET_PACKAGES"
 
+# Disable first run since we want to control all package sources
+export DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1
+
 # Restore the build scripts
 echo "Restoring Build Script projects..."
 (

--- a/build_projects/dotnet-host-build/build.sh
+++ b/build_projects/dotnet-host-build/build.sh
@@ -107,6 +107,11 @@ then
     ulimit -n 1024
 fi
 
+# Clean old NuGet packages
+rm -rf "$HOME/.local/share/NuGet/Cache"
+rm -rf "$HOME/.local/share/NuGet/v3-cache"
+rm -rf "$NUGET_PACKAGES"
+
 # Restore the build scripts
 echo "Restoring Build Script projects..."
 (


### PR DESCRIPTION
In release we will be rebuilding packages so we need to ensure that
builds do not attempt to reuse packages cached from a previous run.

/cc @eerhardt @weshaggard 