### PR TITLE
Add win10-arm64 builds to Jenkins

### DIFF
--- a/netci.groovy
+++ b/netci.groovy
@@ -61,4 +61,41 @@ platformList.each { platform ->
     Utilities.addGithubPRTriggerForBranch(newJob, branch, "${os} ${architecture} ${configuration} Build")
 }
 
+// **************************
+// Define ARM64 building.
+// **************************
+['Windows_NT'].each { os ->
+    ['Release'].each { configurationGroup ->
+        def newJobName = "${configurationGroup.toLowerCase()}_${os.toLowerCase()}_arm64"
+        def arm64Users = ['ianhays', 'kyulee1', 'gkhanna79', 'weshaggard', 'stephentoub', 'rahku', 'ramarag']
+        def newJob = job(Utilities.getFullJobName(project, newJobName, /* isPR */ false)) {
+            steps {
+                // build the world, but don't run the tests
+                batchFile("build.cmd -Configuration ${configurationGroup} -Targets Init,Compile,Package,Publish -Architecure x64 -TargetArch arm64 -ToolsetDir C:\\ats2 -Framework netcoreapp1.1")
+            }
+            label("arm64")
+            
+            // Kick off the test run
+            publishers {
+                archiveArtifacts {
+                    pattern("artifacts/win10-arm64/packages/*.zip")
+                    pattern("artifacts/win10-arm64/corehost/*.nupkg")
+                    onlyIfSuccessful(true)
+                    allowEmpty(false)
+                }
+            }
+        }
 
+        // Set up standard options.
+        Utilities.standardJobSetup(newJob, project, /* isPR */ false, "*/${branch}")
+        
+        // Set a daily trigger
+        Utilities.addPeriodicTrigger(newJob, '@daily')
+        
+        // Set up a PR trigger that is only triggerable by certain members
+        Utilities.addPrivateGithubPRTriggerForBranch(newJob, branch, "Windows_NT ARM64 ${configurationGroup} Build", "(?i).*test\\W+ARM64\\W+${os}\\W+${configurationGroup}", null, arm64Users)
+
+        // Set up a per-push trigger
+        Utilities.addGithubPushTrigger(newJob)
+    }
+}


### PR DESCRIPTION
Adds building and archiving of win10-arm64 assets on a per-push and daily basis. PR builds can also be triggered by a limited set of people, the same as is done in CoreFX and CoreCLR.

@gkhanna79 @ramarag @rahku 