### PR TITLE
Add the Microsoft.DiaSymReader.Native to Microsoft.NETCore.App.

### DIFF
--- a/pkg/projects/Microsoft.NETCore.App/project.json
+++ b/pkg/projects/Microsoft.NETCore.App/project.json
@@ -39,6 +39,7 @@
     "System.Threading.Tasks.Parallel": "4.0.1",
     "System.Threading.Thread": "4.0.0",
     "System.Threading.ThreadPool": "4.0.10",
+    "Microsoft.DiaSymReader.Native": "1.4.0-rc2",
     "Libuv": "1.9.0"
   },
   "frameworks": {

--- a/pkg/projects/Microsoft.NETCore.App/project.json
+++ b/pkg/projects/Microsoft.NETCore.App/project.json
@@ -39,7 +39,7 @@
     "System.Threading.Tasks.Parallel": "4.0.1",
     "System.Threading.Thread": "4.0.0",
     "System.Threading.ThreadPool": "4.0.10",
-    "Microsoft.DiaSymReader.Native": "1.4.0-rc2",
+    "Microsoft.DiaSymReader.Native": "1.4.0",
     "Libuv": "1.9.0"
   },
   "frameworks": {


### PR DESCRIPTION
This is to remove the dependency on diasymreader.dll being registered
as part of the full .NET desktop install.

Issue: https://github.com/dotnet/coreclr/issues/5922