### PR TITLE
Support below nupkgs build in non-Windows environment

### DIFF
--- a/build_projects/dotnet-host-build/CompileTargets.cs
+++ b/build_projects/dotnet-host-build/CompileTargets.cs
@@ -341,7 +341,9 @@ namespace Microsoft.DotNet.Host.Build
         [Target]
         public static BuildTargetResult BuildProjectsForNuGetPackages(BuildTargetContext c)
         {
-            if (CurrentPlatform.IsWindows)
+            string rid = c.BuildContext.Get<string>("TargetRID");
+
+            if (CurrentPlatform.IsWindows || rid == "ubuntu.14.04-arm" || rid == "ubuntu.16.04-arm" || rid == "tizen.4.0.0-armel" )
             {
                 var configuration = c.BuildContext.Get<string>("Configuration");
 


### PR DESCRIPTION
Now, Microsoft.DotNet.PlatformAbstractions and Microsoft.Extensions.DependencyModel's nupkg does not include the necessary dlls for use. This patch should be merged for the cli build.

Related issue: #725 
