### PR TITLE
Fix Pipeline build break

### DIFF
--- a/build_projects/dotnet-host-build/PrepareTargets.cs
+++ b/build_projects/dotnet-host-build/PrepareTargets.cs
@@ -110,7 +110,7 @@ namespace Microsoft.DotNet.Host.Build
                 // Portable build only supports Linux RID
                 targetRID = $"linux-{platformEnv}";
                 realTargetRID = targetRID;
-                
+
                 // Update/set the TARGETRID environment variable that will be used by various parts of the build
                 Environment.SetEnvironmentVariable("TARGETRID", targetRID);
             }
@@ -120,7 +120,7 @@ namespace Microsoft.DotNet.Host.Build
 
             // Save the RID that will be used to create the RID specific subfolder under artifacts folder.
             // See Dirs.cs for details.
-            c.BuildContext["ActualTargetRID"] = realTargetRID; 
+            c.BuildContext["ArtifactsTargetRID"] = realTargetRID; 
             c.BuildContext["LinkPortable"] = linkPortable;
             c.BuildContext["Platform"] = platformEnv;
 

--- a/build_projects/dotnet-host-build/PrepareTargets.cs
+++ b/build_projects/dotnet-host-build/PrepareTargets.cs
@@ -43,8 +43,6 @@ namespace Microsoft.DotNet.Host.Build
             nameof(PackDotnetDebTool))]
         public static BuildTargetResult Init(BuildTargetContext c)
         {
-            // CommonInit(c);
-
             var configEnv = Environment.GetEnvironmentVariable("CONFIGURATION");
             string platformEnv = c.BuildContext.Get<string>("Platform");
             
@@ -111,7 +109,8 @@ namespace Microsoft.DotNet.Host.Build
             {
                 // Portable build only supports Linux RID
                 targetRID = $"linux-{platformEnv}";
-
+                realTargetRID = targetRID;
+                
                 // Update/set the TARGETRID environment variable that will be used by various parts of the build
                 Environment.SetEnvironmentVariable("TARGETRID", targetRID);
             }

--- a/build_projects/dotnet-host-build/TestTargets.cs
+++ b/build_projects/dotnet-host-build/TestTargets.cs
@@ -130,11 +130,13 @@ namespace Microsoft.DotNet.Host.Build
 
                 c.Info($"Running tests in: {project}");
 
+                string actualTargetRid = c.BuildContext.Get<string>("ActualTargetRID");
+                
                 var result = dotnet.Test("--configuration", configuration, "-xml", $"{project}-testResults.xml", "-notrait", "category=failing")
                     .WorkingDirectory(Path.Combine(Dirs.RepoRoot, "test", project))
                     .EnvironmentVariable("PATH", $"{dotnet.BinPath}{Path.PathSeparator}{Environment.GetEnvironmentVariable("PATH")}")
                     .EnvironmentVariable("TEST_ARTIFACTS", Dirs.TestArtifacts)
-                    .EnvironmentVariable("TEST_TARGETRID", rid)
+                    .EnvironmentVariable("TEST_TARGETRID", actualTargetRid)
                     .Execute();
 
                 if (result.ExitCode != 0)

--- a/build_projects/dotnet-host-build/TestTargets.cs
+++ b/build_projects/dotnet-host-build/TestTargets.cs
@@ -130,7 +130,7 @@ namespace Microsoft.DotNet.Host.Build
 
                 c.Info($"Running tests in: {project}");
 
-                string actualTargetRid = c.BuildContext.Get<string>("ActualTargetRID");
+                string actualTargetRid = c.BuildContext.Get<string>("ArtifactsTargetRID");
                 
                 var result = dotnet.Test("--configuration", configuration, "-xml", $"{project}-testResults.xml", "-notrait", "category=failing")
                     .WorkingDirectory(Path.Combine(Dirs.RepoRoot, "test", project))


### PR DESCRIPTION
Only set TARGETRID env var when dealing with Portable Native Binaries case.

Also, added the notion of real Target ID to BuildContext that should be used to lookup the location of artifacts folder for test runs.