### PR TITLE
Introduce rootfs for cross-compilation

### DIFF
--- a/cross/arm-softfp/sources.list.jessie
+++ b/cross/arm-softfp/sources.list.jessie
@@ -1,0 +1,3 @@
+# Debian (sid)   # UNSTABLE
+deb http://ftp.debian.org/debian/ sid main contrib non-free
+deb-src http://ftp.debian.org/debian/ sid main contrib non-free

--- a/cross/arm/sources.list.jessie
+++ b/cross/arm/sources.list.jessie
@@ -1,0 +1,3 @@
+# Debian (sid)   # UNSTABLE
+deb http://ftp.debian.org/debian/ sid main contrib non-free
+deb-src http://ftp.debian.org/debian/ sid main contrib non-free

--- a/cross/arm/sources.list.trusty
+++ b/cross/arm/sources.list.trusty
@@ -1,0 +1,11 @@
+deb http://ports.ubuntu.com/ubuntu-ports/ trusty main restricted universe
+deb-src http://ports.ubuntu.com/ubuntu-ports/ trusty main restricted universe
+
+deb http://ports.ubuntu.com/ubuntu-ports/ trusty-updates main restricted universe
+deb-src http://ports.ubuntu.com/ubuntu-ports/ trusty-updates main restricted universe
+
+deb http://ports.ubuntu.com/ubuntu-ports/ trusty-backports main restricted
+deb-src http://ports.ubuntu.com/ubuntu-ports/ trusty-backports main restricted
+
+deb http://ports.ubuntu.com/ubuntu-ports/ trusty-security main restricted universe multiverse
+deb-src http://ports.ubuntu.com/ubuntu-ports/ trusty-security main restricted universe multiverse

--- a/cross/arm/sources.list.vivid
+++ b/cross/arm/sources.list.vivid
@@ -1,0 +1,11 @@
+deb http://ports.ubuntu.com/ubuntu-ports/ vivid main restricted universe
+deb-src http://ports.ubuntu.com/ubuntu-ports/ vivid main restricted universe
+
+deb http://ports.ubuntu.com/ubuntu-ports/ vivid-updates main restricted universe
+deb-src http://ports.ubuntu.com/ubuntu-ports/ vivid-updates main restricted universe
+
+deb http://ports.ubuntu.com/ubuntu-ports/ vivid-backports main restricted
+deb-src http://ports.ubuntu.com/ubuntu-ports/ vivid-backports main restricted
+
+deb http://ports.ubuntu.com/ubuntu-ports/ vivid-security main restricted universe multiverse
+deb-src http://ports.ubuntu.com/ubuntu-ports/ vivid-security main restricted universe multiverse

--- a/cross/arm/sources.list.wily
+++ b/cross/arm/sources.list.wily
@@ -1,0 +1,11 @@
+deb http://ports.ubuntu.com/ubuntu-ports/ wily main restricted universe
+deb-src http://ports.ubuntu.com/ubuntu-ports/ wily main restricted universe
+
+deb http://ports.ubuntu.com/ubuntu-ports/ wily-updates main restricted universe
+deb-src http://ports.ubuntu.com/ubuntu-ports/ wily-updates main restricted universe
+
+deb http://ports.ubuntu.com/ubuntu-ports/ wily-backports main restricted
+deb-src http://ports.ubuntu.com/ubuntu-ports/ wily-backports main restricted
+
+deb http://ports.ubuntu.com/ubuntu-ports/ wily-security main restricted universe multiverse
+deb-src http://ports.ubuntu.com/ubuntu-ports/ wily-security main restricted universe multiverse

--- a/cross/arm/sources.list.xenial
+++ b/cross/arm/sources.list.xenial
@@ -1,0 +1,11 @@
+deb http://ports.ubuntu.com/ubuntu-ports/ xenial main restricted universe
+deb-src http://ports.ubuntu.com/ubuntu-ports/ xenial main restricted universe
+
+deb http://ports.ubuntu.com/ubuntu-ports/ xenial-updates main restricted universe
+deb-src http://ports.ubuntu.com/ubuntu-ports/ xenial-updates main restricted universe
+
+deb http://ports.ubuntu.com/ubuntu-ports/ xenial-backports main restricted
+deb-src http://ports.ubuntu.com/ubuntu-ports/ xenial-backports main restricted
+
+deb http://ports.ubuntu.com/ubuntu-ports/ xenial-security main restricted universe multiverse
+deb-src http://ports.ubuntu.com/ubuntu-ports/ xenial-security main restricted universe multiverse

--- a/cross/build-rootfs.sh
+++ b/cross/build-rootfs.sh
@@ -3,7 +3,7 @@
 usage()
 {
     echo "Usage: $0 [BuildArch] [UbuntuCodeName] [lldbx.y]"
-    echo "BuildArch can be: arm(default), arm-softfp"
+    echo "BuildArch can be: arm(default), arm-softfp, x86"
     echo "UbuntuCodeName - optional, Code name for Ubuntu, can be: trusty(default), vivid, wily, xenial. If BuildArch is arm-softfp, UbuntuCodeName is ignored."
     echo "lldbx.y - optional, LLDB version, can be: lldb3.6(default), lldb3.8"
 
@@ -38,6 +38,11 @@ for i in "$@"
             __UbuntuArch=armel
             __UbuntuRepo="http://ftp.debian.org/debian/"
             __UbuntuCodeName=jessie
+            ;;
+        x86)
+            __BuildArch=x86
+            __UbuntuArch=i386
+            __UbuntuRepo="http://archive.ubuntu.com/ubuntu/"
             ;;
         lldb3.6)
             __LLDB_Package="lldb-3.6-dev"

--- a/cross/build-rootfs.sh
+++ b/cross/build-rootfs.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+
+usage()
+{
+    echo "Usage: $0 [BuildArch] [UbuntuCodeName] [lldbx.y]"
+    echo "BuildArch can be: arm(default), arm-softfp"
+    echo "UbuntuCodeName - optional, Code name for Ubuntu, can be: trusty(default), vivid, wily, xenial. If BuildArch is arm-softfp, UbuntuCodeName is ignored."
+    echo "lldbx.y - optional, LLDB version, can be: lldb3.6(default), lldb3.8"
+
+    exit 1
+}
+
+__UbuntuCodeName=trusty
+
+__CrossDir=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+__InitialDir=$PWD
+__BuildArch=arm
+__UbuntuArch=armhf
+__UbuntuRepo="http://ports.ubuntu.com/"
+__UbuntuPackagesBase="build-essential libunwind8-dev gettext symlinks liblttng-ust-dev libicu-dev"
+__LLDB_Package="lldb-3.6-dev"
+__UnprocessedBuildArgs=
+
+for i in "$@"
+    do
+        lowerI="$(echo $i | awk '{print tolower($0)}')"
+        case $lowerI in
+        -?|-h|--help)
+            usage
+            exit 1
+            ;;
+        arm)
+            __BuildArch=arm
+            __UbuntuArch=armhf
+            ;;
+        arm-softfp)
+            __BuildArch=arm-softfp
+            __UbuntuArch=armel
+            __UbuntuRepo="http://ftp.debian.org/debian/"
+            __UbuntuCodeName=jessie
+            ;;
+        lldb3.6)
+            __LLDB_Package="lldb-3.6-dev"
+            ;;
+        lldb3.8)
+            __LLDB_Package="lldb-3.8-dev"
+            ;;
+        vivid)
+            if [ "$__UbuntuCodeName" != "jessie" ]; then
+                __UbuntuCodeName=vivid
+            fi
+            ;;
+        wily)
+            if [ "$__UbuntuCodeName" != "jessie" ]; then
+                __UbuntuCodeName=wily
+            fi
+            ;;
+        xenial)
+            if [ "$__UbuntuCodeName" != "jessie" ]; then
+                __UbuntuCodeName=xenial
+            fi
+            ;;
+        jessie)
+            __UbuntuCodeName=jessie
+            __UbuntuRepo="http://ftp.debian.org/debian/"
+            ;;
+        *)
+            __UnprocessedBuildArgs="$__UnprocessedBuildArgs $i"
+            ;;
+    esac
+done
+
+__RootfsDir="$__CrossDir/rootfs/$__BuildArch"
+__UbuntuPackages="$__UbuntuPackagesBase $__LLDB_Package"
+
+if [[ -n "$ROOTFS_DIR" ]]; then
+    __RootfsDir=$ROOTFS_DIR
+fi
+
+if [ -d "$__RootfsDir" ]; then
+    umount $__RootfsDir/*
+    rm -rf $__RootfsDir
+fi
+
+qemu-debootstrap --arch $__UbuntuArch $__UbuntuCodeName $__RootfsDir $__UbuntuRepo
+cp $__CrossDir/$__BuildArch/sources.list.$__UbuntuCodeName $__RootfsDir/etc/apt/sources.list
+chroot $__RootfsDir apt-get update
+chroot $__RootfsDir apt-get -f -y install
+chroot $__RootfsDir apt-get -y install $__UbuntuPackages
+chroot $__RootfsDir symlinks -cr /usr
+umount $__RootfsDir/*

--- a/cross/x86/sources.list.trusty
+++ b/cross/x86/sources.list.trusty
@@ -1,0 +1,11 @@
+deb http://archive.ubuntu.com/ubuntu/ trusty main restricted universe
+deb-src http://archive.ubuntu.com/ubuntu/ trusty main restricted universe
+
+deb http://archive.ubuntu.com/ubuntu/ trusty-updates main restricted universe
+deb-src http://archive.ubuntu.com/ubuntu/ trusty-updates main restricted universe
+
+deb http://archive.ubuntu.com/ubuntu/ trusty-backports main restricted
+deb-src http://archive.ubuntu.com/ubuntu/ trusty-backports main restricted
+
+deb http://archive.ubuntu.com/ubuntu/ trusty-security main restricted universe multiverse
+deb-src http://archive.ubuntu.com/ubuntu/ trusty-security main restricted universe multiverse

--- a/cross/x86/sources.list.vivid
+++ b/cross/x86/sources.list.vivid
@@ -1,0 +1,11 @@
+deb http://archive.ubuntu.com/ubuntu/ vivid main restricted universe
+deb-src http://archive.ubuntu.com/ubuntu/ vivid main restricted universe
+
+deb http://archive.ubuntu.com/ubuntu/ vivid-updates main restricted universe
+deb-src http://archive.ubuntu.com/ubuntu/ vivid-updates main restricted universe
+
+deb http://archive.ubuntu.com/ubuntu/ vivid-backports main restricted
+deb-src http://archive.ubuntu.com/ubuntu/ vivid-backports main restricted
+
+deb http://archive.ubuntu.com/ubuntu/ vivid-security main restricted universe multiverse
+deb-src http://archive.ubuntu.com/ubuntu/ vivid-security main restricted universe multiverse

--- a/cross/x86/sources.list.wily
+++ b/cross/x86/sources.list.wily
@@ -1,0 +1,11 @@
+deb http://archive.ubuntu.com/ubuntu/ wily main restricted universe
+deb-src http://archive.ubuntu.com/ubuntu/ wily main restricted universe
+
+deb http://archive.ubuntu.com/ubuntu/ wily-updates main restricted universe
+deb-src http://archive.ubuntu.com/ubuntu/ wily-updates main restricted universe
+
+deb http://archive.ubuntu.com/ubuntu/ wily-backports main restricted
+deb-src http://archive.ubuntu.com/ubuntu/ wily-backports main restricted
+
+deb http://archive.ubuntu.com/ubuntu/ wily-security main restricted universe multiverse
+deb-src http://archive.ubuntu.com/ubuntu/ wily-security main restricted universe multiverse

--- a/cross/x86/sources.list.xenial
+++ b/cross/x86/sources.list.xenial
@@ -1,0 +1,11 @@
+deb http://archive.ubuntu.com/ubuntu/ xenial main restricted universe
+deb-src http://archive.ubuntu.com/ubuntu/ xenial main restricted universe
+
+deb http://archive.ubuntu.com/ubuntu/ xenial-updates main restricted universe
+deb-src http://archive.ubuntu.com/ubuntu/ xenial-updates main restricted universe
+
+deb http://archive.ubuntu.com/ubuntu/ xenial-backports main restricted
+deb-src http://archive.ubuntu.com/ubuntu/ xenial-backports main restricted
+
+deb http://archive.ubuntu.com/ubuntu/ xenial-security main restricted universe multiverse
+deb-src http://archive.ubuntu.com/ubuntu/ xenial-security main restricted universe multiverse


### PR DESCRIPTION
skip ci please

Introduce rootfs for cross compilation.  I've added scripts for ARM and ARM softfp.
Tested it with `sudo ./cross/build-rootfs.sh arm` and  `sudo ./cross/build-rootfs.sh arm-softfp` as documented in https://github.com/dotnet/coreclr/blob/master/Documentation/building/cross-building.md to keep consistency with CoreCLR and CoreFX.

Basically the code has been imported from CoreCLR and remove x86 and arm64.
rootfs is exactly same with CoreCLR, i.e. we can also build CoreCLR with this rootfs too.
Later we can refine rootfs to reduce size only with required packages if necessary.
BTW CoreFX has a different configuration.
