### PR TITLE
Add creation of /etc/paths.d to host postinstall

### DIFF
--- a/packaging/osx/sharedhost/scripts/postinstall
+++ b/packaging/osx/sharedhost/scripts/postinstall
@@ -11,6 +11,8 @@ INSTALL_DESTINATION=$2
 chmod 755 $INSTALL_DESTINATION/dotnet
 
 # Add the installation directory to the system-wide paths
+# But first create the directory if it doesn't exist
+mkdir -p /etc/paths.d
 echo $INSTALL_DESTINATION | tee /etc/paths.d/dotnet
 
 exit 0


### PR DESCRIPTION
This will make sure that the host is on the path regardless of whether
the version of macOS creates the path by default or not.

Fixes #361, dotnet/cli#4225

/cc @brthor @mellinoe @livarcocc @leecow @richlander 