### PR TITLE
Upgrade nss in the Fedora 23 dockerfile (port release/1.1.0 -> release/1.0.0)

### DIFF
--- a/scripts/docker/fedora.23/Dockerfile
+++ b/scripts/docker/fedora.23/Dockerfile
@@ -24,8 +24,11 @@ RUN dnf install -y libicu \
         libcurl \ 
         openssl-libs \ 
         libunwind \ 
-        lttng-ust && \ 
-    dnf clean all 
+        lttng-ust
+
+RUN dnf upgrade -y nss
+
+RUN dnf clean all 
  
 # Setup User to match Host User, and give superuser permissions 
 ARG USER_ID=0 


### PR DESCRIPTION
Port https://github.com/dotnet/core-setup/pull/541 to release/1.0.0.

This may fix Fedora NuGet restore timeouts in release/1.0.0. It seems to have worked so far in 1.1.0.

@gkhanna79 @mellinoe