### PR TITLE
Handfull of misc build fixes

### DIFF
--- a/NuGet.master.config
+++ b/NuGet.master.config
@@ -1,7 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<configuration>
-  <packageSources>
-    <clear />
-    <add key="NuGet" value="https://api.nuget.org/v3/index.json" />
-  </packageSources>
-</configuration>

--- a/build_projects/Microsoft.DotNet.Cli.Build.Framework/AnsiConsole.cs
+++ b/build_projects/Microsoft.DotNet.Cli.Build.Framework/AnsiConsole.cs
@@ -66,7 +66,7 @@ namespace Microsoft.DotNet.Cli.Build.Framework
             var escapeScan = 0;
             for (;;)
             {
-                var escapeIndex = message.IndexOf("\x1b[", escapeScan);
+                var escapeIndex = message.IndexOf("\x1b[", escapeScan, StringComparison.Ordinal);
                 if (escapeIndex == -1)
                 {
                     var text = message.Substring(escapeScan);

--- a/build_projects/dotnet-host-build/PrepareTargets.cs
+++ b/build_projects/dotnet-host-build/PrepareTargets.cs
@@ -324,7 +324,11 @@ namespace Microsoft.DotNet.Host.Build
             var dotnet = DotNetCli.Stage0;
 
             dotnet.Restore("--verbosity", "verbose", "--disable-parallel")
-                .WorkingDirectory(Path.Combine(c.BuildContext.BuildDirectory, "tools"))
+                .WorkingDirectory(Path.Combine(c.BuildContext.BuildDirectory, "tools", "dotnet-deb-tool"))
+                .Execute()
+                .EnsureSuccessful();
+            dotnet.Restore("--verbosity", "verbose", "--disable-parallel", "--infer-runtimes")
+                .WorkingDirectory(Path.Combine(c.BuildContext.BuildDirectory, "tools", "independent"))
                 .Execute()
                 .EnsureSuccessful();
 

--- a/build_projects/dotnet-host-build/project.json
+++ b/build_projects/dotnet-host-build/project.json
@@ -28,20 +28,5 @@
         "portable-net45+win8"
       ]
     }
-  },
-  "runtimes": {
-    "win7-x64": {},
-    "win7-x86": {},
-    "osx.10.11-x64": {},
-    "ubuntu.14.04-x64": {},
-    "ubuntu.16.04-x64": {},
-    "ubuntu.16.10-x64": {},
-    "centos.7-x64": {},
-    "rhel.7.2-x64": {},
-    "debian.8-x64": {},
-    "fedora.23-x64": {},
-    "fedora.24-x64": {},
-    "opensuse.13.2-x64": {},
-    "opensuse.42.1-x64": {}
   }
 }

--- a/build_projects/shared-build-targets-utils/DependencyVersions.cs
+++ b/build_projects/shared-build-targets-utils/DependencyVersions.cs
@@ -7,7 +7,7 @@ namespace Microsoft.DotNet.Cli.Build
 {
     public class DependencyVersions
     {
-    	public static readonly string CoreCLRVersion = "1.2.0-beta-24815-02";
+        public static readonly string CoreCLRVersion = "1.2.0-beta-24815-02";
         public static readonly string JitVersion = "1.2.0-beta-24815-02";
     }
 }

--- a/build_projects/update-dependencies/UpdateFilesTargets.cs
+++ b/build_projects/update-dependencies/UpdateFilesTargets.cs
@@ -208,7 +208,7 @@ namespace Microsoft.DotNet.Scripts
         [Target]
         public static BuildTargetResult ReplaceDependencyVersions(BuildTargetContext c)
         {
-            ReplaceFileContents(@"build_projects\shared-build-targets-utils\DependencyVersions.cs", fileContents =>
+            ReplaceFileContents(Path.Combine("build_projects", "shared-build-targets-utils", "DependencyVersions.cs"), fileContents =>
             {
                 fileContents = ReplaceDependencyVersion(c, fileContents, "CoreCLRVersion", "Microsoft.NETCore.Runtime.CoreCLR");
                 fileContents = ReplaceDependencyVersion(c, fileContents, "JitVersion", "Microsoft.NETCore.Jit");
@@ -237,7 +237,7 @@ namespace Microsoft.DotNet.Scripts
         [Target]
         public static BuildTargetResult ReplaceCoreHostPackaging(BuildTargetContext c)
         {
-            ReplaceFileContents(@"pkg\dir.props", contents =>
+            ReplaceFileContents(Path.Combine("pkg", "dir.props"), contents =>
             {
                 Regex regex = new Regex(@"Microsoft\.NETCore\.Platforms\\(?<version>.*)\\runtime\.json");
                 string newNetCorePlatformsVersion = c.GetNewVersion("Microsoft.NETCore.Platforms");

--- a/build_projects/update-dependencies/UpdateFilesTargets.cs
+++ b/build_projects/update-dependencies/UpdateFilesTargets.cs
@@ -19,6 +19,7 @@ namespace Microsoft.DotNet.Scripts
     public static class UpdateFilesTargets
     {
         private static HttpClient s_client = new HttpClient();
+        private static readonly string FileUrlScheme = "file://";
 
         [Target(nameof(GetDependencies), nameof(ReplaceVersions))]
         public static BuildTargetResult UpdateFiles(BuildTargetContext c) => c.Success();
@@ -42,7 +43,7 @@ namespace Microsoft.DotNet.Scripts
         {
             List<PackageInfo> newPackageVersions = new List<PackageInfo>();
 
-            using (Stream versionsStream = await s_client.GetStreamAsync(packageVersionsUrl))
+            using (Stream versionsStream = packageVersionsUrl.StartsWith(FileUrlScheme, StringComparison.Ordinal) ? File.OpenRead(packageVersionsUrl.Substring(FileUrlScheme.Length)) : await s_client.GetStreamAsync(packageVersionsUrl))
             using (StreamReader reader = new StreamReader(versionsStream))
             {
                 string currentLine;

--- a/build_projects/update-dependencies/update-dependencies.sh
+++ b/build_projects/update-dependencies/update-dependencies.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) .NET Foundation and contributors. All rights reserved.
+# Licensed under the MIT license. See LICENSE file in the project root for full license information.
+#
+
+set -e
+
+SOURCE="${BASH_SOURCE[0]}"
+while [ -h "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symlink
+  DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
+  SOURCE="$(readlink "$SOURCE")"
+  [[ "$SOURCE" != /* ]] && SOURCE="$DIR/$SOURCE" # if $SOURCE was a relative symlink, we need to resolve it relative to the path where the symlink file was located
+done
+DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
+OLDPATH="$PATH"
+
+REPOROOT="$DIR/../.."
+source "$REPOROOT/scripts/common/_prettyprint.sh"
+
+while [[ $# > 0 ]]; do
+    lowerI="$(echo $1 | awk '{print tolower($0)}')"
+    case $lowerI in
+        --targets)
+            IFS=',' read -r -a targets <<< $2
+            shift
+            ;;
+        --env-vars)
+            IFS=',' read -r -a envVars <<< $2
+            shift
+            ;;
+        --help)
+            echo "Usage: $0 [--targets <TARGETS...>]"
+            echo ""
+            echo "Options:"
+            echo "  --targets <TARGETS...>               Comma separated build targets to run (UpdateFile, PushPR; Default is everything"
+            echo "  --env-vars <'V1=val1','V2=val2'...>  Comma separated list of environment variable name value-pairs"
+            echo "  --help                               Display this help message"
+            exit 0
+            ;;
+        *)
+            break
+            ;;
+    esac
+
+    shift
+done
+
+# Set nuget package cache under the repo
+export NUGET_PACKAGES="$REPOROOT/.nuget/packages"
+
+# Use a repo-local install directory (but not the artifacts directory because that gets cleaned a lot
+[ -z "$DOTNET_INSTALL_DIR" ] && export DOTNET_INSTALL_DIR=$REPOROOT/.dotnet_stage0/$(uname)
+[ -d "$DOTNET_INSTALL_DIR" ] || mkdir -p $DOTNET_INSTALL_DIR
+
+DOTNET_INSTALL_SCRIPT_URL="https://raw.githubusercontent.com/dotnet/cli/rel/1.0.0/scripts/obtain/dotnet-install.sh"
+curl -sSL "$DOTNET_INSTALL_SCRIPT_URL" | bash /dev/stdin --version 1.0.0-preview3-003886 --verbose
+
+# Put stage 0 on the PATH (for this shell only)
+PATH="$DOTNET_INSTALL_DIR:$PATH"
+
+# Increases the file descriptors limit for this bash. It prevents an issue we were hitting during restore
+FILE_DESCRIPTOR_LIMIT=$( ulimit -n )
+if [ $FILE_DESCRIPTOR_LIMIT -lt 1024 ]
+then
+    echo "Increasing file description limit to 1024"
+    ulimit -n 1024
+fi
+
+# Disable first run since we want to control all package sources
+export DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1
+
+# Restore the build scripts
+echo "Restoring Build Script projects..."
+(
+    pushd "$DIR/.."
+    dotnet restore --infer-runtimes --disable-parallel
+    popd
+)
+
+# Build the builder
+echo "Compiling Build Scripts..."
+dotnet publish "$DIR" -o "$DIR/bin" --framework netcoreapp1.0
+
+export PATH="$OLDPATH"
+# Run the builder
+echo "Invoking Build Scripts..."
+echo "Configuration: $CONFIGURATION"
+
+$DIR/bin/update-dependencies -t ${targets[@]} -e ${envVars[@]}
+exit $?

--- a/pkg/pack.cmd
+++ b/pkg/pack.cmd
@@ -10,7 +10,7 @@ call "%__ProjectDir%\init-tools.cmd"
 
 :: Restore dependencies mainly to obtain runtime.json
 pushd "%__ProjectDir%\deps"
-"%__DotNet%" restore --source "https://dotnet.myget.org/F/dotnet-core/api/v3/index.json" --packages "%__ProjectDir%\packages"
+"%__DotNet%" restore --configfile "%__ProjectDir%\..\NuGet.Config" --packages "%__ProjectDir%\packages"
 popd
 
 :: Clean up existing nupkgs

--- a/pkg/pack.sh
+++ b/pkg/pack.sh
@@ -30,7 +30,7 @@ __distro_rid=
 
 # acquire dependencies
 pushd "$__project_dir/deps"
-"$__project_dir/Tools/dotnetcli/dotnet" restore --source "https://dotnet.myget.org/F/dotnet-core/api/v3/index.json" --disable-parallel --packages "$__project_dir/packages"
+"$__project_dir/Tools/dotnetcli/dotnet" restore --configfile "$__project_dir/../NuGet.Config" --disable-parallel --packages "$__project_dir/packages"
 popd
 
 # cleanup existing packages

--- a/tools/independent/RuntimeGraphGenerator/project.json
+++ b/tools/independent/RuntimeGraphGenerator/project.json
@@ -20,20 +20,5 @@
         "portable-net45+wp80+win8+wpa81+dnxcore50"
       ]
     }
-  },
-  "runtimes": {
-    "win7-x64": {},
-    "win7-x86": {},
-    "osx.10.11-x64": {},
-    "ubuntu.14.04-x64": {},
-    "ubuntu.16.04-x64": {},
-    "ubuntu.16.10-x64": {},
-    "centos.7-x64": {},
-    "rhel.7.2-x64": {},
-    "debian.8-x64": {},
-    "fedora.23-x64": {},
-    "fedora.24-x64": {},
-    "opensuse.13.2-x64": {},
-    "opensuse.42.1-x64": {}
   }
 }


### PR DESCRIPTION
While working on getting a composed end to end source build of core-setup working locally on *nix, I've developed these patches.

The major changes are using `--infer-runtimes` in more places (so we don't have to explicitly list or restore runtimes we don't care about for some projects), teaching `update-dependencies` to both work on *nix and to allow pointing it at local files for the version info instead of just remote files and having the Microsoft.NETCore.App build use the root NuGet.config instead of hard-coding it's own sources.