### PR TITLE
Fix self-process lookup for FreeBSD.

### DIFF
--- a/src/corehost/common/pal.h
+++ b/src/corehost/common/pal.h
@@ -132,7 +132,13 @@ namespace pal
 
     #define __cdecl    /* nothing */
     #define __stdcall  /* nothing */
-    #define __fastcall /* nothing */
+    #if !defined(__FreeBSD__)
+        #define __fastcall /* nothing */
+    #else
+        #include <sys/types.h>
+        #include <sys/sysctl.h>
+        #include <sys/param.h>
+    #endif
     #define STDMETHODCALLTYPE __stdcall
 
     typedef char char_t;

--- a/src/corehost/common/pal.unix.cpp
+++ b/src/corehost/common/pal.unix.cpp
@@ -183,6 +183,24 @@ bool pal::get_own_executable_path(pal::string_t* recv)
     }
     return false;
 }
+#elif defined(__FreeBSD__)
+bool pal::get_own_executable_path(pal::string_t* recv)
+{
+    int mib[4];
+    mib[0] = CTL_KERN;
+    mib[1] = KERN_PROC;
+    mib[2] = KERN_PROC_PATHNAME;
+    mib[3] = -1;
+    char buf[PATH_MAX];
+    size_t cb = sizeof(buf);
+    if (sysctl(mib, 4, buf, &cb, NULL, 0) == 0)
+    {
+        recv->assign(buf);
+        return true;
+    }
+    // ENOMEM
+    return false;
+}
 #else
 bool pal::get_own_executable_path(pal::string_t* recv)
 {


### PR DESCRIPTION
Currently dotnet cli stage0 builds for FreeBSD, but does not always work, as it relies on procfs, which is not available on FreeBSD by default.

This patch replaces the current implementation with one based on sysctl(), which ensures it should always resovlve, procfs or no procfs.