### PR TITLE
Add "restore_tools" that gets a new NuGet version for a workaround

### DIFF
--- a/build_projects/dotnet-host-build/build.sh
+++ b/build_projects/dotnet-host-build/build.sh
@@ -110,11 +110,19 @@ fi
 # Disable first run since we want to control all package sources
 export DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1
 
+# Restore the restore tool
+echo "Restoring Restore projects..."
+(
+    cd "$REPOROOT/restore_projects"
+    dotnet restore
+)
+NUGET_RUNNER="$REPOROOT/restore_projects/NuGet.CommandLine.XPlat.Runner"
+
 # Restore the build scripts
 echo "Restoring Build Script projects..."
 (
     cd "$DIR/.."
-    dotnet restore --infer-runtimes
+    dotnet run -p "$NUGET_RUNNER" restore --infer-runtimes --disable-parallel
 )
 
 # Build the builder

--- a/restore_projects/NuGet.CommandLine.XPlat.Runner/Program.cs
+++ b/restore_projects/NuGet.CommandLine.XPlat.Runner/Program.cs
@@ -1,0 +1,10 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using NugetProgram = NuGet.CommandLine.XPlat.Program;
+
+public class Program
+{
+    public static void Main(string[] args) => NugetProgram.Main(args);
+}

--- a/restore_projects/NuGet.CommandLine.XPlat.Runner/project.json
+++ b/restore_projects/NuGet.CommandLine.XPlat.Runner/project.json
@@ -1,0 +1,25 @@
+{
+  "version": "1.0.0-*",
+  "description": "Redirects args to NuGet.CommandLine.XPlat. Allows usage of a newer version of NuGet than the CLI stage 0 has.",
+  "buildOptions": {
+    "debugType": "portable",
+    "emitEntryPoint": true
+  },
+  "dependencies": {
+    "NuGet.CommandLine.XPlat": "3.5.0-rc1-1639"
+  },
+  "frameworks": {
+    "netcoreapp1.0": {
+      "dependencies": {
+        "Microsoft.NETCore.App": {
+          "type": "platform",
+          "version": "1.0.0"
+        }
+      },
+      "imports": [
+        "dnxcore50",
+        "portable-net45+win8"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
To work around https://github.com/NuGet/Home/issues/3190 the recommended way, core-setup needs a new version of NuGet to use `--disable-parallel` to limit HTTP parallelism during `build_projects` restore.

There is a chance that restoring restore_projects will time out just like build_projects does, but there are fewer dependencies so it's less likely.