### PR TITLE
Limit project.json auto-upgrade scope: no UWP or miscellaneous project files (release/1.1.0)

### DIFF
--- a/build_projects/update-dependencies/Dirs.cs
+++ b/build_projects/update-dependencies/Dirs.cs
@@ -8,5 +8,8 @@ namespace Microsoft.DotNet.Scripts
     public static class Dirs
     {
         public static readonly string RepoRoot = Directory.GetCurrentDirectory();
+        public static readonly string Pkg = Path.Combine(RepoRoot, "pkg");
+        public static readonly string PkgProjects = Path.Combine(Pkg, "projects");
+        public static readonly string PkgDeps = Path.Combine(Pkg, "deps");
     }
 }

--- a/build_projects/update-dependencies/UpdateFilesTargets.cs
+++ b/build_projects/update-dependencies/UpdateFilesTargets.cs
@@ -87,24 +87,11 @@ namespace Microsoft.DotNet.Scripts
         {
             List<DependencyInfo> dependencyInfos = c.GetDependencyInfos();
 
-            string[] sourceDirsToUpdate =
+            var projectJsonFiles = new List<string>
             {
-                "build_projects",
-                "pkg",
-                // Don't upgrade RTM versions in InternalAbstractions and DependencyModel.
-                // See https://github.com/dotnet/core-setup/issues/275
-                //"src",
-                "test",
-                "tools"
+                Path.Combine(Dirs.PkgProjects, "Microsoft.NETCore.App", "project.json"),
+                Path.Combine(Dirs.PkgDeps, "project.json")
             };
-
-            IEnumerable<string> projectJsonFiles = sourceDirsToUpdate
-                .SelectMany(name =>
-                    Directory.GetFiles(
-                        Path.Combine(Dirs.RepoRoot, name),
-                        "project.json",
-                        SearchOption.AllDirectories))
-                .ToArray();
 
             JObject projectRoot;
             foreach (string projectJsonFile in projectJsonFiles)

--- a/build_projects/update-dependencies/UpdateFilesTargets.cs
+++ b/build_projects/update-dependencies/UpdateFilesTargets.cs
@@ -91,6 +91,11 @@ namespace Microsoft.DotNet.Scripts
             {
                 Path.Combine(Dirs.PkgProjects, "Microsoft.NETCore.App", "project.json"),
                 Path.Combine(Dirs.PkgDeps, "project.json")
+
+                // Don't auto-upgrade RTM versions in InternalAbstractions and DependencyModel
+                // project.json files. If the code to create projectJsonFiles is changed back to a
+                // recursive file search, don't include "src".
+                // See https://github.com/dotnet/core-setup/issues/275
             };
 
             JObject projectRoot;


### PR DESCRIPTION
Port https://github.com/dotnet/core-setup/pull/797 to release/1.1.0. Removed some conflicting 1.1.0-specific changes that also limited which project.json files to upgrade, but they were much less restrictive.

@gkhanna79 