### PR TITLE
Revert "Update UWP metapackage to reference latest .NET Core 1.1 Seri…

### DIFF
--- a/pkg/projects/Microsoft.NETCore.UniversalWindowsPlatform/project.json
+++ b/pkg/projects/Microsoft.NETCore.UniversalWindowsPlatform/project.json
@@ -19,9 +19,9 @@
     "System.Numerics.Vectors.WindowsRuntime": "4.0.1",
     "System.Reflection.Context": "4.0.1",
     "System.Runtime.InteropServices.WindowsRuntime": "4.0.1",
-    "System.Runtime.Serialization.Json": "4.3.0-preview1-24530-04",
-    "System.Runtime.Serialization.Primitives": "4.3.0-preview1-24530-04",
-    "System.Runtime.Serialization.Xml": "4.3.0-preview1-24530-04",
+    "System.Runtime.Serialization.Json": "4.0.2",
+    "System.Runtime.Serialization.Primitives": "4.1.1",
+    "System.Runtime.Serialization.Xml": "4.1.1",
     "System.Runtime.WindowsRuntime": "4.0.11",
     "System.Runtime.WindowsRuntime.UI.Xaml": "4.0.1",
     "System.ServiceModel.Duplex": "4.0.1",
@@ -30,7 +30,7 @@
     "System.ServiceModel.Primitives": "4.1.0",
     "System.ServiceModel.Security": "4.0.1",
     "System.Text.Encoding.CodePages": "4.0.1",
-    "System.Xml.XmlSerializer": "4.3.0-preview1-24530-04"
+    "System.Xml.XmlSerializer": "4.0.11"
   },
   "frameworks": {
     "netstandard1.5": {}


### PR DESCRIPTION
This reverts commit 62d2a9bcc95a58089e90be6f49f9da6b14bac099.

- Revert the 1.1 Serialization packages. We would like to push out the UWP metapackage 5.3.0-beta to include the newest Microsoft.Net.Native.Compiler package, but we are unaware of testing done on the serialization packages at this time
