### PR TITLE
In 1.1.0, change 1.0.1 to 1.1.0 for PlatformAbstractions and DependencyModel

### DIFF
--- a/src/Microsoft.DotNet.PlatformAbstractions/project.json
+++ b/src/Microsoft.DotNet.PlatformAbstractions/project.json
@@ -1,6 +1,6 @@
 {
   "description": "Abstractions for making code that uses file system and environment testable.",
-  "version": "1.0.1-beta-*",
+  "version": "1.1.0-preview1-*",
   "buildOptions": {
     "warningsAsErrors": true,
     "keyFile": "../../tools/Key.snk",

--- a/src/Microsoft.Extensions.DependencyModel/project.json
+++ b/src/Microsoft.Extensions.DependencyModel/project.json
@@ -1,6 +1,6 @@
 {
   "description": "Abstractions for reading `.deps` files.",
-  "version": "1.0.1-beta-*",
+  "version": "1.1.0-preview1-*",
   "buildOptions": {
     "warningsAsErrors": true,
     "keyFile": "../../tools/Key.snk"


### PR DESCRIPTION
This was colliding with builds in `master`, causing build failures. Plus, these packages are really 1.1.0.

@wtgodbe @gkhanna79 @chcosta @brthor