### PR TITLE
Upgrade nss in the Fedora 23 dockerfile (port release/1.1.0 -> master)

### DIFF
--- a/scripts/docker/fedora.23/Dockerfile
+++ b/scripts/docker/fedora.23/Dockerfile
@@ -24,8 +24,11 @@ RUN dnf install -y libicu \
         libcurl \ 
         openssl-libs \ 
         libunwind \ 
-        lttng-ust && \ 
-    dnf clean all 
+        lttng-ust
+
+RUN dnf upgrade -y nss
+
+RUN dnf clean all 
  
 # Setup User to match Host User, and give superuser permissions 
 ARG USER_ID=0 


### PR DESCRIPTION
Port #541 to master to fix restore timeout issue. The latest repro was during `init-tools` in the pkg build.

@gkhanna79 