### PR TITLE
Update Microsoft.NETCore.App to target netcoreapp1.1

### DIFF
--- a/TestAssets/TestProjects/PortableApp/project.json
+++ b/TestAssets/TestProjects/PortableApp/project.json
@@ -5,7 +5,7 @@
   },
   "dependencies": {},
   "frameworks": {
-    "netcoreapp1.0": {
+    "netcoreapp1.1": {
       "dependencies": {
         "Microsoft.NETCore.App": {
           "type": "platform",

--- a/TestAssets/TestProjects/PortableTestApp/project.json
+++ b/TestAssets/TestProjects/PortableTestApp/project.json
@@ -4,7 +4,7 @@
   "dependencies": {},
 
   "frameworks": {
-    "netcoreapp1.0": {
+    "netcoreapp1.1": {
       "imports": [
         "dotnet5.4",
         "portable-net451+win8"

--- a/TestAssets/TestProjects/StandaloneApp/project.json
+++ b/TestAssets/TestProjects/StandaloneApp/project.json
@@ -3,7 +3,7 @@
     "emitEntryPoint": true
   },
   "frameworks": {
-    "netcoreapp1.0": {
+    "netcoreapp1.1": {
       "dependencies": {
         "Microsoft.NETCore.App": "1.1.0-preview1-*",
         "Newtonsoft.Json": "9.0.1-beta1"

--- a/TestAssets/TestProjects/StandaloneTestApp/project.json
+++ b/TestAssets/TestProjects/StandaloneTestApp/project.json
@@ -3,7 +3,7 @@
     "emitEntryPoint": true
   },
   "frameworks": {
-    "netcoreapp1.0": {
+    "netcoreapp1.1": {
       "imports": [
         "dotnet5.4",
         "portable-net451+win8"

--- a/pkg/projects/Microsoft.NETCore.App/Microsoft.NETCore.App.pkgproj
+++ b/pkg/projects/Microsoft.NETCore.App/Microsoft.NETCore.App.pkgproj
@@ -9,7 +9,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.NETCore.DotNetHost\Microsoft.NETCore.DotNetHostPolicy.pkgproj">
-      <TargetFramework>.NETCoreApp1.0</TargetFramework>
+      <TargetFramework>.NETCoreApp1.1</TargetFramework>
     </ProjectReference>
   </ItemGroup>
 
@@ -26,7 +26,7 @@
 
       <Dependency Include="@(PackageMatch -> '%(PackageId)')" Condition="'%(PackageMatch.PackageVersion)' != ''">
         <Version>%(PackageMatch.PackageVersion)</Version>
-        <TargetFramework>.NETCoreApp1.0</TargetFramework>
+        <TargetFramework>.NETCoreApp1.1</TargetFramework>
       </Dependency>
 
       <!-- List of dependencies to mark as exclude=compile -->
@@ -40,12 +40,152 @@
         <Exclude>Compile</Exclude>
       </Dependency>
 
+      <!-- Only need the placeholder in the netcoreapp1.0 folder -->
       <File Include="$(PlaceholderFile)" >
         <SkipPackageFileCheck>true</SkipPackageFileCheck>
         <TargetPath>lib/netcoreapp1.0</TargetPath>
       </File>
     </ItemGroup>
   </Target>
+
+  <!--
+    Manually include the netcoreapp1.0 dependencies.
+    If any versions change in the release/1.0.0 branch they should
+    also be updated here.
+    https://github.com/dotnet/core-setup/blob/release/1.0.0/pkg/projects/Microsoft.NETCore.App/project.json
+  -->
+  <ItemGroup>
+    <NETCoreApp10Dependency Include="Microsoft.CodeAnalysis.CSharp">
+      <Version>1.3.0</Version>
+      <Exclude>Compile</Exclude>
+    </NETCoreApp10Dependency>
+    <NETCoreApp10Dependency Include="Microsoft.CodeAnalysis.VisualBasic">
+      <Version>1.3.0</Version>
+      <Exclude>Compile</Exclude>
+    </NETCoreApp10Dependency>
+    <NETCoreApp10Dependency Include="Microsoft.CSharp">
+      <Version>4.0.1</Version>
+    </NETCoreApp10Dependency>
+    <NETCoreApp10Dependency Include="Microsoft.NETCore.DotNetHostPolicy">
+      <Version>1.0.1</Version>
+    </NETCoreApp10Dependency>
+    <NETCoreApp10Dependency Include="Microsoft.NETCore.Runtime.CoreCLR">
+      <Version>1.0.4</Version>
+    </NETCoreApp10Dependency>
+    <NETCoreApp10Dependency Include="Microsoft.VisualBasic">
+      <Version>10.0.1</Version>
+    </NETCoreApp10Dependency>
+    <NETCoreApp10Dependency Include="NETStandard.Library">
+      <Version>1.6.0</Version>
+    </NETCoreApp10Dependency>
+    <NETCoreApp10Dependency Include="System.Buffers">
+      <Version>4.0.0</Version>
+    </NETCoreApp10Dependency>
+    <NETCoreApp10Dependency Include="System.Collections.Immutable">
+      <Version>1.2.0</Version>
+    </NETCoreApp10Dependency>
+    <NETCoreApp10Dependency Include="System.ComponentModel">
+      <Version>4.0.1</Version>
+    </NETCoreApp10Dependency>
+    <NETCoreApp10Dependency Include="System.ComponentModel.Annotations">
+      <Version>4.1.0</Version>
+    </NETCoreApp10Dependency>
+    <NETCoreApp10Dependency Include="System.Diagnostics.DiagnosticSource">
+      <Version>4.0.0</Version>
+    </NETCoreApp10Dependency>
+    <NETCoreApp10Dependency Include="System.Diagnostics.Process">
+      <Version>4.1.0</Version>
+    </NETCoreApp10Dependency>
+    <NETCoreApp10Dependency Include="System.Dynamic.Runtime">
+      <Version>4.0.11</Version>
+    </NETCoreApp10Dependency>
+    <NETCoreApp10Dependency Include="System.Globalization.Extensions">
+      <Version>4.0.1</Version>
+    </NETCoreApp10Dependency>
+    <NETCoreApp10Dependency Include="System.IO.FileSystem.Watcher">
+      <Version>4.0.0</Version>
+    </NETCoreApp10Dependency>
+    <NETCoreApp10Dependency Include="System.IO.MemoryMappedFiles">
+      <Version>4.0.0</Version>
+    </NETCoreApp10Dependency>
+    <NETCoreApp10Dependency Include="System.IO.UnmanagedMemoryStream">
+      <Version>4.0.1</Version>
+    </NETCoreApp10Dependency>
+    <NETCoreApp10Dependency Include="System.Linq.Expressions">
+      <Version>4.1.0</Version>
+    </NETCoreApp10Dependency>
+    <NETCoreApp10Dependency Include="System.Linq.Parallel">
+      <Version>4.0.1</Version>
+    </NETCoreApp10Dependency>
+    <NETCoreApp10Dependency Include="System.Linq.Queryable">
+      <Version>4.0.1</Version>
+    </NETCoreApp10Dependency>
+    <NETCoreApp10Dependency Include="System.Net.NameResolution">
+      <Version>4.0.0</Version>
+    </NETCoreApp10Dependency>
+    <NETCoreApp10Dependency Include="System.Net.Requests">
+      <Version>4.0.11</Version>
+    </NETCoreApp10Dependency>
+    <NETCoreApp10Dependency Include="System.Net.Security">
+      <Version>4.0.0</Version>
+    </NETCoreApp10Dependency>
+    <NETCoreApp10Dependency Include="System.Net.WebHeaderCollection">
+      <Version>4.0.1</Version>
+    </NETCoreApp10Dependency>
+    <NETCoreApp10Dependency Include="System.Numerics.Vectors">
+      <Version>4.1.1</Version>
+    </NETCoreApp10Dependency>
+    <NETCoreApp10Dependency Include="System.Reflection.DispatchProxy">
+      <Version>4.0.1</Version>
+    </NETCoreApp10Dependency>
+    <NETCoreApp10Dependency Include="System.Reflection.Metadata">
+      <Version>1.3.0</Version>
+    </NETCoreApp10Dependency>
+    <NETCoreApp10Dependency Include="System.Reflection.TypeExtensions">
+      <Version>4.1.0</Version>
+    </NETCoreApp10Dependency>
+    <NETCoreApp10Dependency Include="System.Resources.Reader">
+      <Version>4.0.0</Version>
+    </NETCoreApp10Dependency>
+    <NETCoreApp10Dependency Include="System.Runtime.Loader">
+      <Version>4.0.0</Version>
+      <Exclude>Compile</Exclude>
+    </NETCoreApp10Dependency>
+    <NETCoreApp10Dependency Include="System.Security.Cryptography.Algorithms">
+      <Version>4.2.0</Version>
+    </NETCoreApp10Dependency>
+    <NETCoreApp10Dependency Include="System.Security.Cryptography.Encoding">
+      <Version>4.0.0</Version>
+    </NETCoreApp10Dependency>
+    <NETCoreApp10Dependency Include="System.Security.Cryptography.Primitives">
+      <Version>4.0.0</Version>
+    </NETCoreApp10Dependency>
+    <NETCoreApp10Dependency Include="System.Security.Cryptography.X509Certificates">
+      <Version>4.1.0</Version>
+    </NETCoreApp10Dependency>
+    <NETCoreApp10Dependency Include="System.Threading.Tasks.Dataflow">
+      <Version>4.6.0</Version>
+    </NETCoreApp10Dependency>
+    <NETCoreApp10Dependency Include="System.Threading.Tasks.Extensions">
+      <Version>4.0.0</Version>
+    </NETCoreApp10Dependency>
+    <NETCoreApp10Dependency Include="System.Threading.Tasks.Parallel">
+      <Version>4.0.1</Version>
+    </NETCoreApp10Dependency>
+    <NETCoreApp10Dependency Include="System.Threading.Thread">
+      <Version>4.0.0</Version>
+    </NETCoreApp10Dependency>
+    <NETCoreApp10Dependency Include="System.Threading.ThreadPool">
+      <Version>4.0.10</Version>
+    </NETCoreApp10Dependency>
+    <NETCoreApp10Dependency Include="Libuv">
+      <Version>1.9.0</Version>
+    </NETCoreApp10Dependency>
+
+    <Dependency Include="@(NETCoreApp10Dependency)">
+      <TargetFramework>.NETCoreApp1.0</TargetFramework>
+    </Dependency>
+  </ItemGroup>
 
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/test/HostActivationTests/project.json
+++ b/test/HostActivationTests/project.json
@@ -16,7 +16,7 @@
     "Newtonsoft.Json": "9.0.1"
   },
   "frameworks": {
-    "netcoreapp1.0": {
+    "netcoreapp1.1": {
       "imports": [
         "dotnet5.4",
         "portable-net451+win8"

--- a/test/TestUtils/TestProjectFixture.cs
+++ b/test/TestUtils/TestProjectFixture.cs
@@ -8,7 +8,7 @@ namespace Microsoft.DotNet.CoreSetup.Test
     /*
      * TestProjectFixture is an abstraction around a TestProject which manages
      * setup of the TestProject, copying test projects for perf on build/restore,
-     * and building/publishing/restoring test projects where necessary. 
+     * and building/publishing/restoring test projects where necessary.
      */
     public class TestProjectFixture
     {
@@ -56,9 +56,9 @@ namespace Microsoft.DotNet.CoreSetup.Test
             _testProjectName = testProjectName;
 
             _exeExtension = exeExtension ?? RuntimeInformationExtensions.GetExeExtensionForCurrentOSPlatform();
-            _sharedLibraryExtension = sharedLibraryExtension 
+            _sharedLibraryExtension = sharedLibraryExtension
                 ?? RuntimeInformationExtensions.GetSharedLibraryExtensionForCurrentPlatform();
-            _sharedLibraryPrefix = sharedLibraryPrefix 
+            _sharedLibraryPrefix = sharedLibraryPrefix
                 ?? RuntimeInformationExtensions.GetSharedLibraryPrefixForCurrentPlatform();
 
             _repoDirectoriesProvider = repoDirectoriesProvider;
@@ -71,12 +71,12 @@ namespace Microsoft.DotNet.CoreSetup.Test
 
             _sdkDotnet = new DotNetCli(dotnetInstallPath ?? DotNetCli.GetStage0Path(repoDirectoriesProvider.RepoRoot));
             _currentRid = currentRid ?? _sdkDotnet.GetRuntimeId();
-            
+
             _builtDotnet = new DotNetCli(repoDirectoriesProvider.BuiltDotnet);
 
             InitializeTestProject(
                 _testProjectName,
-                _testProjectSourceDirectory, 
+                _testProjectSourceDirectory,
                 _testArtifactDirectory,
                 _exeExtension,
                 _sharedLibraryExtension,
@@ -98,8 +98,8 @@ namespace Microsoft.DotNet.CoreSetup.Test
             _sourceTestProject = fixtureToCopy._sourceTestProject;
 
             _testProject = CopyTestProject(
-                fixtureToCopy.TestProject, 
-                _testArtifactDirectory, 
+                fixtureToCopy.TestProject,
+                _testArtifactDirectory,
                 _exeExtension,
                 _sharedLibraryExtension,
                 _sharedLibraryPrefix);
@@ -121,27 +121,27 @@ namespace Microsoft.DotNet.CoreSetup.Test
                 sharedLibraryPrefix);
 
             _testProject = CopyTestProject(
-                _sourceTestProject, 
-                testArtifactDirectory, 
+                _sourceTestProject,
+                testArtifactDirectory,
                 exeExtension,
                 sharedLibraryExtension,
                 sharedLibraryPrefix);
         }
 
         private TestProject CopyTestProject(
-            TestProject sourceTestProject, 
-            string testArtifactDirectory, 
+            TestProject sourceTestProject,
+            string testArtifactDirectory,
             string exeExtension,
             string sharedLibraryExtension,
             string sharedLibraryPrefix)
         {
             string copiedTestProjectDirectory = CalculateTestProjectDirectory(
-                sourceTestProject.ProjectName, 
+                sourceTestProject.ProjectName,
                 testArtifactDirectory);
 
             sourceTestProject.CopyProjectFiles(copiedTestProjectDirectory);
             return new TestProject(
-                copiedTestProjectDirectory, 
+                copiedTestProjectDirectory,
                 exeExtension,
                 sharedLibraryExtension,
                 sharedLibraryPrefix);
@@ -159,7 +159,7 @@ namespace Microsoft.DotNet.CoreSetup.Test
 
             return projectDirectory;
         }
-        
+
         private void ValidateRequiredDirectories(RepoDirectoriesProvider repoDirectoriesProvider)
         {
             if ( ! Directory.Exists(repoDirectoriesProvider.BuiltDotnet))
@@ -179,9 +179,9 @@ namespace Microsoft.DotNet.CoreSetup.Test
         }
 
         public TestProjectFixture BuildProject(
-            DotNetCli dotnet = null, 
-            string runtime = null, 
-            string framework = "netcoreapp1.0",
+            DotNetCli dotnet = null,
+            string runtime = null,
+            string framework = "netcoreapp1.1",
             string outputDirectory = null)
         {
             dotnet = dotnet ?? _sdkDotnet;
@@ -223,7 +223,7 @@ namespace Microsoft.DotNet.CoreSetup.Test
         public TestProjectFixture PublishProject(
             DotNetCli dotnet = null,
             string runtime = null,
-            string framework = "netcoreapp1.0",
+            string framework = "netcoreapp1.1",
             string outputDirectory = null)
         {
             dotnet = dotnet ?? _sdkDotnet;


### PR DESCRIPTION
Fix https://github.com/dotnet/core-setup/issues/456

cc @ericstj @gkhanna79 

Right now the test projects in this branch are still using netcoreapp1.0 as the target framework. I'm still debating whether or not to try and update those to netcoreapp1.1 like I'm doing in master with https://github.com/dotnet/core-setup/pull/462. What do you guys think?