### PR TITLE
Allow upgrade when some packages not in buildinfo (release/1.1.0)

### DIFF
--- a/build_projects/update-dependencies/UpdateFilesTargets.cs
+++ b/build_projects/update-dependencies/UpdateFilesTargets.cs
@@ -236,7 +236,11 @@ namespace Microsoft.DotNet.Scripts
             Regex regex = new Regex($@"{dependencyPropertyName} = ""(?<version>.*)"";");
             string newVersion = c.GetNewVersion(packageId);
 
-            return regex.ReplaceGroupValue(fileContents, "version", newVersion);
+            if (newVersion != null)
+            {
+                fileContents = regex.ReplaceGroupValue(fileContents, "version", newVersion);
+            }
+            return fileContents;
         }
 
         /// <summary>
@@ -250,7 +254,11 @@ namespace Microsoft.DotNet.Scripts
                 Regex regex = new Regex(@"Microsoft\.NETCore\.Platforms\\(?<version>.*)\\runtime\.json");
                 string newNetCorePlatformsVersion = c.GetNewVersion("Microsoft.NETCore.Platforms");
 
-                return regex.ReplaceGroupValue(contents, "version", newNetCorePlatformsVersion);
+                if (newNetCorePlatformsVersion != null)
+                {
+                    contents = regex.ReplaceGroupValue(contents, "version", newNetCorePlatformsVersion);
+                }
+                return contents;
             });
 
             return c.Success();
@@ -266,8 +274,8 @@ namespace Microsoft.DotNet.Scripts
 
             if (string.IsNullOrEmpty(newVersion))
             {
-                c.Error($"Could not find package version information for '{packageId}'");
-                return $"DEPENDENCY '{packageId}' NOT FOUND";
+                c.Info($"Could not find package version information for '{packageId}'");
+                return null;
             }
 
             return newVersion;

--- a/build_projects/update-dependencies/update-dependencies.ps1
+++ b/build_projects/update-dependencies/update-dependencies.ps1
@@ -42,7 +42,7 @@ if (!(Test-Path "$RepoRoot\artifacts"))
 $DOTNET_INSTALL_SCRIPT_URL="https://raw.githubusercontent.com/dotnet/cli/rel/1.0.0/scripts/obtain/dotnet-install.ps1"
 Invoke-WebRequest $DOTNET_INSTALL_SCRIPT_URL -OutFile "$RepoRoot\artifacts\dotnet-install.ps1"
 
-& "$RepoRoot\artifacts\dotnet-install.ps1" -Architecture $Architecture -Verbose
+& "$RepoRoot\artifacts\dotnet-install.ps1" -Version 1.0.0-preview3-003223-3 -Architecture $Architecture -Verbose
 if($LASTEXITCODE -ne 0) { throw "Failed to install stage0" }
 
 # Put the stage0 on the path


### PR DESCRIPTION
Cherry-pick https://github.com/dotnet/core-setup/pull/791.

Also brings in the fix for CLI version, fixed in 1.0.0 here: https://github.com/dotnet/core-setup/pull/574. `--infer-runtimes` didn't work in the floating version.

This prepares the 1.1.0 branch to receive auto-update PRs.

@gkhanna79 