### PR TITLE
Disable parallel during build script restore

### DIFF
--- a/build_projects/dotnet-host-build/build.sh
+++ b/build_projects/dotnet-host-build/build.sh
@@ -114,7 +114,7 @@ export DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1
 echo "Restoring Build Script projects..."
 (
     cd "$DIR/.."
-    dotnet restore --infer-runtimes
+    dotnet restore --infer-runtimes --disable-parallel
 )
 
 # Build the builder


### PR DESCRIPTION
Applies `--disable-parallel` when restoring build script packages, fixing https://github.com/dotnet/core-setup/pull/330. I missed this instance earlier when I was rebasing the fix onto latest.

@gkhanna79 @wtgodbe