### PR TITLE
fixing build.sh typo

### DIFF
--- a/src/corehost/build.sh
+++ b/src/corehost/build.sh
@@ -12,7 +12,7 @@ init_rid_plat()
 
         if [[ "$ID" == "rhel" && $VERSION_ID = 7* ]]; then
             export __rid_plat="rhel.7"
-        elif [ "$ID" == "centos" && "$VERSION_ID" = "7" ]; then
+        elif [[ "$ID" == "centos" && "$VERSION_ID" = "7" ]]; then
             export __rid_plat="rhel.7"
         else
             export __rid_plat="$ID.$VERSION_ID"


### PR DESCRIPTION
- If this PR should not run tests please add text "skipciplease" (remove the marked text, no quotes).
- Please add description for changes you are making.
- If there is an issue related to this PR, please add the reference.

While bootstrapping I see a syntax error on this line, this corrects that.