### PR TITLE
Update badge generation to be based on TargetArch

### DIFF
--- a/build_projects/dotnet-host-build/PublishTargets.cs
+++ b/build_projects/dotnet-host-build/PublishTargets.cs
@@ -115,6 +115,7 @@ namespace Microsoft.DotNet.Host.Build
                     {
                         "win.x86.version",
                         "win.x64.version",
+                        "win.arm64.version",
                         "ubuntu.x64.version",
                         "ubuntu.16.04.x64.version",
                         "ubuntu.16.10.x64.version",
@@ -179,6 +180,7 @@ namespace Microsoft.DotNet.Host.Build
              {
                  { "sharedfx_Windows_x86", false },
                  { "sharedfx_Windows_x64", false },
+                 { "sharedfx_Windows_arm64", false },
                  { "sharedfx_Ubuntu_x64", false },
                  { "sharedfx_Ubuntu_16_04_x64", false },
                  { "sharedfx_Ubuntu_16_10_x64", false },

--- a/build_projects/shared-build-targets-utils/Utils/Monikers.cs
+++ b/build_projects/shared-build-targets-utils/Utils/Monikers.cs
@@ -47,7 +47,7 @@ namespace Microsoft.DotNet.Cli.Build
                      return "openSUSE_42_1_x64";
             }
 
-            return $"{CurrentPlatform.Current}_{CurrentArchitecture.Current}";
+            return $"{CurrentPlatform.Current}_{Environment.GetEnvironmentVariable("TARGETPLATFORM") ?? CurrentArchitecture.Current.ToString()}";
         }
 
         public static string GetDebianHostFxrPackageName(string hostfxrNugetVersion)


### PR DESCRIPTION
It's currently based on current architecture, so we're seeing a win10-arm64 package being created with a x64 badge, making the finalize step think that x64 has been built correctly already. This resulted in the x64 build being ignored repeatedly while the arm64 build was publishing correctly.

@gkhanna79 @dagood

should resolve https://github.com/dotnet/core-setup/issues/378 for master.