### PR TITLE
Allow upgrade when some packages not in buildinfo

### DIFF
--- a/build_projects/update-dependencies/UpdateFilesTargets.cs
+++ b/build_projects/update-dependencies/UpdateFilesTargets.cs
@@ -224,7 +224,11 @@ namespace Microsoft.DotNet.Scripts
             Regex regex = new Regex($@"{dependencyPropertyName} = ""(?<version>.*)"";");
             string newVersion = c.GetNewVersion(packageId);
 
-            return regex.ReplaceGroupValue(fileContents, "version", newVersion);
+            if (newVersion != null)
+            {
+                fileContents = regex.ReplaceGroupValue(fileContents, "version", newVersion);
+            }
+            return fileContents;
         }
 
         /// <summary>
@@ -238,7 +242,11 @@ namespace Microsoft.DotNet.Scripts
                 Regex regex = new Regex(@"Microsoft\.NETCore\.Platforms\\(?<version>.*)\\runtime\.json");
                 string newNetCorePlatformsVersion = c.GetNewVersion("Microsoft.NETCore.Platforms");
 
-                return regex.ReplaceGroupValue(contents, "version", newNetCorePlatformsVersion);
+                if (newNetCorePlatformsVersion != null)
+                {
+                    contents = regex.ReplaceGroupValue(contents, "version", newNetCorePlatformsVersion);
+                }
+                return contents;
             });
 
             return c.Success();
@@ -254,8 +262,8 @@ namespace Microsoft.DotNet.Scripts
 
             if (string.IsNullOrEmpty(newVersion))
             {
-                c.Error($"Could not find package version information for '{packageId}'");
-                return $"DEPENDENCY '{packageId}' NOT FOUND";
+                c.Info($"Could not find package version information for '{packageId}'");
+                return null;
             }
 
             return newVersion;


### PR DESCRIPTION
This changes dependency auto-update behavior to allow the buildinfos listed on dotnet/versions to not contain packages. Instead of writing an error and writing a garbage sentinel value into a PR, auto-update will not change the version that wasn't found.

This change can be cherry-picked into the 1.0.0 and 1.1.0 branches without conflicts. The intent is to fix auto-upgrade for 1.1.0: https://github.com/dotnet/core-setup/pull/787. I tested in 1.1.0 and it makes the expected changes without erroring because there is no new servicing Platforms package.

I'm flowing this from master to 1.1.0/1.0.0 instead of directly PRing for servicing future release branches.

@gkhanna79 