### PR TITLE
Prevent any refs from runtime packages

### DIFF
--- a/pkg/projects/Microsoft.NETCore.App/Microsoft.NETCore.App.pkgproj
+++ b/pkg/projects/Microsoft.NETCore.App/Microsoft.NETCore.App.pkgproj
@@ -4,6 +4,7 @@
 
   <PropertyGroup>
     <IsLineupPackage Condition="'$(PackageTargetRuntime)' == ''">true</IsLineupPackage>
+    <PreventImplementationReference Condition="'$(PackageTargetRuntime)' != ''">true</PreventImplementationReference>
     <Version>$(NetCoreAppVersion)</Version>
     <PackagePlatform>AnyCPU</PackagePlatform>
     <SkipPackageFileCheck>true</SkipPackageFileCheck>


### PR DESCRIPTION
NuGet has a bug where it's consider RID-specific assets for compile.
https://github.com/NuGet/Home/issues/4207

Workaround that by putting a placeholder under ref.

/cc @weshaggard 