### PR TITLE
[release/1.1.0] Enable Fedora 24 builds

### DIFF
--- a/TestAssets/TestProjects/StandaloneApp/project.json
+++ b/TestAssets/TestProjects/StandaloneApp/project.json
@@ -28,6 +28,7 @@
     "rhel.7.2-x64": {},
     "debian.8-x64": {},
     "fedora.23-x64": {},
+    "fedora.24-x64": {},
     "opensuse.13.2-x64": {},
     "opensuse.42.1-x64": {}
   }

--- a/TestAssets/TestProjects/StandaloneTestApp/project.json
+++ b/TestAssets/TestProjects/StandaloneTestApp/project.json
@@ -38,6 +38,7 @@
     "rhel.7.2-x64": {},
     "debian.8-x64": {},
     "fedora.23-x64": {},
+    "fedora.24-x64": {},
     "opensuse.13.2-x64": {},
     "opensuse.42.1-x64": {}
   }

--- a/build_projects/dotnet-host-build/CompileTargets.cs
+++ b/build_projects/dotnet-host-build/CompileTargets.cs
@@ -35,6 +35,7 @@ namespace Microsoft.DotNet.Host.Build
             { "rhel.7.2-x64", "rhel.7-x64" },
             { "debian.8-x64", "debian.8-x64" },
             { "fedora.23-x64", "fedora.23-x64" },
+            { "fedora.24-x64", "fedora.24-x64" },
             { "opensuse.13.2-x64", "opensuse.13.2-x64" },
             { "opensuse.42.1-x64", "opensuse.42.1-x64" }
         };

--- a/build_projects/dotnet-host-build/PublishTargets.cs
+++ b/build_projects/dotnet-host-build/PublishTargets.cs
@@ -123,6 +123,7 @@ namespace Microsoft.DotNet.Host.Build
                         "debian.x64.version",
                         "centos.x64.version",
                         "fedora.23.x64.version",
+                        "fedora.24.x64.version",
                         "opensuse.13.2.x64.version",
                         "opensuse.42.1.x64.version"
                     };

--- a/build_projects/dotnet-host-build/build.sh
+++ b/build_projects/dotnet-host-build/build.sh
@@ -95,7 +95,7 @@ done < "$REPOROOT/branchinfo.txt"
 
 
 DOTNET_INSTALL_SCRIPT_URL="https://raw.githubusercontent.com/dotnet/cli/rel/1.0.0/scripts/obtain/dotnet-install.sh"
-curl -sSL "$DOTNET_INSTALL_SCRIPT_URL" | bash /dev/stdin --version 1.0.0-preview3-003223-5 --verbose
+curl -sSL "$DOTNET_INSTALL_SCRIPT_URL" | bash /dev/stdin --version 1.0.0-preview3-003223-6 --verbose
 
 # Put stage 0 on the PATH (for this shell only)
 PATH="$DOTNET_INSTALL_DIR:$PATH"

--- a/build_projects/dotnet-host-build/build.sh
+++ b/build_projects/dotnet-host-build/build.sh
@@ -95,7 +95,7 @@ done < "$REPOROOT/branchinfo.txt"
 
 
 DOTNET_INSTALL_SCRIPT_URL="https://raw.githubusercontent.com/dotnet/cli/rel/1.0.0/scripts/obtain/dotnet-install.sh"
-curl -sSL "$DOTNET_INSTALL_SCRIPT_URL" | bash /dev/stdin --version 1.0.0-preview3-003223-3 --verbose
+curl -sSL "$DOTNET_INSTALL_SCRIPT_URL" | bash /dev/stdin --version 1.0.0-preview3-003223-5 --verbose
 
 # Put stage 0 on the PATH (for this shell only)
 PATH="$DOTNET_INSTALL_DIR:$PATH"

--- a/build_projects/dotnet-host-build/project.json
+++ b/build_projects/dotnet-host-build/project.json
@@ -40,6 +40,7 @@
     "rhel.7.2-x64": {},
     "debian.8-x64": {},
     "fedora.23-x64": {},
+    "fedora.24-x64": {},
     "opensuse.13.2-x64": {},
     "opensuse.42.1-x64": {}
   }

--- a/build_projects/shared-build-targets-utils/Utils/Monikers.cs
+++ b/build_projects/shared-build-targets-utils/Utils/Monikers.cs
@@ -41,6 +41,8 @@ namespace Microsoft.DotNet.Cli.Build
                      return "Ubuntu_16_10_x64";
                 case "fedora.23-x64":
                      return "Fedora_23_x64";
+                case "fedora.24-x64":
+                     return "Fedora_24_x64";
                 case "opensuse.13.2-x64":
                      return "openSUSE_13_2_x64";
                 case "opensuse.42.1-x64":

--- a/pkg/projects/Microsoft.NETCore.DotNetHost/Microsoft.NETCore.DotNetHost.builds
+++ b/pkg/projects/Microsoft.NETCore.DotNetHost/Microsoft.NETCore.DotNetHost.builds
@@ -43,6 +43,10 @@
       <OSGroup>Linux</OSGroup>
       <Platform>amd64</Platform>
     </Project>
+    <Project Condition="'$(TargetsLinux)' == 'true' and '$(DistroRid)' == 'fedora.24-x64'" Include="fedora.24/Microsoft.NETCore.DotNetHost.pkgproj">
+      <OSGroup>Linux</OSGroup>
+      <Platform>amd64</Platform>
+    </Project>
     <Project Condition="'$(TargetsLinux)' == 'true' and '$(DistroRid)' == 'debian.8-x64'" Include="debian/Microsoft.NETCore.DotNetHost.pkgproj">
       <OSGroup>Linux</OSGroup>
       <Platform>amd64</Platform>

--- a/pkg/projects/Microsoft.NETCore.DotNetHost/Microsoft.NETCore.DotNetHost.pkgproj
+++ b/pkg/projects/Microsoft.NETCore.DotNetHost/Microsoft.NETCore.DotNetHost.pkgproj
@@ -40,6 +40,9 @@
     <ProjectReference Include="fedora.23\Microsoft.NETCore.DotNetHost.pkgproj">
       <Platform>amd64</Platform>
     </ProjectReference>
+    <ProjectReference Include="fedora.24\Microsoft.NETCore.DotNetHost.pkgproj">
+      <Platform>amd64</Platform>
+    </ProjectReference>
     <ProjectReference Include="debian\Microsoft.NETCore.DotNetHost.pkgproj">
       <Platform>amd64</Platform>
     </ProjectReference>

--- a/pkg/projects/Microsoft.NETCore.DotNetHost/Microsoft.NETCore.DotNetHostPolicy.builds
+++ b/pkg/projects/Microsoft.NETCore.DotNetHost/Microsoft.NETCore.DotNetHostPolicy.builds
@@ -43,6 +43,10 @@
       <OSGroup>Linux</OSGroup>
       <Platform>amd64</Platform>
     </Project>
+    <Project Condition="'$(TargetsLinux)' == 'true' and '$(DistroRid)' == 'fedora.24-x64'" Include="fedora.24/Microsoft.NETCore.DotNetHostPolicy.pkgproj">
+      <OSGroup>Linux</OSGroup>
+      <Platform>amd64</Platform>
+    </Project>
     <Project Condition="'$(TargetsLinux)' == 'true' and '$(DistroRid)' == 'debian.8-x64'" Include="debian/Microsoft.NETCore.DotNetHostPolicy.pkgproj">
       <OSGroup>Linux</OSGroup>
       <Platform>amd64</Platform>

--- a/pkg/projects/Microsoft.NETCore.DotNetHost/Microsoft.NETCore.DotNetHostPolicy.pkgproj
+++ b/pkg/projects/Microsoft.NETCore.DotNetHost/Microsoft.NETCore.DotNetHostPolicy.pkgproj
@@ -43,6 +43,9 @@
     <ProjectReference Include="fedora.23\Microsoft.NETCore.DotNetHostPolicy.pkgproj">
       <Platform>amd64</Platform>
     </ProjectReference>
+    <ProjectReference Include="fedora.24\Microsoft.NETCore.DotNetHostPolicy.pkgproj">
+      <Platform>amd64</Platform>
+    </ProjectReference>
     <ProjectReference Include="debian\Microsoft.NETCore.DotNetHostPolicy.pkgproj">
       <Platform>amd64</Platform>
     </ProjectReference>

--- a/pkg/projects/Microsoft.NETCore.DotNetHost/Microsoft.NETCore.DotNetHostResolver.builds
+++ b/pkg/projects/Microsoft.NETCore.DotNetHost/Microsoft.NETCore.DotNetHostResolver.builds
@@ -43,6 +43,10 @@
       <OSGroup>Linux</OSGroup>
       <Platform>amd64</Platform>
     </Project>
+    <Project Condition="'$(TargetsLinux)' == 'true' and '$(DistroRid)' == 'fedora.24-x64'" Include="fedora.24/Microsoft.NETCore.DotNetHostResolver.pkgproj">
+      <OSGroup>Linux</OSGroup>
+      <Platform>amd64</Platform>
+    </Project>
     <Project Condition="'$(TargetsLinux)' == 'true' and '$(DistroRid)' == 'debian.8-x64'" Include="debian/Microsoft.NETCore.DotNetHostResolver.pkgproj">
       <OSGroup>Linux</OSGroup>
       <Platform>amd64</Platform>

--- a/pkg/projects/Microsoft.NETCore.DotNetHost/Microsoft.NETCore.DotNetHostResolver.pkgproj
+++ b/pkg/projects/Microsoft.NETCore.DotNetHost/Microsoft.NETCore.DotNetHostResolver.pkgproj
@@ -43,6 +43,9 @@
     <ProjectReference Include="fedora.23\Microsoft.NETCore.DotNetHostResolver.pkgproj">
       <Platform>amd64</Platform>
     </ProjectReference>
+    <ProjectReference Include="fedora.24\Microsoft.NETCore.DotNetHostResolver.pkgproj">
+      <Platform>amd64</Platform>
+    </ProjectReference>
     <ProjectReference Include="debian\Microsoft.NETCore.DotNetHostResolver.pkgproj">
       <Platform>amd64</Platform>
     </ProjectReference>

--- a/pkg/projects/Microsoft.NETCore.DotNetHost/fedora.24/Microsoft.NETCore.DotNetHost.pkgproj
+++ b/pkg/projects/Microsoft.NETCore.DotNetHost/fedora.24/Microsoft.NETCore.DotNetHost.pkgproj
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  
+  <PropertyGroup>
+    <Version>$(HostVersion)</Version>
+    <SkipPackageFileCheck>true</SkipPackageFileCheck>
+    <MinOSForArch>fedora.24</MinOSForArch>
+    <PackageTargetRuntime>$(MinOSForArch)-$(PackagePlatform)</PackageTargetRuntime>
+    <Serviceable>true</Serviceable>
+  </PropertyGroup>
+  
+  <ItemGroup>
+    <ArchitectureSpecificNativeFile Include="$(DotNetHostBinDir)/dotnet" />
+
+    <File Include="@(ArchitectureSpecificNativeFile)">
+      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
+    </File>
+    <File Include="$(ProjectDir)/version.txt" />
+  </ItemGroup>
+
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/pkg/projects/Microsoft.NETCore.DotNetHost/fedora.24/Microsoft.NETCore.DotNetHostPolicy.pkgproj
+++ b/pkg/projects/Microsoft.NETCore.DotNetHost/fedora.24/Microsoft.NETCore.DotNetHostPolicy.pkgproj
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  
+  <PropertyGroup>
+    <Version>$(HostPolicyVersion)</Version>
+    <SkipPackageFileCheck>true</SkipPackageFileCheck>
+    <MinOSForArch>fedora.24</MinOSForArch>
+    <PackageTargetRuntime>$(MinOSForArch)-$(PackagePlatform)</PackageTargetRuntime>
+    <Serviceable>true</Serviceable>
+  </PropertyGroup>
+  
+  <ItemGroup>
+    <Dependency Include="Microsoft.NETCore.DotNetHostResolver">
+      <Version>$(HostResolverFullVersion)</Version>
+    </Dependency>
+
+    <ArchitectureSpecificNativeFile Include="$(DotNetHostBinDir)/libhostpolicy.so"/>
+
+    <File Include="@(ArchitectureSpecificNativeFile)">
+      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
+    </File>
+    <File Include="$(ProjectDir)/version.txt" />
+  </ItemGroup>
+
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/pkg/projects/Microsoft.NETCore.DotNetHost/fedora.24/Microsoft.NETCore.DotNetHostResolver.pkgproj
+++ b/pkg/projects/Microsoft.NETCore.DotNetHost/fedora.24/Microsoft.NETCore.DotNetHostResolver.pkgproj
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  
+  <PropertyGroup>
+    <Version>$(HostResolverVersion)</Version>
+    <SkipPackageFileCheck>true</SkipPackageFileCheck>
+    <MinOSForArch>fedora.24</MinOSForArch>
+    <PackageTargetRuntime>$(MinOSForArch)-$(PackagePlatform)</PackageTargetRuntime>
+    <Serviceable>true</Serviceable>
+  </PropertyGroup>
+  
+  <ItemGroup>
+    <Dependency Include="Microsoft.NETCore.DotNetHost">
+      <Version>$(HostFullVersion)</Version>
+    </Dependency>
+
+    <ArchitectureSpecificNativeFile Include="$(DotNetHostBinDir)/libhostfxr.so"/>
+
+    <File Include="@(ArchitectureSpecificNativeFile)">
+      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
+    </File>
+    <File Include="$(ProjectDir)/version.txt" />
+  </ItemGroup>
+
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/scripts/docker/fedora.24/Dockerfile
+++ b/scripts/docker/fedora.24/Dockerfile
@@ -1,0 +1,24 @@
+FROM fedora:24
+
+RUN dnf install -y bash git cmake wget which python clang-3.8.0-2.fc24.x86_64 llvm-devel-3.8.0-1.fc24.x86_64 make libicu-devel lldb-devel.x86_64 \
+                   libunwind-devel.x86_64 lttng-ust-devel.x86_64 uuid-devel libuuid-devel tar glibc-locale-source zlib-devel libcurl-devel \
+                   krb5-devel openssl-devel autoconf libtool hostname
+
+RUN dnf upgrade -y nss
+
+RUN dnf clean all
+
+# Setup User to match Host User, and give superuser permissions 
+ARG USER_ID=0 
+RUN useradd -m code_executor -u ${USER_ID} -g wheel
+RUN echo 'code_executor ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers 
+ 
+# With the User Change, we need to change permissions on these directories 
+RUN chmod -R a+rwx /usr/local 
+RUN chmod -R a+rwx /home
+ 
+# Set user to the one we just created 
+USER ${USER_ID} 
+ 
+# Set working directory 
+WORKDIR /opt/code

--- a/scripts/docker/fedora.24/Dockerfile
+++ b/scripts/docker/fedora.24/Dockerfile
@@ -16,6 +16,9 @@ RUN echo 'code_executor ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
 # With the User Change, we need to change permissions on these directories 
 RUN chmod -R a+rwx /usr/local 
 RUN chmod -R a+rwx /home
+
+# Force buildtools to publish for Fedora 23
+ENV __PUBLISH_RID=fedora.23-x64
  
 # Set user to the one we just created 
 USER ${USER_ID} 

--- a/tools/independent/RuntimeGraphGenerator/project.json
+++ b/tools/independent/RuntimeGraphGenerator/project.json
@@ -32,6 +32,7 @@
     "rhel.7.2-x64": {},
     "debian.8-x64": {},
     "fedora.23-x64": {},
+    "fedora.24-x64": {},
     "opensuse.13.2-x64": {},
     "opensuse.42.1-x64": {}
   }


### PR DESCRIPTION
Fedora 24 is the last new distro we plan to support in 1.1.0. This adds the packaging projects and build work to make that happen. I needed to update the version of CLI we are downloading in order to make a small fix in the Fedora 24 bootstrap version. The contents of the 003223-6 folder are the same as the 003223-3 folder (previously used), except for that small Fedora 24 fix. We need to put everything in a new folder because we are using a "caching" service for our downloads, and it doesn't correctly handle blobs that have been changed or deleted.