### PR TITLE
Use CLI from SDK channel so we have CLIs for new Linux Distros

### DIFF
--- a/build_projects/dotnet-host-build/build.ps1
+++ b/build_projects/dotnet-host-build/build.ps1
@@ -101,7 +101,7 @@ if (!(Test-Path "$RepoRoot\artifacts"))
 $DOTNET_INSTALL_SCRIPT_URL="https://raw.githubusercontent.com/dotnet/cli/rel/1.0.0/scripts/obtain/dotnet-install.ps1"
 Invoke-WebRequest $DOTNET_INSTALL_SCRIPT_URL -OutFile "$RepoRoot\artifacts\dotnet-install.ps1"
 
-& "$RepoRoot\artifacts\dotnet-install.ps1" -Architecture $Architecture -Verbose
+& "$RepoRoot\artifacts\dotnet-install.ps1" -Channel Sdk -Version 1.0.0-preview3-003223 -Architecture $Architecture -Verbose
 if($LASTEXITCODE -ne 0) { throw "Failed to install stage0" }
 
 # Put the stage0 on the path

--- a/build_projects/dotnet-host-build/build.sh
+++ b/build_projects/dotnet-host-build/build.sh
@@ -94,7 +94,7 @@ done < "$REPOROOT/branchinfo.txt"
 [ -d "$DOTNET_INSTALL_DIR" ] || mkdir -p $DOTNET_INSTALL_DIR
 
 DOTNET_INSTALL_SCRIPT_URL="https://raw.githubusercontent.com/dotnet/cli/rel/1.0.0/scripts/obtain/dotnet-install.sh"
-curl -sSL "$DOTNET_INSTALL_SCRIPT_URL" | bash /dev/stdin --channel rel-1.0.0 --verbose
+curl -sSL "$DOTNET_INSTALL_SCRIPT_URL" | bash /dev/stdin --channel Sdk --version 1.0.0-preview3-003223 --verbose
 
 # Put stage 0 on the PATH (for this shell only)
 PATH="$DOTNET_INSTALL_DIR:$PATH"

--- a/build_projects/shared-build-targets-utils/Utils/Crossgen.cs
+++ b/build_projects/shared-build-targets-utils/Utils/Crossgen.cs
@@ -75,8 +75,8 @@ namespace Microsoft.DotNet.Cli.Build
 
             return Path.Combine(
                 Dirs.NuGetPackages,
-                packageId.ToLower(),
-                _jitVersion.ToLower());
+                packageId,
+                _jitVersion);
         }
 
         private string GetCoreLibsDirForVersion()
@@ -113,8 +113,8 @@ namespace Microsoft.DotNet.Cli.Build
 
             return Path.Combine(
                 Dirs.NuGetPackages,
-                packageId.ToLower(),
-                _coreClrVersion.ToLower());
+                packageId,
+                _coreClrVersion);
         }
 
         private string GetCoreCLRRid()

--- a/tools/independent/RuntimeGraphGenerator/RuntimeGraphManager.cs
+++ b/tools/independent/RuntimeGraphGenerator/RuntimeGraphManager.cs
@@ -22,7 +22,7 @@ namespace Microsoft.DotNet.ProjectModel
                     var runtimeJson =  ((PackageDescription) export.Library).PackageLibrary.Files.FirstOrDefault(f => f == RuntimeJsonFileName);
                     if (runtimeJson != null)
                     {
-                        var runtimeJsonFullName = Path.Combine(export.Library.Path.ToLower(), runtimeJson);
+                        var runtimeJsonFullName = Path.Combine(export.Library.Path, runtimeJson);
                         graph = RuntimeGraph.Merge(graph, JsonRuntimeFormat.ReadRuntimeGraph(runtimeJsonFullName));
                     }
                 }


### PR DESCRIPTION
This changes core-setup to pull its CLI from a known good version in the 'Sdk' channel (same as what CoreFX is doing). This channel/version has a CLI for Ubuntu16.10 and OpenSUSE42.1, so this should fix the failures in the pipeline for core-setup.
