### PR TITLE
Removing ToLower workarounds in DependencyModel Resolution.

### DIFF
--- a/src/Microsoft.Extensions.DependencyModel/Resolution/PackageCacheCompilationAssemblyResolver.cs
+++ b/src/Microsoft.Extensions.DependencyModel/Resolution/PackageCacheCompilationAssemblyResolver.cs
@@ -51,8 +51,12 @@ namespace Microsoft.Extensions.DependencyModel.Resolution
                 string packagePath;
                 if (ResolverUtils.TryResolvePackagePath(_fileSystem, library, _packageCacheDirectory, out packagePath))
                 {
-                    var hashAlgorithm = library.Hash.Substring(0, hashSplitterPos);
-                    var cacheHashFileName = $"{library.Name.ToLowerInvariant()}.{library.Version.ToLowerInvariant()}.nupkg.{hashAlgorithm}";
+                    string cacheHashFileName = library.HashPath;
+                    if (string.IsNullOrEmpty(cacheHashFileName))
+                    {
+                        var hashAlgorithm = library.Hash.Substring(0, hashSplitterPos);
+                        cacheHashFileName = $"{library.Name}.{library.Version}.nupkg.{hashAlgorithm}";
+                    }
                     var cacheHashPath = Path.Combine(packagePath, cacheHashFileName);
 
                     if (_fileSystem.File.Exists(cacheHashPath) &&

--- a/src/Microsoft.Extensions.DependencyModel/Resolution/ResolverUtils.cs
+++ b/src/Microsoft.Extensions.DependencyModel/Resolution/ResolverUtils.cs
@@ -11,10 +11,13 @@ namespace Microsoft.Extensions.DependencyModel.Resolution
     {
         internal static bool TryResolvePackagePath(IFileSystem fileSystem, CompilationLibrary library, string basePath, out string packagePath)
         {
-            packagePath = Path.Combine(
-                basePath,
-                library.Name.ToLowerInvariant(),
-                library.Version.ToLowerInvariant());
+            var path = library.Path;
+            if (string.IsNullOrEmpty(path))
+            {
+                path = Path.Combine(library.Name, library.Version);
+            }
+
+            packagePath = Path.Combine(basePath, path);
 
             if (fileSystem.Directory.Exists(packagePath))
             {

--- a/test/Microsoft.Extensions.DependencyModel.Tests/PackageResolverTest.cs
+++ b/test/Microsoft.Extensions.DependencyModel.Tests/PackageResolverTest.cs
@@ -96,7 +96,7 @@ namespace Microsoft.Extensions.DependencyModel.Tests
 
         internal static string GetPackagesPath(string basePath, string id, string version)
         {
-            return Path.Combine(basePath, id.ToLowerInvariant(), version.ToLowerInvariant());
+            return Path.Combine(basePath, id, version);
         }
     }
 }

--- a/test/Microsoft.Extensions.DependencyModel.Tests/TestLibraryFactory.cs
+++ b/test/Microsoft.Extensions.DependencyModel.Tests/TestLibraryFactory.cs
@@ -12,8 +12,8 @@ namespace Microsoft.Extensions.DependencyModel.Tests
         public static readonly string DefaultVersion = "1.2.3.7";
         public static readonly Dependency[] DefaultDependencies = { };
         public static readonly bool DefaultServiceable = true;
-        public static readonly string DefaultPath = "MyPackagePath";
-        public static readonly string DefaultHashPath = "MyPackageHashPath";
+        public static readonly string DefaultPath = null;
+        public static readonly string DefaultHashPath = null;
 
         public static readonly string DefaultAssembly = "My.Package.dll";
         public static readonly string SecondAssembly = "My.PackageEx.dll";


### PR DESCRIPTION
These workarounds are no longer valid.  The Resolution logic should be respecting Path and HashPath properties, and falling back to straight PackageId Version values, if those are not set.

Fix #423

@pranavkm @joelverhagen 

/cc @gkhanna79 @livarcocc 