### PR TITLE
Fix arm cross-compile target arg

### DIFF
--- a/cross/arm/toolchain.cmake
+++ b/cross/arm/toolchain.cmake
@@ -7,7 +7,7 @@ set(CMAKE_SYSTEM_PROCESSOR armv7l)
 ## Specify the toolchain
 set(TOOLCHAIN "arm-linux-gnueabihf")
 
-add_compile_options(-target armv7-linux-gnueabihf)
+add_compile_options(-target arm-linux-gnueabihf)
 add_compile_options(-mthumb)
 add_compile_options(-mfpu=vfpv3)
 add_compile_options(--sysroot=${CROSS_ROOTFS})


### PR DESCRIPTION
Build currently fails on "armv7-linux-gnueabihf: No such file or directory" running xenial (and no package/binary/file exists with that name, that I'm aware) -- I know most are testing on trusty, so we may need to branch if trusty doesn't have an "arm-linux-gnueabihf"