### PR TITLE
Add support for the "path" property in the .deps.json file

### DIFF
--- a/Microsoft.DotNet.CoreSetup.sln
+++ b/Microsoft.DotNet.CoreSetup.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
-VisualStudioVersion = 14.0.25123.0
+VisualStudioVersion = 14.0.25420.1
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{5A29E8E3-A0FC-4C57-81DD-297B56D1A119}"
 	ProjectSection(SolutionItems) = preProject
@@ -30,6 +30,14 @@ EndProject
 Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "dotnet-deb-tool", "tools\dotnet-deb-tool\dotnet-deb-tool.xproj", "{F39F3D8B-B26F-4C77-B08C-D6CA753EE84E}"
 EndProject
 Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "TestUtils", "test\TestUtils\TestUtils.xproj", "{42095367-4423-4157-BD31-D1A8E3B823B9}"
+EndProject
+Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "Microsoft.DotNet.InternalAbstractions", "src\Microsoft.DotNet.PlatformAbstractions\Microsoft.DotNet.InternalAbstractions.xproj", "{BD4F0750-4E81-4AD2-90B5-E470881792C3}"
+EndProject
+Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "Microsoft.Extensions.DependencyModel", "src\Microsoft.Extensions.DependencyModel\Microsoft.Extensions.DependencyModel.xproj", "{688870C8-9843-4F9E-8576-D39290AD0F25}"
+EndProject
+Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "Microsoft.Extensions.DependencyModel.Tests", "test\Microsoft.Extensions.DependencyModel.Tests\Microsoft.Extensions.DependencyModel.Tests.xproj", "{4A4711D8-4312-49FC-87B5-4F183F4C6A51}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{FAA448DA-7D1C-4481-915D-5765BF906332}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -171,6 +179,54 @@ Global
 		{42095367-4423-4157-BD31-D1A8E3B823B9}.RelWithDebInfo|Any CPU.Build.0 = Release|Any CPU
 		{42095367-4423-4157-BD31-D1A8E3B823B9}.RelWithDebInfo|x64.ActiveCfg = Release|Any CPU
 		{42095367-4423-4157-BD31-D1A8E3B823B9}.RelWithDebInfo|x64.Build.0 = Release|Any CPU
+		{BD4F0750-4E81-4AD2-90B5-E470881792C3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{BD4F0750-4E81-4AD2-90B5-E470881792C3}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{BD4F0750-4E81-4AD2-90B5-E470881792C3}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{BD4F0750-4E81-4AD2-90B5-E470881792C3}.Debug|x64.Build.0 = Debug|Any CPU
+		{BD4F0750-4E81-4AD2-90B5-E470881792C3}.MinSizeRel|Any CPU.ActiveCfg = Debug|Any CPU
+		{BD4F0750-4E81-4AD2-90B5-E470881792C3}.MinSizeRel|Any CPU.Build.0 = Debug|Any CPU
+		{BD4F0750-4E81-4AD2-90B5-E470881792C3}.MinSizeRel|x64.ActiveCfg = Debug|Any CPU
+		{BD4F0750-4E81-4AD2-90B5-E470881792C3}.MinSizeRel|x64.Build.0 = Debug|Any CPU
+		{BD4F0750-4E81-4AD2-90B5-E470881792C3}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{BD4F0750-4E81-4AD2-90B5-E470881792C3}.Release|Any CPU.Build.0 = Release|Any CPU
+		{BD4F0750-4E81-4AD2-90B5-E470881792C3}.Release|x64.ActiveCfg = Release|Any CPU
+		{BD4F0750-4E81-4AD2-90B5-E470881792C3}.Release|x64.Build.0 = Release|Any CPU
+		{BD4F0750-4E81-4AD2-90B5-E470881792C3}.RelWithDebInfo|Any CPU.ActiveCfg = Release|Any CPU
+		{BD4F0750-4E81-4AD2-90B5-E470881792C3}.RelWithDebInfo|Any CPU.Build.0 = Release|Any CPU
+		{BD4F0750-4E81-4AD2-90B5-E470881792C3}.RelWithDebInfo|x64.ActiveCfg = Release|Any CPU
+		{BD4F0750-4E81-4AD2-90B5-E470881792C3}.RelWithDebInfo|x64.Build.0 = Release|Any CPU
+		{688870C8-9843-4F9E-8576-D39290AD0F25}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{688870C8-9843-4F9E-8576-D39290AD0F25}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{688870C8-9843-4F9E-8576-D39290AD0F25}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{688870C8-9843-4F9E-8576-D39290AD0F25}.Debug|x64.Build.0 = Debug|Any CPU
+		{688870C8-9843-4F9E-8576-D39290AD0F25}.MinSizeRel|Any CPU.ActiveCfg = Debug|Any CPU
+		{688870C8-9843-4F9E-8576-D39290AD0F25}.MinSizeRel|Any CPU.Build.0 = Debug|Any CPU
+		{688870C8-9843-4F9E-8576-D39290AD0F25}.MinSizeRel|x64.ActiveCfg = Debug|Any CPU
+		{688870C8-9843-4F9E-8576-D39290AD0F25}.MinSizeRel|x64.Build.0 = Debug|Any CPU
+		{688870C8-9843-4F9E-8576-D39290AD0F25}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{688870C8-9843-4F9E-8576-D39290AD0F25}.Release|Any CPU.Build.0 = Release|Any CPU
+		{688870C8-9843-4F9E-8576-D39290AD0F25}.Release|x64.ActiveCfg = Release|Any CPU
+		{688870C8-9843-4F9E-8576-D39290AD0F25}.Release|x64.Build.0 = Release|Any CPU
+		{688870C8-9843-4F9E-8576-D39290AD0F25}.RelWithDebInfo|Any CPU.ActiveCfg = Release|Any CPU
+		{688870C8-9843-4F9E-8576-D39290AD0F25}.RelWithDebInfo|Any CPU.Build.0 = Release|Any CPU
+		{688870C8-9843-4F9E-8576-D39290AD0F25}.RelWithDebInfo|x64.ActiveCfg = Release|Any CPU
+		{688870C8-9843-4F9E-8576-D39290AD0F25}.RelWithDebInfo|x64.Build.0 = Release|Any CPU
+		{4A4711D8-4312-49FC-87B5-4F183F4C6A51}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4A4711D8-4312-49FC-87B5-4F183F4C6A51}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4A4711D8-4312-49FC-87B5-4F183F4C6A51}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{4A4711D8-4312-49FC-87B5-4F183F4C6A51}.Debug|x64.Build.0 = Debug|Any CPU
+		{4A4711D8-4312-49FC-87B5-4F183F4C6A51}.MinSizeRel|Any CPU.ActiveCfg = Debug|Any CPU
+		{4A4711D8-4312-49FC-87B5-4F183F4C6A51}.MinSizeRel|Any CPU.Build.0 = Debug|Any CPU
+		{4A4711D8-4312-49FC-87B5-4F183F4C6A51}.MinSizeRel|x64.ActiveCfg = Debug|Any CPU
+		{4A4711D8-4312-49FC-87B5-4F183F4C6A51}.MinSizeRel|x64.Build.0 = Debug|Any CPU
+		{4A4711D8-4312-49FC-87B5-4F183F4C6A51}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4A4711D8-4312-49FC-87B5-4F183F4C6A51}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4A4711D8-4312-49FC-87B5-4F183F4C6A51}.Release|x64.ActiveCfg = Release|Any CPU
+		{4A4711D8-4312-49FC-87B5-4F183F4C6A51}.Release|x64.Build.0 = Release|Any CPU
+		{4A4711D8-4312-49FC-87B5-4F183F4C6A51}.RelWithDebInfo|Any CPU.ActiveCfg = Release|Any CPU
+		{4A4711D8-4312-49FC-87B5-4F183F4C6A51}.RelWithDebInfo|Any CPU.Build.0 = Release|Any CPU
+		{4A4711D8-4312-49FC-87B5-4F183F4C6A51}.RelWithDebInfo|x64.ActiveCfg = Release|Any CPU
+		{4A4711D8-4312-49FC-87B5-4F183F4C6A51}.RelWithDebInfo|x64.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -184,5 +240,8 @@ Global
 		{386D412C-003C-47B1-8258-0E35865CB7C4} = {5CE8410C-3100-4F41-8FA9-E6B4132D9703}
 		{F39F3D8B-B26F-4C77-B08C-D6CA753EE84E} = {0722D325-24C8-4E83-B5AF-0A083E7F0749}
 		{42095367-4423-4157-BD31-D1A8E3B823B9} = {5CE8410C-3100-4F41-8FA9-E6B4132D9703}
+		{BD4F0750-4E81-4AD2-90B5-E470881792C3} = {FAA448DA-7D1C-4481-915D-5765BF906332}
+		{688870C8-9843-4F9E-8576-D39290AD0F25} = {FAA448DA-7D1C-4481-915D-5765BF906332}
+		{4A4711D8-4312-49FC-87B5-4F183F4C6A51} = {5CE8410C-3100-4F41-8FA9-E6B4132D9703}
 	EndGlobalSection
 EndGlobal

--- a/src/Microsoft.Extensions.DependencyModel/CompilationLibrary.cs
+++ b/src/Microsoft.Extensions.DependencyModel/CompilationLibrary.cs
@@ -17,7 +17,19 @@ namespace Microsoft.Extensions.DependencyModel
             IEnumerable<string> assemblies,
             IEnumerable<Dependency> dependencies,
             bool serviceable)
-            : base(type, name, version, hash,  dependencies, serviceable)
+            : this(type, name, version, hash, assemblies, dependencies, serviceable, path: null)
+        {
+        }
+
+        public CompilationLibrary(string type,
+            string name,
+            string version,
+            string hash,
+            IEnumerable<string> assemblies,
+            IEnumerable<Dependency> dependencies,
+            bool serviceable,
+            string path)
+            : base(type, name, version, hash, dependencies, serviceable, path)
         {
             if (assemblies == null)
             {

--- a/src/Microsoft.Extensions.DependencyModel/DependencyContextJsonReader.cs
+++ b/src/Microsoft.Extensions.DependencyModel/DependencyContextJsonReader.cs
@@ -496,6 +496,7 @@ namespace Microsoft.Extensions.DependencyModel
             string hash = null;
             string type = null;
             bool serviceable = false;
+            string path = null;
 
             reader.ReadStartObject();
 
@@ -512,6 +513,9 @@ namespace Microsoft.Extensions.DependencyModel
                     case DependencyContextStrings.ServiceablePropertyName:
                         serviceable = reader.ReadAsBoolean().GetValueOrDefault(false);
                         break;
+                    case DependencyContextStrings.PathPropertyName:
+                        path = reader.ReadAsString();
+                        break;
                     default:
                         throw new FormatException($"Unknown property name '{reader.Value}'");
                 }
@@ -523,7 +527,8 @@ namespace Microsoft.Extensions.DependencyModel
             {
                 Hash = hash,
                 Type = Pool(type),
-                Serviceable = serviceable
+                Serviceable = serviceable,
+                Path = path
             };
         }
 
@@ -632,12 +637,21 @@ namespace Microsoft.Extensions.DependencyModel
                     nativeLibraryGroups: nativeLibraryGroups,
                     resourceAssemblies: targetLibrary.Resources ?? Enumerable.Empty<ResourceAssembly>(),
                     dependencies: targetLibrary.Dependencies,
-                    serviceable: stub.Serviceable);
+                    serviceable: stub.Serviceable,
+                    path: stub.Path);
             }
             else
             {
                 var assemblies = (targetLibrary.Compilations != null) ? targetLibrary.Compilations : Enumerable.Empty<string>();
-                return new CompilationLibrary(stub.Type, name, version, stub.Hash, assemblies, targetLibrary.Dependencies, stub.Serviceable);
+                return new CompilationLibrary(
+                    stub.Type,
+                    name,
+                    version,
+                    stub.Hash,
+                    assemblies,
+                    targetLibrary.Dependencies,
+                    stub.Serviceable,
+                    stub.Path);
             }
         }
 
@@ -699,6 +713,8 @@ namespace Microsoft.Extensions.DependencyModel
             public string Type;
 
             public bool Serviceable;
+
+            public string Path;
         }
     }
 }

--- a/src/Microsoft.Extensions.DependencyModel/DependencyContextStrings.cs
+++ b/src/Microsoft.Extensions.DependencyModel/DependencyContextStrings.cs
@@ -23,6 +23,8 @@ namespace Microsoft.Extensions.DependencyModel
 
         internal const string Sha512PropertyName = "sha512";
 
+        internal const string PathPropertyName = "path";
+
         internal const string TypePropertyName = "type";
 
         internal const string ServiceablePropertyName = "serviceable";

--- a/src/Microsoft.Extensions.DependencyModel/DependencyContextWriter.cs
+++ b/src/Microsoft.Extensions.DependencyModel/DependencyContextWriter.cs
@@ -143,6 +143,7 @@ namespace Microsoft.Extensions.DependencyModel
                     Debug.Assert(compilationLibrary.Version == runtimeLibrary.Version);
                     Debug.Assert(compilationLibrary.Hash == runtimeLibrary.Hash);
                     Debug.Assert(compilationLibrary.Type == runtimeLibrary.Type);
+                    Debug.Assert(compilationLibrary.Path == runtimeLibrary.Path);
                 }
 
                 var library = (Library)compilationLibrary ?? (Library)runtimeLibrary;
@@ -329,8 +330,8 @@ namespace Microsoft.Extensions.DependencyModel
             return new JObject(
                 new JProperty(DependencyContextStrings.TypePropertyName, library.Type),
                 new JProperty(DependencyContextStrings.ServiceablePropertyName, library.Serviceable),
-                new JProperty(DependencyContextStrings.Sha512PropertyName, library.Hash)
-                );
+                new JProperty(DependencyContextStrings.Sha512PropertyName, library.Hash),
+                new JProperty(DependencyContextStrings.PathPropertyName, library.Path));
         }
 
         private string NormalizePath(string path)

--- a/src/Microsoft.Extensions.DependencyModel/Library.cs
+++ b/src/Microsoft.Extensions.DependencyModel/Library.cs
@@ -9,7 +9,23 @@ namespace Microsoft.Extensions.DependencyModel
 {
     public class Library
     {
-        public Library(string type, string name, string version, string hash, IEnumerable<Dependency> dependencies, bool serviceable)
+        public Library(string type,
+            string name,
+            string version,
+            string hash,
+            IEnumerable<Dependency> dependencies,
+            bool serviceable)
+            : this(type, name, version, hash, dependencies, serviceable, path: null)
+        {
+        }
+
+        public Library(string type,
+            string name,
+            string version,
+            string hash,
+            IEnumerable<Dependency> dependencies,
+            bool serviceable,
+            string path)
         {
             if (string.IsNullOrEmpty(type))
             {
@@ -33,6 +49,7 @@ namespace Microsoft.Extensions.DependencyModel
             Hash = hash;
             Dependencies = dependencies.ToArray();
             Serviceable = serviceable;
+            Path = path;
         }
 
         public string Type { get; }
@@ -46,5 +63,7 @@ namespace Microsoft.Extensions.DependencyModel
         public IReadOnlyList<Dependency> Dependencies { get; }
 
         public bool Serviceable { get; }
+
+        public string Path { get; }
     }
 }

--- a/src/Microsoft.Extensions.DependencyModel/RuntimeLibrary.cs
+++ b/src/Microsoft.Extensions.DependencyModel/RuntimeLibrary.cs
@@ -9,8 +9,7 @@ namespace Microsoft.Extensions.DependencyModel
 {
     public class RuntimeLibrary : Library
     {
-        public RuntimeLibrary(
-            string type,
+        public RuntimeLibrary(string type,
             string name,
             string version,
             string hash,
@@ -19,7 +18,30 @@ namespace Microsoft.Extensions.DependencyModel
             IEnumerable<ResourceAssembly> resourceAssemblies,
             IEnumerable<Dependency> dependencies,
             bool serviceable)
-            : base(type, name, version, hash, dependencies, serviceable)
+            : this(type,
+                  name,
+                  version,
+                  hash,
+                  runtimeAssemblyGroups,
+                  nativeLibraryGroups,
+                  resourceAssemblies,
+                  dependencies,
+                  serviceable,
+                  path: null)
+        {
+        }
+
+        public RuntimeLibrary(string type,
+            string name,
+            string version,
+            string hash,
+            IReadOnlyList<RuntimeAssetGroup> runtimeAssemblyGroups,
+            IReadOnlyList<RuntimeAssetGroup> nativeLibraryGroups,
+            IEnumerable<ResourceAssembly> resourceAssemblies,
+            IEnumerable<Dependency> dependencies,
+            bool serviceable,
+            string path)
+            : base(type, name, version, hash, dependencies, serviceable, path)
         {
             if (runtimeAssemblyGroups == null)
             {

--- a/test/Microsoft.Extensions.DependencyModel.Tests/DependencyContextJsonReaderTest.cs
+++ b/test/Microsoft.Extensions.DependencyModel.Tests/DependencyContextJsonReaderTest.cs
@@ -169,7 +169,8 @@ namespace Microsoft.Extensions.DependencyModel.Tests
         ""System.Banana/1.0.0"": {
             ""type"": ""package"",
             ""serviceable"": false,
-            ""sha512"": ""HASH-System.Banana""
+            ""sha512"": ""HASH-System.Banana"",
+            ""path"": ""PackagePath""
         },
     }
 }");
@@ -185,6 +186,43 @@ namespace Microsoft.Extensions.DependencyModel.Tests
             package.Hash.Should().Be("HASH-System.Banana");
             package.Type.Should().Be("package");
             package.Serviceable.Should().Be(false);
+            package.Path.Should().Be("PackagePath");
+        }
+
+        [Fact]
+        public void ReadsCompilationTargetWithMissingPath()
+        {
+            var context = Read(
+@"{
+    ""targets"": {
+        "".NETCoreApp,Version=v1.0"": {
+            ""System.Banana/1.0.0"": {
+                ""dependencies"": {
+                    ""System.Foo"": ""1.0.0""
+                },
+                ""compile"": {
+                    ""ref/dotnet5.4/System.Banana.dll"": { }
+                }
+            }
+        }
+    },
+    ""libraries"":{
+        ""System.Banana/1.0.0"": {
+            ""type"": ""package"",
+            ""serviceable"": false,
+            ""sha512"": ""HASH-System.Banana""
+        },
+    }
+}");
+            context.CompileLibraries.Should().HaveCount(1);
+
+            var package = context.CompileLibraries.Should().Contain(l => l.Name == "System.Banana").Subject;
+            package.Version.Should().Be("1.0.0");
+            package.Assemblies.Should().BeEquivalentTo("ref/dotnet5.4/System.Banana.dll");
+            package.Hash.Should().Be("HASH-System.Banana");
+            package.Type.Should().Be("package");
+            package.Serviceable.Should().Be(false);
+            package.Path.Should().BeNull();
         }
 
         [Fact]
@@ -272,7 +310,8 @@ namespace Microsoft.Extensions.DependencyModel.Tests
         ""System.Banana/1.0.0"": {
             ""type"": ""package"",
             ""serviceable"": false,
-            ""sha512"": ""HASH-System.Banana""
+            ""sha512"": ""HASH-System.Banana"",
+            ""path"": ""PackagePath""
         },
     }
 }");
@@ -288,6 +327,7 @@ namespace Microsoft.Extensions.DependencyModel.Tests
             package.Hash.Should().Be("HASH-System.Banana");
             package.Type.Should().Be("package");
             package.Serviceable.Should().Be(false);
+            package.Path.Should().Be("PackagePath");
             package.ResourceAssemblies.Should().Contain(a => a.Path == "System.Banana.resources.dll")
                 .Subject.Locale.Should().Be("en-US");
 

--- a/test/Microsoft.Extensions.DependencyModel.Tests/DependencyContextJsonWriterTests.cs
+++ b/test/Microsoft.Extensions.DependencyModel.Tests/DependencyContextJsonWriterTests.cs
@@ -124,7 +124,8 @@ namespace Microsoft.Extensions.DependencyModel.Tests
                                         new [] {
                                             new Dependency("Fruits.Abstract.dll","2.0.0")
                                         },
-                                        true
+                                        true,
+                                        "PackagePath"
                                     )
                             }));
 
@@ -143,6 +144,7 @@ namespace Microsoft.Extensions.DependencyModel.Tests
             library.Should().HavePropertyValue("sha512", "HASH");
             library.Should().HavePropertyValue("type", "package");
             library.Should().HavePropertyValue("serviceable", true);
+            library.Should().HavePropertyValue("path", "PackagePath");
         }
 
         [Fact]
@@ -171,7 +173,8 @@ namespace Microsoft.Extensions.DependencyModel.Tests
                                         new [] {
                                             new Dependency("Fruits.Abstract.dll","2.0.0")
                                         },
-                                        true
+                                        true,
+                                        "PackagePath"
                                     ),
                             }));
 
@@ -207,6 +210,7 @@ namespace Microsoft.Extensions.DependencyModel.Tests
             library.Should().HavePropertyValue("sha512", "HASH");
             library.Should().HavePropertyValue("type", "package");
             library.Should().HavePropertyValue("serviceable", true);
+            library.Should().HavePropertyValue("path", "PackagePath");
         }
 
         [Fact]
@@ -227,7 +231,8 @@ namespace Microsoft.Extensions.DependencyModel.Tests
                                         new [] {
                                             new Dependency("Fruits.Abstract.dll","2.0.0")
                                         },
-                                        true
+                                        true,
+                                        "PackagePath"
                                     )
                             },
                             runtimeLibraries: new[]
@@ -249,7 +254,8 @@ namespace Microsoft.Extensions.DependencyModel.Tests
                                         new [] {
                                             new Dependency("Fruits.Abstract.dll","2.0.0")
                                         },
-                                        true
+                                        true,
+                                        "PackagePath"
                                     ),
                             }));
 
@@ -284,6 +290,7 @@ namespace Microsoft.Extensions.DependencyModel.Tests
             library.Should().HavePropertyValue("sha512", "HASH");
             library.Should().HavePropertyValue("type", "package");
             library.Should().HavePropertyValue("serviceable", true);
+            library.Should().HavePropertyValue("path", "PackagePath");
         }
 
         [Fact]
@@ -310,7 +317,8 @@ namespace Microsoft.Extensions.DependencyModel.Tests
                                         new [] {
                                             new Dependency("Fruits.Abstract.dll","2.0.0")
                                         },
-                                        true
+                                        true,
+                                        "PackagePath"
                                     ),
                             }));
 
@@ -331,6 +339,7 @@ namespace Microsoft.Extensions.DependencyModel.Tests
             library.Should().HavePropertyValue("sha512", "HASH");
             library.Should().HavePropertyValue("type", "package");
             library.Should().HavePropertyValue("serviceable", true);
+            library.Should().HavePropertyValue("path", "PackagePath");
         }
 
         [Fact]
@@ -357,7 +366,8 @@ namespace Microsoft.Extensions.DependencyModel.Tests
                                         },
                                         new ResourceAssembly[] { },
                                         new Dependency[] { },
-                                        true
+                                        true,
+                                        "PackagePath"
                                     ),
                             }));
 
@@ -406,7 +416,8 @@ namespace Microsoft.Extensions.DependencyModel.Tests
                                             new ResourceAssembly("en-US/Fruits.resources.dll", "en-US")
                                         },
                                         new Dependency[] { },
-                                        true
+                                        true,
+                                        "PackagePath"
                                     ),
                             }));
 
@@ -440,7 +451,8 @@ namespace Microsoft.Extensions.DependencyModel.Tests
                                             new ResourceAssembly("en-US/Fruits.resources.dll", "en-US")
                                         },
                                         new Dependency[] { },
-                                        true
+                                        true,
+                                        "PackagePath"
                                     ),
                             }));
 
@@ -471,7 +483,8 @@ namespace Microsoft.Extensions.DependencyModel.Tests
                                         new [] {
                                             new Dependency("Fruits.Abstract.dll","2.0.0")
                                         },
-                                        true
+                                        true,
+                                        "PackagePath"
                                     )
                             }));
 

--- a/test/Microsoft.Extensions.DependencyModel.Tests/DependencyContextLoaderTests.cs
+++ b/test/Microsoft.Extensions.DependencyModel.Tests/DependencyContextLoaderTests.cs
@@ -166,7 +166,8 @@ namespace Microsoft.Extensions.DependencyModel.Tests
                 "HASH",
                 new string[] { },
                 new Dependency[] { },
-                false);
+                false,
+                "path");
         }
 
         private RuntimeLibrary CreateRuntime(string name)
@@ -180,7 +181,8 @@ namespace Microsoft.Extensions.DependencyModel.Tests
                 new RuntimeAssetGroup[] { },
                 new ResourceAssembly[] { },
                 new Dependency[] {},
-                false);
+                false,
+                "path");
         }
     }
 }

--- a/test/Microsoft.Extensions.DependencyModel.Tests/DependencyContextTests.cs
+++ b/test/Microsoft.Extensions.DependencyModel.Tests/DependencyContextTests.cs
@@ -28,7 +28,8 @@ namespace Microsoft.Extensions.DependencyModel.Tests
                         new RuntimeAssetGroup[] { },
                         new ResourceAssembly[] { },
                         new Dependency[] { },
-                        serviceable: false)
+                        serviceable: false,
+                        path: "PackagePath")
                 },
                 runtimeGraph: new RuntimeFallbacks[] { });
 
@@ -99,7 +100,8 @@ namespace Microsoft.Extensions.DependencyModel.Tests
                     new CompilationLibrary("package", "System.Banana", "1.0.0", "hash",
                         new [] { Path.Combine("ref", "netstandard1.3", "System.Banana.dll") },
                         new Dependency[] { },
-                        serviceable: false)
+                        serviceable: false,
+                        path: "PackagePath")
                 },
                 runtimeLibraries: new[] {
                     new RuntimeLibrary("package", "System.Banana", "1.0.0", "hash",
@@ -119,7 +121,8 @@ namespace Microsoft.Extensions.DependencyModel.Tests
                         },
                         new ResourceAssembly[] { },
                         new Dependency[] { },
-                        serviceable: false)
+                        serviceable: false,
+                        path: "PackagePath")
                 },
                 runtimeGraph: new[] {
                     new RuntimeFallbacks("win10-x64", "win10", "win81-x64", "win81", "win8-x64", "win8", "win7-x64", "win7", "win-x64", "win", "any", "base"),

--- a/test/Microsoft.Extensions.DependencyModel.Tests/TestLibraryFactory.cs
+++ b/test/Microsoft.Extensions.DependencyModel.Tests/TestLibraryFactory.cs
@@ -12,6 +12,7 @@ namespace Microsoft.Extensions.DependencyModel.Tests
         public static readonly string DefaultVersion = "1.2.3.7";
         public static readonly Dependency[] DefaultDependencies = { };
         public static readonly bool DefaultServiceable = true;
+        public static readonly string DefaultPath = "MyPackagePath";
 
         public static readonly string DefaultAssembly = "My.Package.dll";
         public static readonly string SecondAssembly = "My.PackageEx.dll";
@@ -37,7 +38,8 @@ namespace Microsoft.Extensions.DependencyModel.Tests
             string hash = null,
             string[] assemblies = null,
             Dependency[] dependencies = null,
-            bool? serviceable = null)
+            bool? serviceable = null,
+            string path = null)
         {
             return new CompilationLibrary(
                 libraryType ?? DefaultType,
@@ -46,8 +48,8 @@ namespace Microsoft.Extensions.DependencyModel.Tests
                 hash ?? DefaultHash,
                 assemblies ?? DefaultAssemblies,
                 dependencies ?? DefaultDependencies,
-                serviceable ?? DefaultServiceable
-                );
+                serviceable ?? DefaultServiceable,
+                path ?? DefaultPath);
         }
     }
 


### PR DESCRIPTION
@eerhardt mentioned that Microsoft.Extensions.DependencyModel project moved to core-setup repository in my cli PR https://github.com/dotnet/cli/pull/4032. This PR is porting the relevant changes from that cli to core-setup.

The purpose of this PR is to support the `"path"` property in the `.deps.json` file. Eventually the DotNetHost will prefer this "path" proper over the concatenation of ID and version when looking for a package in the global packages folder.

This is part of step #3 in this NuGet issue: https://github.com/NuGet/Home/issues/2522. 

/cc @eerhardt @livarcocc @gkhanna79 @piotrpMSFT @schellap 
