### PR TITLE
Enable the Fedora 24 build in master

### DIFF
--- a/TestAssets/TestProjects/StandaloneApp/project.json
+++ b/TestAssets/TestProjects/StandaloneApp/project.json
@@ -28,6 +28,7 @@
     "rhel.7.2-x64": {},
     "debian.8-x64": {},
     "fedora.23-x64": {},
+    "fedora.24-x64": {},
     "opensuse.13.2-x64": {},
     "opensuse.42.1-x64": {}
   }

--- a/TestAssets/TestProjects/StandaloneTestApp/project.json
+++ b/TestAssets/TestProjects/StandaloneTestApp/project.json
@@ -38,6 +38,7 @@
     "rhel.7.2-x64": {},
     "debian.8-x64": {},
     "fedora.23-x64": {},
+    "fedora.24-x64": {},
     "opensuse.13.2-x64": {},
     "opensuse.42.1-x64": {}
   }

--- a/build_projects/dotnet-host-build/CompileTargets.cs
+++ b/build_projects/dotnet-host-build/CompileTargets.cs
@@ -35,6 +35,7 @@ namespace Microsoft.DotNet.Host.Build
             { "rhel.7.2-x64", "rhel.7-x64" },
             { "debian.8-x64", "debian.8-x64" },
             { "fedora.23-x64", "fedora.23-x64" },
+            { "fedora.24-x64", "fedora.24-x64" },
             { "opensuse.13.2-x64", "opensuse.13.2-x64" },
             { "opensuse.42.1-x64", "opensuse.42.1-x64" }
         };

--- a/build_projects/dotnet-host-build/PublishTargets.cs
+++ b/build_projects/dotnet-host-build/PublishTargets.cs
@@ -190,6 +190,7 @@ namespace Microsoft.DotNet.Host.Build
                  { "sharedfx_Debian_x64", false },
                  { "sharedfx_CentOS_x64", false },
                  { "sharedfx_Fedora_23_x64", false },
+                 { "sharedfx_Fedora_24_x64", false },
                  { "sharedfx_openSUSE_13_2_x64", false },
                  { "sharedfx_openSUSE_42_1_x64", false }
              };

--- a/build_projects/dotnet-host-build/PublishTargets.cs
+++ b/build_projects/dotnet-host-build/PublishTargets.cs
@@ -124,6 +124,7 @@ namespace Microsoft.DotNet.Host.Build
                         "debian.x64.version",
                         "centos.x64.version",
                         "fedora.23.x64.version",
+                        "fedora.24.x64.version",
                         "opensuse.13.2.x64.version",
                         "opensuse.42.1.x64.version"
                     };

--- a/build_projects/dotnet-host-build/project.json
+++ b/build_projects/dotnet-host-build/project.json
@@ -40,6 +40,7 @@
     "rhel.7.2-x64": {},
     "debian.8-x64": {},
     "fedora.23-x64": {},
+    "fedora.24-x64": {},
     "opensuse.13.2-x64": {},
     "opensuse.42.1-x64": {}
   }

--- a/build_projects/shared-build-targets-utils/Utils/Monikers.cs
+++ b/build_projects/shared-build-targets-utils/Utils/Monikers.cs
@@ -59,6 +59,8 @@ namespace Microsoft.DotNet.Cli.Build
                      return "Ubuntu_16_10_x64";
                 case "fedora.23-x64":
                      return "Fedora_23_x64";
+                case "fedora.24-x64":
+                     return "Fedora_24_x64";
                 case "opensuse.13.2-x64":
                      return "openSUSE_13_2_x64";
                 case "opensuse.42.1-x64":

--- a/build_projects/shared-build-targets-utils/Utils/Monikers.cs
+++ b/build_projects/shared-build-targets-utils/Utils/Monikers.cs
@@ -37,7 +37,7 @@ namespace Microsoft.DotNet.Cli.Build
         {
             string rid = Environment.GetEnvironmentVariable("TARGETRID") ?? RuntimeEnvironment.GetRuntimeIdentifier();
 
-            if (rid == "ubuntu.16.04-x64" || rid == "ubuntu.16.10-x64" || rid == "fedora.23-x64" || rid == "opensuse.13.2-x64" || rid == "opensuse.42.1-x64")
+            if (rid == "ubuntu.16.04-x64" || rid == "ubuntu.16.10-x64" || rid == "fedora.23-x64" || rid == "fedora.24-x64" || rid == "opensuse.13.2-x64" || rid == "opensuse.42.1-x64")
             {
                 return $"{artifactPrefix}-{rid}.{version}";
             }

--- a/pkg/projects/Microsoft.NETCore.DotNetHost/Microsoft.NETCore.DotNetHost.builds
+++ b/pkg/projects/Microsoft.NETCore.DotNetHost/Microsoft.NETCore.DotNetHost.builds
@@ -43,6 +43,10 @@
       <OSGroup>Linux</OSGroup>
       <Platform>amd64</Platform>
     </Project>
+    <Project Condition="'$(TargetsLinux)' == 'true' and '$(DistroRid)' == 'fedora.24-x64'" Include="fedora.24/Microsoft.NETCore.DotNetHost.pkgproj">
+      <OSGroup>Linux</OSGroup>
+      <Platform>amd64</Platform>
+    </Project>
     <Project Condition="'$(TargetsLinux)' == 'true' and '$(DistroRid)' == 'debian.8-x64'" Include="debian/Microsoft.NETCore.DotNetHost.pkgproj">
       <OSGroup>Linux</OSGroup>
       <Platform>amd64</Platform>

--- a/pkg/projects/Microsoft.NETCore.DotNetHost/Microsoft.NETCore.DotNetHost.pkgproj
+++ b/pkg/projects/Microsoft.NETCore.DotNetHost/Microsoft.NETCore.DotNetHost.pkgproj
@@ -40,6 +40,9 @@
     <ProjectReference Include="fedora.23\Microsoft.NETCore.DotNetHost.pkgproj">
       <Platform>amd64</Platform>
     </ProjectReference>
+    <ProjectReference Include="fedora.24\Microsoft.NETCore.DotNetHost.pkgproj">
+      <Platform>amd64</Platform>
+    </ProjectReference>
     <ProjectReference Include="debian\Microsoft.NETCore.DotNetHost.pkgproj">
       <Platform>amd64</Platform>
     </ProjectReference>

--- a/pkg/projects/Microsoft.NETCore.DotNetHost/Microsoft.NETCore.DotNetHostPolicy.builds
+++ b/pkg/projects/Microsoft.NETCore.DotNetHost/Microsoft.NETCore.DotNetHostPolicy.builds
@@ -43,6 +43,10 @@
       <OSGroup>Linux</OSGroup>
       <Platform>amd64</Platform>
     </Project>
+    <Project Condition="'$(TargetsLinux)' == 'true' and '$(DistroRid)' == 'fedora.24-x64'" Include="fedora.24/Microsoft.NETCore.DotNetHostPolicy.pkgproj">
+      <OSGroup>Linux</OSGroup>
+      <Platform>amd64</Platform>
+    </Project>
     <Project Condition="'$(TargetsLinux)' == 'true' and '$(DistroRid)' == 'debian.8-x64'" Include="debian/Microsoft.NETCore.DotNetHostPolicy.pkgproj">
       <OSGroup>Linux</OSGroup>
       <Platform>amd64</Platform>

--- a/pkg/projects/Microsoft.NETCore.DotNetHost/Microsoft.NETCore.DotNetHostPolicy.pkgproj
+++ b/pkg/projects/Microsoft.NETCore.DotNetHost/Microsoft.NETCore.DotNetHostPolicy.pkgproj
@@ -43,6 +43,9 @@
     <ProjectReference Include="fedora.23\Microsoft.NETCore.DotNetHostPolicy.pkgproj">
       <Platform>amd64</Platform>
     </ProjectReference>
+    <ProjectReference Include="fedora.24\Microsoft.NETCore.DotNetHostPolicy.pkgproj">
+      <Platform>amd64</Platform>
+    </ProjectReference>
     <ProjectReference Include="debian\Microsoft.NETCore.DotNetHostPolicy.pkgproj">
       <Platform>amd64</Platform>
     </ProjectReference>

--- a/pkg/projects/Microsoft.NETCore.DotNetHost/Microsoft.NETCore.DotNetHostResolver.builds
+++ b/pkg/projects/Microsoft.NETCore.DotNetHost/Microsoft.NETCore.DotNetHostResolver.builds
@@ -43,6 +43,10 @@
       <OSGroup>Linux</OSGroup>
       <Platform>amd64</Platform>
     </Project>
+    <Project Condition="'$(TargetsLinux)' == 'true' and '$(DistroRid)' == 'fedora.24-x64'" Include="fedora.24/Microsoft.NETCore.DotNetHostResolver.pkgproj">
+      <OSGroup>Linux</OSGroup>
+      <Platform>amd64</Platform>
+    </Project>
     <Project Condition="'$(TargetsLinux)' == 'true' and '$(DistroRid)' == 'debian.8-x64'" Include="debian/Microsoft.NETCore.DotNetHostResolver.pkgproj">
       <OSGroup>Linux</OSGroup>
       <Platform>amd64</Platform>

--- a/pkg/projects/Microsoft.NETCore.DotNetHost/Microsoft.NETCore.DotNetHostResolver.pkgproj
+++ b/pkg/projects/Microsoft.NETCore.DotNetHost/Microsoft.NETCore.DotNetHostResolver.pkgproj
@@ -43,6 +43,9 @@
     <ProjectReference Include="fedora.23\Microsoft.NETCore.DotNetHostResolver.pkgproj">
       <Platform>amd64</Platform>
     </ProjectReference>
+    <ProjectReference Include="fedora.24\Microsoft.NETCore.DotNetHostResolver.pkgproj">
+      <Platform>amd64</Platform>
+    </ProjectReference>
     <ProjectReference Include="debian\Microsoft.NETCore.DotNetHostResolver.pkgproj">
       <Platform>amd64</Platform>
     </ProjectReference>

--- a/pkg/projects/Microsoft.NETCore.DotNetHost/fedora.24/Microsoft.NETCore.DotNetHost.pkgproj
+++ b/pkg/projects/Microsoft.NETCore.DotNetHost/fedora.24/Microsoft.NETCore.DotNetHost.pkgproj
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  
+  <PropertyGroup>
+    <Version>$(HostVersion)</Version>
+    <SkipPackageFileCheck>true</SkipPackageFileCheck>
+    <MinOSForArch>fedora.24</MinOSForArch>
+    <PackageTargetRuntime>$(MinOSForArch)-$(PackagePlatform)</PackageTargetRuntime>
+    <Serviceable>true</Serviceable>
+  </PropertyGroup>
+  
+  <ItemGroup>
+    <ArchitectureSpecificNativeFile Include="$(DotNetHostBinDir)/dotnet" />
+
+    <File Include="@(ArchitectureSpecificNativeFile)">
+      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
+    </File>
+    <File Include="$(ProjectDir)/version.txt" />
+  </ItemGroup>
+
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/pkg/projects/Microsoft.NETCore.DotNetHost/fedora.24/Microsoft.NETCore.DotNetHostPolicy.pkgproj
+++ b/pkg/projects/Microsoft.NETCore.DotNetHost/fedora.24/Microsoft.NETCore.DotNetHostPolicy.pkgproj
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  
+  <PropertyGroup>
+    <Version>$(HostPolicyVersion)</Version>
+    <SkipPackageFileCheck>true</SkipPackageFileCheck>
+    <MinOSForArch>fedora.24</MinOSForArch>
+    <PackageTargetRuntime>$(MinOSForArch)-$(PackagePlatform)</PackageTargetRuntime>
+    <Serviceable>true</Serviceable>
+  </PropertyGroup>
+  
+  <ItemGroup>
+    <Dependency Include="Microsoft.NETCore.DotNetHostResolver">
+      <Version>$(HostResolverFullVersion)</Version>
+    </Dependency>
+
+    <ArchitectureSpecificNativeFile Include="$(DotNetHostBinDir)/libhostpolicy.so"/>
+
+    <File Include="@(ArchitectureSpecificNativeFile)">
+      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
+    </File>
+    <File Include="$(ProjectDir)/version.txt" />
+  </ItemGroup>
+
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/pkg/projects/Microsoft.NETCore.DotNetHost/fedora.24/Microsoft.NETCore.DotNetHostResolver.pkgproj
+++ b/pkg/projects/Microsoft.NETCore.DotNetHost/fedora.24/Microsoft.NETCore.DotNetHostResolver.pkgproj
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  
+  <PropertyGroup>
+    <Version>$(HostResolverVersion)</Version>
+    <SkipPackageFileCheck>true</SkipPackageFileCheck>
+    <MinOSForArch>fedora.24</MinOSForArch>
+    <PackageTargetRuntime>$(MinOSForArch)-$(PackagePlatform)</PackageTargetRuntime>
+    <Serviceable>true</Serviceable>
+  </PropertyGroup>
+  
+  <ItemGroup>
+    <Dependency Include="Microsoft.NETCore.DotNetHost">
+      <Version>$(HostFullVersion)</Version>
+    </Dependency>
+
+    <ArchitectureSpecificNativeFile Include="$(DotNetHostBinDir)/libhostfxr.so"/>
+
+    <File Include="@(ArchitectureSpecificNativeFile)">
+      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
+    </File>
+    <File Include="$(ProjectDir)/version.txt" />
+  </ItemGroup>
+
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/scripts/docker/fedora.24/Dockerfile
+++ b/scripts/docker/fedora.24/Dockerfile
@@ -1,0 +1,24 @@
+FROM fedora:24
+
+RUN dnf install -y bash git cmake wget which python clang-3.8.0-2.fc24.x86_64 llvm-devel-3.8.0-1.fc24.x86_64 make libicu-devel lldb-devel.x86_64 \
+                   libunwind-devel.x86_64 lttng-ust-devel.x86_64 uuid-devel libuuid-devel tar glibc-locale-source zlib-devel libcurl-devel \
+                   krb5-devel openssl-devel autoconf libtool hostname
+
+RUN dnf upgrade -y nss
+
+RUN dnf clean all
+
+# Setup User to match Host User, and give superuser permissions 
+ARG USER_ID=0 
+RUN useradd -m code_executor -u ${USER_ID} -g wheel
+RUN echo 'code_executor ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers 
+ 
+# With the User Change, we need to change permissions on these directories 
+RUN chmod -R a+rwx /usr/local 
+RUN chmod -R a+rwx /home
+ 
+# Set user to the one we just created 
+USER ${USER_ID} 
+ 
+# Set working directory 
+WORKDIR /opt/code

--- a/scripts/docker/fedora.24/Dockerfile
+++ b/scripts/docker/fedora.24/Dockerfile
@@ -8,6 +8,10 @@ RUN dnf upgrade -y nss
 
 RUN dnf clean all
 
+# Set a different rid to publish buildtools for, until we update to a version which
+# natively supports fedora.24-x64
+ENV __PUBLISH_RID=fedora.23-x64
+
 # Setup User to match Host User, and give superuser permissions 
 ARG USER_ID=0 
 RUN useradd -m code_executor -u ${USER_ID} -g wheel

--- a/tools/independent/RuntimeGraphGenerator/project.json
+++ b/tools/independent/RuntimeGraphGenerator/project.json
@@ -32,6 +32,7 @@
     "rhel.7.2-x64": {},
     "debian.8-x64": {},
     "fedora.23-x64": {},
+    "fedora.24-x64": {},
     "opensuse.13.2-x64": {},
     "opensuse.42.1-x64": {}
   }


### PR DESCRIPTION
This is just a port of the relevant commits from release/1.1.0 into master that enable building for Fedora 24.