### PR TITLE
Add support for the "hashPath" property in the .deps.json file

### DIFF
--- a/src/Microsoft.Extensions.DependencyModel/CompilationLibrary.cs
+++ b/src/Microsoft.Extensions.DependencyModel/CompilationLibrary.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Extensions.DependencyModel
             IEnumerable<string> assemblies,
             IEnumerable<Dependency> dependencies,
             bool serviceable)
-            : this(type, name, version, hash, assemblies, dependencies, serviceable, path: null)
+            : this(type, name, version, hash, assemblies, dependencies, serviceable, path: null, hashPath: null)
         {
         }
 
@@ -28,8 +28,9 @@ namespace Microsoft.Extensions.DependencyModel
             IEnumerable<string> assemblies,
             IEnumerable<Dependency> dependencies,
             bool serviceable,
-            string path)
-            : base(type, name, version, hash, dependencies, serviceable, path)
+            string path,
+            string hashPath)
+            : base(type, name, version, hash, dependencies, serviceable, path, hashPath)
         {
             if (assemblies == null)
             {

--- a/src/Microsoft.Extensions.DependencyModel/DependencyContextJsonReader.cs
+++ b/src/Microsoft.Extensions.DependencyModel/DependencyContextJsonReader.cs
@@ -497,6 +497,7 @@ namespace Microsoft.Extensions.DependencyModel
             string type = null;
             bool serviceable = false;
             string path = null;
+            string hashPath = null;
 
             reader.ReadStartObject();
 
@@ -516,6 +517,9 @@ namespace Microsoft.Extensions.DependencyModel
                     case DependencyContextStrings.PathPropertyName:
                         path = reader.ReadAsString();
                         break;
+                    case DependencyContextStrings.HashPathPropertyName:
+                        hashPath = reader.ReadAsString();
+                        break;
                     default:
                         throw new FormatException($"Unknown property name '{reader.Value}'");
                 }
@@ -528,7 +532,8 @@ namespace Microsoft.Extensions.DependencyModel
                 Hash = hash,
                 Type = Pool(type),
                 Serviceable = serviceable,
-                Path = path
+                Path = path,
+                HashPath = hashPath
             };
         }
 
@@ -638,7 +643,8 @@ namespace Microsoft.Extensions.DependencyModel
                     resourceAssemblies: targetLibrary.Resources ?? Enumerable.Empty<ResourceAssembly>(),
                     dependencies: targetLibrary.Dependencies,
                     serviceable: stub.Serviceable,
-                    path: stub.Path);
+                    path: stub.Path,
+                    hashPath: stub.HashPath);
             }
             else
             {
@@ -651,7 +657,8 @@ namespace Microsoft.Extensions.DependencyModel
                     assemblies,
                     targetLibrary.Dependencies,
                     stub.Serviceable,
-                    stub.Path);
+                    stub.Path,
+                    stub.HashPath);
             }
         }
 
@@ -715,6 +722,8 @@ namespace Microsoft.Extensions.DependencyModel
             public bool Serviceable;
 
             public string Path;
+
+            public string HashPath;
         }
     }
 }

--- a/src/Microsoft.Extensions.DependencyModel/DependencyContextJsonReader.cs
+++ b/src/Microsoft.Extensions.DependencyModel/DependencyContextJsonReader.cs
@@ -75,7 +75,9 @@ namespace Microsoft.Extensions.DependencyModel
                     case DependencyContextStrings.RuntimesPropertyName:
                         runtimeFallbacks = ReadRuntimes(reader);
                         break;
-
+                    default:
+                        reader.Skip();
+                        break;
                 }
             }
 
@@ -177,8 +179,6 @@ namespace Microsoft.Extensions.DependencyModel
                     case DependencyContextStrings.RuntimeTargetSignaturePropertyName:
                         runtimeSignature = propertyValue;
                         break;
-                    default:
-                        throw new FormatException($"Unknown property name '{propertyName}'");
                 }
             }
 
@@ -243,7 +243,8 @@ namespace Microsoft.Extensions.DependencyModel
                         generateXmlDocumentation = reader.ReadAsBoolean();
                         break;
                     default:
-                        throw new FormatException($"Unknown property name '{reader.Value}'");
+                        reader.Skip();
+                        break;
                 }
             }
 
@@ -338,7 +339,8 @@ namespace Microsoft.Extensions.DependencyModel
                         compileOnly = reader.ReadAsBoolean();
                         break;
                     default:
-                        throw new FormatException($"Unknown property name '{reader.Value}'");
+                        reader.Skip();
+                        break;
                 }
             }
 
@@ -421,8 +423,6 @@ namespace Microsoft.Extensions.DependencyModel
                         case DependencyContextStrings.AssetTypePropertyName:
                             runtimeTarget.Type = Pool(propertyValue);
                             break;
-                        default:
-                            throw new FormatException($"Unknown property name '{propertyName}'");
                     }
                 }
 
@@ -521,7 +521,8 @@ namespace Microsoft.Extensions.DependencyModel
                         hashPath = reader.ReadAsString();
                         break;
                     default:
-                        throw new FormatException($"Unknown property name '{reader.Value}'");
+                        reader.Skip();
+                        break;
                 }
             }
 
@@ -572,7 +573,7 @@ namespace Microsoft.Extensions.DependencyModel
             var nameWithVersion = targetLibrary.Name;
             LibraryStub stub;
 
-            if (!libraryStubs.TryGetValue(nameWithVersion, out stub))
+            if (libraryStubs == null || !libraryStubs.TryGetValue(nameWithVersion, out stub))
             {
                 throw new InvalidOperationException($"Cannot find library information for {nameWithVersion}");
             }

--- a/src/Microsoft.Extensions.DependencyModel/DependencyContextStrings.cs
+++ b/src/Microsoft.Extensions.DependencyModel/DependencyContextStrings.cs
@@ -25,6 +25,8 @@ namespace Microsoft.Extensions.DependencyModel
 
         internal const string PathPropertyName = "path";
 
+        internal const string HashPathPropertyName = "hashPath";
+
         internal const string TypePropertyName = "type";
 
         internal const string ServiceablePropertyName = "serviceable";

--- a/src/Microsoft.Extensions.DependencyModel/DependencyContextWriter.cs
+++ b/src/Microsoft.Extensions.DependencyModel/DependencyContextWriter.cs
@@ -144,6 +144,7 @@ namespace Microsoft.Extensions.DependencyModel
                     Debug.Assert(compilationLibrary.Hash == runtimeLibrary.Hash);
                     Debug.Assert(compilationLibrary.Type == runtimeLibrary.Type);
                     Debug.Assert(compilationLibrary.Path == runtimeLibrary.Path);
+                    Debug.Assert(compilationLibrary.HashPath == runtimeLibrary.HashPath);
                 }
 
                 var library = (Library)compilationLibrary ?? (Library)runtimeLibrary;
@@ -331,7 +332,8 @@ namespace Microsoft.Extensions.DependencyModel
                 new JProperty(DependencyContextStrings.TypePropertyName, library.Type),
                 new JProperty(DependencyContextStrings.ServiceablePropertyName, library.Serviceable),
                 new JProperty(DependencyContextStrings.Sha512PropertyName, library.Hash),
-                new JProperty(DependencyContextStrings.PathPropertyName, library.Path));
+                new JProperty(DependencyContextStrings.PathPropertyName, library.Path),
+                new JProperty(DependencyContextStrings.HashPathPropertyName, library.HashPath));
         }
 
         private string NormalizePath(string path)

--- a/src/Microsoft.Extensions.DependencyModel/DependencyContextWriter.cs
+++ b/src/Microsoft.Extensions.DependencyModel/DependencyContextWriter.cs
@@ -328,12 +328,22 @@ namespace Microsoft.Extensions.DependencyModel
 
         private JObject WriteLibrary(Library library)
         {
-            return new JObject(
+            var libraryJson = new JObject(
                 new JProperty(DependencyContextStrings.TypePropertyName, library.Type),
                 new JProperty(DependencyContextStrings.ServiceablePropertyName, library.Serviceable),
-                new JProperty(DependencyContextStrings.Sha512PropertyName, library.Hash),
-                new JProperty(DependencyContextStrings.PathPropertyName, library.Path),
-                new JProperty(DependencyContextStrings.HashPathPropertyName, library.HashPath));
+                new JProperty(DependencyContextStrings.Sha512PropertyName, library.Hash));
+
+            if (library.Path != null)
+            {
+                libraryJson.Add(new JProperty(DependencyContextStrings.PathPropertyName, library.Path));
+            }
+
+            if (library.HashPath != null)
+            {
+                libraryJson.Add(new JProperty(DependencyContextStrings.HashPathPropertyName, library.HashPath));
+            }
+
+            return libraryJson;
         }
 
         private string NormalizePath(string path)

--- a/src/Microsoft.Extensions.DependencyModel/JsonTextReaderExtensions.cs
+++ b/src/Microsoft.Extensions.DependencyModel/JsonTextReaderExtensions.cs
@@ -16,7 +16,19 @@ namespace Microsoft.Extensions.DependencyModel
             if (reader.Read() && reader.TokenType == JsonToken.PropertyName)
             {
                 name = (string)reader.Value;
-                value = reader.ReadAsString();
+                
+                if (reader.Read())
+                {
+                    if (reader.TokenType == JsonToken.String)
+                    {
+                        value = (string)reader.Value;
+                    }
+                    else
+                    {
+                        reader.Skip();
+                    }
+                }
+
                 return true;
             }
 

--- a/src/Microsoft.Extensions.DependencyModel/Library.cs
+++ b/src/Microsoft.Extensions.DependencyModel/Library.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Extensions.DependencyModel
             string hash,
             IEnumerable<Dependency> dependencies,
             bool serviceable)
-            : this(type, name, version, hash, dependencies, serviceable, path: null)
+            : this(type, name, version, hash, dependencies, serviceable, path: null, hashPath: null)
         {
         }
 
@@ -25,7 +25,8 @@ namespace Microsoft.Extensions.DependencyModel
             string hash,
             IEnumerable<Dependency> dependencies,
             bool serviceable,
-            string path)
+            string path,
+            string hashPath)
         {
             if (string.IsNullOrEmpty(type))
             {
@@ -50,6 +51,7 @@ namespace Microsoft.Extensions.DependencyModel
             Dependencies = dependencies.ToArray();
             Serviceable = serviceable;
             Path = path;
+            HashPath = hashPath;
         }
 
         public string Type { get; }
@@ -65,5 +67,7 @@ namespace Microsoft.Extensions.DependencyModel
         public bool Serviceable { get; }
 
         public string Path { get; }
+
+        public string HashPath { get; }
     }
 }

--- a/src/Microsoft.Extensions.DependencyModel/RuntimeLibrary.cs
+++ b/src/Microsoft.Extensions.DependencyModel/RuntimeLibrary.cs
@@ -27,7 +27,8 @@ namespace Microsoft.Extensions.DependencyModel
                   resourceAssemblies,
                   dependencies,
                   serviceable,
-                  path: null)
+                  path: null,
+                  hashPath: null)
         {
         }
 
@@ -40,8 +41,16 @@ namespace Microsoft.Extensions.DependencyModel
             IEnumerable<ResourceAssembly> resourceAssemblies,
             IEnumerable<Dependency> dependencies,
             bool serviceable,
-            string path)
-            : base(type, name, version, hash, dependencies, serviceable, path)
+            string path,
+            string hashPath)
+            : base(type,
+                  name,
+                  version,
+                  hash,
+                  dependencies,
+                  serviceable,
+                  path,
+                  hashPath)
         {
             if (runtimeAssemblyGroups == null)
             {

--- a/test/Microsoft.Extensions.DependencyModel.Tests/DependencyContextBuilderTests.cs
+++ b/test/Microsoft.Extensions.DependencyModel.Tests/DependencyContextBuilderTests.cs
@@ -19,7 +19,6 @@ namespace Microsoft.Extensions.DependencyModel.Tests
         private NuGetFramework _defaultFramework;
         private string _defaultName = "Library.Name";
         private string _defaultHash = "Hash";
-        private string _defaultPath = "the/Package/PATH";
         private NuGetVersion _defaultVersion = new NuGetVersion(1, 2, 3, new []{"dev"}, string.Empty);
 
         public DependencyContext Build(CommonCompilerOptions compilerOptions = null,
@@ -138,7 +137,8 @@ namespace Microsoft.Extensions.DependencyModel.Tests
                                 LibraryType.ReferenceAssembly,
                                 LibraryDependencyType.Default)
                         },
-                        path: "path/TO/package"),
+                        path: "path/TO/package",
+                        hashPath: "Pack.Age.1.2.3.nupkg.sha512"),
                     resourceAssemblies: new[]
                     {
                         new LibraryResourceAssembly(
@@ -178,8 +178,10 @@ namespace Microsoft.Extensions.DependencyModel.Tests
             lib.Dependencies.Should().OnlyContain(l => l.Name == "System.Collections" && l.Version == "3.3.3");
             lib.ResourceAssemblies.Should().OnlyContain(l => l.Path == "en-US/Pack.Age.resources.dll" && l.Locale == "en-US");
 
-            // When ProjectModel supports path in the lock file library, this should assert "path/TO/package".
-            lib.Path.Should().BeNull(); 
+            // When ProjectModel supports path and hashPath in the lock file library, this should assert the values
+            // provided above.
+            lib.Path.Should().BeNull();
+            lib.HashPath.Should().BeNull();
 
             lib.RuntimeAssemblyGroups.GetDefaultAssets().Should().OnlyContain(l => l == "lib/Pack.Age.dll");
             lib.RuntimeAssemblyGroups.GetRuntimeAssets("win8-x64").Should().OnlyContain(l => l == "win8-x64/Pack.Age.dll");
@@ -192,6 +194,7 @@ namespace Microsoft.Extensions.DependencyModel.Tests
             asm.Dependencies.Should().BeEmpty();
             asm.RuntimeAssemblyGroups.GetDefaultAssets().Should().OnlyContain(l => l == "System.Collections.dll");
             asm.Path.Should().BeNull();
+            asm.HashPath.Should().BeNull();
         }
 
         [Fact]
@@ -239,7 +242,8 @@ namespace Microsoft.Extensions.DependencyModel.Tests
                             LibraryType.ReferenceAssembly,
                             LibraryDependencyType.Default)
                     },
-                    path: "path/TO/package"),
+                    path: "path/TO/package",
+                    hashPath: "Pack.Age.1.2.3.nupkg.sha512"),
                     compilationAssemblies: new[]
                     {
                         new LibraryAsset("Dll", "lib/Pack.Age.dll", ""),
@@ -263,8 +267,10 @@ namespace Microsoft.Extensions.DependencyModel.Tests
             lib.Dependencies.Should().OnlyContain(l => l.Name == "System.Collections" && l.Version == "3.3.3");
             lib.Assemblies.Should().OnlyContain(a => a == "lib/Pack.Age.dll");
 
-            // When ProjectModel supports path in the lock file library, this should assert "path/TO/package".
+            // When ProjectModel supports path and hashPath in the lock file library, this should assert the values
+            // provided above.
             lib.Path.Should().BeNull();
+            lib.HashPath.Should().BeNull();
 
             var asm = context.CompileLibraries.Should().Contain(l => l.Name == "System.Collections").Subject;
             asm.Type.Should().Be("referenceassembly");
@@ -273,6 +279,7 @@ namespace Microsoft.Extensions.DependencyModel.Tests
             asm.Dependencies.Should().BeEmpty();
             asm.Assemblies.Should().OnlyContain(a => a == "System.Collections.dll");
             asm.Path.Should().BeNull();
+            asm.HashPath.Should().BeNull();
         }
 
         [Fact]
@@ -366,7 +373,8 @@ namespace Microsoft.Extensions.DependencyModel.Tests
             string hash = null,
             IEnumerable<LibraryRange> dependencies = null,
             bool? servicable = null,
-            string path = null)
+            string path = null,
+            string hashPath = null)
         {
             // The LockFilePackageLibrary type in Microsoft.DotNet.ProjectModel currently does not
             // support the "path" property. Therefore, the path property to this method is ignored

--- a/test/Microsoft.Extensions.DependencyModel.Tests/DependencyContextJsonReaderTest.cs
+++ b/test/Microsoft.Extensions.DependencyModel.Tests/DependencyContextJsonReaderTest.cs
@@ -190,7 +190,7 @@ namespace Microsoft.Extensions.DependencyModel.Tests
         }
 
         [Fact]
-        public void ReadsCompilationTargetWithMissingPath()
+        public void ReadsCompilationTargetWithMissingPathAndHashPath()
         {
             var context = Read(
 @"{
@@ -223,6 +223,7 @@ namespace Microsoft.Extensions.DependencyModel.Tests
             package.Type.Should().Be("package");
             package.Serviceable.Should().Be(false);
             package.Path.Should().BeNull();
+            package.HashPath.Should().BeNull();
         }
 
         [Fact]
@@ -311,7 +312,8 @@ namespace Microsoft.Extensions.DependencyModel.Tests
             ""type"": ""package"",
             ""serviceable"": false,
             ""sha512"": ""HASH-System.Banana"",
-            ""path"": ""PackagePath""
+            ""path"": ""PackagePath"",
+            ""hashPath"": ""PackageHashPath""
         },
     }
 }");
@@ -328,6 +330,7 @@ namespace Microsoft.Extensions.DependencyModel.Tests
             package.Type.Should().Be("package");
             package.Serviceable.Should().Be(false);
             package.Path.Should().Be("PackagePath");
+            package.HashPath.Should().Be("PackageHashPath");
             package.ResourceAssemblies.Should().Contain(a => a.Path == "System.Banana.resources.dll")
                 .Subject.Locale.Should().Be("en-US");
 

--- a/test/Microsoft.Extensions.DependencyModel.Tests/DependencyContextJsonReaderTest.cs
+++ b/test/Microsoft.Extensions.DependencyModel.Tests/DependencyContextJsonReaderTest.cs
@@ -281,6 +281,45 @@ namespace Microsoft.Extensions.DependencyModel.Tests
         }
 
         [Fact]
+        public void ReadsCompilationTargetWithNullPathAndHashPath()
+        {
+            var context = Read(
+@"{
+    ""targets"": {
+        "".NETCoreApp,Version=v1.0"": {
+            ""System.Banana/1.0.0"": {
+                ""dependencies"": {
+                    ""System.Foo"": ""1.0.0""
+                },
+                ""compile"": {
+                    ""ref/dotnet5.4/System.Banana.dll"": { }
+                }
+            }
+        }
+    },
+    ""libraries"":{
+        ""System.Banana/1.0.0"": {
+            ""type"": ""package"",
+            ""serviceable"": false,
+            ""sha512"": ""HASH-System.Banana"",
+            ""path"": null,
+            ""hashPath"": null
+        },
+    }
+}");
+            context.CompileLibraries.Should().HaveCount(1);
+
+            var package = context.CompileLibraries.Should().Contain(l => l.Name == "System.Banana").Subject;
+            package.Version.Should().Be("1.0.0");
+            package.Assemblies.Should().BeEquivalentTo("ref/dotnet5.4/System.Banana.dll");
+            package.Hash.Should().Be("HASH-System.Banana");
+            package.Type.Should().Be("package");
+            package.Serviceable.Should().Be(false);
+            package.Path.Should().BeNull();
+            package.HashPath.Should().BeNull();
+        }
+
+        [Fact]
         public void ReadsCompilationTargetWithMissingPathAndHashPath()
         {
             var context = Read(

--- a/test/Microsoft.Extensions.DependencyModel.Tests/DependencyContextJsonWriterTests.cs
+++ b/test/Microsoft.Extensions.DependencyModel.Tests/DependencyContextJsonWriterTests.cs
@@ -125,7 +125,8 @@ namespace Microsoft.Extensions.DependencyModel.Tests
                                             new Dependency("Fruits.Abstract.dll","2.0.0")
                                         },
                                         true,
-                                        "PackagePath"
+                                        "PackagePath",
+                                        "PackageHashPath"
                                     )
                             }));
 
@@ -145,6 +146,7 @@ namespace Microsoft.Extensions.DependencyModel.Tests
             library.Should().HavePropertyValue("type", "package");
             library.Should().HavePropertyValue("serviceable", true);
             library.Should().HavePropertyValue("path", "PackagePath");
+            library.Should().HavePropertyValue("hashPath", "PackageHashPath");
         }
 
         [Fact]
@@ -174,7 +176,8 @@ namespace Microsoft.Extensions.DependencyModel.Tests
                                             new Dependency("Fruits.Abstract.dll","2.0.0")
                                         },
                                         true,
-                                        "PackagePath"
+                                        "PackagePath",
+                                        "PackageHashPath"
                                     ),
                             }));
 
@@ -211,6 +214,7 @@ namespace Microsoft.Extensions.DependencyModel.Tests
             library.Should().HavePropertyValue("type", "package");
             library.Should().HavePropertyValue("serviceable", true);
             library.Should().HavePropertyValue("path", "PackagePath");
+            library.Should().HavePropertyValue("hashPath", "PackageHashPath");
         }
 
         [Fact]
@@ -232,7 +236,8 @@ namespace Microsoft.Extensions.DependencyModel.Tests
                                             new Dependency("Fruits.Abstract.dll","2.0.0")
                                         },
                                         true,
-                                        "PackagePath"
+                                        "PackagePath",
+                                        "PackageHashPath"
                                     )
                             },
                             runtimeLibraries: new[]
@@ -255,7 +260,8 @@ namespace Microsoft.Extensions.DependencyModel.Tests
                                             new Dependency("Fruits.Abstract.dll","2.0.0")
                                         },
                                         true,
-                                        "PackagePath"
+                                        "PackagePath",
+                                        "PackageHashPath"
                                     ),
                             }));
 
@@ -291,6 +297,7 @@ namespace Microsoft.Extensions.DependencyModel.Tests
             library.Should().HavePropertyValue("type", "package");
             library.Should().HavePropertyValue("serviceable", true);
             library.Should().HavePropertyValue("path", "PackagePath");
+            library.Should().HavePropertyValue("hashPath", "PackageHashPath");
         }
 
         [Fact]
@@ -318,7 +325,8 @@ namespace Microsoft.Extensions.DependencyModel.Tests
                                             new Dependency("Fruits.Abstract.dll","2.0.0")
                                         },
                                         true,
-                                        "PackagePath"
+                                        "PackagePath",
+                                        "PackageHashPath"
                                     ),
                             }));
 
@@ -340,6 +348,7 @@ namespace Microsoft.Extensions.DependencyModel.Tests
             library.Should().HavePropertyValue("type", "package");
             library.Should().HavePropertyValue("serviceable", true);
             library.Should().HavePropertyValue("path", "PackagePath");
+            library.Should().HavePropertyValue("hashPath", "PackageHashPath");
         }
 
         [Fact]
@@ -367,7 +376,8 @@ namespace Microsoft.Extensions.DependencyModel.Tests
                                         new ResourceAssembly[] { },
                                         new Dependency[] { },
                                         true,
-                                        "PackagePath"
+                                        "PackagePath",
+                                        "PackageHashPath"
                                     ),
                             }));
 
@@ -417,7 +427,8 @@ namespace Microsoft.Extensions.DependencyModel.Tests
                                         },
                                         new Dependency[] { },
                                         true,
-                                        "PackagePath"
+                                        "PackagePath",
+                                        "PackageHashPath"
                                     ),
                             }));
 
@@ -452,7 +463,8 @@ namespace Microsoft.Extensions.DependencyModel.Tests
                                         },
                                         new Dependency[] { },
                                         true,
-                                        "PackagePath"
+                                        "PackagePath",
+                                        "PackageHashPath"
                                     ),
                             }));
 
@@ -484,7 +496,8 @@ namespace Microsoft.Extensions.DependencyModel.Tests
                                             new Dependency("Fruits.Abstract.dll","2.0.0")
                                         },
                                         true,
-                                        "PackagePath"
+                                        "PackagePath",
+                                        "PackageHashPath"
                                     )
                             }));
 

--- a/test/Microsoft.Extensions.DependencyModel.Tests/DependencyContextJsonWriterTests.cs
+++ b/test/Microsoft.Extensions.DependencyModel.Tests/DependencyContextJsonWriterTests.cs
@@ -150,6 +150,49 @@ namespace Microsoft.Extensions.DependencyModel.Tests
         }
 
         [Fact]
+        public void ExcludesPathAndHashPath()
+        {
+            var result = Save(Create(
+                            "Target",
+                            "runtime",
+                            true,
+                            compileLibraries: new[]
+                            {
+                                new CompilationLibrary(
+                                        "package",
+                                        "PackageName",
+                                        "1.2.3",
+                                        "HASH",
+                                        new [] {"Banana.dll"},
+                                        new [] {
+                                            new Dependency("Fruits.Abstract.dll","2.0.0")
+                                        },
+                                        true,
+                                        path: null,
+                                        hashPath: null
+                                    )
+                            }));
+
+            // targets
+            var targets = result.Should().HavePropertyAsObject("targets").Subject;
+            var target = targets.Should().HavePropertyAsObject("Target").Subject;
+            var library = target.Should().HavePropertyAsObject("packagename/1.2.3").Subject;
+            var dependencies = library.Should().HavePropertyAsObject("dependencies").Subject;
+            dependencies.Should().HavePropertyValue("Fruits.Abstract.dll", "2.0.0");
+            library.Should().HavePropertyAsObject("compile")
+                .Subject.Should().HaveProperty("Banana.dll");
+
+            //libraries
+            var libraries = result.Should().HavePropertyAsObject("libraries").Subject;
+            library = libraries.Should().HavePropertyAsObject("packagename/1.2.3").Subject;
+            library.Should().HavePropertyValue("sha512", "HASH");
+            library.Should().HavePropertyValue("type", "package");
+            library.Should().HavePropertyValue("serviceable", true);
+            library.Should().NotHaveProperty("path");
+            library.Should().NotHaveProperty("hashPath");
+        }
+
+        [Fact]
         public void WritesRuntimeLibrariesToRuntimeTarget()
         {
             var result = Save(Create(

--- a/test/Microsoft.Extensions.DependencyModel.Tests/DependencyContextLoaderTests.cs
+++ b/test/Microsoft.Extensions.DependencyModel.Tests/DependencyContextLoaderTests.cs
@@ -167,7 +167,8 @@ namespace Microsoft.Extensions.DependencyModel.Tests
                 new string[] { },
                 new Dependency[] { },
                 false,
-                "path");
+                "path",
+                "hashPath");
         }
 
         private RuntimeLibrary CreateRuntime(string name)
@@ -182,7 +183,8 @@ namespace Microsoft.Extensions.DependencyModel.Tests
                 new ResourceAssembly[] { },
                 new Dependency[] {},
                 false,
-                "path");
+                "path",
+                "hashPath");
         }
     }
 }

--- a/test/Microsoft.Extensions.DependencyModel.Tests/DependencyContextTests.cs
+++ b/test/Microsoft.Extensions.DependencyModel.Tests/DependencyContextTests.cs
@@ -29,7 +29,8 @@ namespace Microsoft.Extensions.DependencyModel.Tests
                         new ResourceAssembly[] { },
                         new Dependency[] { },
                         serviceable: false,
-                        path: "PackagePath")
+                        path: "PackagePath",
+                        hashPath: "PackageHashPath")
                 },
                 runtimeGraph: new RuntimeFallbacks[] { });
 
@@ -101,7 +102,8 @@ namespace Microsoft.Extensions.DependencyModel.Tests
                         new [] { Path.Combine("ref", "netstandard1.3", "System.Banana.dll") },
                         new Dependency[] { },
                         serviceable: false,
-                        path: "PackagePath")
+                        path: "PackagePath",
+                        hashPath: "PackageHashPath")
                 },
                 runtimeLibraries: new[] {
                     new RuntimeLibrary("package", "System.Banana", "1.0.0", "hash",
@@ -122,7 +124,8 @@ namespace Microsoft.Extensions.DependencyModel.Tests
                         new ResourceAssembly[] { },
                         new Dependency[] { },
                         serviceable: false,
-                        path: "PackagePath")
+                        path: "PackagePath",
+                        hashPath: "PackageHashPath")
                 },
                 runtimeGraph: new[] {
                     new RuntimeFallbacks("win10-x64", "win10", "win81-x64", "win81", "win8-x64", "win8", "win7-x64", "win7", "win-x64", "win", "any", "base"),

--- a/test/Microsoft.Extensions.DependencyModel.Tests/TestLibraryFactory.cs
+++ b/test/Microsoft.Extensions.DependencyModel.Tests/TestLibraryFactory.cs
@@ -13,6 +13,7 @@ namespace Microsoft.Extensions.DependencyModel.Tests
         public static readonly Dependency[] DefaultDependencies = { };
         public static readonly bool DefaultServiceable = true;
         public static readonly string DefaultPath = "MyPackagePath";
+        public static readonly string DefaultHashPath = "MyPackageHashPath";
 
         public static readonly string DefaultAssembly = "My.Package.dll";
         public static readonly string SecondAssembly = "My.PackageEx.dll";
@@ -39,7 +40,8 @@ namespace Microsoft.Extensions.DependencyModel.Tests
             string[] assemblies = null,
             Dependency[] dependencies = null,
             bool? serviceable = null,
-            string path = null)
+            string path = null,
+            string hashPath = null)
         {
             return new CompilationLibrary(
                 libraryType ?? DefaultType,
@@ -49,7 +51,8 @@ namespace Microsoft.Extensions.DependencyModel.Tests
                 assemblies ?? DefaultAssemblies,
                 dependencies ?? DefaultDependencies,
                 serviceable ?? DefaultServiceable,
-                path ?? DefaultPath);
+                path ?? DefaultPath,
+                hashPath ?? DefaultHashPath);
         }
     }
 


### PR DESCRIPTION
Similar to my previous PR (https://github.com/dotnet/core-setup/pull/235), this adds the `"hashPath"` property to the .deps.json file. This allows the CLI to pass down the path to the hash file instead of [DotNetHost building it itself](https://github.com/dotnet/core-setup/blob/989f0ec1319529b337caf93a6a333bec1551a088/src/corehost/cli/deps_entry.cpp#L168-L175).

I have raised this issue to @gkhanna79 and folks over email and we have not yet come to a conclusion on this course correction, but I wanted to get this change ready just in case.

**Edit:** I have also make the .deps.json parser allow unknown extra properties in objects. This was behavior was supported in version 1.0.0 of DependencyModel, but regressed after some performance work (moving from `JObject` to `JsonTextReader`).

/cc @gkhanna79 @livarcocc @eerhardt @pakrym 
