### PR TITLE
Allow upgrade when some packages not in buildinfo (release/1.0.0)

### DIFF
--- a/build_projects/update-dependencies/UpdateFilesTargets.cs
+++ b/build_projects/update-dependencies/UpdateFilesTargets.cs
@@ -219,7 +219,11 @@ namespace Microsoft.DotNet.Scripts
             Regex regex = new Regex($@"{dependencyPropertyName} = ""(?<version>.*)"";");
             string newVersion = c.GetNewVersion(packageId);
 
-            return regex.ReplaceGroupValue(fileContents, "version", newVersion);
+            if (newVersion != null)
+            {
+                fileContents = regex.ReplaceGroupValue(fileContents, "version", newVersion);
+            }
+            return fileContents;
         }
 
         /// <summary>
@@ -233,7 +237,11 @@ namespace Microsoft.DotNet.Scripts
                 Regex regex = new Regex(@"Microsoft\.NETCore\.Platforms\\(?<version>.*)\\runtime\.json");
                 string newNetCorePlatformsVersion = c.GetNewVersion("Microsoft.NETCore.Platforms");
 
-                return regex.ReplaceGroupValue(contents, "version", newNetCorePlatformsVersion);
+                if (newNetCorePlatformsVersion != null)
+                {
+                    contents = regex.ReplaceGroupValue(contents, "version", newNetCorePlatformsVersion);
+                }
+                return contents;
             });
 
             return c.Success();
@@ -249,8 +257,8 @@ namespace Microsoft.DotNet.Scripts
 
             if (string.IsNullOrEmpty(newVersion))
             {
-                c.Error($"Could not find package version information for '{packageId}'");
-                return $"DEPENDENCY '{packageId}' NOT FOUND";
+                c.Info($"Could not find package version information for '{packageId}'");
+                return null;
             }
 
             return newVersion;


### PR DESCRIPTION
Cherry-pick https://github.com/dotnet/core-setup/pull/791.

I also ran `UpdateFiles` to generate an example upgrade. It's the same as https://github.com/dotnet/core-setup/pull/787 but skipping the bad upgrade. (**Removed because the branch isn't ready yet**.)

@gkhanna79 