### PR TITLE
Publish the sharedframework for netcoreapp1.1

### DIFF
--- a/build_projects/dotnet-host-build/PrepareTargets.cs
+++ b/build_projects/dotnet-host-build/PrepareTargets.cs
@@ -52,7 +52,7 @@ namespace Microsoft.DotNet.Host.Build
                     targetRID = $"win7-{RuntimeEnvironment.RuntimeArchitecture}";
                 }
             }
-            string targetFramework = Environment.GetEnvironmentVariable("TARGETFRAMEWORK") ?? "netcoreapp1.0";
+            string targetFramework = Environment.GetEnvironmentVariable("TARGETFRAMEWORK") ?? "netcoreapp1.1";
 
             if (string.IsNullOrEmpty(configEnv))
             {

--- a/build_projects/dotnet-host-build/build.ps1
+++ b/build_projects/dotnet-host-build/build.ps1
@@ -8,7 +8,7 @@ param(
     [string]$Architecture="x64",
     [string]$TargetArch="",
     [string]$ToolsetDir="",
-    [string]$Framework="netcoreapp1.0",
+    [string]$Framework="netcoreapp1.1",
     [string[]]$Targets=@("Default"),
     [string[]]$EnvVars=@(),
     [switch]$NoPackage,


### PR DESCRIPTION
Right now, we're referencing the new Microsoft.NETCore.App package, but still publishing it for `netcoreapp1.0`. We should publish it for `netcoreapp1.1` by default.

@gkhanna79 , @brthor 