### PR TITLE
Upgrade nss in the Fedora 23 dockerfile

### DIFF
--- a/scripts/docker/fedora.23/Dockerfile
+++ b/scripts/docker/fedora.23/Dockerfile
@@ -24,8 +24,11 @@ RUN dnf install -y libicu \
         libcurl \ 
         openssl-libs \ 
         libunwind \ 
-        lttng-ust && \ 
-    dnf clean all 
+        lttng-ust
+
+RUN dnf upgrade -y nss
+
+RUN dnf clean all 
  
 # Setup User to match Host User, and give superuser permissions 
 ARG USER_ID=0 


### PR DESCRIPTION
This solved all of the "download timeout" problems we were seeing on Fedora 24. It's possible it will help us out on Fedora 23 as well.

@dagood, @gkhanna79 
