### PR TITLE
Bump UWP metapackage post-servicing

### DIFF
--- a/pkg/projects/Microsoft.NETCore.UniversalWindowsPlatform/Microsoft.NETCore.UniversalWindowsPlatform.pkgproj
+++ b/pkg/projects/Microsoft.NETCore.UniversalWindowsPlatform/Microsoft.NETCore.UniversalWindowsPlatform.pkgproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
 
   <PropertyGroup>
-    <Version>5.2.2</Version>
+    <Version>5.2.3</Version>
     <PackagePlatform>AnyCPU</PackagePlatform>
   </PropertyGroup>
 


### PR DESCRIPTION
This is required to move out of the way of https://github.com/dotnet/core-setup/pull/209