### PR TITLE
Add '--verbose' option

### DIFF
--- a/build_projects/dotnet-host-build/build.sh
+++ b/build_projects/dotnet-host-build/build.sh
@@ -45,6 +45,9 @@ while [[ $# > 0 ]]; do
         --build-driver-only)
             __BuildDriverOnly=1
             ;;
+        --verbose)
+            export DOTNET_BUILD_VERBOSE=1
+            ;;
         --help)
             echo "Usage: $0 [--configuration <CONFIGURATION>] [--skip-prereqs] [--nopackage] [--docker <IMAGENAME>] [--help] [--targets <TARGETS...>]"
             echo ""


### PR DESCRIPTION
This option exports DOTNET_BUILD_VERBOSE environment variable.

Related issue: #801 