### PR TITLE
On release branches, don't publish symbol packages

### DIFF
--- a/build_projects/dotnet-host-build/PrepareTargets.cs
+++ b/build_projects/dotnet-host-build/PrepareTargets.cs
@@ -151,6 +151,7 @@ namespace Microsoft.DotNet.Host.Build
             c.BuildContext["BuildVersion"] = buildVersion;
             c.BuildContext["HostVersion"] = hostVersion;
             c.BuildContext["CommitHash"] = commitHash;
+            c.BuildContext["BranchName"] = branchInfo.Entries["BRANCH_NAME"];
 
             // Define the version string to be used based upon whether we are stabilizing the versions or not.
             if (!fStabilizePackageVersion)


### PR DESCRIPTION
When the branch (according to branchinfo.txt) starts with `release/`, don't publish symbol packages.

Addresses https://github.com/dotnet/core-setup/issues/595 for master (1.2.0+) and it sounds like we'll merge it into 1.1.x (and 1.0.x?).

@gkhanna79 @wtgodbe 