### PR TITLE
Publish zip only for Windows used by Antares

### DIFF
--- a/build_projects/dotnet-host-build/PublishTargets.cs
+++ b/build_projects/dotnet-host-build/PublishTargets.cs
@@ -349,6 +349,7 @@ namespace Microsoft.DotNet.Host.Build
         }
 
         [Target]
+        [BuildPlatforms(BuildPlatform.Windows)]
         public static BuildTargetResult PublishSharedFrameworkArchiveToAzure(BuildTargetContext c)
         {
             var version = SharedFrameworkNugetVersion;


### PR DESCRIPTION
Be a good citizen about Azure blob storage. Antares only needs Windows.

Cc @brthor 