### PR TITLE
Add rid-moniker mappings for openSUSE 42.1 and Ubuntu 16.10

### DIFF
--- a/build_projects/shared-build-targets-utils/Utils/Monikers.cs
+++ b/build_projects/shared-build-targets-utils/Utils/Monikers.cs
@@ -19,7 +19,7 @@ namespace Microsoft.DotNet.Cli.Build
         {
             string rid = Environment.GetEnvironmentVariable("TARGETRID") ?? RuntimeEnvironment.GetRuntimeIdentifier();
 
-            if (rid == "ubuntu.16.04-x64" || rid == "fedora.23-x64" || rid == "opensuse.13.2-x64")
+            if (rid == "ubuntu.16.04-x64" || rid == "ubuntu.16.10-x64" || rid == "fedora.23-x64" || rid == "opensuse.13.2-x64" || rid == "opensuse.42.1-x64")
             {
                 return $"{artifactPrefix}-{rid}.{version}";
             }
@@ -37,10 +37,14 @@ namespace Microsoft.DotNet.Cli.Build
             {
                 case "ubuntu.16.04-x64":
                      return "Ubuntu_16_04_x64";
+                case "ubuntu.16.10-x64":
+                     return "Ubuntu_16_10_x64";
                 case "fedora.23-x64":
                      return "Fedora_23_x64";
                 case "opensuse.13.2-x64":
                      return "openSUSE_13_2_x64";
+                case "opensuse.42.1-x64":
+                     return "openSUSE_42_1_x64";
             }
 
             return $"{CurrentPlatform.Current}_{CurrentArchitecture.Current}";


### PR DESCRIPTION
I've missed a couple of places that need special handling for the new RIDs. The official builds failed because there wasn't an appropriate mapping for the new RIDs in this code here. Technically I had added it to the list that the build fails and complains about, but there is an additional mapping that is used to go from the actual RID to the key used in the other list (the "badge moniker").

cc: @brthor 