### PR TITLE
[WIP - DO NOT MERGE] Enable producing Microsoft.NETCore.App 1.0.1 package

### DIFF
--- a/TestAssets/TestProjects/PortableApp/project.json
+++ b/TestAssets/TestProjects/PortableApp/project.json
@@ -9,7 +9,7 @@
       "dependencies": {
         "Microsoft.NETCore.App": {
           "type": "platform",
-          "version": "1.0.2-servicing-*"
+          "version": "1.0.1-servicing-*"
         },
         "Newtonsoft.Json": "9.0.1-beta1"
       }

--- a/TestAssets/TestProjects/PortableTestApp/project.json
+++ b/TestAssets/TestProjects/PortableTestApp/project.json
@@ -12,7 +12,7 @@
       "dependencies": {
         "Microsoft.NETCore.App": {
           "type": "platform",
-          "version": "1.0.2-servicing-*"
+          "version": "1.0.1-servicing-*"
         },
         "Newtonsoft.Json": "9.0.1-beta1",
         "xunit": "2.1.0",

--- a/TestAssets/TestProjects/StandaloneApp/project.json
+++ b/TestAssets/TestProjects/StandaloneApp/project.json
@@ -5,7 +5,7 @@
   "frameworks": {
     "netcoreapp1.0": {
       "dependencies": {
-        "Microsoft.NETCore.App": "1.0.2-servicing-*",
+        "Microsoft.NETCore.App": "1.0.1-servicing-*",
         "Newtonsoft.Json": "9.0.1-beta1"
       }
     }

--- a/TestAssets/TestProjects/StandaloneTestApp/project.json
+++ b/TestAssets/TestProjects/StandaloneTestApp/project.json
@@ -9,7 +9,7 @@
         "portable-net451+win8"
       ],
       "dependencies": {
-        "Microsoft.NETCore.App": "1.0.2-servicing-*",
+        "Microsoft.NETCore.App": "1.0.1-servicing-*",
         "Newtonsoft.Json": "9.0.1-beta1",
         "xunit": "2.1.0",
         "xunit.netcore.extensions": "1.0.0-prerelease-00206",

--- a/branchinfo.txt
+++ b/branchinfo.txt
@@ -3,13 +3,9 @@
 # Each line is expected to be in the format "[Name]=[Value]".
 #
 #
-# !!! WARNING !!! WARNING !!! WARNING !!! WARNING !!! WARNING !!! WARNING
-#       "master" branch temporarily produced 1.0.1 builds. The value here
-#       should be > 1.0.1
-#
 MAJOR_VERSION=1
 MINOR_VERSION=0
-PATCH_VERSION=2
+PATCH_VERSION=1
 RELEASE_SUFFIX=servicing
 CHANNEL=preview
 BRANCH_NAME=release/1.0.0

--- a/pkg/projects/Microsoft.NETCore.App/Microsoft.NETCore.App.pkgproj
+++ b/pkg/projects/Microsoft.NETCore.App/Microsoft.NETCore.App.pkgproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
 
   <PropertyGroup>
-    <Version>1.0.2</Version>
+    <Version>1.0.1</Version>
     <PackagePlatform>AnyCPU</PackagePlatform>
   </PropertyGroup>
 

--- a/pkg/projects/Microsoft.NETCore.App/project.json
+++ b/pkg/projects/Microsoft.NETCore.App/project.json
@@ -3,7 +3,7 @@
     "Microsoft.CodeAnalysis.CSharp": "1.3.0",
     "Microsoft.CodeAnalysis.VisualBasic": "1.3.0",
     "Microsoft.CSharp": "4.0.1",
-    "Microsoft.NETCore.Runtime.CoreCLR": "1.0.2",
+    "Microsoft.NETCore.Runtime.CoreCLR": "1.0.4",
     "Microsoft.VisualBasic": "10.0.1",
     "NETStandard.Library": "1.6.0",
     "System.Buffers": "4.0.0",


### PR DESCRIPTION
@weshaggard @ellismg @eerhardt @mellinoe PTAL

On Windows, post a build, I have confirmed that package name, zips and installation folder contain 1.0.1 as expected.

I have also observed that the host bundled in the SharedFX Bundle MSI is the same as in RTM Bundle MSI and thus, I didn't have to update any host versions.

CC @Petermarcu @leecow @schellap 

