### PR TITLE
Increase NuGet push timeout from 300s to 3600s

### DIFF
--- a/build_projects/dotnet-host-build/NugetUtil.cs
+++ b/build_projects/dotnet-host-build/NugetUtil.cs
@@ -35,6 +35,7 @@ namespace Microsoft.DotNet.Cli.Build
                     "push",
                     "-s", destinationUrl,
                     "-k", apiKey,
+                    "--timeout", "3600",
                     path);
 
                 if (result != 0)


### PR DESCRIPTION
Fixes https://github.com/dotnet/core-setup/issues/1030 (timeout when publishing packages to NuGet).

@AlfredoMS FYI. Since the buildtools/pipebuild system package publish is so different I doubt this will affect your work. 3600s is already the default for our other builds.

/cc @ericstj @gkhanna79 