### PR TITLE
Enable passing parameters to corehost buildscript for Linux ARM

### DIFF
--- a/build_projects/dotnet-host-build/CompileTargets.cs
+++ b/build_projects/dotnet-host-build/CompileTargets.cs
@@ -164,7 +164,6 @@ namespace Microsoft.DotNet.Host.Build
             var configuration = c.BuildContext.Get<string>("Configuration");
             string rid = c.BuildContext.Get<string>("TargetRID");
             string platform = c.BuildContext.Get<string>("Platform");
-            string crossCompiler = c.BuildContext.Get<string>("CrossCompiler");
 
             // Generate build files
             var cmakeOut = Path.Combine(Dirs.CorehostLatest, "cmake");
@@ -306,11 +305,6 @@ namespace Microsoft.DotNet.Host.Build
                 buildScriptArgList.Add(rid);
                 buildScriptArgList.Add("--commithash");
                 buildScriptArgList.Add(commitHash);
-
-                if (crossCompiler != null) {
-                    buildScriptArgList.Add("--xcompiler");
-                    buildScriptArgList.Add(crossCompiler);
-                }
 
                 ExecIn(cmakeOut, buildScriptFile, buildScriptArgList);
 

--- a/build_projects/dotnet-host-build/CompileTargets.cs
+++ b/build_projects/dotnet-host-build/CompileTargets.cs
@@ -289,37 +289,30 @@ namespace Microsoft.DotNet.Host.Build
                         throw new PlatformNotSupportedException("Target Architecture: " + platform + " is not currently supported.");
                 }
 
-                if (crossCompiler == null) {
-                    ExecIn(cmakeOut, Path.Combine(c.BuildContext.BuildDirectory, "src", "corehost", "build.sh"),
-                            "--arch",
-                            arch,
-                            "--hostver",
-                            hostVersion.LatestHostVersion.ToString(),
-                            "--fxrver",
-                            hostVersion.LatestHostFxrVersion.ToString(),
-                            "--policyver",
-                            hostVersion.LatestHostPolicyVersion.ToString(),
-                            "--rid",
-                            rid,
-                            "--commithash",
-                            commitHash);
-                } else {
-                    ExecIn(cmakeOut, Path.Combine(c.BuildContext.BuildDirectory, "src", "corehost", "build.sh"),
-                            "--arch",
-                            arch,
-                            "--hostver",
-                            hostVersion.LatestHostVersion.ToString(),
-                            "--fxrver",
-                            hostVersion.LatestHostFxrVersion.ToString(),
-                            "--policyver",
-                            hostVersion.LatestHostPolicyVersion.ToString(),
-                            "--rid",
-                            rid,
-                            "--commithash",
-                            commitHash,
-                            "--xcompiler",
-                            crossCompiler);
+                // Why does Windows directly call cmake but Linux/Mac calls "build.sh" in the corehost dir?
+                // See the comment in "src/corehost/build.sh" for details. It doesn't work for some reason.
+                List<string> buildScriptArgList = new List<string>();
+                string buildScriptFile  = Path.Combine(corehostSrcDir, "build.sh");
+
+                buildScriptArgList.Add("--arch");
+                buildScriptArgList.Add(arch);
+                buildScriptArgList.Add("--hostver");
+                buildScriptArgList.Add(hostVersion.LatestHostVersion.ToString());
+                buildScriptArgList.Add("--fxrver");
+                buildScriptArgList.Add(hostVersion.LatestHostFxrVersion.ToString());
+                buildScriptArgList.Add("--policyver");
+                buildScriptArgList.Add(hostVersion.LatestHostPolicyVersion.ToString());
+                buildScriptArgList.Add("--rid");
+                buildScriptArgList.Add(rid);
+                buildScriptArgList.Add("--commithash");
+                buildScriptArgList.Add(commitHash);
+
+                if (crossCompiler != null) {
+                    buildScriptArgList.Add("--xcompiler");
+                    buildScriptArgList.Add(crossCompiler);
                 }
+
+                ExecIn(cmakeOut, buildScriptFile, buildScriptArgList);
 
                 // Copy the output out
                 File.Copy(Path.Combine(cmakeOut, "cli", "exe", "dotnet"), Path.Combine(Dirs.CorehostLatest, "dotnet"), overwrite: true);

--- a/build_projects/dotnet-host-build/CompileTargets.cs
+++ b/build_projects/dotnet-host-build/CompileTargets.cs
@@ -164,6 +164,7 @@ namespace Microsoft.DotNet.Host.Build
             var configuration = c.BuildContext.Get<string>("Configuration");
             string rid = c.BuildContext.Get<string>("TargetRID");
             string platform = c.BuildContext.Get<string>("Platform");
+            string crossCompiler = c.BuildContext.Get<string>("CrossCompiler");
 
             // Generate build files
             var cmakeOut = Path.Combine(Dirs.CorehostLatest, "cmake");
@@ -275,19 +276,50 @@ namespace Microsoft.DotNet.Host.Build
             }
             else
             {
-                ExecIn(cmakeOut, Path.Combine(c.BuildContext.BuildDirectory, "src", "corehost", "build.sh"),
-                        "--arch",
-                        "x64",
-                        "--hostver",
-                        hostVersion.LatestHostVersion.ToString(),
-                        "--fxrver",
-                        hostVersion.LatestHostFxrVersion.ToString(),
-                        "--policyver",
-                        hostVersion.LatestHostPolicyVersion.ToString(),
-                        "--rid",
-                        rid,
-                        "--commithash",
-                        commitHash);
+                string arch;
+                switch (platform.ToLower())
+                {
+                    case "x64":
+                        arch = "x64";
+                        break;
+                    case "arm":
+                        arch = "arm";
+                        break;
+                    default:
+                        throw new PlatformNotSupportedException("Target Architecture: " + platform + " is not currently supported.");
+                }
+
+                if (crossCompiler == null) {
+                    ExecIn(cmakeOut, Path.Combine(c.BuildContext.BuildDirectory, "src", "corehost", "build.sh"),
+                            "--arch",
+                            arch,
+                            "--hostver",
+                            hostVersion.LatestHostVersion.ToString(),
+                            "--fxrver",
+                            hostVersion.LatestHostFxrVersion.ToString(),
+                            "--policyver",
+                            hostVersion.LatestHostPolicyVersion.ToString(),
+                            "--rid",
+                            rid,
+                            "--commithash",
+                            commitHash);
+                } else {
+                    ExecIn(cmakeOut, Path.Combine(c.BuildContext.BuildDirectory, "src", "corehost", "build.sh"),
+                            "--arch",
+                            arch,
+                            "--hostver",
+                            hostVersion.LatestHostVersion.ToString(),
+                            "--fxrver",
+                            hostVersion.LatestHostFxrVersion.ToString(),
+                            "--policyver",
+                            hostVersion.LatestHostPolicyVersion.ToString(),
+                            "--rid",
+                            rid,
+                            "--commithash",
+                            commitHash,
+                            "--xcompiler",
+                            crossCompiler);
+                }
 
                 // Copy the output out
                 File.Copy(Path.Combine(cmakeOut, "cli", "exe", "dotnet"), Path.Combine(Dirs.CorehostLatest, "dotnet"), overwrite: true);

--- a/build_projects/dotnet-host-build/PrepareTargets.cs
+++ b/build_projects/dotnet-host-build/PrepareTargets.cs
@@ -44,6 +44,7 @@ namespace Microsoft.DotNet.Host.Build
             var configEnv = Environment.GetEnvironmentVariable("CONFIGURATION");
             string platformEnv = Environment.GetEnvironmentVariable("TARGETPLATFORM") ?? RuntimeEnvironment.RuntimeArchitecture.ToString();
             string targetRID = Environment.GetEnvironmentVariable("TARGETRID");
+            string crossCompiler = Environment.GetEnvironmentVariable("CROSSCOMPILER");
             if (targetRID == null)
             {
                 targetRID = RuntimeEnvironment.GetRuntimeIdentifier();
@@ -64,6 +65,7 @@ namespace Microsoft.DotNet.Host.Build
             c.BuildContext["Platform"] = platformEnv;
             c.BuildContext["TargetRID"] = targetRID;
             c.BuildContext["TargetFramework"] = targetFramework;
+            c.BuildContext["CrossCompiler"] = crossCompiler;
 
             c.Info($"Building {c.BuildContext["Configuration"]} to: {Dirs.Output}");
             c.Info("Build Environment:");

--- a/build_projects/dotnet-host-build/PrepareTargets.cs
+++ b/build_projects/dotnet-host-build/PrepareTargets.cs
@@ -44,7 +44,6 @@ namespace Microsoft.DotNet.Host.Build
             var configEnv = Environment.GetEnvironmentVariable("CONFIGURATION");
             string platformEnv = Environment.GetEnvironmentVariable("TARGETPLATFORM") ?? RuntimeEnvironment.RuntimeArchitecture.ToString();
             string targetRID = Environment.GetEnvironmentVariable("TARGETRID");
-            string crossCompiler = Environment.GetEnvironmentVariable("CROSSCOMPILER");
             if (targetRID == null)
             {
                 targetRID = RuntimeEnvironment.GetRuntimeIdentifier();
@@ -65,7 +64,6 @@ namespace Microsoft.DotNet.Host.Build
             c.BuildContext["Platform"] = platformEnv;
             c.BuildContext["TargetRID"] = targetRID;
             c.BuildContext["TargetFramework"] = targetFramework;
-            c.BuildContext["CrossCompiler"] = crossCompiler;
 
             c.Info($"Building {c.BuildContext["Configuration"]} to: {Dirs.Output}");
             c.Info("Build Environment:");


### PR DESCRIPTION
Related issue: #725

To enable cross building of corehost, add environmental variable for cross compiler in build scripts.

Signed-off-by: Hyung-Kyu Choi <hk0110.choi@samsung.com>