### PR TITLE
explicitly use clang for cross-compile build

### DIFF
--- a/src/corehost/build.sh
+++ b/src/corehost/build.sh
@@ -171,7 +171,13 @@ __base_rid=$__rid_plat-$__build_arch_lowcase
 echo "Building Corehost from $DIR to $(pwd)"
 set -x # turn on trace
 if [ $__CrossBuild == 1 ]; then
-    cmake "$DIR" -G "Unix Makefiles" $__cmake_defines -DCLI_CMAKE_RUNTIME_ID:STRING=$__runtime_id -DCLI_CMAKE_HOST_VER:STRING=$__host_ver -DCLI_CMAKE_APPHOST_VER:STRING=$__apphost_ver -DCLI_CMAKE_HOST_FXR_VER:STRING=$__fxr_ver -DCLI_CMAKE_HOST_POLICY_VER:STRING=$__policy_ver -DCLI_CMAKE_PKG_RID:STRING=$__base_rid -DCLI_CMAKE_COMMIT_HASH:STRING=$__commit_hash -DCMAKE_TOOLCHAIN_FILE=$DIR/../../cross/$__build_arch_lowcase/toolchain.cmake
+    __clang=$(which clang-3.6 || echo)
+    __clangxx=$(which clang++-3.6 || echo)
+    if [ -z $__clang ] || [ -z $__clangxx ]; then
+        echo "clang-3.6 is required to cross-compile corehost"
+        exit -1
+    fi
+    cmake "$DIR" -G "Unix Makefiles" $__cmake_defines -DCMAKE_C_COMPILER=$__clang -DCMAKE_CXX_COMPILER=$__clangxx -DCLI_CMAKE_RUNTIME_ID:STRING=$__runtime_id -DCLI_CMAKE_HOST_VER:STRING=$__host_ver -DCLI_CMAKE_APPHOST_VER:STRING=$__apphost_ver -DCLI_CMAKE_HOST_FXR_VER:STRING=$__fxr_ver -DCLI_CMAKE_HOST_POLICY_VER:STRING=$__policy_ver -DCLI_CMAKE_PKG_RID:STRING=$__base_rid -DCLI_CMAKE_COMMIT_HASH:STRING=$__commit_hash -DCMAKE_TOOLCHAIN_FILE=$DIR/../../cross/$__build_arch_lowcase/toolchain.cmake
 else
     cmake "$DIR" -G "Unix Makefiles" $__cmake_defines -DCLI_CMAKE_RUNTIME_ID:STRING=$__runtime_id -DCLI_CMAKE_HOST_VER:STRING=$__host_ver -DCLI_CMAKE_APPHOST_VER:STRING=$__apphost_ver -DCLI_CMAKE_HOST_FXR_VER:STRING=$__fxr_ver -DCLI_CMAKE_HOST_POLICY_VER:STRING=$__policy_ver -DCLI_CMAKE_PKG_RID:STRING=$__base_rid -DCLI_CMAKE_COMMIT_HASH:STRING=$__commit_hash
 fi


### PR DESCRIPTION
On systems where clang is not the default C compiler (or similarly clang++ for C++), cross-compiles will fail since they're attempting to use GCC/G++, which doesn't have a "-target" CLI arg.

This commit adds the CMAKE_C_COMPILER and CMAKE_CXX_COMPILER environment variables to the cmake call in corehost's build script when cross-compiling, to force clang as the C/C++ compiler.

2 questions:
1. GCC/G++ seem to work fine for non-cross-compiles, but do we want to make them use clang too, for consistency?
2. There doesn't appear to be any build documentation on minimum system requirements, so this is using the newest version of clang found on the machine. Do we want to add minimum build requirements documentation and/or set a specific required version of clang?