### PR TITLE
Increase timeout for acquiring lease from 1 to 5 minutes

### DIFF
--- a/build_projects/shared-build-targets-utils/Publishing/AzurePublisher.cs
+++ b/build_projects/shared-build-targets-utils/Publishing/AzurePublisher.cs
@@ -123,7 +123,7 @@ namespace Microsoft.DotNet.Cli.Build
                 try
                 {
                     CloudBlockBlob cloudBlob = _blobContainer.GetBlockBlobReference(blob);
-                    System.Threading.Tasks.Task<string> task = cloudBlob.AcquireLeaseAsync(TimeSpan.FromMinutes(1), null);
+                    System.Threading.Tasks.Task<string> task = cloudBlob.AcquireLeaseAsync(TimeSpan.FromMinutes(5), null);
                     task.Wait();
                     return task.Result;
                 }


### PR DESCRIPTION
This should solve the 'lease expired' issue in the Windows signing jobs.