### PR TITLE
Disable GenerateDebs target for building ubuntu arm.

### DIFF
--- a/build_projects/Microsoft.DotNet.Cli.Build.Framework/CurrentArchitecture.cs
+++ b/build_projects/Microsoft.DotNet.Cli.Build.Framework/CurrentArchitecture.cs
@@ -31,9 +31,35 @@ namespace Microsoft.DotNet.Cli.Build.Framework
             }
         }
 
+        public static bool Isarm
+        {
+            get
+            {
+                var archName = Environment.GetEnvironmentVariable("TARGETPLATFORM");
+                return string.Equals(archName, "arm", StringComparison.OrdinalIgnoreCase);
+            }
+        }
+
+        public static bool Isarm64
+        {
+            get
+            {
+                var archName = Environment.GetEnvironmentVariable("TARGETPLATFORM");
+                return string.Equals(archName, "arm64", StringComparison.OrdinalIgnoreCase);
+            }
+        }
+
         private static BuildArchitecture DetermineCurrentArchitecture()
         {
-            if (Isx86)
+            if (Isarm)
+            {
+                return BuildArchitecture.arm;
+            }
+            else if (Isarm64)
+            {
+                return BuildArchitecture.arm64;
+            }
+            else if (Isx86)
             {
                 return BuildArchitecture.x86;
             }

--- a/build_projects/Microsoft.DotNet.Cli.Build.Framework/Enumerations/BuildArchitecture.cs
+++ b/build_projects/Microsoft.DotNet.Cli.Build.Framework/Enumerations/BuildArchitecture.cs
@@ -3,6 +3,8 @@ namespace Microsoft.DotNet.Cli.Build.Framework
     public enum BuildArchitecture
     {
         x86 = 1,
-        x64 = 2
+        x64 = 2,
+        arm = 3,
+        arm64 = 4
     }
 }

--- a/build_projects/dotnet-host-build/DebTargets.cs
+++ b/build_projects/dotnet-host-build/DebTargets.cs
@@ -17,6 +17,7 @@ namespace Microsoft.DotNet.Host.Build
                 nameof(GenerateHostFxrDeb),
                 nameof(GenerateSharedFrameworkDeb))]
         [BuildPlatforms(BuildPlatform.Ubuntu, BuildPlatform.Debian)]
+        [BuildArchitectures(BuildArchitecture.x64)]
         public static BuildTargetResult GenerateDebs(BuildTargetContext c)
         {
             return c.Success();
@@ -161,6 +162,7 @@ namespace Microsoft.DotNet.Host.Build
         [Target(nameof(InstallSharedFramework),
                 nameof(RemovePackages))]
         [BuildPlatforms(BuildPlatform.Ubuntu, BuildPlatform.Debian)]
+        [BuildArchitectures(BuildArchitecture.x64)]
         public static BuildTargetResult TestDebInstaller(BuildTargetContext c)
         {
             return c.Success();


### PR DESCRIPTION
By using BuidlArchitectures attribute, the GenerateDebs target is disabled.
BuildArchitecture.arm enumeration is also added.

Related issue : #849 