### PR TITLE
Use latest packages and fix arm64 build

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -3,5 +3,22 @@
 REM Copyright (c) .NET Foundation and contributors. All rights reserved.
 REM Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+:Arg_Loop
+:: Since the native build requires some configuration information before msbuild is called, we have to do some manual args parsing
+if [%1] == [] goto :InvokeBuild
+if /i [%1] == [-TargetArch] if /i [%2] == [arm64] ( 
+    if not defined VS140COMNTOOLS (
+        echo Error: Visual Studio 2015 required  
+        echo        Please see https://github.com/dotnet/corefx/blob/master/Documentation/project-docs/developer-guide.md for build instructions.
+        exit /b 1
+    )
+    call "%VS140COMNTOOLS%\..\..\VC\vcvarsall.bat" x86_amd64
+    goto :InvokeBuild
+)
+
+shift
+goto :Arg_Loop
+
+:InvokeBuild
 powershell -NoProfile -NoLogo -Command "%~dp0build_projects\dotnet-host-build\build.ps1 %*; exit $LastExitCode;"
 if %errorlevel% neq 0 exit /b %errorlevel%

--- a/build_projects/shared-build-targets-utils/DependencyVersions.cs
+++ b/build_projects/shared-build-targets-utils/DependencyVersions.cs
@@ -9,7 +9,5 @@ namespace Microsoft.DotNet.Cli.Build
     {
         public static readonly string CoreCLRVersion = "1.1.0-beta-24509-04";
         public static readonly string JitVersion = "1.1.0-beta-24509-04";
-        public static readonly string CoreCLRVersion_Latest = "1.1.0-beta-24415-01";
-        public static readonly string JitVersion_Latest = "1.1.0-beta-24415-01";
     }
 }

--- a/build_projects/shared-build-targets-utils/Utils/SharedFrameworkPublisher.cs
+++ b/build_projects/shared-build-targets-utils/Utils/SharedFrameworkPublisher.cs
@@ -16,7 +16,7 @@ namespace Microsoft.DotNet.Cli.Build
     public class SharedFrameworkPublisher
     {
         public static string s_sharedFrameworkName = "Microsoft.NETCore.App";
-        
+
         private string _sharedFrameworkTemplateSourceRoot;
         private string _sharedFrameworkNugetVersion;
         private string _sharedFrameworkRid;
@@ -30,7 +30,7 @@ namespace Microsoft.DotNet.Cli.Build
         private string _corehostPackageSource;
 
         public SharedFrameworkPublisher(
-            string repoRoot, 
+            string repoRoot,
             string corehostLockedDirectory,
             string corehostLatestDirectory,
             string corehostPackageSource,
@@ -42,9 +42,7 @@ namespace Microsoft.DotNet.Cli.Build
             _corehostLockedDirectory = corehostLockedDirectory;
             _corehostLatestDirectory = corehostLatestDirectory;
             _corehostPackageSource = corehostPackageSource;
-            _crossgenUtil = (sharedFrameworkRid == "win10-arm64") ?
-                new Crossgen(DependencyVersions.CoreCLRVersion_Latest, DependencyVersions.JitVersion_Latest, sharedFrameworkRid) : 
-                new Crossgen(DependencyVersions.CoreCLRVersion, DependencyVersions.JitVersion); 
+            _crossgenUtil = new Crossgen(DependencyVersions.CoreCLRVersion, DependencyVersions.JitVersion, sharedFrameworkRid == "win10-arm64" ? sharedFrameworkRid : null);
 
             _sharedFrameworkTemplateSourceRoot = Path.Combine(repoRoot, "src", "sharedframework", "framework");
             _sharedFrameworkNugetVersion = sharedFrameworkNugetVersion;
@@ -53,8 +51,8 @@ namespace Microsoft.DotNet.Cli.Build
             _sharedFrameworkTarget = sharedFrameworkTarget;
 
             _sharedFrameworkSourceRoot = GenerateSharedFrameworkProject(
-                _sharedFrameworkNugetVersion, 
-                _sharedFrameworkTemplateSourceRoot, 
+                _sharedFrameworkNugetVersion,
+                _sharedFrameworkTemplateSourceRoot,
                 _sharedFrameworkRid,
                 _sharedFrameworkTarget);
         }
@@ -114,7 +112,7 @@ namespace Microsoft.DotNet.Cli.Build
 
             // Clean up artifacts that dotnet-publish generates which we don't need
             PublishMutationUtilties.CleanPublishOutput(
-                sharedFrameworkNameAndVersionRoot, 
+                sharedFrameworkNameAndVersionRoot,
                 "framework",
                 deleteRuntimeConfigJson: true,
                 deleteDepsJson: false);
@@ -128,7 +126,7 @@ namespace Microsoft.DotNet.Cli.Build
             GenerateRuntimeGraph(dotnetCli, destinationDeps);
 
             CopyHostArtifactsToSharedFramework(sharedFrameworkNameAndVersionRoot, hostFxrVersion);
-            
+
             _crossgenUtil.CrossgenDirectory(sharedFrameworkNameAndVersionRoot, sharedFrameworkNameAndVersionRoot);
 
             // Generate .version file for sharedfx
@@ -196,7 +194,7 @@ namespace Microsoft.DotNet.Cli.Build
 
         private string GenerateSharedFrameworkProject(
             string sharedFrameworkNugetVersion,
-            string sharedFrameworkTemplatePath, 
+            string sharedFrameworkTemplatePath,
             string rid,
             string targetFramework)
         {


### PR DESCRIPTION
Fixes the arm64 build by adding a vcvarsall.bat call to set the path variables we need. Also updates the package versions to the latest from coreclr and corefx.

@dagood @gkhanna79 