### PR TITLE
Update LibUV version in netcoreapp1.0

### DIFF
--- a/pkg/projects/Microsoft.NETCore.App/Microsoft.NETCore.App.pkgproj
+++ b/pkg/projects/Microsoft.NETCore.App/Microsoft.NETCore.App.pkgproj
@@ -179,7 +179,7 @@
       <Version>4.0.10</Version>
     </NETCoreApp10Dependency>
     <NETCoreApp10Dependency Include="Libuv">
-      <Version>1.9.0</Version>
+      <Version>1.9.1</Version>
     </NETCoreApp10Dependency>
 
     <Dependency Include="@(NETCoreApp10Dependency)">


### PR DESCRIPTION
Since M.N.App now carries references of netcoreapp1.0, and we are updating LibUV version in LTS branch as well, we should update in the static references M.N.App 1.1.0 carries for netcoreapp1.0.

@weshaggard PTAL

@leecow @Petermarcu FYI

