### PR TITLE
Collection of small build improvements

### DIFF
--- a/NuGet.Config
+++ b/NuGet.Config
@@ -8,4 +8,7 @@
     <add key="cli-deps" value="https://dotnet.myget.org/F/cli-deps/api/v3/index.json" />
     <add key="api.nuget.org" value="https://api.nuget.org/v3/index.json" />
   </packageSources>
+  <disabledPackageSources>
+    <clear />
+  </disabledPackageSources>
 </configuration>

--- a/build_projects/update-dependencies/UpdateFilesTargets.cs
+++ b/build_projects/update-dependencies/UpdateFilesTargets.cs
@@ -90,7 +90,7 @@ namespace Microsoft.DotNet.Scripts
 
             var projectJsonFiles = new List<string>
             {
-                Path.Combine(Dirs.PkgProjects, "Microsoft.NETCore.App", "project.json"),
+                Path.Combine(Dirs.PkgProjects, "Microsoft.NETCore.App", "project.json.template"),
                 Path.Combine(Dirs.PkgDeps, "project.json")
             };
             //projectJsonFiles.AddRange(Directory.GetFiles(Dirs.RepoRoot, "project.json", SearchOption.AllDirectories));

--- a/pkg/dir.props
+++ b/pkg/dir.props
@@ -69,19 +69,16 @@
 
   <Import Project="$(ToolsDir)Build.Common.props" Condition="Exists('$(ToolsDir)Build.Common.props')" />
 
-  <ItemGroup>
-    <NuGetSource Include="https:%2F%2Fdotnet.myget.org/F/dotnet-core-dev-eng/api/v3/index.json" />
-    <NuGetSource Include="https:%2F%2Fdotnet.myget.org/F/dotnet-core/api/v3/index.json" />
-    <!-- needed for Microsoft.DiaSymReader.Native, potentially find a better feed -->
-    <NuGetSource Include="https:%2F%2Fapi.nuget.org/v3/index.json" />
-  </ItemGroup>
+  <PropertyGroup>
+    <NuGetConfigFile Condition="'$(NuGetConfigFile)' == ''">$(ProjectDir)/../NuGet.Config</NuGetConfigFile>
+  </PropertyGroup>
 
   <PropertyGroup>
     <DotNetTool Condition="'$(DotNetTool)' == '' and '$(OsEnvironment)'!='Unix'">$(DotnetCliPath)dotnet.exe</DotNetTool>
     <DotNetTool Condition="'$(DotNetTool)' == '' and '$(OsEnvironment)'=='Unix'">$(DotnetCliPath)dotnet</DotNetTool>
     <DotNetRestoreCommand>"$(DotNetTool)" restore</DotNetRestoreCommand>
     <DotNetRestoreCommand>$(DotNetRestoreCommand) --packages "$(PackagesDir.TrimEnd('/\'.ToCharArray()))"</DotNetRestoreCommand>
-    <DotNetRestoreCommand>$(DotNetRestoreCommand) @(NuGetSource->'--source %(Identity)', ' ')</DotNetRestoreCommand>
+    <DotNetRestoreCommand>$(DotNetRestoreCommand) --configfile "$(NuGetConfigFile)"</DotNetRestoreCommand>
     <DnuRestoreCommand>$(DotNetRestoreCommand)</DnuRestoreCommand>
   </PropertyGroup>
 

--- a/pkg/projects/Microsoft.NETCore.App/Microsoft.NETCore.App.depproj
+++ b/pkg/projects/Microsoft.NETCore.App/Microsoft.NETCore.App.depproj
@@ -66,7 +66,13 @@
 
     <!-- simple check to make sure we don't accidentally pull an old 
          package that should have been merged to the primary package -->
-    <Error Text="Unexpected System package %(_secondaryFilesByPackagePath.NuGetPackageId)" Condition="$([System.String]::new('%(_secondaryFilesByPackagePath.NuGetPackageId)').Contains('System.'))" />
+    <ItemGroup>
+      <PermittedSystemPackages Include="System.ValueTuple" />
+      <_secondarySystemPackages Include="@(_secondaryFilesByPackagePath->'%(NuGetPackageId)')"
+                                Condition="$([System.String]::new('%(NuGetPackageId)').Contains('System.'))" />
+      <_secondarySystemPackages Remove="@(PermittedSystemPackages)" />
+    </ItemGroup>
+    <Error Text="Unexpected System package(s) @(_secondarySystemPackages)" Condition="'@(_secondarySystemPackages)' != ''" />
 
     <Message Importance="low" Text="%(FilesToPackage.PackagePath) -> @(FilesToPackage)" />
   </Target>


### PR DESCRIPTION
- Get dependency updating working again
- Use NuGet.Config instead of passing an explicit list of sources
- Baseline System.ValueTuple problem when consuming a new Roslyn