### PR TITLE
Make update-dependencies use same CLI as build.ps1 (master)

### DIFF
--- a/build_projects/update-dependencies/update-dependencies.ps1
+++ b/build_projects/update-dependencies/update-dependencies.ps1
@@ -42,7 +42,7 @@ if (!(Test-Path "$RepoRoot\artifacts"))
 $DOTNET_INSTALL_SCRIPT_URL="https://raw.githubusercontent.com/dotnet/cli/rel/1.0.0/scripts/obtain/dotnet-install.ps1"
 Invoke-WebRequest $DOTNET_INSTALL_SCRIPT_URL -OutFile "$RepoRoot\artifacts\dotnet-install.ps1"
 
-& "$RepoRoot\artifacts\dotnet-install.ps1" -Architecture $Architecture -Verbose
+& "$RepoRoot\artifacts\dotnet-install.ps1" -Version 1.0.0-preview3-003886 -Architecture $Architecture -Verbose
 if($LASTEXITCODE -ne 0) { throw "Failed to install stage0" }
 
 # Put the stage0 on the path


### PR DESCRIPTION
Same as https://github.com/dotnet/core-setup/pull/574 (release/1.1.0). The auto-update build script got out of date, so this syncs `update-dependencies.ps1` with `build.ps1` to allow auto-PR builds to succeed.

After merging this, I'll merge https://github.com/dotnet/versions/pull/102 to turn on core-setup master auto-PRs.

@gkhanna79 @brianrob 