### PR TITLE
Revert "use docker for ubuntu 16 jenkins builds"

### DIFF
--- a/netci.groovy
+++ b/netci.groovy
@@ -34,9 +34,6 @@ platformList.each { platform ->
     else if (os == 'Ubuntu') {
         buildCommand = "./build.sh --skip-prereqs --configuration ${configuration} --docker ubuntu.14.04 --targets Default"
     }
-    else if (os == 'Ubuntu16.04') {
-        buildCommand = "./build.sh --skip-prereqs --configuration ${configuration} --docker ubuntu.16.04 --targets Default"
-    }
     else {
         // Jenkins non-Ubuntu CI machines don't have docker
         buildCommand = "./build.sh --skip-prereqs --configuration ${configuration} --targets Default"


### PR DESCRIPTION
Reverts dotnet/core-setup#164

docker is not available on the Jenkins CI machines. 

netci.groovy changes are unfortunately only testable post-merge.

@piotrpMSFT 