### PR TITLE
Move package dependencies to pj for maestro

### DIFF
--- a/pkg/projects/Microsoft.NETCore.App/Microsoft.NETCore.App.depproj
+++ b/pkg/projects/Microsoft.NETCore.App/Microsoft.NETCore.App.depproj
@@ -14,6 +14,12 @@
   <ItemGroup>
     <None Include="project.json" />
   </ItemGroup>
+  <ItemGroup Condition="'$(NuGetRuntimeIdentifier)' == ''">
+    <!-- Bring in Platforms for RID graph, NETStandard.Library for build-tools -->
+    <DependenciesToPackage Include="NETStandard.Library" />
+    <DependenciesToPackage Include="Microsoft.NETCore.Platforms" />
+  </ItemGroup>
+
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 
   <Target Name="GetFilesToPackage" DependsOnTargets="ResolveNuGetPackages" Returns="@(FilesToPackage)">
@@ -65,6 +71,32 @@
     <Message Importance="low" Text="%(FilesToPackage.PackagePath) -> @(FilesToPackage)" />
   </Target>
 
+  <Target Name="GetDependenciesToPackage" Condition="'@(DependenciesToPackage)' != ''" DependsOnTargets="ResolveNuGetPackages" Returns="@(_DependenciesToPackageWithVersion)">
+    <!-- hack because current nuget task doesn't return version for ReferencedNuGetPackages,
+         can be removed once we switch to msbuild-based nuget & use PackageReference-->
+    <ReadLinesFromFile File="$(ProjectJson)">
+      <Output TaskParameter="Lines" ItemName="ProjectJsonLines" />
+    </ReadLinesFromFile>
+
+    <ItemGroup>
+      <PackageMatch Include="@(ProjectJsonLines)">
+        <PackageId>$([System.Text.RegularExpressions.Regex]::Match('%(Identity)', '(\w[^:&quot;]*)'))</PackageId>
+        <PackageVersion>$([System.Text.RegularExpressions.Regex]::Match('%(Identity)', '(\d+\.\d+.\d+[^&quot;]*)'))</PackageVersion>
+      </PackageMatch>
+
+      <ReferencedPackage Include="@(PackageMatch -> '%(PackageId)')" Condition="'%(PackageMatch.PackageVersion)' != ''">
+        <Version>%(PackageMatch.PackageVersion)</Version>
+      </ReferencedPackage>
+      
+      <!-- intersect ReferencedPackage with DependenciesToPackage -->
+      <_DependenciesToPackageWithVersion Include="@(ReferencedPackage)" Condition="'@(ReferencedPackage)' == '@(DependenciesToPackage)' AND '%(Identity)' != ''">
+        <TargetFramework>$(PackageTargetFramework)</TargetFramework>
+      </_DependenciesToPackageWithVersion>
+    </ItemGroup>
+
+    <Message Importance="low" Text="%(_DependenciesToPackageWithVersion.Identity) : %(_DependenciesToPackageWithVersion.Version) : %(_DependenciesToPackageWithVersion.TargetFramework)" />
+  </Target>
+ 
   <!-- only calculate paths from this project, don't copy -->
   <Target Name="Build" DependsOnTargets="GetFilesToPackage" />
   

--- a/pkg/projects/Microsoft.NETCore.App/Microsoft.NETCore.App.pkgproj
+++ b/pkg/projects/Microsoft.NETCore.App/Microsoft.NETCore.App.pkgproj
@@ -61,16 +61,6 @@
     <File Include="$(PlaceHolderFile)">
       <TargetPath>.NETCoreApp</TargetPath>
     </File>
-
-    <!-- Bring in Platforms for RID graph, NETStandard.Library for build-tools -->
-    <Dependency Include="Microsoft.NETCore.Platforms">
-      <Version>1.2.0-beta-24911-51</Version>
-      <TargetFramework>.NETCoreApp2.0</TargetFramework>
-    </Dependency>
-    <Dependency Include="NETStandard.Library">
-      <Version>2.0.0-beta-24909-0</Version>
-      <TargetFramework>.NETCoreApp2.0</TargetFramework>
-    </Dependency>
   </ItemGroup>
 
   <!-- Redistributed package content from other nuget packages-->
@@ -144,4 +134,15 @@
   </Target>
 
   <Target Name="GetPackageReport" />
+
+  <Target Name="GetDependenciesToPackage" AfterTargets="ExpandProjectReferences">
+    <!-- allow projects to provide dependencies -->
+    <MSBuild Targets="GetDependenciesToPackage"
+             BuildInParallel="$(BuildInParallel)"
+             Projects="@(_NonPkgProjProjectReference)"
+             Properties="$(ProjectProperties)">
+      <Output TaskParameter="TargetOutputs"
+              ItemName="Dependency" />
+    </MSBuild>
+  </Target>
 </Project>

--- a/pkg/projects/Microsoft.NETCore.App/project.json.template
+++ b/pkg/projects/Microsoft.NETCore.App/project.json.template
@@ -11,7 +11,10 @@
     "Microsoft.Private.CoreFx.NETCoreApp": "4.4.0-beta-24911-51",
     "Microsoft.NETCore.Runtime.CoreCLR": "1.2.0-beta-24909-02",
     "Microsoft.DiaSymReader.Native": "1.4.0",
-    "Libuv": "1.10.0-preview1-22033"
+    "Libuv": "1.10.0-preview1-22033",
+
+    "Microsoft.NETCore.Platforms": "1.2.0-beta-24911-51",
+    "NETStandard.Library": "2.0.0-beta-24909-0"
   },
   "frameworks": {
     "netcoreapp2.0": { }


### PR DESCRIPTION
This moves the package dependencies to the project.json.template so that
maestro can auto update them.

We can delete the hacky portion of this once we have msbuild-based CLI
that supports PackageReference.

/cc @weshaggard