### PR TITLE
Limit project.json auto-upgrade scope: no UWP or miscellaneous project files (release/1.0.0)

### DIFF
--- a/build_projects/update-dependencies/Dirs.cs
+++ b/build_projects/update-dependencies/Dirs.cs
@@ -8,5 +8,8 @@ namespace Microsoft.DotNet.Scripts
     public static class Dirs
     {
         public static readonly string RepoRoot = Directory.GetCurrentDirectory();
+        public static readonly string Pkg = Path.Combine(RepoRoot, "pkg");
+        public static readonly string PkgProjects = Path.Combine(Pkg, "projects");
+        public static readonly string PkgDeps = Path.Combine(Pkg, "deps");
     }
 }

--- a/build_projects/update-dependencies/UpdateFilesTargets.cs
+++ b/build_projects/update-dependencies/UpdateFilesTargets.cs
@@ -87,7 +87,11 @@ namespace Microsoft.DotNet.Scripts
         {
             List<DependencyInfo> dependencyInfos = c.GetDependencyInfos();
 
-            IEnumerable<string> projectJsonFiles = Directory.GetFiles(Dirs.RepoRoot, "project.json", SearchOption.AllDirectories);
+            var projectJsonFiles = new List<string>
+            {
+                Path.Combine(Dirs.PkgProjects, "Microsoft.NETCore.App", "project.json"),
+                Path.Combine(Dirs.PkgDeps, "project.json")
+            };
 
             JObject projectRoot;
             foreach (string projectJsonFile in projectJsonFiles)


### PR DESCRIPTION
Ports the part of https://github.com/dotnet/core-setup/pull/596 that limits auto-update to a static list of files. Results in an auto-upgrade like https://github.com/dagood/core-setup/commit/557a0c295aa8c0e6707f419b7aa695db80a6d568 from stable.

Removes UWP auto-update noticed in https://github.com/dotnet/core-setup/pull/795. If this is merged and there's no new coreclr build, there will be no auto-upgrade changes to make.

I'll port this to release/1.1.0 too.

@gkhanna79 
/cc @weshaggard 