### PR TITLE
Adding support for "painting" the native crypto library

### DIFF
--- a/packaging/osx/sharedframework/scripts/postinstall
+++ b/packaging/osx/sharedframework/scripts/postinstall
@@ -6,8 +6,34 @@
 
 PACKAGE=$1
 INSTALL_DESTINATION=$2
+LIBCRYPTO_NAME=libcrypto.1.0.0.dylib
+LIBSSL_NAME=libssl.1.0.0.dylib
+
+# Using this form to allow power users to export both of these
+if [ -z $OPENSSL_PATH ]; then OPENSSL_PATH=/usr/local/opt/openssl/lib; fi
+if [ -z $LINK_DEST ]; then LINK_DEST=/usr/local/lib; fi
+
+# Ugly, but we need this to actually get the version
+#VERSION=${INSTALL_PKG_SESSION_ID##"com.microsoft.dotnet.sharedframework.Microsoft.NETCore.App."}
+#VERSION=${VERSION%%".component.osx.x64"}
+#CORE_LIB_FILE_PATH=$INSTALL_DESTINATION/shared/Microsoft.NETCore.App/$VERSION/System.Security.Cryptography.Native.dylib
+
 
 # A temporary fix for the permissions issue(s)
 chmod -R 755 $INSTALL_DESTINATION/shared
+
+if [ -e "$OPENSSL_PATH/$LIBSSL_NAME" ] && [ -e "$OPENSSL_PATH/$LIBCRYPTO_NAME" ]
+then
+   if [ ! -e "$LINK_DEST/$LIBSSL_NAME" ] && [ ! -e "$LINK_DEST/$LIBCRYPTO_NAME" ]
+   then
+       mkdir -p "$LINK_DEST"
+       ln -s "$OPENSSL_PATH/$LIBSSL_NAME" "$LINK_DEST"
+       ln -s "$OPENSSL_PATH/$LIBCRYPTO_NAME" "$LINK_DEST"
+   fi
+    #sudo install_name_tool \
+        #-add_rpath $OPENSSL_PATH \
+        #$CORE_LIB_FILE_PATH
+fi
+  
 
 exit 0

--- a/packaging/osx/sharedframework/scripts/postinstall
+++ b/packaging/osx/sharedframework/scripts/postinstall
@@ -13,12 +13,6 @@ LIBSSL_NAME=libssl.1.0.0.dylib
 if [ -z $OPENSSL_PATH ]; then OPENSSL_PATH=/usr/local/opt/openssl/lib; fi
 if [ -z $LINK_DEST ]; then LINK_DEST=/usr/local/lib; fi
 
-# Ugly, but we need this to actually get the version
-#VERSION=${INSTALL_PKG_SESSION_ID##"com.microsoft.dotnet.sharedframework.Microsoft.NETCore.App."}
-#VERSION=${VERSION%%".component.osx.x64"}
-#CORE_LIB_FILE_PATH=$INSTALL_DESTINATION/shared/Microsoft.NETCore.App/$VERSION/System.Security.Cryptography.Native.dylib
-
-
 # A temporary fix for the permissions issue(s)
 chmod -R 755 $INSTALL_DESTINATION/shared
 
@@ -30,9 +24,6 @@ then
        ln -s "$OPENSSL_PATH/$LIBSSL_NAME" "$LINK_DEST"
        ln -s "$OPENSSL_PATH/$LIBCRYPTO_NAME" "$LINK_DEST"
    fi
-    #sudo install_name_tool \
-        #-add_rpath $OPENSSL_PATH \
-        #$CORE_LIB_FILE_PATH
 fi
   
 

--- a/packaging/osx/sharedframework/shared-framework-distribution-template.xml
+++ b/packaging/osx/sharedframework/shared-framework-distribution-template.xml
@@ -3,7 +3,7 @@
     <title>{SharedFxBrandName} (x64)</title>
     <license file="eula.rtf" mime-type="application/rtf" />
     <background file="dotnetbackground.png" mime-type="image/png"/>
-    <options customize="never" require-scripts="true" />
+    <options customize="never" require-scripts="false" />
     <volume-check>
         <allowed-os-version>
             <os-version min="10.10" />
@@ -26,19 +26,4 @@
     <pkg-ref id="{SharedFxComponentId}.pkg">{SharedFxComponentId}.pkg</pkg-ref>
     <pkg-ref id="{HostFxrComponentId}.pkg">{HostFxrComponentId}.pkg</pkg-ref>
     <pkg-ref id="{SharedHostComponentId}.pkg">{SharedHostComponentId}.pkg</pkg-ref>
-    <installation-check script="openSSLCheck()" />
-    <script><![CDATA[
-        function openSSLCheck()
-        {
-            var openSSLRoot = "/usr/local/opt/openssl/lib/";
-            if (!system.files.fileExistsAtPath(openSSLRoot + "libcrypto.1.0.0.dylib") || 
-                !system.files.fileExistsAtPath(openSSLRoot + "libssl.1.0.0.dylib")
-                ){
-                    my.result.type = "Fatal";
-                    my.result.message = "OpenSSL was not detected on this machine. Please install OpenSSL to continue. Refer to https://dot.net/core for instructions.";
-                    return false;
-                }
-            return true; 
-        } 
-    ]]></script>
 </installer-gui-script>

--- a/packaging/osx/sharedframework/shared-framework-distribution-template.xml
+++ b/packaging/osx/sharedframework/shared-framework-distribution-template.xml
@@ -3,7 +3,7 @@
     <title>{SharedFxBrandName} (x64)</title>
     <license file="eula.rtf" mime-type="application/rtf" />
     <background file="dotnetbackground.png" mime-type="image/png"/>
-    <options customize="never" require-scripts="false" />
+    <options customize="never" require-scripts="true" />
     <volume-check>
         <allowed-os-version>
             <os-version min="10.10" />
@@ -26,4 +26,19 @@
     <pkg-ref id="{SharedFxComponentId}.pkg">{SharedFxComponentId}.pkg</pkg-ref>
     <pkg-ref id="{HostFxrComponentId}.pkg">{HostFxrComponentId}.pkg</pkg-ref>
     <pkg-ref id="{SharedHostComponentId}.pkg">{SharedHostComponentId}.pkg</pkg-ref>
+    <installation-check script="openSSLCheck()" />
+    <script><![CDATA[
+        function openSSLCheck()
+        {
+            var openSSLRoot = "/usr/local/opt/openssl/lib/";
+            if (!system.files.fileExistsAtPath(openSSLRoot + "libcrypto.1.0.0.dylib") || 
+                !system.files.fileExistsAtPath(openSSLRoot + "libssl.1.0.0.dylib")
+                ){
+                    my.result.type = "Fatal";
+                    my.result.message = "OpenSSL was not detected on this machine. Please install OpenSSL to continue. Refer to https://dot.net/core for instructions.";
+                    return false;
+                }
+            return true; 
+        } 
+    ]]></script>
 </installer-gui-script>


### PR DESCRIPTION
Recently, Homebrew has changed its policies to disallow the --force
linking of OpenSSL. Because we need OpenSSL in the loader path, we had
several options and the best recommended one was to use
instal_name_tool to add a resolve path to the
System.Security.Cryptography.Native.dylib file.

This change makes that operation automatic when installing from the
PKG as part of its postinstall script. However, the user would still
need to install OpenSSL through brew in order for this to work.

/cc @eerhardt @mellinoe @bartonjs @piotrpMSFT @brthor 