### PR TITLE
Support building on alpine Linux

### DIFF
--- a/src/corehost/cli/json/casablanca/include/cpprest/asyncrt_utils.h
+++ b/src/corehost/cli/json/casablanca/include/cpprest/asyncrt_utils.h
@@ -39,10 +39,9 @@
 #endif
 
 #ifndef _WIN32
-//#include <boost/algorithm/string.hpp>
+#include <sys/time.h>
 #ifdef __GLIBC__
 #include <xlocale.h>
-#include <sys/time.h>
 #endif
 #endif
 


### PR DESCRIPTION
@janvorli 
I just deleted the #ifdef that was commented out, and moved the <sys/time.h> include outside of the GLIBC define so that it gets defined for all non-Windows builds. Platforms using glibc should have the same inclusions as before.