### PR TITLE
Generate DotNet nupkgs for ubuntu.14.04-arm and ubuntu.16.04-arm

### DIFF
--- a/build_projects/dotnet-host-build/CompileTargets.cs
+++ b/build_projects/dotnet-host-build/CompileTargets.cs
@@ -28,7 +28,9 @@ namespace Microsoft.DotNet.Host.Build
             { "win10-arm64", "win10-arm64" },
             { "osx.10.10-x64", "osx.10.10-x64" },
             { "osx.10.11-x64", "osx.10.10-x64" },
+            { "ubuntu.14.04-arm", "ubuntu.14.04-arm" },
             { "ubuntu.14.04-x64", "ubuntu.14.04-x64" },
+            { "ubuntu.16.04-arm", "ubuntu.16.04-arm" },
             { "ubuntu.16.04-x64", "ubuntu.16.04-x64" },
             { "ubuntu.16.10-x64", "ubuntu.16.10-x64" },
             { "centos.7-x64", "rhel.7-x64" },
@@ -386,10 +388,23 @@ namespace Microsoft.DotNet.Host.Build
             var hostNugetversion = hostVersion.LatestHostVersion.ToString();
             var content = $@"{c.BuildContext["CommitHash"]}{Environment.NewLine}{hostNugetversion}{Environment.NewLine}";
             var pkgDir = Path.Combine(c.BuildContext.BuildDirectory, "pkg");
-            var packCmd = "pack." + (CurrentPlatform.IsWindows ? "cmd" : "sh");
             string rid = HostPackageSupportedRids[c.BuildContext.Get<string>("TargetRID")];
             File.WriteAllText(Path.Combine(pkgDir, "version.txt"), content);
-            Exec(Path.Combine(pkgDir, packCmd));
+
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                Exec(Path.Combine(pkgDir, "pack.cmd"));
+            }
+            else
+            {
+                List<string> buildScriptArgList = new List<string>();
+                string buildScriptFile = Path.Combine(pkgDir, "pack.sh");
+
+                buildScriptArgList.Add("--rid");
+                buildScriptArgList.Add(rid);
+
+                Exec(buildScriptFile, buildScriptArgList);
+            }
 
             foreach (var file in Directory.GetFiles(Path.Combine(pkgDir, "bin", "packages"), "*.nupkg"))
             {

--- a/pkg/pack.sh
+++ b/pkg/pack.sh
@@ -11,6 +11,16 @@ init_distro_name()
     fi
 }
 
+usage()
+{
+    echo "Usage: $0 --rid <Runtime Identifier>"
+    echo ""
+    echo "Options:"
+    echo "  --rid <Runtime Identifier>        Target Runtime Identifier"
+
+    exit 1
+}
+
 set -e
 
 # determine current directory
@@ -24,6 +34,23 @@ done
 # initialize variables
 __project_dir="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
 __distro_rid=
+
+while [ "$1" != "" ]; do
+    lowerI="$(echo $1 | awk '{print tolower($0)}')"
+    case $lowerI in
+        -h|--help)
+            usage
+            exit 1
+            ;;
+        --rid)
+            shift
+            __distro_rid=$1
+            ;;
+        *)
+        echo "Unknown argument to pack.sh $1"; exit 1
+    esac
+    shift
+done
 
 # setup msbuild
 "$__project_dir/init-tools.sh"
@@ -44,7 +71,9 @@ if [ "$(uname -s)" == "Darwin" ]; then
     __targets_param="TargetsOSX=true"
 else
     __targets_param="TargetsLinux=true"
-    init_distro_name
+    if [ -z $__distro_rid ]; then
+        init_distro_name
+    fi
 fi
 
 __common_parameters="/p:$__targets_param /p:DistroRid=$__distro_rid /verbosity:minimal"

--- a/pkg/projects/Microsoft.NETCore.DotNetHost/Microsoft.NETCore.DotNetHost.builds
+++ b/pkg/projects/Microsoft.NETCore.DotNetHost/Microsoft.NETCore.DotNetHost.builds
@@ -31,9 +31,17 @@
       <OSGroup>Linux</OSGroup>
       <Platform>amd64</Platform>
     </Project>
+    <Project Condition="'$(TargetsLinux)' == 'true' and '$(DistroRid)' == 'ubuntu.14.04-arm'" Include="ubuntu.14.04/Microsoft.NETCore.DotNetHost.pkgproj">
+      <OSGroup>Linux</OSGroup>
+      <Platform>arm</Platform>
+    </Project>
     <Project Condition="'$(TargetsLinux)' == 'true' and '$(DistroRid)' == 'ubuntu.14.04-x64'" Include="ubuntu.14.04/Microsoft.NETCore.DotNetHost.pkgproj">
       <OSGroup>Linux</OSGroup>
       <Platform>amd64</Platform>
+    </Project>
+    <Project Condition="'$(TargetsLinux)' == 'true' and '$(DistroRid)' == 'ubuntu.16.04-arm'" Include="ubuntu.16.04/Microsoft.NETCore.DotNetHost.pkgproj">
+      <OSGroup>Linux</OSGroup>
+      <Platform>arm</Platform>
     </Project>
     <Project Condition="'$(TargetsLinux)' == 'true' and '$(DistroRid)' == 'ubuntu.16.04-x64'" Include="ubuntu.16.04/Microsoft.NETCore.DotNetHost.pkgproj">
       <OSGroup>Linux</OSGroup>

--- a/pkg/projects/Microsoft.NETCore.DotNetHost/Microsoft.NETCore.DotNetHostPolicy.builds
+++ b/pkg/projects/Microsoft.NETCore.DotNetHost/Microsoft.NETCore.DotNetHostPolicy.builds
@@ -31,9 +31,17 @@
       <OSGroup>Linux</OSGroup>
       <Platform>amd64</Platform>
     </Project>
+    <Project Condition="'$(TargetsLinux)' == 'true' and '$(DistroRid)' == 'ubuntu.14.04-arm'" Include="ubuntu.14.04/Microsoft.NETCore.DotNetHostPolicy.pkgproj">
+      <OSGroup>Linux</OSGroup>
+      <Platform>arm</Platform>
+    </Project>
     <Project Condition="'$(TargetsLinux)' == 'true' and '$(DistroRid)' == 'ubuntu.14.04-x64'" Include="ubuntu.14.04/Microsoft.NETCore.DotNetHostPolicy.pkgproj">
       <OSGroup>Linux</OSGroup>
       <Platform>amd64</Platform>
+    </Project>
+    <Project Condition="'$(TargetsLinux)' == 'true' and '$(DistroRid)' == 'ubuntu.16.04-arm'" Include="ubuntu.16.04/Microsoft.NETCore.DotNetHostPolicy.pkgproj">
+      <OSGroup>Linux</OSGroup>
+      <Platform>arm</Platform>
     </Project>
     <Project Condition="'$(TargetsLinux)' == 'true' and '$(DistroRid)' == 'ubuntu.16.04-x64'" Include="ubuntu.16.04/Microsoft.NETCore.DotNetHostPolicy.pkgproj">
       <OSGroup>Linux</OSGroup>

--- a/pkg/projects/Microsoft.NETCore.DotNetHost/Microsoft.NETCore.DotNetHostResolver.builds
+++ b/pkg/projects/Microsoft.NETCore.DotNetHost/Microsoft.NETCore.DotNetHostResolver.builds
@@ -31,9 +31,17 @@
       <OSGroup>Linux</OSGroup>
       <Platform>amd64</Platform>
     </Project>
+    <Project Condition="'$(TargetsLinux)' == 'true' and '$(DistroRid)' == 'ubuntu.14.04-arm'" Include="ubuntu.14.04/Microsoft.NETCore.DotNetHostResolver.pkgproj">
+      <OSGroup>Linux</OSGroup>
+      <Platform>arm</Platform>
+    </Project>
     <Project Condition="'$(TargetsLinux)' == 'true' and '$(DistroRid)' == 'ubuntu.14.04-x64'" Include="ubuntu.14.04/Microsoft.NETCore.DotNetHostResolver.pkgproj">
       <OSGroup>Linux</OSGroup>
       <Platform>amd64</Platform>
+    </Project>
+    <Project Condition="'$(TargetsLinux)' == 'true' and '$(DistroRid)' == 'ubuntu.16.04-arm'" Include="ubuntu.16.04/Microsoft.NETCore.DotNetHostResolver.pkgproj">
+      <OSGroup>Linux</OSGroup>
+      <Platform>arm</Platform>
     </Project>
     <Project Condition="'$(TargetsLinux)' == 'true' and '$(DistroRid)' == 'ubuntu.16.04-x64'" Include="ubuntu.16.04/Microsoft.NETCore.DotNetHostResolver.pkgproj">
       <OSGroup>Linux</OSGroup>


### PR DESCRIPTION
Add runtime id for ubuntu.14.04-arm and ubuntu.16.04-arm
Currently, pkg/pack.sh does not support cross build.
By adding --rid option, pack.sh supports to generate DotNet nupkgs for arm.

Related issue : #813 