### PR TITLE
Revert various changes from 1.0.2

### DIFF
--- a/build_projects/dotnet-host-build/CompileTargets.cs
+++ b/build_projects/dotnet-host-build/CompileTargets.cs
@@ -31,7 +31,6 @@ namespace Microsoft.DotNet.Host.Build
             { "win7-x86", "win7-x86" },
             { "osx.10.10-x64", "osx.10.10-x64" },
             { "osx.10.11-x64", "osx.10.10-x64" },
-            { "osx.10.12-x64", "osx.10.10-x64" },
             { "ubuntu.14.04-x64", "ubuntu.14.04-x64" },
             { "ubuntu.16.04-x64", "ubuntu.16.04-x64" },
             { "centos.7-x64", "rhel.7-x64" },
@@ -298,8 +297,8 @@ namespace Microsoft.DotNet.Host.Build
 
                 Console.WriteLine($"Copying package {fileName} to artifacts directory {Dirs.CorehostLocalPackages}.");
             }
-            
-            // Comment out the loop below if we dont want to validate the built host packages
+            /*
+            Disable package list check to enable building only certain packages
             foreach (var item in hostVersion.LatestHostPackages)
             {
                 var fileFilter = $"runtime.{HostPackagePlatformRid}.{item.Key}.{item.Value.ToString()}.nupkg";
@@ -308,7 +307,7 @@ namespace Microsoft.DotNet.Host.Build
                     throw new BuildFailureException($"Nupkg for {fileFilter} was not created.");
                 }
             }
-            
+            */
             return c.Success();
         }
 

--- a/build_projects/dotnet-host-build/project.json
+++ b/build_projects/dotnet-host-build/project.json
@@ -6,7 +6,7 @@
   },
   "dependencies": {
     "NETStandard.Library": "1.6.0",
-    "Microsoft.NETCore.Runtime.CoreCLR": "1.0.5-servicing-24601-01",
+    "Microsoft.NETCore.Runtime.CoreCLR": "1.0.2",
     "Microsoft.CSharp": "4.0.1",
     "System.Dynamic.Runtime": "4.0.11",
     "System.Reflection.Metadata": "1.3.0",

--- a/build_projects/dotnet-host-build/project.json
+++ b/build_projects/dotnet-host-build/project.json
@@ -6,7 +6,7 @@
   },
   "dependencies": {
     "NETStandard.Library": "1.6.0",
-    "Microsoft.NETCore.Runtime.CoreCLR": "1.0.5-servicing-24603-01",
+    "Microsoft.NETCore.Runtime.CoreCLR": "1.0.5-servicing-24601-01",
     "Microsoft.CSharp": "4.0.1",
     "System.Dynamic.Runtime": "4.0.11",
     "System.Reflection.Metadata": "1.3.0",

--- a/build_projects/shared-build-targets-utils/DependencyVersions.cs
+++ b/build_projects/shared-build-targets-utils/DependencyVersions.cs
@@ -7,7 +7,9 @@ namespace Microsoft.DotNet.Cli.Build
 {
     public class DependencyVersions
     {
-        public static readonly string CoreCLRVersion = "1.0.5-servicing-24530-02";
-        public static readonly string JitVersion = "1.0.5-servicing-24530-02";
+        // TODO: Update these for consuming servicing version of CoreCLR packages
+        //       Also, update CoreCLR package referenced at /Users/gkhanna/Github/gkhanna79/core-setup/pkg/projects/Microsoft.NETCore.App/project.json
+        public static readonly string CoreCLRVersion = "1.0.4";
+        public static readonly string JitVersion = "1.0.4";
     }
 }

--- a/build_projects/shared-build-targets-utils/DependencyVersions.cs
+++ b/build_projects/shared-build-targets-utils/DependencyVersions.cs
@@ -7,7 +7,7 @@ namespace Microsoft.DotNet.Cli.Build
 {
     public class DependencyVersions
     {
-        public static readonly string CoreCLRVersion = "1.0.5-servicing-24601-01";
-        public static readonly string JitVersion = "1.0.5-servicing-24601-01";
+        public static readonly string CoreCLRVersion = "1.0.5-servicing-24530-02";
+        public static readonly string JitVersion = "1.0.5-servicing-24530-02";
     }
 }

--- a/build_projects/shared-build-targets-utils/DependencyVersions.cs
+++ b/build_projects/shared-build-targets-utils/DependencyVersions.cs
@@ -7,7 +7,7 @@ namespace Microsoft.DotNet.Cli.Build
 {
     public class DependencyVersions
     {
-        public static readonly string CoreCLRVersion = "1.0.5-servicing-24603-01";
-        public static readonly string JitVersion = "1.0.5-servicing-24603-01";
+        public static readonly string CoreCLRVersion = "1.0.5-servicing-24601-01";
+        public static readonly string JitVersion = "1.0.5-servicing-24601-01";
     }
 }

--- a/build_projects/shared-build-targets-utils/DependencyVersions.cs
+++ b/build_projects/shared-build-targets-utils/DependencyVersions.cs
@@ -7,9 +7,7 @@ namespace Microsoft.DotNet.Cli.Build
 {
     public class DependencyVersions
     {
-        // TODO: Update these for consuming servicing version of CoreCLR packages
-        //       Also, update CoreCLR package referenced at /Users/gkhanna/Github/gkhanna79/core-setup/pkg/projects/Microsoft.NETCore.App/project.json
-        public static readonly string CoreCLRVersion = "1.0.4";
-        public static readonly string JitVersion = "1.0.4";
+        public static readonly string CoreCLRVersion = "1.0.2";
+        public static readonly string JitVersion = "1.0.2";
     }
 }

--- a/build_projects/shared-build-targets-utils/Utils/HostVersion.cs
+++ b/build_projects/shared-build-targets-utils/Utils/HostVersion.cs
@@ -61,15 +61,13 @@ namespace Microsoft.DotNet.Cli.Build
         //
 
         // Full versions and package information.
-        //
-        // Set the variable below to true to generate stable versions of the host packages
         public bool EnsureStableVersion => false;
         public string LatestHostPrerelease => "servicing";
         public string LatestHostBuildMajor => CommitCountString;
         public string LatestHostBuildMinor => "00";
-        public VerInfo LatestHostVersion => new VerInfo(1, 0, 2, LatestHostPrerelease, LatestHostBuildMajor, LatestHostBuildMinor, CommitCountString);
-        public VerInfo LatestHostFxrVersion => new VerInfo(1, 0, 2, LatestHostPrerelease, LatestHostBuildMajor, LatestHostBuildMinor, CommitCountString);
-        public VerInfo LatestHostPolicyVersion => new VerInfo(1, 0, 2, LatestHostPrerelease, LatestHostBuildMajor, LatestHostBuildMinor, CommitCountString);
+        public VerInfo LatestHostVersion => new VerInfo(1, 0, 1, LatestHostPrerelease, LatestHostBuildMajor, LatestHostBuildMinor, CommitCountString);
+        public VerInfo LatestHostFxrVersion => new VerInfo(1, 0, 1, LatestHostPrerelease, LatestHostBuildMajor, LatestHostBuildMinor, CommitCountString);
+        public VerInfo LatestHostPolicyVersion => new VerInfo(1, 0, 1, LatestHostPrerelease, LatestHostBuildMajor, LatestHostBuildMinor, CommitCountString);
   
         public Dictionary<string, VerInfo> LatestHostPackages => new Dictionary<string, VerInfo>()
         {
@@ -95,9 +93,7 @@ namespace Microsoft.DotNet.Cli.Build
         //
         // Locked muxer for consumption in CLI.
         //
-        // Set this variable to toggle muxer locking. We set it to true once a stable release has been shipped
-        // and we wish to have the subsequent servicing releases lock to it.
-        public bool IsLocked = false; 
+        public bool IsLocked = true; // Set this variable to toggle muxer locking.
         public VerInfo LockedHostFxrVersion => IsLocked ? new VerInfo(1, 0, 1, "", "", "", CommitCountString) : LatestHostFxrVersion;
         public VerInfo LockedHostVersion    => IsLocked ? new VerInfo(1, 0, 1, "", "", "", CommitCountString) : LatestHostVersion;
     }

--- a/build_projects/update-dependencies/project.json
+++ b/build_projects/update-dependencies/project.json
@@ -7,7 +7,7 @@
   "dependencies": {
     "NETStandard.Library": "1.6.0",
     "Microsoft.CSharp": "4.0.1",
-    "Microsoft.NETCore.Runtime.CoreCLR": "1.0.5-servicing-24603-01",
+    "Microsoft.NETCore.Runtime.CoreCLR": "1.0.5-servicing-24601-01",
     "System.Runtime.Serialization.Primitives": "4.1.1",
     "Microsoft.DotNet.Cli.Build.Framework": {
       "target": "project"

--- a/build_projects/update-dependencies/project.json
+++ b/build_projects/update-dependencies/project.json
@@ -7,7 +7,7 @@
   "dependencies": {
     "NETStandard.Library": "1.6.0",
     "Microsoft.CSharp": "4.0.1",
-    "Microsoft.NETCore.Runtime.CoreCLR": "1.0.5-servicing-24601-01",
+    "Microsoft.NETCore.Runtime.CoreCLR": "1.0.2",
     "System.Runtime.Serialization.Primitives": "4.1.1",
     "Microsoft.DotNet.Cli.Build.Framework": {
       "target": "project"

--- a/pkg/deps/project.json
+++ b/pkg/deps/project.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "Microsoft.NETCore.Platforms": "1.0.2-servicing-24611-05"
+    "Microsoft.NETCore.Platforms": "1.0.2-servicing-24610-01"
   },
   "frameworks": {
     "dnxcore50": {

--- a/pkg/deps/project.json
+++ b/pkg/deps/project.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "Microsoft.NETCore.Platforms": "1.0.2-servicing-24607-01"
+    "Microsoft.NETCore.Platforms": "1.0.2-servicing-24606-05"
   },
   "frameworks": {
     "dnxcore50": {

--- a/pkg/deps/project.json
+++ b/pkg/deps/project.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "Microsoft.NETCore.Platforms": "1.0.2-servicing-24610-01"
+    "Microsoft.NETCore.Platforms": "1.0.2-servicing-24607-01"
   },
   "frameworks": {
     "dnxcore50": {

--- a/pkg/deps/project.json
+++ b/pkg/deps/project.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "Microsoft.NETCore.Platforms": "1.0.2-servicing-24606-05"
+    "Microsoft.NETCore.Platforms": "1.0.1"
   },
   "frameworks": {
     "dnxcore50": {

--- a/pkg/dir.props
+++ b/pkg/dir.props
@@ -28,7 +28,7 @@
   <PropertyGroup>
     <PackageOutputPath>$(PackagesOutDir)</PackageOutputPath>
     <SymbolPackageOutputPath>$(SymbolPackagesOutDir)</SymbolPackageOutputPath>
-    <RuntimeIdGraphDefinitionFile>$(ProjectDir)packages\Microsoft.NETCore.Platforms\1.0.2-servicing-24610-01\runtime.json</RuntimeIdGraphDefinitionFile>
+    <RuntimeIdGraphDefinitionFile>$(ProjectDir)packages\Microsoft.NETCore.Platforms\1.0.2-servicing-24607-01\runtime.json</RuntimeIdGraphDefinitionFile>
     <PackageLicenseFile>$(ProjectDir)projects/dotnet_library_license.txt</PackageLicenseFile>
     <PackageThirdPartyNoticesFile>$(ProjectDir)projects/ThirdPartyNotices.txt</PackageThirdPartyNoticesFile>
     <PackageDescriptionFile>$(ProjectDir)projects/descriptions.json</PackageDescriptionFile>

--- a/pkg/dir.props
+++ b/pkg/dir.props
@@ -28,7 +28,7 @@
   <PropertyGroup>
     <PackageOutputPath>$(PackagesOutDir)</PackageOutputPath>
     <SymbolPackageOutputPath>$(SymbolPackagesOutDir)</SymbolPackageOutputPath>
-    <RuntimeIdGraphDefinitionFile>$(ProjectDir)packages\Microsoft.NETCore.Platforms\1.0.2-servicing-24611-05\runtime.json</RuntimeIdGraphDefinitionFile>
+    <RuntimeIdGraphDefinitionFile>$(ProjectDir)packages\Microsoft.NETCore.Platforms\1.0.2-servicing-24610-01\runtime.json</RuntimeIdGraphDefinitionFile>
     <PackageLicenseFile>$(ProjectDir)projects/dotnet_library_license.txt</PackageLicenseFile>
     <PackageThirdPartyNoticesFile>$(ProjectDir)projects/ThirdPartyNotices.txt</PackageThirdPartyNoticesFile>
     <PackageDescriptionFile>$(ProjectDir)projects/descriptions.json</PackageDescriptionFile>

--- a/pkg/dir.props
+++ b/pkg/dir.props
@@ -28,7 +28,7 @@
   <PropertyGroup>
     <PackageOutputPath>$(PackagesOutDir)</PackageOutputPath>
     <SymbolPackageOutputPath>$(SymbolPackagesOutDir)</SymbolPackageOutputPath>
-    <RuntimeIdGraphDefinitionFile>$(ProjectDir)packages\Microsoft.NETCore.Platforms\1.0.2-servicing-24606-05\runtime.json</RuntimeIdGraphDefinitionFile>
+    <RuntimeIdGraphDefinitionFile>$(ProjectDir)packages\Microsoft.NETCore.Platforms\1.0.1\runtime.json</RuntimeIdGraphDefinitionFile>
     <PackageLicenseFile>$(ProjectDir)projects/dotnet_library_license.txt</PackageLicenseFile>
     <PackageThirdPartyNoticesFile>$(ProjectDir)projects/ThirdPartyNotices.txt</PackageThirdPartyNoticesFile>
     <PackageDescriptionFile>$(ProjectDir)projects/descriptions.json</PackageDescriptionFile>

--- a/pkg/dir.props
+++ b/pkg/dir.props
@@ -28,7 +28,7 @@
   <PropertyGroup>
     <PackageOutputPath>$(PackagesOutDir)</PackageOutputPath>
     <SymbolPackageOutputPath>$(SymbolPackagesOutDir)</SymbolPackageOutputPath>
-    <RuntimeIdGraphDefinitionFile>$(ProjectDir)packages\Microsoft.NETCore.Platforms\1.0.2-servicing-24607-01\runtime.json</RuntimeIdGraphDefinitionFile>
+    <RuntimeIdGraphDefinitionFile>$(ProjectDir)packages\Microsoft.NETCore.Platforms\1.0.2-servicing-24606-05\runtime.json</RuntimeIdGraphDefinitionFile>
     <PackageLicenseFile>$(ProjectDir)projects/dotnet_library_license.txt</PackageLicenseFile>
     <PackageThirdPartyNoticesFile>$(ProjectDir)projects/ThirdPartyNotices.txt</PackageThirdPartyNoticesFile>
     <PackageDescriptionFile>$(ProjectDir)projects/descriptions.json</PackageDescriptionFile>

--- a/pkg/projects/Microsoft.NETCore.App/project.json
+++ b/pkg/projects/Microsoft.NETCore.App/project.json
@@ -3,7 +3,7 @@
     "Microsoft.CodeAnalysis.CSharp": "1.3.0",
     "Microsoft.CodeAnalysis.VisualBasic": "1.3.0",
     "Microsoft.CSharp": "4.0.1",
-    "Microsoft.NETCore.Runtime.CoreCLR": "1.0.5-servicing-24603-01",
+    "Microsoft.NETCore.Runtime.CoreCLR": "1.0.5-servicing-24601-01",
     "Microsoft.VisualBasic": "10.0.1",
     "NETStandard.Library": "1.6.0",
     "System.Buffers": "4.0.0",

--- a/pkg/projects/Microsoft.NETCore.App/project.json
+++ b/pkg/projects/Microsoft.NETCore.App/project.json
@@ -3,7 +3,7 @@
     "Microsoft.CodeAnalysis.CSharp": "1.3.0",
     "Microsoft.CodeAnalysis.VisualBasic": "1.3.0",
     "Microsoft.CSharp": "4.0.1",
-    "Microsoft.NETCore.Runtime.CoreCLR": "1.0.5-servicing-24530-02",
+    "Microsoft.NETCore.Runtime.CoreCLR": "1.0.4",
     "Microsoft.VisualBasic": "10.0.1",
     "NETStandard.Library": "1.6.0",
     "System.Buffers": "4.0.0",

--- a/pkg/projects/Microsoft.NETCore.App/project.json
+++ b/pkg/projects/Microsoft.NETCore.App/project.json
@@ -3,7 +3,7 @@
     "Microsoft.CodeAnalysis.CSharp": "1.3.0",
     "Microsoft.CodeAnalysis.VisualBasic": "1.3.0",
     "Microsoft.CSharp": "4.0.1",
-    "Microsoft.NETCore.Runtime.CoreCLR": "1.0.5-servicing-24601-01",
+    "Microsoft.NETCore.Runtime.CoreCLR": "1.0.5-servicing-24530-02",
     "Microsoft.VisualBasic": "10.0.1",
     "NETStandard.Library": "1.6.0",
     "System.Buffers": "4.0.0",

--- a/pkg/projects/Microsoft.NETCore.UniversalWindowsPlatform/project.json
+++ b/pkg/projects/Microsoft.NETCore.UniversalWindowsPlatform/project.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
     "Microsoft.NETCore.Portable.Compatibility": "1.0.2",
-    "Microsoft.NETCore.Runtime.CoreCLR": "1.0.5-servicing-24601-01",
+    "Microsoft.NETCore.Runtime.CoreCLR": "1.0.3",
     "Microsoft.NETCore.Targets": "1.0.2",
     "Microsoft.Win32.Primitives": "4.0.1",
     "System.ComponentModel.EventBasedAsync": "4.0.11",

--- a/pkg/projects/Microsoft.NETCore.UniversalWindowsPlatform/project.json
+++ b/pkg/projects/Microsoft.NETCore.UniversalWindowsPlatform/project.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
     "Microsoft.NETCore.Portable.Compatibility": "1.0.2",
-    "Microsoft.NETCore.Runtime.CoreCLR": "1.0.5-servicing-24603-01",
+    "Microsoft.NETCore.Runtime.CoreCLR": "1.0.5-servicing-24601-01",
     "Microsoft.NETCore.Targets": "1.0.2",
     "Microsoft.Win32.Primitives": "4.0.1",
     "System.ComponentModel.EventBasedAsync": "4.0.11",

--- a/pkg/projects/Microsoft.NETCore/project.json
+++ b/pkg/projects/Microsoft.NETCore/project.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
     "Microsoft.CSharp": "4.0.1",
-    "Microsoft.NETCore.Platforms": "1.0.2-servicing-24606-05",
+    "Microsoft.NETCore.Platforms": "1.0.1",
     "Microsoft.VisualBasic": "10.0.1",
     "System.AppContext": "4.1.0",
     "System.Collections": "4.0.11",
@@ -26,7 +26,7 @@
     "System.Linq.Expressions": "4.1.0",
     "System.Linq.Parallel": "4.0.1",
     "System.Linq.Queryable": "4.0.1",
-    "System.Net.Http": "4.1.1-servicing-24606-05",
+    "System.Net.Http": "4.1.0",
     "System.Net.NetworkInformation": "4.1.0",
     "System.Net.Primitives": "4.0.11",
     "System.Numerics.Vectors": "4.1.1",

--- a/pkg/projects/Microsoft.NETCore/project.json
+++ b/pkg/projects/Microsoft.NETCore/project.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
     "Microsoft.CSharp": "4.0.1",
-    "Microsoft.NETCore.Platforms": "1.0.2-servicing-24610-01",
+    "Microsoft.NETCore.Platforms": "1.0.2-servicing-24607-01",
     "Microsoft.VisualBasic": "10.0.1",
     "System.AppContext": "4.1.0",
     "System.Collections": "4.0.11",
@@ -26,7 +26,7 @@
     "System.Linq.Expressions": "4.1.0",
     "System.Linq.Parallel": "4.0.1",
     "System.Linq.Queryable": "4.0.1",
-    "System.Net.Http": "4.1.1-servicing-24610-01",
+    "System.Net.Http": "4.1.1-servicing-24607-01",
     "System.Net.NetworkInformation": "4.1.0",
     "System.Net.Primitives": "4.0.11",
     "System.Numerics.Vectors": "4.1.1",

--- a/pkg/projects/Microsoft.NETCore/project.json
+++ b/pkg/projects/Microsoft.NETCore/project.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
     "Microsoft.CSharp": "4.0.1",
-    "Microsoft.NETCore.Platforms": "1.0.2-servicing-24611-05",
+    "Microsoft.NETCore.Platforms": "1.0.2-servicing-24610-01",
     "Microsoft.VisualBasic": "10.0.1",
     "System.AppContext": "4.1.0",
     "System.Collections": "4.0.11",
@@ -26,7 +26,7 @@
     "System.Linq.Expressions": "4.1.0",
     "System.Linq.Parallel": "4.0.1",
     "System.Linq.Queryable": "4.0.1",
-    "System.Net.Http": "4.1.1-servicing-24611-05",
+    "System.Net.Http": "4.1.1-servicing-24610-01",
     "System.Net.NetworkInformation": "4.1.0",
     "System.Net.Primitives": "4.0.11",
     "System.Numerics.Vectors": "4.1.1",

--- a/pkg/projects/Microsoft.NETCore/project.json
+++ b/pkg/projects/Microsoft.NETCore/project.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
     "Microsoft.CSharp": "4.0.1",
-    "Microsoft.NETCore.Platforms": "1.0.2-servicing-24607-01",
+    "Microsoft.NETCore.Platforms": "1.0.2-servicing-24606-05",
     "Microsoft.VisualBasic": "10.0.1",
     "System.AppContext": "4.1.0",
     "System.Collections": "4.0.11",
@@ -26,7 +26,7 @@
     "System.Linq.Expressions": "4.1.0",
     "System.Linq.Parallel": "4.0.1",
     "System.Linq.Queryable": "4.0.1",
-    "System.Net.Http": "4.1.1-servicing-24607-01",
+    "System.Net.Http": "4.1.1-servicing-24606-05",
     "System.Net.NetworkInformation": "4.1.0",
     "System.Net.Primitives": "4.0.11",
     "System.Numerics.Vectors": "4.1.1",

--- a/pkg/projects/packages.builds
+++ b/pkg/projects/packages.builds
@@ -13,7 +13,6 @@
   <!-- Specify the packages to be rebuilt, for servicing, here -->
   <ItemGroup Condition="'$(BuildAllPackages)' == 'false'" >
     <Project Include="Microsoft.NETCore.App\Microsoft.NETCore.App.builds" />
-    <Project Include="Microsoft.NETCore.DotNetHost\*.builds" />
   </ItemGroup>
 
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />

--- a/tools/independent/RuntimeGraphGenerator/project.json
+++ b/tools/independent/RuntimeGraphGenerator/project.json
@@ -11,7 +11,7 @@
     "Microsoft.DotNet.ProjectModel": "1.0.0-rc2-002794",
     "Microsoft.DotNet.Cli.Utils": "1.0.0-preview2-002794",
     "NETStandard.Library": "1.6.0",
-    "Microsoft.NETCore.Runtime.CoreCLR": "1.0.5-servicing-24601-01"
+    "Microsoft.NETCore.Runtime.CoreCLR": "1.0.2"
   },
   "frameworks": {
     "netcoreapp1.0": {

--- a/tools/independent/RuntimeGraphGenerator/project.json
+++ b/tools/independent/RuntimeGraphGenerator/project.json
@@ -11,7 +11,7 @@
     "Microsoft.DotNet.ProjectModel": "1.0.0-rc2-002794",
     "Microsoft.DotNet.Cli.Utils": "1.0.0-preview2-002794",
     "NETStandard.Library": "1.6.0",
-    "Microsoft.NETCore.Runtime.CoreCLR": "1.0.5-servicing-24603-01"
+    "Microsoft.NETCore.Runtime.CoreCLR": "1.0.5-servicing-24601-01"
   },
   "frameworks": {
     "netcoreapp1.0": {


### PR DESCRIPTION
This PR reverts various changes we took in 1.0.2 but should be in 1.0.3:

1) Networking fixes
2) RID fallback graph update for Sierra

Post this change, we only have the fixes for the OSX PATH issue on Sierra.

@weshaggard @ericstj PTAL

CC @leecow @schellap @Petermarcu @dagood @wtgodbe 

