### PR TITLE
Add CROSS and ROOTFS_DIR environment for ARM

### DIFF
--- a/build_projects/dotnet-host-build/CompileTargets.cs
+++ b/build_projects/dotnet-host-build/CompileTargets.cs
@@ -164,6 +164,7 @@ namespace Microsoft.DotNet.Host.Build
             var configuration = c.BuildContext.Get<string>("Configuration");
             string rid = c.BuildContext.Get<string>("TargetRID");
             string platform = c.BuildContext.Get<string>("Platform");
+            string crossEnv = c.BuildContext.Get<string>("Cross");
 
             // Generate build files
             var cmakeOut = Path.Combine(Dirs.CorehostLatest, "cmake");
@@ -305,6 +306,11 @@ namespace Microsoft.DotNet.Host.Build
                 buildScriptArgList.Add(rid);
                 buildScriptArgList.Add("--commithash");
                 buildScriptArgList.Add(commitHash);
+
+                if (string.Equals(crossEnv, "1"))
+                {
+                    buildScriptArgList.Add("--cross");
+                }
 
                 ExecIn(cmakeOut, buildScriptFile, buildScriptArgList);
 

--- a/build_projects/dotnet-host-build/PrepareTargets.cs
+++ b/build_projects/dotnet-host-build/PrepareTargets.cs
@@ -59,16 +59,29 @@ namespace Microsoft.DotNet.Host.Build
                 configEnv = "Debug";
             }
 
+            string crossEnv = Environment.GetEnvironmentVariable("CROSS") ?? "0";
+            if (string.Equals(crossEnv, "1"))
+            {
+                string rootfsDir = Environment.GetEnvironmentVariable("ROOTFS_DIR");
+                if (string.IsNullOrEmpty(rootfsDir))
+                {
+                    rootfsDir = Path.Combine(Dirs.RepoRoot, "cross", "rootfs", platformEnv);
+                    Environment.SetEnvironmentVariable("ROOTFS_DIR", rootfsDir);
+                }
+            }
+
             c.BuildContext["Configuration"] = configEnv;
             c.BuildContext["Channel"] = Environment.GetEnvironmentVariable("CHANNEL");
             c.BuildContext["Platform"] = platformEnv;
             c.BuildContext["TargetRID"] = targetRID;
             c.BuildContext["TargetFramework"] = targetFramework;
+            c.BuildContext["Cross"] = crossEnv;
 
             c.Info($"Building {c.BuildContext["Configuration"]} to: {Dirs.Output}");
             c.Info("Build Environment:");
             c.Info($" Operating System: {RuntimeEnvironment.OperatingSystem} {RuntimeEnvironment.OperatingSystemVersion}");
             c.Info($" Platform: " + platformEnv);
+            c.Info($" Cross Build: " + int.Parse(crossEnv));
 
             return c.Success();
         }


### PR DESCRIPTION
This PR should be merged after previous PR #747 & #749 

The CROSS env is passed through the BuildContext to the build.sh in corehost.
If the value is set, corehost build script gives '--cross' arguments.
ROOTFS_DIR can support to specify the location of rootfs as CoreCLR does.
If ROOTFS_DIR env is not defined,
the default value(./cross/rootfs/${TARGETPLATFORM}/) will be used.

You can build corehost for ARM using following commands.
`./build.sh --env-vars TARGETPLATFORM=arm,TARGETRID=ubuntu.16.04-arm,CROSS=1`
`./build.sh --env-vars TARGETPLATFORM=arm,TARGETRID=ubuntu.16.04-arm,CROSS=1,ROOTFS_DIR=/home/jyoung/git/dotnet/rootfs-coreclr/arm/`

Related issue: #729


I posted this PR to share with other developers.
@hqueue 