### PR TITLE
Fix release/1.0.0 auto-update: remove -Channel to fix dotnet-install CLI url

### DIFF
--- a/build_projects/update-dependencies/update-dependencies.ps1
+++ b/build_projects/update-dependencies/update-dependencies.ps1
@@ -42,7 +42,7 @@ if (!(Test-Path "$RepoRoot\artifacts"))
 $DOTNET_INSTALL_SCRIPT_URL="https://raw.githubusercontent.com/dotnet/cli/rel/1.0.0/scripts/obtain/dotnet-install.ps1"
 Invoke-WebRequest $DOTNET_INSTALL_SCRIPT_URL -OutFile "$RepoRoot\artifacts\dotnet-install.ps1"
 
-& "$RepoRoot\artifacts\dotnet-install.ps1" -Channel preview -Architecture $Architecture -Verbose
+& "$RepoRoot\artifacts\dotnet-install.ps1" -Architecture $Architecture -Verbose
 if($LASTEXITCODE -ne 0) { throw "Failed to install stage0" }
 
 # Put the stage0 on the path

--- a/pkg/pack.cmd
+++ b/pkg/pack.cmd
@@ -8,7 +8,7 @@ call "%__ProjectDir%\init-tools.cmd"
 
 :: Restore dependencies mainly to obtain runtime.json
 pushd "%__ProjectDir%\deps"
-"%__ProjectDir%\Tools\dotnetcli\dotnet.exe" restore --source "https://dotnet.myget.org/F/dotnet-core" --packages "%__ProjectDir%\packages"
+"%__ProjectDir%\Tools\dotnetcli\dotnet.exe" restore --source "https://dotnet.myget.org/F/dotnet-core/api/v3/index.json" --packages "%__ProjectDir%\packages"
 popd
 
 :: Clean up existing nupkgs

--- a/pkg/pack.sh
+++ b/pkg/pack.sh
@@ -30,7 +30,7 @@ __distro_rid=
 
 # acquire dependencies
 pushd "$__project_dir/deps"
-"$__project_dir/Tools/dotnetcli/dotnet" restore --source "https://dotnet.myget.org/F/dotnet-core" --packages "$__project_dir/packages"
+"$__project_dir/Tools/dotnetcli/dotnet" restore --source "https://dotnet.myget.org/F/dotnet-core/api/v3/index.json" --packages "$__project_dir/packages"
 popd
 
 # cleanup existing packages


### PR DESCRIPTION
The `-Channel preview` argument was causing dotnet-install to guess the wrong URL to install a working CLI, resulting in a 404.

This is the fix that was implemented to enable auto-update on `release/1.1.0`, and `master` will need this problem fixed too.

@gkhanna79