### PR TITLE
Add registry keys to allow WER to create proper minidump

### DIFF
--- a/packaging/windows/sharedframework/registrykeys.wxs
+++ b/packaging/windows/sharedframework/registrykeys.wxs
@@ -13,6 +13,32 @@
           <RegistryValue Action="write" Name="1.0.0-rc2" Type="integer" Value="1" KeyPath="yes"/>
         </RegistryKey>
       </Component>
+
+<!-- Set registry keys to allow WER to genereate correct dumps-->
+      <Component Directory="TARGETDIR">
+        <RegistryKey Root="HKLM" Key="SOFTWARE\Microsoft\Windows\Windows Error Reporting\RuntimeExceptionHelperModules">
+          <RegistryValue Action="write" Name="[DOTNETHOME]shared\$(var.FrameworkName)\$(var.FrameworkDisplayVersion)\mscordaccore.dll" Type="integer" Value="0" KeyPath="yes"/>
+        </RegistryKey>
+      </Component>
+      
+      <Component Directory="TARGETDIR">
+        <RegistryKey Root="HKLM" Key="SOFTWARE\Microsoft\Windows NT\CurrentVersion\KnownManagedDebuggingDlls">
+          <RegistryValue Action="write" Name="[DOTNETHOME]shared\$(var.FrameworkName)\$(var.FrameworkDisplayVersion)\mscordaccore.dll" Type="integer" Value="0" KeyPath="yes"/>
+        </RegistryKey>
+      </Component>
+      
+      <Component Directory="TARGETDIR">
+        <RegistryKey Root="HKLM" Key="SOFTWARE\Microsoft\Windows NT\CurrentVersion\KnownFunctionTableDlls">
+          <RegistryValue Action="write" Name="[DOTNETHOME]shared\$(var.FrameworkName)\$(var.FrameworkDisplayVersion)\mscordaccore.dll" Type="integer" Value="0" KeyPath="yes"/>
+        </RegistryKey>
+      </Component>
+      
+      <Component Directory="TARGETDIR">
+        <RegistryKey Root="HKLM" Key="SOFTWARE\Microsoft\Windows NT\CurrentVersion\MiniDumpAuxiliaryDlls">
+          <RegistryValue Action="write" Name="[DOTNETHOME]shared\$(var.FrameworkName)\$(var.FrameworkDisplayVersion)\coreclr.dll" Type="string" Value="[DOTNETHOME]shared\$(var.FrameworkName)\$(var.FrameworkDisplayVersion)\mscordaccore.dll" KeyPath="yes"/>
+        </RegistryKey>
+      </Component>
+
     </ComponentGroup>
   </Fragment>
 </Wix>


### PR DESCRIPTION
Environment variables will be set to allow WER to generate proper minidumps if app fails.
See: https://github.com/dotnet/coreclr/issues/7722 for more info
