### PR TITLE
Updating CoreClr to servicing-24601-01

### DIFF
--- a/build_projects/dotnet-host-build/project.json
+++ b/build_projects/dotnet-host-build/project.json
@@ -6,7 +6,7 @@
   },
   "dependencies": {
     "NETStandard.Library": "1.6.0",
-    "Microsoft.NETCore.Runtime.CoreCLR": "1.0.2",
+    "Microsoft.NETCore.Runtime.CoreCLR": "1.0.5-servicing-24601-01",
     "Microsoft.CSharp": "4.0.1",
     "System.Dynamic.Runtime": "4.0.11",
     "System.Reflection.Metadata": "1.3.0",

--- a/build_projects/shared-build-targets-utils/DependencyVersions.cs
+++ b/build_projects/shared-build-targets-utils/DependencyVersions.cs
@@ -7,7 +7,7 @@ namespace Microsoft.DotNet.Cli.Build
 {
     public class DependencyVersions
     {
-        public static readonly string CoreCLRVersion = "1.0.5-servicing-24530-02";
-        public static readonly string JitVersion = "1.0.5-servicing-24530-02";
+        public static readonly string CoreCLRVersion = "1.0.5-servicing-24601-01";
+        public static readonly string JitVersion = "1.0.5-servicing-24601-01";
     }
 }

--- a/build_projects/update-dependencies/project.json
+++ b/build_projects/update-dependencies/project.json
@@ -7,7 +7,7 @@
   "dependencies": {
     "NETStandard.Library": "1.6.0",
     "Microsoft.CSharp": "4.0.1",
-    "Microsoft.NETCore.Runtime.CoreCLR": "1.0.2",
+    "Microsoft.NETCore.Runtime.CoreCLR": "1.0.5-servicing-24601-01",
     "System.Runtime.Serialization.Primitives": "4.1.1",
     "Microsoft.DotNet.Cli.Build.Framework": {
       "target": "project"

--- a/pkg/projects/Microsoft.NETCore.App/project.json
+++ b/pkg/projects/Microsoft.NETCore.App/project.json
@@ -3,7 +3,7 @@
     "Microsoft.CodeAnalysis.CSharp": "1.3.0",
     "Microsoft.CodeAnalysis.VisualBasic": "1.3.0",
     "Microsoft.CSharp": "4.0.1",
-    "Microsoft.NETCore.Runtime.CoreCLR": "1.0.5-servicing-24530-02",
+    "Microsoft.NETCore.Runtime.CoreCLR": "1.0.5-servicing-24601-01",
     "Microsoft.VisualBasic": "10.0.1",
     "NETStandard.Library": "1.6.0",
     "System.Buffers": "4.0.0",

--- a/pkg/projects/Microsoft.NETCore.UniversalWindowsPlatform/project.json
+++ b/pkg/projects/Microsoft.NETCore.UniversalWindowsPlatform/project.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
     "Microsoft.NETCore.Portable.Compatibility": "1.0.2",
-    "Microsoft.NETCore.Runtime.CoreCLR": "1.0.3",
+    "Microsoft.NETCore.Runtime.CoreCLR": "1.0.5-servicing-24601-01",
     "Microsoft.NETCore.Targets": "1.0.2",
     "Microsoft.Win32.Primitives": "4.0.1",
     "System.ComponentModel.EventBasedAsync": "4.0.11",

--- a/tools/independent/RuntimeGraphGenerator/project.json
+++ b/tools/independent/RuntimeGraphGenerator/project.json
@@ -11,7 +11,7 @@
     "Microsoft.DotNet.ProjectModel": "1.0.0-rc2-002794",
     "Microsoft.DotNet.Cli.Utils": "1.0.0-preview2-002794",
     "NETStandard.Library": "1.6.0",
-    "Microsoft.NETCore.Runtime.CoreCLR": "1.0.2"
+    "Microsoft.NETCore.Runtime.CoreCLR": "1.0.5-servicing-24601-01"
   },
   "frameworks": {
     "netcoreapp1.0": {


### PR DESCRIPTION
https://github.com/dotnet/core-setup/pull/406, but without downgrading corefx from post-1.0.0 servicing release.