### PR TITLE
Disable parallel restore to avoid restore timeout failure (master)

### DIFF
--- a/build_projects/dotnet-host-build/TestTargets.cs
+++ b/build_projects/dotnet-host-build/TestTargets.cs
@@ -36,7 +36,8 @@ namespace Microsoft.DotNet.Host.Build
 
             dotnet.Restore(
                     "--fallbacksource", Dirs.CorehostLocalPackages,
-                    "--fallbacksource", Dirs.CorehostDummyPackages)
+                    "--fallbacksource", Dirs.CorehostDummyPackages,
+                    "--disable-parallel")
                 .WorkingDirectory(Path.Combine(Dirs.RepoRoot, "TestAssets"))
                 .Execute()
                 .EnsureSuccessful();
@@ -50,7 +51,7 @@ namespace Microsoft.DotNet.Host.Build
             var dotnet = DotNetCli.Stage0;
             CleanBinObj(c, Path.Combine(Dirs.RepoRoot, "test"));
 
-            dotnet.Restore()
+            dotnet.Restore("--disable-parallel")
                 .WorkingDirectory(Path.Combine(Dirs.RepoRoot, "test"))
                 .Execute()
                 .EnsureSuccessful();

--- a/build_projects/shared-build-targets-utils/Utils/DebPackageCreator.cs
+++ b/build_projects/shared-build-targets-utils/Utils/DebPackageCreator.cs
@@ -153,8 +153,8 @@ namespace Microsoft.DotNet.Cli.Build
             File.WriteAllText(projectJsonFile, GetDotnetDebProjectJsonContents());
 
             Command restore = _dotnetDebToolPackageSource == null 
-                ? _dotnet.Restore()
-                : _dotnet.Restore("-f", $"{_dotnetDebToolPackageSource}");
+                ? _dotnet.Restore("--disable-parallel")
+                : _dotnet.Restore("-f", $"{_dotnetDebToolPackageSource}", "--disable-parallel");
 
             restore
                 .WorkingDirectory(Path.GetDirectoryName(projectJsonFile))

--- a/pkg/init-tools.sh
+++ b/pkg/init-tools.sh
@@ -15,6 +15,9 @@ __PROJECT_JSON_FILE=$__PROJECT_JSON_PATH/project.json
 __PROJECT_JSON_CONTENTS="{ \"dependencies\": { \"Microsoft.DotNet.BuildTools\": \"$__BUILD_TOOLS_PACKAGE_VERSION\" }, \"frameworks\": { \"netcoreapp1.0\": { } } }"
 __INIT_TOOLS_DONE_MARKER=$__PROJECT_JSON_PATH/done
 
+# On xplat, limit HTTP parallelism to avoid restore timeouts.
+export __INIT_TOOLS_RESTORE_ARGS="--disable-parallel"
+
 # Extended version of platform detection logic from dotnet/cli/scripts/obtain/dotnet-install.sh 16692fc
 get_current_linux_name() {
     # Detect Distro
@@ -111,8 +114,8 @@ if [ ! -e $__INIT_TOOLS_DONE_MARKER ]; then
 
     if [ ! -e $__BUILD_TOOLS_PATH ]; then
         echo "Restoring BuildTools version $__BUILD_TOOLS_PACKAGE_VERSION..."
-        echo "Running: $__DOTNET_CMD restore \"$__PROJECT_JSON_FILE\" --no-cache --packages $__PACKAGES_DIR --source $__BUILDTOOLS_SOURCE" >> $__init_tools_log
-        $__DOTNET_CMD restore "$__PROJECT_JSON_FILE" --no-cache --packages $__PACKAGES_DIR --source $__BUILDTOOLS_SOURCE >> $__init_tools_log
+        echo "Running: $__DOTNET_CMD restore \"$__PROJECT_JSON_FILE\" --no-cache --packages $__PACKAGES_DIR --source $__BUILDTOOLS_SOURCE" --disable-parallel >> $__init_tools_log
+        $__DOTNET_CMD restore "$__PROJECT_JSON_FILE" --no-cache --packages $__PACKAGES_DIR --source $__BUILDTOOLS_SOURCE --disable-parallel >> $__init_tools_log
         if [ ! -e "$__BUILD_TOOLS_PATH/init-tools.sh" ]; then echo "ERROR: Could not restore build tools correctly. See '$__init_tools_log' for more details."1>&2; fi
     fi
 

--- a/pkg/pack.sh
+++ b/pkg/pack.sh
@@ -30,7 +30,7 @@ __distro_rid=
 
 # acquire dependencies
 pushd "$__project_dir/deps"
-"$__project_dir/Tools/dotnetcli/dotnet" restore --source "https://dotnet.myget.org/F/dotnet-core/api/v3/index.json" --packages "$__project_dir/packages"
+"$__project_dir/Tools/dotnetcli/dotnet" restore --source "https://dotnet.myget.org/F/dotnet-core/api/v3/index.json" --disable-parallel --packages "$__project_dir/packages"
 popd
 
 # cleanup existing packages

--- a/test/TestUtils/TestProjectFixture.cs
+++ b/test/TestUtils/TestProjectFixture.cs
@@ -270,6 +270,7 @@ namespace Microsoft.DotNet.CoreSetup.Test
                 restoreArgs.Add("-f");
                 restoreArgs.Add(fallbackSource);
             }
+            restoreArgs.Add("--disable-parallel");
 
             _sdkDotnet.Restore(restoreArgs.ToArray())
                 .WorkingDirectory(_testProject.ProjectDirectory)


### PR DESCRIPTION
In the new version of CLI, `--disable-parallel` includes limiting parallel http requests. Docker container builds sometimes hit restore errors when there are too many parallel requests.

Addresses https://github.com/dotnet/core-setup/issues/327 for master.

Ports https://github.com/dotnet/core-setup/pull/323 from release/1.1.0.

@gkhanna79 @wtgodbe @chcosta @mellinoe