### PR TITLE
Enable WinArm32 build

### DIFF
--- a/build_projects/dotnet-host-build/CompileTargets.cs
+++ b/build_projects/dotnet-host-build/CompileTargets.cs
@@ -207,8 +207,7 @@ namespace Microsoft.DotNet.Host.Build
                     case "arm":
                         cmakeBaseRid = "-DCLI_CMAKE_PKG_RID:STRING=win8-arm";
                         visualStudio = "Visual Studio 14 2015 ARM";
-                        archMacro = "-DCLI_CMAKE_PLATFORM_ARCH_ARM=1";
-                        cmakeExtraArgs += "-DCMAKE_SYSTEM_VERSION=10.0";
+                        archMacro = "-DCLI_CMAKE_PLATFORM_ARCH_ARM=1 -DCMAKE_SYSTEM_VERSION=10.0";
                         arch = "arm";
                         break;
                     case "arm64":
@@ -241,7 +240,6 @@ namespace Microsoft.DotNet.Host.Build
                     cmakeBaseRid,
                     cmakeCommitHash,
                     cmakeResourceDir,
-                    cmakeExtraArgs,
                     "-G",
                     visualStudio);
 

--- a/build_projects/dotnet-host-build/CompileTargets.cs
+++ b/build_projects/dotnet-host-build/CompileTargets.cs
@@ -24,6 +24,7 @@ namespace Microsoft.DotNet.Host.Build
             // Key: Current platform RID. Value: The actual publishable (non-dummy) package name produced by the build system for this RID.
             { "win7-x64", "win7-x64" },
             { "win7-x86", "win7-x86" },
+            { "win8-arm", "win8-arm" },
             { "win10-arm64", "win10-arm64" },
             { "osx.10.10-x64", "osx.10.10-x64" },
             { "osx.10.11-x64", "osx.10.10-x64" },
@@ -193,6 +194,7 @@ namespace Microsoft.DotNet.Host.Build
                 string cmakeHostFxrVer = $"-DCLI_CMAKE_HOST_FXR_VER:STRING={hostVersion.LatestHostFxrVersion.ToString()}";
                 string cmakeCommitHash = $"-DCLI_CMAKE_COMMIT_HASH:STRING={commitHash}";
                 string cmakeResourceDir = $"-DCLI_CMAKE_RESOURCE_DIR:STRING={resourceDir}";
+                string cmakeExtraArgs = "";
 
                 switch (platform.ToLower())
                 {
@@ -201,6 +203,13 @@ namespace Microsoft.DotNet.Host.Build
                         visualStudio = "Visual Studio 14 2015";
                         archMacro = "-DCLI_CMAKE_PLATFORM_ARCH_I386=1";
                         arch = "x86";
+                        break;
+                    case "arm":
+                        cmakeBaseRid = "-DCLI_CMAKE_PKG_RID:STRING=win8-arm";
+                        visualStudio = "Visual Studio 14 2015 ARM";
+                        archMacro = "-DCLI_CMAKE_PLATFORM_ARCH_ARM=1";
+                        cmakeExtraArgs += "-DCMAKE_SYSTEM_VERSION=10.0";
+                        arch = "arm";
                         break;
                     case "arm64":
                         cmakeBaseRid = "-DCLI_CMAKE_PKG_RID:STRING=win10-arm64";
@@ -232,6 +241,7 @@ namespace Microsoft.DotNet.Host.Build
                     cmakeBaseRid,
                     cmakeCommitHash,
                     cmakeResourceDir,
+                    cmakeExtraArgs,
                     "-G",
                     visualStudio);
 

--- a/build_projects/dotnet-host-build/PublishTargets.cs
+++ b/build_projects/dotnet-host-build/PublishTargets.cs
@@ -115,6 +115,7 @@ namespace Microsoft.DotNet.Host.Build
                     {
                         "win.x86.version",
                         "win.x64.version",
+                        "win.arm.version",
                         "win.arm64.version",
                         "ubuntu.x64.version",
                         "ubuntu.16.04.x64.version",
@@ -180,6 +181,7 @@ namespace Microsoft.DotNet.Host.Build
              {
                  { "sharedfx_Windows_x86", false },
                  { "sharedfx_Windows_x64", false },
+                 { "sharedfx_Windows_arm", false },
                  { "sharedfx_Windows_arm64", false },
                  { "sharedfx_Ubuntu_x64", false },
                  { "sharedfx_Ubuntu_16_04_x64", false },

--- a/build_projects/dotnet-host-build/build.ps1
+++ b/build_projects/dotnet-host-build/build.ps1
@@ -21,7 +21,7 @@ if($Help)
     Write-Host "Options:"
     Write-Host "  -Configuration <CONFIGURATION>     Build the specified Configuration (Debug or Release, default: Debug)"
     Write-Host "  -Architecture  <ARCHITECTURE>      Build on the specified architecture (x64 or x86 (supported only on Windows), default: x64)"
-    Write-Host "  -TargetArch  <ARCHITECTURE>        Build for the specified architecture (x64, x86 (supported only on Windows), or arm64, default: x64)"
+    Write-Host "  -TargetArch  <ARCHITECTURE>        Build for the specified architecture (x64, x86 (supported only on Windows), arm, or arm64, default: x64)"
     Write-Host "  -ToolsetDir  <TOOLSETDIR>          Temporary variable specifying a path to a toolset to use when building the native host for ARM64. To be removed when the toolset is publicly available. )"
     Write-Host "  -Framework  <FRAMEWORK>            Build the specified framework (netcoreapp1.0 or netcoreapp1.1, default: netcoreapp1.0)"
     Write-Host "  -Targets <TARGETS...>              Comma separated build targets to run (Init, Compile, Publish, etc.; Default is a full build and publish)"
@@ -62,6 +62,10 @@ if($TargetArch -eq "x86" -and $Architecture -ne "x86")
 if($TargetArch -eq "x64" -and $Architecture -ne "x64")
 {
     $env:TARGETRID = "win7-x64";
+}
+if($TargetArch -eq "arm")
+{
+    $env:TARGETRID = "win8-arm";
 }
 
 if($NoPackage)

--- a/build_projects/shared-build-targets-utils/DependencyVersions.cs
+++ b/build_projects/shared-build-targets-utils/DependencyVersions.cs
@@ -7,7 +7,7 @@ namespace Microsoft.DotNet.Cli.Build
 {
     public class DependencyVersions
     {
-    	public static readonly string CoreCLRVersion = "1.2.0-beta-24522-03";
-        public static readonly string JitVersion = "1.2.0-beta-24522-03";
+    	public static readonly string CoreCLRVersion = "1.2.0-beta-24619-03";
+        public static readonly string JitVersion = "1.2.0-beta-24619-03";
     }
 }

--- a/build_projects/shared-build-targets-utils/Utils/Crossgen.cs
+++ b/build_projects/shared-build-targets-utils/Utils/Crossgen.cs
@@ -38,14 +38,27 @@ namespace Microsoft.DotNet.Cli.Build
         private string GetCrossgenPathForVersion()
         {
             var crossgenPackagePath = GetCrossGenPackagePathForVersion();
+            string ridCrossgen = null;
 
             if (crossgenPackagePath == null)
             {
-                return null;
+                return ridCrossgen;
             }
-            return (_targetRID == "win10-arm64") ?
-                Path.Combine(crossgenPackagePath, "tools", "x64_arm64", $"crossgen{Constants.ExeSuffix}") :
-                Path.Combine(crossgenPackagePath, "tools", $"crossgen{Constants.ExeSuffix}");
+
+            if (_targetRID == "win8-arm")
+            {
+                ridCrossgen = Path.Combine(crossgenPackagePath, "tools", "x86_arm", $"crossgen{Constants.ExeSuffix}");
+            }
+            else if (_targetRID == "win10-arm64")
+            {
+                ridCrossgen = Path.Combine(crossgenPackagePath, "tools", "x64_arm64", $"crossgen{Constants.ExeSuffix}");
+            }
+            else
+            {
+                ridCrossgen = Path.Combine(crossgenPackagePath, "tools", $"crossgen{Constants.ExeSuffix}");
+            }
+
+            return ridCrossgen;
         }
 
         private string GetLibCLRJitPathForVersion()
@@ -57,9 +70,19 @@ namespace Microsoft.DotNet.Cli.Build
             {
                 return null;
             }
-            return (_targetRID == "win10-arm64") ?
-                Path.Combine(jitPackagePath, "runtimes", "x64_arm64", "native", $"{Constants.DynamicLibPrefix}clrjit{Constants.DynamicLibSuffix}") :
-                Path.Combine(jitPackagePath, "runtimes", jitRid, "native", $"{Constants.DynamicLibPrefix}clrjit{Constants.DynamicLibSuffix}");
+
+            string jitPath = Path.Combine(jitPackagePath, "runtimes", jitRid, "native", $"{Constants.DynamicLibPrefix}clrjit{Constants.DynamicLibSuffix}");
+            
+            if (_targetRID == "win8-arm") 
+            {
+                jitPath = Path.Combine(jitPackagePath, "runtimes", "x86_arm", "native", $"{Constants.DynamicLibPrefix}clrjit{Constants.DynamicLibSuffix}");
+            }
+            else if (_targetRID == "win10-arm64") 
+            {
+                jitPath = Path.Combine(jitPackagePath, "runtimes", "x64_arm64", "native", $"{Constants.DynamicLibPrefix}clrjit{Constants.DynamicLibSuffix}");
+            }
+            
+            return jitPath;
         }
 
         private string GetJitPackagePathForVersion()

--- a/build_projects/shared-build-targets-utils/Utils/SharedFrameworkPublisher.cs
+++ b/build_projects/shared-build-targets-utils/Utils/SharedFrameworkPublisher.cs
@@ -42,7 +42,16 @@ namespace Microsoft.DotNet.Cli.Build
             _corehostLockedDirectory = corehostLockedDirectory;
             _corehostLatestDirectory = corehostLatestDirectory;
             _corehostPackageSource = corehostPackageSource;
-            _crossgenUtil = new Crossgen(DependencyVersions.CoreCLRVersion, DependencyVersions.JitVersion, sharedFrameworkRid == "win10-arm64" ? sharedFrameworkRid : null);
+
+            string crossgenRID = null;
+
+            // If we are dealing with cross-targeting compilation, then specify the 
+            // correct RID for crossgen to use when compiling SharedFramework.
+            if ((sharedFrameworkRid == "win8-arm") || (sharedFrameworkRid == "win10-arm64"))
+            {
+                crossgenRID = sharedFrameworkRid;
+            }
+            _crossgenUtil = new Crossgen(DependencyVersions.CoreCLRVersion, DependencyVersions.JitVersion, crossgenRID);
 
             _sharedFrameworkTemplateSourceRoot = Path.Combine(repoRoot, "src", "sharedframework", "framework");
             _sharedFrameworkNugetVersion = sharedFrameworkNugetVersion;

--- a/packaging/windows/host/generatemsi.ps1
+++ b/packaging/windows/host/generatemsi.ps1
@@ -9,6 +9,7 @@ param(
     [Parameter(Mandatory=$true)][string]$SharedHostMSIVersion,
     [Parameter(Mandatory=$true)][string]$SharedHostNugetVersion,
     [Parameter(Mandatory=$true)][string]$Architecture,
+    [Parameter(Mandatory=$true)][string]$TargetArchitecture,
     [Parameter(Mandatory=$true)][string]$WixObjRoot
 )
 
@@ -31,6 +32,7 @@ function RunCandle
         -dProductMoniker="$ProductMoniker" `
         -dBuildVersion="$SharedHostMSIVersion" `
         -dNugetVersion="$SharedHostNugetVersion" `
+        -dTargetArchitecture="$TargetArchitecture" `
         -arch $Architecture `
         "$AuthWsxRoot\host.wxs" `
         "$AuthWsxRoot\provider.wxs" `

--- a/packaging/windows/host/variables.wxi
+++ b/packaging/windows/host/variables.wxi
@@ -7,7 +7,7 @@
   <?define Dotnet_ProductVersion   =   "$(var.BuildVersion)" ?>
   <?define Dotnet_BuildVersion   =   "$(var.BuildVersion)" ?>
   <?define Manufacturer     =   "Microsoft Corporation" ?>
-  <?define ProductName      =   "$(var.ProductMoniker) ($(sys.BUILDARCH))" ?>
+  <?define ProductName      =   "$(var.ProductMoniker) ($(var.TargetArchitecture))" ?>
   <?define ProductLanguage  =   "1033" ?>
   <?define ProductVersion   =   "$(var.Dotnet_ProductVersion)" ?>
   <?define LCID  = "$(var.ProductLanguage)"?>

--- a/packaging/windows/hostfxr/generatemsi.ps1
+++ b/packaging/windows/hostfxr/generatemsi.ps1
@@ -9,6 +9,7 @@ param(
     [Parameter(Mandatory=$true)][string]$HostFxrMSIVersion,
     [Parameter(Mandatory=$true)][string]$HostFxrNugetVersion,
     [Parameter(Mandatory=$true)][string]$Architecture,
+    [Parameter(Mandatory=$true)][string]$TargetArchitecture,
     [Parameter(Mandatory=$true)][string]$WixObjRoot
 )
 
@@ -63,6 +64,7 @@ function RunCandle
         -dBuildVersion="$HostFxrMSIVersion" `
         -dNugetVersion="$HostFxrNugetVersion" `
         -dComponentVersion="$ComponentVersion" `
+        -dTargetArchitecture="$TargetArchitecture" `
         -arch $Architecture `
         -ext WixDependencyExtension.dll `
         "$AuthWsxRoot\hostfxr.wxs" `

--- a/packaging/windows/hostfxr/variables.wxi
+++ b/packaging/windows/hostfxr/variables.wxi
@@ -8,7 +8,7 @@
   <?define HostFxr_ProductVersion   =   "$(var.BuildVersion)" ?>
   <?define HostFxr_BuildVersion   =   "$(var.BuildVersion)" ?>
   <?define Manufacturer     =   "Microsoft Corporation" ?>
-  <?define ProductName      =   "$(var.ProductMoniker) ($(sys.BUILDARCH))" ?>
+  <?define ProductName      =   "$(var.ProductMoniker) ($(var.TargetArchitecture))" ?>
   <?define ProductLanguage  =   "1033" ?>
   <?define ProductVersion   =   "$(var.HostFxr_ProductVersion)" ?>
   <?define LCID  = "$(var.ProductLanguage)"?>

--- a/packaging/windows/sharedframework/bundle.wxs
+++ b/packaging/windows/sharedframework/bundle.wxs
@@ -24,7 +24,7 @@
     <swid:Tag Regid="microsoft.com" InstallPath="[DOTNETHOME]" />
 
     <Variable Name="DOTNETHOME" Type="string" Value="[ProgramFiles6432Folder]dotnet" bal:Overridable="no" />
-    <Variable Name="BUNDLEMONIKER" Type="string" Value="$(var.ProductMoniker)" bal:Overridable="no" />
+    <Variable Name="BUNDLEMONIKER" Type="string" Value="$(var.ProductMoniker) ($(var.TargetArchitecture))" bal:Overridable="no" />
 
     <Chain DisableSystemRestore="yes" ParallelCache="yes">
       <ExePackage Name="VC_redist.$(var.Platform).exe"

--- a/packaging/windows/sharedframework/generatebundle.ps1
+++ b/packaging/windows/sharedframework/generatebundle.ps1
@@ -13,6 +13,7 @@ param(
     [Parameter(Mandatory=$true)][string]$SharedFrameworkNugetName,
     [Parameter(Mandatory=$true)][string]$SharedFrameworkNugetVersion,
     [Parameter(Mandatory=$true)][string]$SharedFrameworkUpgradeCode,
+    [Parameter(Mandatory=$true)][string]$TargetArchitecture,
     [Parameter(Mandatory=$true)][string]$Architecture
 )
 
@@ -40,6 +41,7 @@ function RunCandleForBundle
         -dFrameworkDisplayVersion="$SharedFrameworkNugetVersion" `
         -dFrameworkComponentVersion="$SharedFrameworkComponentVersion" `
         -dFrameworkUpgradeCode="$SharedFrameworkUpgradeCode" `
+        -dTargetArchitecture="$TargetArchitecture" `
         -arch "$Architecture" `
         -ext WixBalExtension.dll `
         -ext WixUtilExtension.dll `

--- a/packaging/windows/sharedframework/generatemsi.ps1
+++ b/packaging/windows/sharedframework/generatemsi.ps1
@@ -11,6 +11,7 @@ param(
     [Parameter(Mandatory=$true)][string]$SharedFrameworkNugetVersion,
     [Parameter(Mandatory=$true)][string]$SharedFrameworkUpgradeCode,
     [Parameter(Mandatory=$true)][string]$Architecture,
+    [Parameter(Mandatory=$true)][string]$TargetArchitecture,
     [Parameter(Mandatory=$true)][string]$WixObjRoot
 )
 
@@ -66,6 +67,7 @@ function RunCandle
         -dFrameworkDisplayVersion="$SharedFrameworkNugetVersion" `
         -dFrameworkComponentVersion="$SharedFrameworkComponentVersion" `
         -dFrameworkUpgradeCode="$SharedFrameworkUpgradeCode" `
+        -dTargetArchitecture="$TargetArchitecture" `
         -dBuildVersion="$DotnetMSIVersion" `
         -arch $Architecture `
         -ext WixDependencyExtension.dll `

--- a/packaging/windows/sharedframework/variables.wxi
+++ b/packaging/windows/sharedframework/variables.wxi
@@ -5,7 +5,7 @@
   <?define Servicing_Key_SPIndex   =   "0" ?>
   <?define Servicing_Key_SPName   =   "Beta" ?>
   <?define Manufacturer     =   "Microsoft Corporation" ?>
-  <?define ProductName      =   "$(var.ProductMoniker) ($(sys.BUILDARCH))" ?>
+  <?define ProductName      =   "$(var.ProductMoniker) ($(var.TargetArchitecture))" ?>
   <?define ProductLanguage  =   "1033" ?>
   <?define ProductVersion   =   "$(var.BuildVersion)" ?>
   <?define LCID  = "$(var.ProductLanguage)"?>

--- a/pkg/projects/Microsoft.NETCore.App/project.json
+++ b/pkg/projects/Microsoft.NETCore.App/project.json
@@ -3,7 +3,7 @@
     "Microsoft.CodeAnalysis.CSharp": "1.3.0",
     "Microsoft.CodeAnalysis.VisualBasic": "1.3.0",
     "Microsoft.CSharp": "4.0.1",
-    "Microsoft.NETCore.Runtime.CoreCLR": "1.2.0-beta-24522-03",
+    "Microsoft.NETCore.Runtime.CoreCLR": "1.2.0-beta-24619-03",
     "Microsoft.VisualBasic": "10.0.1",
     "NETStandard.Library": "1.6.1-preview1-24508-08",
     "System.Buffers": "4.0.0",

--- a/pkg/projects/Microsoft.NETCore.DotNetHost/Microsoft.NETCore.DotNetHost.builds
+++ b/pkg/projects/Microsoft.NETCore.DotNetHost/Microsoft.NETCore.DotNetHost.builds
@@ -21,6 +21,10 @@
     </Project>
     <Project Condition="'$(TargetsWindows)' == 'true'" Include="win/Microsoft.NETCore.DotNetHost.pkgproj">
       <OSGroup>Windows_NT</OSGroup>
+      <Platform>arm</Platform>
+    </Project>
+    <Project Condition="'$(TargetsWindows)' == 'true'" Include="win/Microsoft.NETCore.DotNetHost.pkgproj">
+      <OSGroup>Windows_NT</OSGroup>
       <Platform>arm64</Platform>
     </Project>
     <Project Condition="'$(TargetsLinux)' == 'true' and ('$(DistroRid)' =='centos.7-x64' or $(DistroRid.StartsWith('rhel.7')))" Include="rhel/Microsoft.NETCore.DotNetHost.pkgproj">

--- a/pkg/projects/Microsoft.NETCore.DotNetHost/Microsoft.NETCore.DotNetHost.pkgproj
+++ b/pkg/projects/Microsoft.NETCore.DotNetHost/Microsoft.NETCore.DotNetHost.pkgproj
@@ -6,7 +6,7 @@
     <Version>$(HostVersion)</Version>
     <SkipPackageFileCheck>true</SkipPackageFileCheck>
     <SkipValidatePackage>true</SkipValidatePackage>
-    <PackagePlatforms>x64;x86;arm64;</PackagePlatforms>
+    <PackagePlatforms>x64;x86;arm;arm64;</PackagePlatforms>
     <OutputPath>$(PackagesOutputPath)</OutputPath>
     <IncludeRuntimeJson>true</IncludeRuntimeJson>
     <Serviceable>true</Serviceable>
@@ -18,6 +18,9 @@
     </ProjectReference>
     <ProjectReference Include="win\Microsoft.NETCore.DotNetHost.pkgproj">
       <Platform>x86</Platform>
+    </ProjectReference>
+    <ProjectReference Include="win\Microsoft.NETCore.DotNetHost.pkgproj">
+      <Platform>arm</Platform>
     </ProjectReference>
     <ProjectReference Include="win\Microsoft.NETCore.DotNetHost.pkgproj">
       <Platform>arm64</Platform>

--- a/pkg/projects/Microsoft.NETCore.DotNetHost/Microsoft.NETCore.DotNetHostPolicy.builds
+++ b/pkg/projects/Microsoft.NETCore.DotNetHost/Microsoft.NETCore.DotNetHostPolicy.builds
@@ -21,6 +21,10 @@
     </Project>
     <Project Condition="'$(TargetsWindows)' == 'true'" Include="win/Microsoft.NETCore.DotNetHostPolicy.pkgproj">
       <OSGroup>Windows_NT</OSGroup>
+      <Platform>arm</Platform>
+    </Project>
+    <Project Condition="'$(TargetsWindows)' == 'true'" Include="win/Microsoft.NETCore.DotNetHostPolicy.pkgproj">
+      <OSGroup>Windows_NT</OSGroup>
       <Platform>arm64</Platform>
     </Project>
     <Project Condition="'$(TargetsLinux)' == 'true' and ('$(DistroRid)' =='centos.7-x64' or $(DistroRid.StartsWith('rhel.7')))" Include="rhel/Microsoft.NETCore.DotNetHostPolicy.pkgproj">

--- a/pkg/projects/Microsoft.NETCore.DotNetHost/Microsoft.NETCore.DotNetHostPolicy.pkgproj
+++ b/pkg/projects/Microsoft.NETCore.DotNetHost/Microsoft.NETCore.DotNetHostPolicy.pkgproj
@@ -6,7 +6,7 @@
     <Version>$(HostPolicyVersion)</Version>
     <SkipPackageFileCheck>true</SkipPackageFileCheck>
     <SkipValidatePackage>true</SkipValidatePackage>
-    <PackagePlatforms>x64;x86;arm64;</PackagePlatforms>
+    <PackagePlatforms>x64;x86;arm;arm64;</PackagePlatforms>
     <OutputPath>$(PackagesOutputPath)</OutputPath>
     <IncludeRuntimeJson>true</IncludeRuntimeJson>
     <Serviceable>true</Serviceable>
@@ -21,6 +21,9 @@
     </ProjectReference>
     <ProjectReference Include="win\Microsoft.NETCore.DotNetHostPolicy.pkgproj">
       <Platform>x86</Platform>
+    </ProjectReference>
+    <ProjectReference Include="win\Microsoft.NETCore.DotNetHostPolicy.pkgproj">
+      <Platform>arm</Platform>
     </ProjectReference>
     <ProjectReference Include="win\Microsoft.NETCore.DotNetHostPolicy.pkgproj">
       <Platform>arm64</Platform>

--- a/pkg/projects/Microsoft.NETCore.DotNetHost/Microsoft.NETCore.DotNetHostResolver.builds
+++ b/pkg/projects/Microsoft.NETCore.DotNetHost/Microsoft.NETCore.DotNetHostResolver.builds
@@ -21,6 +21,10 @@
     </Project>
     <Project Condition="'$(TargetsWindows)' == 'true'" Include="win/Microsoft.NETCore.DotNetHostResolver.pkgproj">
       <OSGroup>Windows_NT</OSGroup>
+      <Platform>arm</Platform>
+    </Project>
+    <Project Condition="'$(TargetsWindows)' == 'true'" Include="win/Microsoft.NETCore.DotNetHostResolver.pkgproj">
+      <OSGroup>Windows_NT</OSGroup>
       <Platform>arm64</Platform>
     </Project>
     <Project Condition="'$(TargetsLinux)' == 'true' and ('$(DistroRid)' =='centos.7-x64' or $(DistroRid.StartsWith('rhel.7')))" Include="rhel/Microsoft.NETCore.DotNetHostResolver.pkgproj">

--- a/pkg/projects/Microsoft.NETCore.DotNetHost/Microsoft.NETCore.DotNetHostResolver.pkgproj
+++ b/pkg/projects/Microsoft.NETCore.DotNetHost/Microsoft.NETCore.DotNetHostResolver.pkgproj
@@ -6,7 +6,7 @@
     <Version>$(HostResolverVersion)</Version>
     <SkipPackageFileCheck>true</SkipPackageFileCheck>
     <SkipValidatePackage>true</SkipValidatePackage>
-    <PackagePlatforms>x64;x86;arm64;</PackagePlatforms>
+    <PackagePlatforms>x64;x86;arm;arm64;</PackagePlatforms>
     <OutputPath>$(PackagesOutputPath)</OutputPath>
     <IncludeRuntimeJson>true</IncludeRuntimeJson>
     <Serviceable>true</Serviceable>
@@ -21,6 +21,9 @@
     </ProjectReference>
     <ProjectReference Include="win\Microsoft.NETCore.DotNetHostResolver.pkgproj">
       <Platform>x86</Platform>
+    </ProjectReference>
+    <ProjectReference Include="win\Microsoft.NETCore.DotNetHostResolver.pkgproj">
+      <Platform>arm</Platform>
     </ProjectReference>
     <ProjectReference Include="win\Microsoft.NETCore.DotNetHostResolver.pkgproj">
       <Platform>arm64</Platform>

--- a/src/corehost/cli/dll/CMakeLists.txt
+++ b/src/corehost/cli/dll/CMakeLists.txt
@@ -60,3 +60,8 @@ if(WIN32)
 endif()
 add_library(hostpolicy SHARED ${SOURCES} ${RESOURCES})
 
+# Specify the import library to link against for Arm32 build since the default set is minimal
+if (WIN32 AND CLI_CMAKE_PLATFORM_ARCH_ARM)
+    target_link_libraries(hostpolicy shell32.lib)
+endif()
+

--- a/src/corehost/cli/exe/CMakeLists.txt
+++ b/src/corehost/cli/exe/CMakeLists.txt
@@ -46,6 +46,11 @@ endif()
 add_executable(dotnet ${SOURCES} ${RESOURCES})
 install(TARGETS dotnet DESTINATION bin)
 
+# Specify the import library to link against for Arm32 build since the default set is minimal
+if (WIN32 AND CLI_CMAKE_PLATFORM_ARCH_ARM)
+    target_link_libraries(dotnet shell32.lib)
+endif()
+
 if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
     target_link_libraries (dotnet "dl" "pthread")
 endif()

--- a/src/corehost/cli/fxr/CMakeLists.txt
+++ b/src/corehost/cli/fxr/CMakeLists.txt
@@ -57,4 +57,9 @@ if(WIN32)
 endif()
 add_library(hostfxr SHARED ${SOURCES} ${RESOURCES})
 
+# Specify the import library to link against for Arm32 build since the default set is minimal
+if (WIN32 AND CLI_CMAKE_PLATFORM_ARCH_ARM)
+    target_link_libraries(hostfxr shell32.lib)
+endif()
+
 

--- a/src/corehost/cli/setup.cmake
+++ b/src/corehost/cli/setup.cmake
@@ -85,6 +85,15 @@ else()
     message(FATAL_ERROR "Unknown target architecture")
 endif()
 
+# Specify the Windows SDK to be used for Arm builds
+if (WIN32 AND CLI_CMAKE_PLATFORM_ARCH_ARM)
+    if(NOT DEFINED CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION OR CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION STREQUAL "" )
+	      message(FATAL_ERROR "Windows SDK is required for the Arm32 build.")
+      else()
+	      message("Using Windows SDK version ${CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION}")
+      endif()
+endif ()
+
 if("${CLI_CMAKE_RUNTIME_ID}" STREQUAL "")
     message(FATAL_ERROR "Runtime ID not specified")
 else()

--- a/src/corehost/common/pal.windows.cpp
+++ b/src/corehost/common/pal.windows.cpp
@@ -161,7 +161,6 @@ bool pal::get_default_servicing_directory(string_t* recv)
     if (!pal::getenv(_X("ProgramFiles(x86)"), recv))
 #else
     // In WOW64 mode, PF maps to PFx86.
-    // For Arm64, there is no wow mode as of now, so this should be fine
     if (!pal::getenv(_X("ProgramFiles"), recv))
 #endif
     {


### PR DESCRIPTION
This change enables building Core-Setup for WinArm32. 

@schellap @ianhays PTAL

