### PR TITLE
Publish PlatformAbstractions and DependencyModel packages to Azure

### DIFF
--- a/build_projects/dotnet-host-build/PublishTargets.cs
+++ b/build_projects/dotnet-host-build/PublishTargets.cs
@@ -228,6 +228,7 @@ namespace Microsoft.DotNet.Host.Build
             nameof(PublishTargets.PublishDotnetDebToolPackage),
             nameof(PublishTargets.PublishDebFilesToDebianRepo),
             nameof(PublishTargets.PublishCoreHostPackages),
+            nameof(PublishTargets.PublishManagedPackages),
             nameof(PublishTargets.PublishSharedFrameworkVersionBadge))]
         public static BuildTargetResult PublishArtifacts(BuildTargetContext c) => c.Success();
 
@@ -272,6 +273,22 @@ namespace Microsoft.DotNet.Host.Build
                 var hostBlob = $"{Channel}/Binaries/{SharedFrameworkNugetVersion}/{Path.GetFileName(file)}";
                 AzurePublisherTool.PublishFile(hostBlob, file);
                 Console.WriteLine($"Publishing package {hostBlob} to Azure.");
+            }
+
+            return c.Success();
+        }
+
+        [Target]
+        public static BuildTargetResult PublishManagedPackages(BuildTargetContext c)
+        {
+            if (EnvVars.Signed)
+            {
+                foreach (var file in Directory.GetFiles(Dirs.Packages, "*.nupkg"))
+                {
+                    var hostBlob = $"{Channel}/Binaries/{SharedFrameworkNugetVersion}/{Path.GetFileName(file)}";
+                    AzurePublisherTool.PublishFile(hostBlob, file);
+                    Console.WriteLine($"Publishing package {hostBlob} to Azure.");
+                }
             }
 
             return c.Success();

--- a/build_projects/shared-build-targets-utils/Utils/EnvVars.cs
+++ b/build_projects/shared-build-targets-utils/Utils/EnvVars.cs
@@ -7,6 +7,8 @@ namespace Microsoft.DotNet.Cli.Build
     {
         public static readonly bool Verbose = GetBool("DOTNET_BUILD_VERBOSE");
 
+        public static readonly bool Signed = GetBool("SIGNED_PACKAGES");
+
         private static bool GetBool(string name, bool defaultValue = false)
         {
             var str = Environment.GetEnvironmentVariable(name);


### PR DESCRIPTION
CC @gkhanna79 @dagood @livarcocc

This change will allow us to publish the Microsoft.Dotnet.PlatformAbstractions and Microsoft.Extensions.DependencyModel packages to Azure - from there they'll be picked up by core-setup's finalizer step and published to MyGet, meaning we'll need to disable the 'nuget publisher' step in the Windows builds. To account for only wanting to publish the signed, Windows versions of these packages, we'll set a variable named "SIGNED_PACKAGES" to 'true' in the Windows signing build definitions, and 'false' in all others.
