### PR TITLE
No need to delete temp R2R Files

### DIFF
--- a/build_projects/shared-build-targets-utils/Utils/Crossgen.cs
+++ b/build_projects/shared-build-targets-utils/Utils/Crossgen.cs
@@ -224,7 +224,6 @@ namespace Microsoft.DotNet.Cli.Build
                 ExecSilent(_crossGenPath, crossgenArgs, env);
 
                 File.Copy(tempPathName, file, overwrite: true);
-                File.Delete(tempPathName);
             }
         }
     }


### PR DESCRIPTION
This is no longer required since the files are created in intermediates folder that will get cleaned up eventually.

Also, this helps with non-deterministic locking of files when attempting delete.

@schellap PTAL