### PR TITLE
Make update-dependencies use same CLI as build.ps1 (release/1.0.0)

### DIFF
--- a/build_projects/update-dependencies/update-dependencies.ps1
+++ b/build_projects/update-dependencies/update-dependencies.ps1
@@ -39,10 +39,10 @@ if (!(Test-Path "$RepoRoot\artifacts"))
 }
 
 # Install a stage 0
-$DOTNET_INSTALL_SCRIPT_URL="https://raw.githubusercontent.com/dotnet/cli/rel/1.0.0/scripts/obtain/dotnet-install.ps1"
+$DOTNET_INSTALL_SCRIPT_URL="https://raw.githubusercontent.com/dotnet/cli/rel/1.0.0-preview2/scripts/obtain/dotnet-install.ps1"
 Invoke-WebRequest $DOTNET_INSTALL_SCRIPT_URL -OutFile "$RepoRoot\artifacts\dotnet-install.ps1"
 
-& "$RepoRoot\artifacts\dotnet-install.ps1" -Architecture $Architecture -Verbose
+& "$RepoRoot\artifacts\dotnet-install.ps1" -version 1.0.0-preview2-003121 -Architecture $Architecture -Verbose
 if($LASTEXITCODE -ne 0) { throw "Failed to install stage0" }
 
 # Put the stage0 on the path


### PR DESCRIPTION
This updates the `update-dependencies.ps1` script to use the same fixed CLI version as the rest of the build. See 24a2454a6b02bad6d3cb0a41a3cecdda1af0de89 and 7d1231b47177cd2867cbe64df10d4627cb8158b1.

This fixes a break in the dependency auto-update builds.

@gkhanna79 @wtgodbe 