### PR TITLE
Enable Deb Packages for Ubuntu 16.04

### DIFF
--- a/build_projects/dotnet-host-build/DebTargets.cs
+++ b/build_projects/dotnet-host-build/DebTargets.cs
@@ -26,6 +26,15 @@ namespace Microsoft.DotNet.Host.Build
         [BuildPlatforms(BuildPlatform.Ubuntu)]
         public static BuildTargetResult GenerateSharedHostDeb(BuildTargetContext c)
         {
+            // Ubuntu 16.04 Jenkins Machines don't have docker or debian package build tools
+            // So we need to skip this target if the tools aren't present.
+            // https://github.com/dotnet/core-setup/issues/167
+            if (DebuildNotPresent())
+            {
+                c.Info("Debuild not present, skipping target: {nameof(GenerateSharedHostDeb)}");
+                return c.Success();
+            }
+
             var packageName = Monikers.GetDebianSharedHostPackageName(c);
             var version = c.BuildContext.Get<HostVersion>("HostVersion").LockedHostVersion.ToString();
             var inputRoot = c.BuildContext.Get<string>("SharedHostPublishRoot");
@@ -59,6 +68,15 @@ namespace Microsoft.DotNet.Host.Build
         [BuildPlatforms(BuildPlatform.Ubuntu)]
         public static BuildTargetResult GenerateHostFxrDeb(BuildTargetContext c)
         {
+            // Ubuntu 16.04 Jenkins Machines don't have docker or debian package build tools
+            // So we need to skip this target if the tools aren't present.
+            // https://github.com/dotnet/core-setup/issues/167
+            if (DebuildNotPresent())
+            {
+                c.Info("Debuild not present, skipping target: {nameof(GenerateHostFxrDeb)}");
+                return c.Success();
+            }
+
             var hostFxrVersion = c.BuildContext.Get<HostVersion>("HostVersion").LockedHostFxrVersion.ToString();
             var packageName = Monikers.GetDebianHostFxrPackageName(hostFxrVersion);
             var sharedHostVersion = c.BuildContext.Get<HostVersion>("HostVersion").LockedHostVersion.ToString();
@@ -94,6 +112,15 @@ namespace Microsoft.DotNet.Host.Build
         [BuildPlatforms(BuildPlatform.Ubuntu)]
         public static BuildTargetResult GenerateSharedFrameworkDeb(BuildTargetContext c)
         {
+            // Ubuntu 16.04 Jenkins Machines don't have docker or debian package build tools
+            // So we need to skip this target if the tools aren't present.
+            // https://github.com/dotnet/core-setup/issues/167
+            if (DebuildNotPresent())
+            {
+                c.Info("Debuild not present, skipping target: {nameof(GenerateSharedFrameworkDeb)}");
+                return c.Success();
+            }
+
             var sharedFrameworkNugetVersion = c.BuildContext.Get<string>("SharedFrameworkNugetVersion");
             var packageName = Monikers.GetDebianSharedFrameworkPackageName(sharedFrameworkNugetVersion);
             var sharedHostVersion = c.BuildContext.Get<HostVersion>("HostVersion").LockedHostVersion.ToString();
@@ -142,6 +169,15 @@ namespace Microsoft.DotNet.Host.Build
         [Target]
         public static BuildTargetResult InstallSharedHost(BuildTargetContext c)
         {
+            // Ubuntu 16.04 Jenkins Machines don't have docker or debian package build tools
+            // So we need to skip this target if the tools aren't present.
+            // https://github.com/dotnet/core-setup/issues/167
+            if (DebuildNotPresent())
+            {
+                c.Info("Debuild not present, skipping target: {nameof(InstallSharedHost)}");
+                return c.Success();
+            }
+
             InstallPackage(c.BuildContext.Get<string>("SharedHostInstallerFile"));
             
             return c.Success();
@@ -150,6 +186,15 @@ namespace Microsoft.DotNet.Host.Build
         [Target(nameof(InstallSharedHost))]
         public static BuildTargetResult InstallHostFxr(BuildTargetContext c)
         {
+            // Ubuntu 16.04 Jenkins Machines don't have docker or debian package build tools
+            // So we need to skip this target if the tools aren't present.
+            // https://github.com/dotnet/core-setup/issues/167
+            if (DebuildNotPresent())
+            {
+                c.Info("Debuild not present, skipping target: {nameof(InstallHostFxr)}");
+                return c.Success();
+            }
+
             InstallPackage(c.BuildContext.Get<string>("HostFxrInstallerFile"));
             
             return c.Success();
@@ -158,6 +203,15 @@ namespace Microsoft.DotNet.Host.Build
         [Target(nameof(InstallHostFxr))]
         public static BuildTargetResult InstallSharedFramework(BuildTargetContext c)
         {
+            // Ubuntu 16.04 Jenkins Machines don't have docker or debian package build tools
+            // So we need to skip this target if the tools aren't present.
+            // https://github.com/dotnet/core-setup/issues/167
+            if (DebuildNotPresent())
+            {
+                c.Info("Debuild not present, skipping target: {nameof(InstallSharedFramework)}");
+                return c.Success();
+            }
+
             InstallPackage(c.BuildContext.Get<string>("SharedFrameworkInstallerFile"));
             
             return c.Success();
@@ -166,6 +220,15 @@ namespace Microsoft.DotNet.Host.Build
         [Target]
         public static BuildTargetResult RemovePackages(BuildTargetContext c)
         {
+            // Ubuntu 16.04 Jenkins Machines don't have docker or debian package build tools
+            // So we need to skip this target if the tools aren't present.
+            // https://github.com/dotnet/core-setup/issues/167
+            if (DebuildNotPresent())
+            {
+                c.Info("Debuild not present, skipping target: {nameof(RemovePackages)}");
+                return c.Success();
+            }
+
             var sharedFrameworkNugetVersion = c.BuildContext.Get<string>("SharedFrameworkNugetVersion");
             var hostFxrVersion = c.BuildContext.Get<HostVersion>("HostVersion").LockedHostFxrVersion.ToString();
             
@@ -196,6 +259,11 @@ namespace Microsoft.DotNet.Host.Build
             Cmd("sudo", "dpkg", "-r", packageName)
                 .Execute()
                 .EnsureSuccessful();
+        }
+
+        private static bool DebuildNotPresent()
+        {
+            return Cmd("/usr/bin/env", "debuild", "-h").Execute().ExitCode != 0;
         }
     }
 }

--- a/build_projects/dotnet-host-build/DebTargets.cs
+++ b/build_projects/dotnet-host-build/DebTargets.cs
@@ -23,7 +23,7 @@ namespace Microsoft.DotNet.Host.Build
         }
 
         [Target]
-        [BuildPlatforms(BuildPlatform.Ubuntu, "14.04")]
+        [BuildPlatforms(BuildPlatform.Ubuntu)]
         public static BuildTargetResult GenerateSharedHostDeb(BuildTargetContext c)
         {
             var packageName = Monikers.GetDebianSharedHostPackageName(c);
@@ -56,7 +56,7 @@ namespace Microsoft.DotNet.Host.Build
         }
 
         [Target]
-        [BuildPlatforms(BuildPlatform.Ubuntu, "14.04")]
+        [BuildPlatforms(BuildPlatform.Ubuntu)]
         public static BuildTargetResult GenerateHostFxrDeb(BuildTargetContext c)
         {
             var hostFxrVersion = c.BuildContext.Get<HostVersion>("HostVersion").LockedHostFxrVersion.ToString();
@@ -91,7 +91,7 @@ namespace Microsoft.DotNet.Host.Build
         }
 
         [Target(nameof(InstallSharedHost))]
-        [BuildPlatforms(BuildPlatform.Ubuntu, "14.04")]
+        [BuildPlatforms(BuildPlatform.Ubuntu)]
         public static BuildTargetResult GenerateSharedFrameworkDeb(BuildTargetContext c)
         {
             var sharedFrameworkNugetVersion = c.BuildContext.Get<string>("SharedFrameworkNugetVersion");
@@ -133,7 +133,7 @@ namespace Microsoft.DotNet.Host.Build
 
         [Target(nameof(InstallSharedFramework),
                 nameof(RemovePackages))]
-        [BuildPlatforms(BuildPlatform.Ubuntu, "14.04")]
+        [BuildPlatforms(BuildPlatform.Ubuntu)]
         public static BuildTargetResult TestDebInstaller(BuildTargetContext c)
         {
             return c.Success();

--- a/build_projects/dotnet-host-build/PublishTargets.cs
+++ b/build_projects/dotnet-host-build/PublishTargets.cs
@@ -243,7 +243,7 @@ namespace Microsoft.DotNet.Host.Build
             nameof(PublishSharedFrameworkDebToDebianRepo),
             nameof(PublishHostFxrDebToDebianRepo),
             nameof(PublishSharedHostDebToDebianRepo))]
-        [BuildPlatforms(BuildPlatform.Ubuntu, "14.04")]
+        [BuildPlatforms(BuildPlatform.Ubuntu)]
         public static BuildTargetResult PublishDebFilesToDebianRepo(BuildTargetContext c)
         {
             return c.Success();
@@ -274,11 +274,6 @@ namespace Microsoft.DotNet.Host.Build
         [Target]
         public static BuildTargetResult PublishSharedHostInstallerFileToAzure(BuildTargetContext c)
         {
-            if (CurrentPlatform.IsUbuntu && !CurrentPlatform.IsVersion("14.04"))
-            {
-                return c.Success();
-            }
-
             var version = SharedHostNugetVersion;
             var installerFile = c.BuildContext.Get<string>("SharedHostInstallerFile");
 
@@ -295,11 +290,6 @@ namespace Microsoft.DotNet.Host.Build
         [Target]
         public static BuildTargetResult PublishHostFxrInstallerFileToAzure(BuildTargetContext c)
         {
-            if (CurrentPlatform.IsUbuntu && !CurrentPlatform.IsVersion("14.04"))
-            {
-                return c.Success();
-            }
-
             var version = HostFxrNugetVersion;
             var installerFile = c.BuildContext.Get<string>("HostFxrInstallerFile");
 
@@ -316,11 +306,6 @@ namespace Microsoft.DotNet.Host.Build
         [Target]
         public static BuildTargetResult PublishSharedFrameworkInstallerFileToAzure(BuildTargetContext c)
         {
-            if (CurrentPlatform.IsUbuntu && !CurrentPlatform.IsVersion("14.04"))
-            {
-                return c.Success();
-            }
-
             var version = SharedFrameworkNugetVersion;
             var installerFile = c.BuildContext.Get<string>("SharedFrameworkInstallerFile");
 
@@ -333,11 +318,6 @@ namespace Microsoft.DotNet.Host.Build
         [BuildPlatforms(BuildPlatform.OSX, BuildPlatform.Windows)]
         public static BuildTargetResult PublishCombinedMuxerHostFxrFrameworkInstallerFileToAzure(BuildTargetContext c)
         {
-            if (CurrentPlatform.IsUbuntu && !CurrentPlatform.IsVersion("14.04"))
-            {
-                return c.Success();
-            }
-
             var version = SharedFrameworkNugetVersion;
             var installerFile = c.BuildContext.Get<string>("CombinedMuxerHostFxrFrameworkInstallerFile");
 
@@ -367,7 +347,7 @@ namespace Microsoft.DotNet.Host.Build
         }
 
         [Target]
-        [BuildPlatforms(BuildPlatform.Ubuntu, "14.04")]
+        [BuildPlatforms(BuildPlatform.Ubuntu)]
         public static BuildTargetResult PublishSharedFrameworkDebToDebianRepo(BuildTargetContext c)
         {
             var version = SharedFrameworkNugetVersion;
@@ -385,7 +365,7 @@ namespace Microsoft.DotNet.Host.Build
         }
 
         [Target]
-        [BuildPlatforms(BuildPlatform.Ubuntu, "14.04")]
+        [BuildPlatforms(BuildPlatform.Ubuntu)]
         public static BuildTargetResult PublishSharedHostDebToDebianRepo(BuildTargetContext c)
         {
             var version = SharedHostNugetVersion;
@@ -403,7 +383,7 @@ namespace Microsoft.DotNet.Host.Build
         }
 
         [Target]
-        [BuildPlatforms(BuildPlatform.Ubuntu, "14.04")]
+        [BuildPlatforms(BuildPlatform.Ubuntu)]
         public static BuildTargetResult PublishHostFxrDebToDebianRepo(BuildTargetContext c)
         {
             var version = HostFxrNugetVersion;

--- a/scripts/docker/ubuntu.16.04/Dockerfile
+++ b/scripts/docker/ubuntu.16.04/Dockerfile
@@ -25,7 +25,8 @@ RUN apt-get update && \
         liblttng-ust0 \
         libssl1.0.0 \
         zlib1g \
-        libuuid1 && \
+        libuuid1 \
+        liblldb-3.6 && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
Add Ubuntu 16.04 debian packages

Worked with @chuan to get the xenial distribution added to our repo, and have added the appropriate environment variables to our build definition. 

Tested with our test feed, for anyone wanting to try it out (on ubuntu 16.04):
```
sudo sh -c 'echo "deb [arch=amd64] https://apt-mo.trafficmanager.net/repos/dotnet-dev/ xenial main" > /etc/apt/sources.list.d/dotnetdev.list'
sudo apt-key adv --keyserver apt-mo.trafficmanager.net --recv-keys 417A0893
sudo apt-get update

sudo apt-get install dotnet-sharedframework-microsoft.netcore.app-1.0.0
```

@Petermarcu @piotrpMSFT @ellismg @eerhardt 