### PR TITLE
On release branches, don't publish symbol packages (release/1.1.0)

### DIFF
--- a/build_projects/dotnet-host-build/PrepareTargets.cs
+++ b/build_projects/dotnet-host-build/PrepareTargets.cs
@@ -136,6 +136,7 @@ namespace Microsoft.DotNet.Host.Build
             c.BuildContext["BuildVersion"] = buildVersion;
             c.BuildContext["HostVersion"] = hostVersion;
             c.BuildContext["CommitHash"] = commitHash;
+            c.BuildContext["BranchName"] = branchInfo.Entries["BRANCH_NAME"];
             c.BuildContext["SharedFrameworkNugetVersion"] = buildVersion.NetCoreAppVersion;
 
             c.Info($"Building Version: {hostVersion.LatestHostVersion.WithoutSuffix} (NuGet Packages: {hostVersion.LatestHostVersion})");

--- a/build_projects/dotnet-host-build/PublishTargets.cs
+++ b/build_projects/dotnet-host-build/PublishTargets.cs
@@ -29,6 +29,8 @@ namespace Microsoft.DotNet.Host.Build
 
         private static string HostFxrNugetVersion { get; set; }
 
+        private static bool IncludeSymbolPackages { get; set; }
+
         [Target]
         public static BuildTargetResult InitPublish(BuildTargetContext c)
         {
@@ -39,6 +41,9 @@ namespace Microsoft.DotNet.Host.Build
             HostFxrNugetVersion = c.BuildContext.Get<HostVersion>("HostVersion").LockedHostFxrVersion.ToString();
             Channel = c.BuildContext.Get<string>("Channel");
             CommitHash = c.BuildContext.Get<string>("CommitHash");
+
+            // Do not publish symbol packages on a release branch.
+            IncludeSymbolPackages = !c.BuildContext.Get<string>("BranchName").StartsWith("release/");
 
             return c.Success();
         }
@@ -59,7 +64,7 @@ namespace Microsoft.DotNet.Host.Build
         {
             string nugetFeedUrl = EnvVars.EnsureVariable("CLI_NUGET_FEED_URL");
             string apiKey = EnvVars.EnsureVariable("CLI_NUGET_API_KEY");
-            NuGetUtil.PushPackages(Dirs.Packages, nugetFeedUrl, apiKey);
+            NuGetUtil.PushPackages(Dirs.Packages, nugetFeedUrl, apiKey, IncludeSymbolPackages);
 
             return c.Success();
         }
@@ -168,7 +173,7 @@ namespace Microsoft.DotNet.Host.Build
 
             string nugetFeedUrl = EnvVars.EnsureVariable("NUGET_FEED_URL");
             string apiKey = EnvVars.EnsureVariable("NUGET_API_KEY");
-            NuGetUtil.PushPackages(Dirs.PackagesNoRID, nugetFeedUrl, apiKey);
+            NuGetUtil.PushPackages(Dirs.PackagesNoRID, nugetFeedUrl, apiKey, IncludeSymbolPackages);
 
             string githubAuthToken = EnvVars.EnsureVariable("GITHUB_PASSWORD");
             VersionRepoUpdater repoUpdater = new VersionRepoUpdater(githubAuthToken);


### PR DESCRIPTION
Port https://github.com/dotnet/core-setup/pull/600

Stop publishing symbol packages to MyGet in 1.1.0 for any future spins--escrow reset and/or servicing. I don't think we need a new build for this change, it just needs to be here for future builds.

@gkhanna79 @wtgodbe