### PR TITLE
Fix build for Alpine Linux

### DIFF
--- a/src/corehost/cli/json/casablanca/include/cpprest/asyncrt_utils.h
+++ b/src/corehost/cli/json/casablanca/include/cpprest/asyncrt_utils.h
@@ -40,8 +40,9 @@
 
 #ifndef _WIN32
 //#include <boost/algorithm/string.hpp>
-#if !defined(ANDROID) && !defined(__ANDROID__) // CodePlex 269
+#ifdef __GLIBC__
 #include <xlocale.h>
+#include <sys/time.h>
 #endif
 #endif
 


### PR DESCRIPTION
Alpine Linux uses musl-libc and Android uses bionic; what both have in
common is `__GLIBC__` unavailable. This fixes the condition in
Casablanca header where an explicit `__ANDROID__` is used. Instead
checking for `__GLIBC__` fixes the build for both platforms.

Another fix is to include `<sys/time.h>` header which is required for
`timeval` on some Unix platforms.

Progress towards: https://github.com/dotnet/coreclr/issues/917#issuecomment-229827373

/cc @schellap, @ericstj, @jkotas