### PR TITLE
Port pull request #316 from master to release/1.1.0

### DIFF
--- a/src/Microsoft.Extensions.DependencyModel/DependencyContextWriter.cs
+++ b/src/Microsoft.Extensions.DependencyModel/DependencyContextWriter.cs
@@ -117,9 +117,7 @@ namespace Microsoft.Extensions.DependencyModel
         {
             return new JObject(
                 libraries.Select(library =>
-                    // TODO: remove the hack of calling "ToLowerInvariant()" on library Name and Version once
-                    // https://github.com/dotnet/core-setup/pull/64/ is merged and taken into the CLI
-                    new JProperty(library.Name.ToLowerInvariant() + DependencyContextStrings.VersionSeperator + library.Version.ToLowerInvariant(), WriteTargetLibrary(library))));
+                    new JProperty(library.Name + DependencyContextStrings.VersionSeperator + library.Version, WriteTargetLibrary(library))));
         }
 
         private JObject WritePortableTarget(IReadOnlyList<RuntimeLibrary> runtimeLibraries, IReadOnlyList<CompilationLibrary> compilationLibraries)
@@ -149,9 +147,7 @@ namespace Microsoft.Extensions.DependencyModel
 
                 var library = (Library)compilationLibrary ?? (Library)runtimeLibrary;
                 targetObject.Add(
-                    // TODO: remove the hack of calling "ToLowerInvariant()" on library Name and Version once
-                    // https://github.com/dotnet/core-setup/pull/64/ is merged and taken into the CLI
-                    new JProperty(library.Name.ToLowerInvariant() + DependencyContextStrings.VersionSeperator + library.Version.ToLowerInvariant(),
+                    new JProperty(library.Name + DependencyContextStrings.VersionSeperator + library.Version,
                         WritePortableTargetLibrary(runtimeLibrary, compilationLibrary)
                         )
                     );
@@ -319,9 +315,7 @@ namespace Microsoft.Extensions.DependencyModel
         {
             var allLibraries =
                 context.RuntimeLibraries.Cast<Library>().Concat(context.CompileLibraries)
-                    // TODO: remove the hack of calling "ToLowerInvariant()" on library Name and Version once
-                    // https://github.com/dotnet/core-setup/pull/64/ is merged and taken into the CLI
-                    .GroupBy(library => library.Name.ToLowerInvariant() + DependencyContextStrings.VersionSeperator + library.Version.ToLowerInvariant());
+                    .GroupBy(library => library.Name + DependencyContextStrings.VersionSeperator + library.Version);
 
             return new JObject(allLibraries.Select(libraries => new JProperty(libraries.Key, WriteLibrary(libraries.First()))));
         }

--- a/test/Microsoft.Extensions.DependencyModel.Tests/DependencyContextJsonWriterTests.cs
+++ b/test/Microsoft.Extensions.DependencyModel.Tests/DependencyContextJsonWriterTests.cs
@@ -1,12 +1,9 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.IO;
-using System.Linq;
-using System.Threading.Tasks;
+using FluentAssertions;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using Xunit;
-using FluentAssertions;
 
 namespace Microsoft.Extensions.DependencyModel.Tests
 {
@@ -133,7 +130,7 @@ namespace Microsoft.Extensions.DependencyModel.Tests
             // targets
             var targets = result.Should().HavePropertyAsObject("targets").Subject;
             var target = targets.Should().HavePropertyAsObject("Target").Subject;
-            var library = target.Should().HavePropertyAsObject("packagename/1.2.3").Subject;
+            var library = target.Should().HavePropertyAsObject("PackageName/1.2.3").Subject;
             var dependencies = library.Should().HavePropertyAsObject("dependencies").Subject;
             dependencies.Should().HavePropertyValue("Fruits.Abstract.dll", "2.0.0");
             library.Should().HavePropertyAsObject("compile")
@@ -141,7 +138,7 @@ namespace Microsoft.Extensions.DependencyModel.Tests
 
             //libraries
             var libraries = result.Should().HavePropertyAsObject("libraries").Subject;
-            library = libraries.Should().HavePropertyAsObject("packagename/1.2.3").Subject;
+            library = libraries.Should().HavePropertyAsObject("PackageName/1.2.3").Subject;
             library.Should().HavePropertyValue("sha512", "HASH");
             library.Should().HavePropertyValue("type", "package");
             library.Should().HavePropertyValue("serviceable", true);
@@ -176,7 +173,7 @@ namespace Microsoft.Extensions.DependencyModel.Tests
             // targets
             var targets = result.Should().HavePropertyAsObject("targets").Subject;
             var target = targets.Should().HavePropertyAsObject("Target").Subject;
-            var library = target.Should().HavePropertyAsObject("packagename/1.2.3").Subject;
+            var library = target.Should().HavePropertyAsObject("PackageName/1.2.3").Subject;
             var dependencies = library.Should().HavePropertyAsObject("dependencies").Subject;
             dependencies.Should().HavePropertyValue("Fruits.Abstract.dll", "2.0.0");
             library.Should().HavePropertyAsObject("compile")
@@ -184,7 +181,7 @@ namespace Microsoft.Extensions.DependencyModel.Tests
 
             //libraries
             var libraries = result.Should().HavePropertyAsObject("libraries").Subject;
-            library = libraries.Should().HavePropertyAsObject("packagename/1.2.3").Subject;
+            library = libraries.Should().HavePropertyAsObject("PackageName/1.2.3").Subject;
             library.Should().HavePropertyValue("sha512", "HASH");
             library.Should().HavePropertyValue("type", "package");
             library.Should().HavePropertyValue("serviceable", true);
@@ -227,7 +224,7 @@ namespace Microsoft.Extensions.DependencyModel.Tests
             // targets
             var targets = result.Should().HavePropertyAsObject("targets").Subject;
             var target = targets.Should().HavePropertyAsObject("Target").Subject;
-            var library = target.Should().HavePropertyAsObject("packagename/1.2.3").Subject;
+            var library = target.Should().HavePropertyAsObject("PackageName/1.2.3").Subject;
             var dependencies = library.Should().HavePropertyAsObject("dependencies").Subject;
             dependencies.Should().HavePropertyValue("Fruits.Abstract.dll", "2.0.0");
 
@@ -252,7 +249,7 @@ namespace Microsoft.Extensions.DependencyModel.Tests
 
             //libraries
             var libraries = result.Should().HavePropertyAsObject("libraries").Subject;
-            library = libraries.Should().HavePropertyAsObject("packagename/1.2.3").Subject;
+            library = libraries.Should().HavePropertyAsObject("PackageName/1.2.3").Subject;
             library.Should().HavePropertyValue("sha512", "HASH");
             library.Should().HavePropertyValue("type", "package");
             library.Should().HavePropertyValue("serviceable", true);
@@ -311,7 +308,7 @@ namespace Microsoft.Extensions.DependencyModel.Tests
             // targets
             var targets = result.Should().HavePropertyAsObject("targets").Subject;
             var target = targets.Should().HavePropertyAsObject("Target").Subject;
-            var library = target.Should().HavePropertyAsObject("packagename/1.2.3").Subject;
+            var library = target.Should().HavePropertyAsObject("PackageName/1.2.3").Subject;
             var dependencies = library.Should().HavePropertyAsObject("dependencies").Subject;
             dependencies.Should().HavePropertyValue("Fruits.Abstract.dll", "2.0.0");
 
@@ -335,7 +332,7 @@ namespace Microsoft.Extensions.DependencyModel.Tests
 
             //libraries
             var libraries = result.Should().HavePropertyAsObject("libraries").Subject;
-            library = libraries.Should().HavePropertyAsObject("packagename/1.2.3").Subject;
+            library = libraries.Should().HavePropertyAsObject("PackageName/1.2.3").Subject;
             library.Should().HavePropertyValue("sha512", "HASH");
             library.Should().HavePropertyValue("type", "package");
             library.Should().HavePropertyValue("serviceable", true);
@@ -376,7 +373,7 @@ namespace Microsoft.Extensions.DependencyModel.Tests
             // targets
             var targets = result.Should().HavePropertyAsObject("targets").Subject;
             var target = targets.Should().HavePropertyAsObject("Target/runtime").Subject;
-            var library = target.Should().HavePropertyAsObject("packagename/1.2.3").Subject;
+            var library = target.Should().HavePropertyAsObject("PackageName/1.2.3").Subject;
             var dependencies = library.Should().HavePropertyAsObject("dependencies").Subject;
             dependencies.Should().HavePropertyValue("Fruits.Abstract.dll", "2.0.0");
             library.Should().HavePropertyAsObject("runtime")
@@ -386,7 +383,7 @@ namespace Microsoft.Extensions.DependencyModel.Tests
 
             //libraries
             var libraries = result.Should().HavePropertyAsObject("libraries").Subject;
-            library = libraries.Should().HavePropertyAsObject("packagename/1.2.3").Subject;
+            library = libraries.Should().HavePropertyAsObject("PackageName/1.2.3").Subject;
             library.Should().HavePropertyValue("sha512", "HASH");
             library.Should().HavePropertyValue("type", "package");
             library.Should().HavePropertyValue("serviceable", true);
@@ -427,7 +424,7 @@ namespace Microsoft.Extensions.DependencyModel.Tests
             // targets
             var targets = result.Should().HavePropertyAsObject("targets").Subject;
             var target = targets.Should().HavePropertyAsObject("Target").Subject;
-            var library = target.Should().HavePropertyAsObject("packagename/1.2.3").Subject;
+            var library = target.Should().HavePropertyAsObject("PackageName/1.2.3").Subject;
 
             var runtimeTargets = library.Should().HavePropertyAsObject("runtimeTargets").Subject;
 
@@ -477,7 +474,7 @@ namespace Microsoft.Extensions.DependencyModel.Tests
 
             var targets = result.Should().HavePropertyAsObject("targets").Subject;
             var target = targets.Should().HavePropertyAsObject("Target/runtime").Subject;
-            var library = target.Should().HavePropertyAsObject("packagename/1.2.3").Subject;
+            var library = target.Should().HavePropertyAsObject("PackageName/1.2.3").Subject;
             var resources = library.Should().HavePropertyAsObject("resources").Subject;
             var resource = resources.Should().HavePropertyAsObject("en-US/Fruits.resources.dll").Subject;
             resource.Should().HavePropertyValue("locale", "en-US");
@@ -513,7 +510,7 @@ namespace Microsoft.Extensions.DependencyModel.Tests
 
             var targets = result.Should().HavePropertyAsObject("targets").Subject;
             var target = targets.Should().HavePropertyAsObject("Target").Subject;
-            var library = target.Should().HavePropertyAsObject("packagename/1.2.3").Subject;
+            var library = target.Should().HavePropertyAsObject("PackageName/1.2.3").Subject;
             var resources = library.Should().HavePropertyAsObject("resources").Subject;
             var resource = resources.Should().HavePropertyAsObject("en-US/Fruits.resources.dll").Subject;
             resource.Should().HavePropertyValue("locale", "en-US");
@@ -547,7 +544,7 @@ namespace Microsoft.Extensions.DependencyModel.Tests
             // targets
             var targets = result.Should().HavePropertyAsObject("targets").Subject;
             var target = targets.Should().HavePropertyAsObject("Target").Subject;
-            var library = target.Should().HavePropertyAsObject("packagename/1.2.3").Subject;
+            var library = target.Should().HavePropertyAsObject("PackageName/1.2.3").Subject;
             library.Should().HavePropertyValue("compileOnly", true);
         }
 


### PR DESCRIPTION
PR https://github.com/dotnet/core-setup/pull/316 reverts a hack made in DependencyModel which always lowercases library ID an version strings in the .deps.json file. This was a temporary workaround so that newer NuGet builds could be used before the down-stream components (e.g. DotNetHost) knew about the lowercase package paths. Now that DotNetHost, DependencyModel, and CLI know about the lowercase paths (by means of the `"path"` and `"hashPath"` properties), we can revert this hack.

This PR cherry picks the commit produced by PR https://github.com/dotnet/core-setup/pull/316 (commit 9f47a2ee769dd9e152839839ddb1eb11458eb5da)

Tested by manually changing the .deps.json to have original case library name and versions and running `dotnet foo.dll` on `dotnet build` output and `dotnet publish` output on a Linux machine.

Example .deps.json file:

<pre>
{
  ...
  "targets": {
      ...
      <b>"Newtonsoft.Json/9.0.1"</b>: {
        "dependencies": {
          "System.Runtime.Serialization.Primitives": "4.1.1"
        },
        "runtime": {
          "lib/netstandard1.0/Newtonsoft.Json.dll": {}
        }
      },
      ...
  },
  "libraries": {
     ...
    <b>"Newtonsoft.Json/9.0.1"</b>: {
      "type": "package",
      "serviceable": true,
      "sha512": "sha512-U82mHQSKaIk+lpSVCbWYKNavmNH1i5xrExDEquU1i6I5pV6UMOqRnJRSlKO3cMPfcpp0RgDY+8jUXHdQ4IfXvw==",
      "path": "newtonsoft.json/9.0.1",
      "hashPath": "newtonsoft.json.9.0.1.nupkg.sha512"
    }
    ...
  }
}
</pre>

/cc @eerhardt @gkhanna79 