### PR TITLE
[release/1.1.0] Add handling for Fedora 24 in some build code.

### DIFF
--- a/build_projects/dotnet-host-build/PublishTargets.cs
+++ b/build_projects/dotnet-host-build/PublishTargets.cs
@@ -190,6 +190,7 @@ namespace Microsoft.DotNet.Host.Build
                  { "sharedfx_Debian_x64", false },
                  { "sharedfx_CentOS_x64", false },
                  { "sharedfx_Fedora_23_x64", false },
+                 { "sharedfx_Fedora_24_x64", false },
                  { "sharedfx_openSUSE_13_2_x64", false },
                  { "sharedfx_openSUSE_42_1_x64", false }
              };

--- a/build_projects/shared-build-targets-utils/Utils/Monikers.cs
+++ b/build_projects/shared-build-targets-utils/Utils/Monikers.cs
@@ -19,7 +19,7 @@ namespace Microsoft.DotNet.Cli.Build
         {
             string rid = Environment.GetEnvironmentVariable("TARGETRID") ?? RuntimeEnvironment.GetRuntimeIdentifier();
 
-            if (rid == "ubuntu.16.04-x64" || rid == "ubuntu.16.10-x64" || rid == "fedora.23-x64" || rid == "opensuse.13.2-x64" || rid == "opensuse.42.1-x64")
+            if (rid == "ubuntu.16.04-x64" || rid == "ubuntu.16.10-x64" || rid == "fedora.23-x64" || rid == "fedora.24-x64" || rid == "opensuse.13.2-x64" || rid == "opensuse.42.1-x64")
             {
                 return $"{artifactPrefix}-{rid}.{version}";
             }


### PR DESCRIPTION
`CheckIfAllBuildsHavePublished()` fails if it encounters a name that it doesn't know about. In our case, it was failing because the new configuration's name wasn't listed in here. There was also another piece of code that I noticed which controls some moniker strings. It needed to be special-cased for Fedora 24.

@gkhanna79 