### PR TITLE
Add '--skiptests' option to skip tests

### DIFF
--- a/build_projects/dotnet-host-build/TestTargets.cs
+++ b/build_projects/dotnet-host-build/TestTargets.cs
@@ -26,6 +26,7 @@ namespace Microsoft.DotNet.Host.Build
             nameof(RestoreTests),
             nameof(BuildTests),
             nameof(RunTests))]
+        [Environment("DOTNET_BUILD_SKIP_TESTS", null, "0", "false")]
         public static BuildTargetResult Test(BuildTargetContext c) => c.Success();
 
         [Target]

--- a/build_projects/dotnet-host-build/build.sh
+++ b/build_projects/dotnet-host-build/build.sh
@@ -35,6 +35,9 @@ while [[ $# > 0 ]]; do
             IFS=',' read -r -a envVars <<< $2
             shift
             ;;
+        --skiptests)
+            export DOTNET_BUILD_SKIP_TESTS=1
+            ;;
         --nopackage)
             export DOTNET_BUILD_SKIP_PACKAGING=1
             ;;


### PR DESCRIPTION
This patch support to skip tests by using '--skiptests' option.

Related issue : #847 

The result is like below:
```
[TARGET     <] [ OK ] [00:00:45.538] Compile                                                    (Microsoft.DotNet.Host.Build.CompileTargets.Compile)
Skipping, Target Conditions not met: Test
[TARGET     >] [....] [00:00:45.538] Package                                                    (Microsoft.DotNet.Host.Build.PackageTargets.Package)
```
