### PR TITLE
Add PlatformManifest props to NETCore.App

### DIFF
--- a/pkg/dir.props
+++ b/pkg/dir.props
@@ -12,6 +12,9 @@
 
     <!-- Output directories -->
     <BinDir Condition="'$(BinDir)'==''">$(ProjectDir)bin/</BinDir>
+    <ObjDir Condition="'$(ObjDir)'==''">$(BinDir)obj/</ObjDir>
+    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'==''">$(ObjDir)</BaseIntermediateOutputPath>
+
     <TestWorkingDir Condition="'$(TestWorkingDir)'==''">$(BinDir)tests/</TestWorkingDir>
     <PackagesOutDir Condition="'$(PackagesOutDir)'==''">$(BinDir)packages/</PackagesOutDir>
     <SymbolPackagesOutDir Condition="'$(SymbolPackagesOutDir)'==''">$(PackagesOutDir)</SymbolPackagesOutDir>
@@ -24,6 +27,8 @@
     <BuildToolsTaskDir Condition="'$(BuildToolsTargets45)' == 'true' OR '$(MSBuildRuntimeType)' != 'Core'">$(ToolsDir)net45/</BuildToolsTaskDir>
     <PackagingTaskDir Condition="'$(BuildToolsTaskDir)' != ''">$(BuildToolsTaskDir)</PackagingTaskDir>
     <UseRoslynCompilers Condition="'$(UseRoslynCompilers)'=='' and '$(OSEnvironment)'!='Windows_NT'">false</UseRoslynCompilers>
+    <!-- core-setup does its own versioning -->
+    <SkipVersionGeneration>true</SkipVersionGeneration>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -79,6 +84,7 @@
   <PropertyGroup>
     <DotNetTool Condition="'$(DotNetTool)' == '' and '$(OsEnvironment)'!='Unix'">$(DotnetCliPath)dotnet.exe</DotNetTool>
     <DotNetTool Condition="'$(DotNetTool)' == '' and '$(OsEnvironment)'=='Unix'">$(DotnetCliPath)dotnet</DotNetTool>
+    <OverrideToolHost Condition="'$(MSBuildRuntimeType)' == 'Core'">$(DotNetTool)</OverrideToolHost>
     <DotNetRestoreCommand>"$(DotNetTool)" restore</DotNetRestoreCommand>
     <DotNetRestoreCommand>$(DotNetRestoreCommand) --packages "$(PackagesDir.TrimEnd('/\'.ToCharArray()))"</DotNetRestoreCommand>
     <DotNetRestoreCommand>$(DotNetRestoreCommand) @(NuGetSource->'--source %(Identity)', ' ')</DotNetRestoreCommand>

--- a/pkg/dir.props
+++ b/pkg/dir.props
@@ -104,4 +104,113 @@
     <Error Condition="'$(BuildNumberMinor)'==''" Text="BuildNumberMinor is undefined" />
   </Target>
 
+  <!--
+  Projects that have no OS-specific implementations just use Debug and Release for $(Configuration).
+  Projects that do have OS-specific implementations use OS_Debug and OS_Release, for all OS's we support even
+  if the code is the same between some OS's (so if you have some project that just calls POSIX APIs, we still have
+  OSX_[Debug|Release] and Linux_[Debug|Release] configurations.  We do this so that we place all the output under
+  a single binary folder and can have a similar experience between the command line and Visual Studio.
+  -->
+
+  <!--
+  If Configuration is empty that means we are not being built in VS and so folks need to explicitly pass the different
+  values for $(ConfigurationGroup), $(TargetGroup), or $(OSGroup) or accept the defaults for them.
+  -->
+  <PropertyGroup Condition="'$(Configuration)'==''">
+    <ConfigurationGroup Condition="'$(ConfigurationGroup)'==''">Debug</ConfigurationGroup>
+    <Configuration>$(ConfigurationGroup)</Configuration>
+    <Configuration Condition="'$(TargetGroup)'!=''">$(TargetGroup)_$(Configuration)</Configuration>
+    <Configuration Condition="'$(OSGroup)'!='' and '$(OSGroup)'!='AnyOS'">$(OSGroup)_$(Configuration)</Configuration>
+  </PropertyGroup>
+
+  <!--
+  If Configuration is set then someone explicitly passed it in or we building from VS. In either case
+  default $(ConfigurationGroup), $(TargetGroup), or $(OSGroup) from the Configuration if they aren't
+  already explicitly set.
+  -->
+  <PropertyGroup Condition="'$(Configuration)'!=''">
+    <ConfigurationGroup Condition="'$(ConfigurationGroup)'=='' and $(Configuration.EndsWith('Debug'))">Debug</ConfigurationGroup>
+    <ConfigurationGroup Condition="'$(ConfigurationGroup)'=='' and $(Configuration.EndsWith('Release'))">Release</ConfigurationGroup>
+    <ConfigurationGroup Condition="'$(ConfigurationGroup)'==''">Debug</ConfigurationGroup>
+
+    <BuildAllOSGroups Condition="'$(BuildAllOSGroups)' == ''">true</BuildAllOSGroups>
+
+    <OSGroup Condition="'$(OSGroup)'=='' and $(Configuration.StartsWith('Windows'))">Windows_NT</OSGroup>
+    <OSGroup Condition="'$(OSGroup)'=='' and $(Configuration.StartsWith('Unix'))">Unix</OSGroup>
+    <OSGroup Condition="'$(OSGroup)'=='' and $(Configuration.StartsWith('Linux'))">Linux</OSGroup>
+    <OSGroup Condition="'$(OSGroup)'=='' and $(Configuration.StartsWith('OSX'))">OSX</OSGroup>
+    <OSGroup Condition="'$(OSGroup)'=='' and $(Configuration.StartsWith('FreeBSD'))">FreeBSD</OSGroup>
+    <OSGroup Condition="'$(OSGroup)'=='' and $(Configuration.StartsWith('NetBSD'))">NetBSD</OSGroup>
+    <OSGroup Condition="'$(OSGroup)'==''">AnyOS</OSGroup>
+
+    <TargetGroup Condition="'$(TargetGroup)'=='' and $(Configuration.Contains('netcore50aot'))">netcore50aot</TargetGroup>
+    <TargetGroup Condition="'$(TargetGroup)'=='' and $(Configuration.Contains('netstandard13aot'))">netstandard13aot</TargetGroup>
+    <TargetGroup Condition="'$(TargetGroup)'=='' and $(Configuration.Contains('netstandard15aot'))">netstandard15aot</TargetGroup>
+    <TargetGroup Condition="'$(TargetGroup)'=='' and $(Configuration.Contains('netcore50'))">netcore50</TargetGroup>
+    <TargetGroup Condition="'$(TargetGroup)'=='' and $(Configuration.Contains('netcoreapp1.0'))">netcoreapp1.0</TargetGroup>
+    <TargetGroup Condition="'$(TargetGroup)'=='' and $(Configuration.Contains('netcoreapp1.1'))">netcoreapp1.1</TargetGroup>
+    <TargetGroup Condition="'$(TargetGroup)'=='' and $(Configuration.Contains('dnxcore50'))">dnxcore50</TargetGroup>
+    <TargetGroup Condition="'$(TargetGroup)'=='' and $(Configuration.Contains('net463'))">net463</TargetGroup>
+    <TargetGroup Condition="'$(TargetGroup)'=='' and $(Configuration.Contains('net462'))">net462</TargetGroup>
+    <TargetGroup Condition="'$(TargetGroup)'=='' and $(Configuration.Contains('net461'))">net461</TargetGroup>
+    <TargetGroup Condition="'$(TargetGroup)'=='' and $(Configuration.Contains('net46'))">net46</TargetGroup>
+    <TargetGroup Condition="'$(TargetGroup)'=='' and $(Configuration.Contains('net45'))">net45</TargetGroup>
+    <TargetGroup Condition="'$(TargetGroup)'=='' and $(Configuration.Contains('net451'))">net451</TargetGroup>
+    <TargetGroup Condition="'$(TargetGroup)'=='' and $(Configuration.Contains('win8'))">win8</TargetGroup>
+    <TargetGroup Condition="'$(TargetGroup)'=='' and $(Configuration.Contains('wpa81'))">wpa81</TargetGroup>
+    <TargetGroup Condition="'$(TargetGroup)'=='' and $(Configuration.Contains('uap101aot'))">uap101aot</TargetGroup>
+    <TargetGroup Condition="'$(TargetGroup)'=='' and $(Configuration.Contains('uap101'))">uap101</TargetGroup>
+  </PropertyGroup>
+
+  <!-- Set up Default symbol and optimization for Configuration -->
+  <Choose>
+    <When Condition="'$(ConfigurationGroup)'=='Debug'">
+      <PropertyGroup>
+        <DebugSymbols Condition="'$(DebugSymbols)' == ''">true</DebugSymbols>
+        <Optimize Condition="'$(Optimize)' == ''">false</Optimize>
+        <DebugType Condition="'$(DebugType)' == ''">full</DebugType>
+        <DefineConstants>$(DefineConstants),DEBUG,TRACE</DefineConstants>
+      </PropertyGroup>
+    </When>
+    <When Condition="'$(ConfigurationGroup)' == 'Release'">
+      <PropertyGroup>
+        <DebugSymbols Condition="'$(DebugSymbols)' == ''">true</DebugSymbols>
+        <Optimize Condition="'$(Optimize)' == ''">true</Optimize>
+        <DebugType Condition="'$(DebugType)' == ''">pdbonly</DebugType>
+        <DefineConstants>$(DefineConstants),TRACE</DefineConstants>
+      </PropertyGroup>
+    </When>
+    <Otherwise>
+      <PropertyGroup>
+        <ConfigurationErrorMsg>$(ConfigurationErrorMsg);Unknown ConfigurationGroup [$(ConfigurationGroup)] specificed in your project.</ConfigurationErrorMsg>
+      </PropertyGroup>
+    </Otherwise>
+  </Choose>
+
+  <!-- Disable some standard properties for building our projects -->
+  <PropertyGroup>
+    <NoStdLib>true</NoStdLib>
+    <NoExplicitReferenceToStdLib>true</NoExplicitReferenceToStdLib>
+    <AddAdditionalExplicitAssemblyReferences>false</AddAdditionalExplicitAssemblyReferences>
+    <GenerateTargetFrameworkAttribute>false</GenerateTargetFrameworkAttribute>
+  </PropertyGroup>
+
+  <!-- Set up handling of build warnings -->
+  <PropertyGroup>
+    <WarningLevel>4</WarningLevel>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+  </PropertyGroup>
+
+  <!-- Set up the default output and intermediate paths -->
+  <PropertyGroup>
+    <OSPlatformConfig>$(OSGroup).$(Platform).$(ConfigurationGroup)</OSPlatformConfig>
+    <TargetOutputRelPath Condition="'$(TargetGroup)'!=''">$(TargetGroup)/</TargetOutputRelPath>
+
+    <BaseOutputPath Condition="'$(BaseOutputPath)'==''">$(BinDir)</BaseOutputPath>
+    <OutputPathSubfolder Condition="'$(IsCompatAssembly)'=='true'">/Compat</OutputPathSubfolder>
+    <OutputPath Condition="'$(OutputPath)'==''">$(BaseOutputPath)$(OSPlatformConfig)/$(MSBuildProjectName)/$(TargetOutputRelPath)$(OutputPathSubfolder)</OutputPath>
+
+    <IntermediateOutputRootPath Condition="'$(IntermediateOutputRootPath)' == ''">$(BaseIntermediateOutputPath)$(OSPlatformConfig)/</IntermediateOutputRootPath>
+    <IntermediateOutputPath Condition="'$(IntermediateOutputPath)' == ''">$(IntermediateOutputRootPath)$(MSBuildProjectName)/$(TargetOutputRelPath)</IntermediateOutputPath>
+  </PropertyGroup>
 </Project>

--- a/pkg/dir.targets
+++ b/pkg/dir.targets
@@ -13,4 +13,15 @@
 
   <Import Project="$(ToolsDir)/Build.Common.targets" Condition="'$(UseLiveBuildTools)' != 'true'" />
 
+  <PropertyGroup>
+    <!-- We don't use any of MSBuild's resolution logic for resolving the framework, so just set these two properties to any folder that exists to skip
+         the GenerateReferenceAssemblyPaths task (not target) and to prevent it from outputting a warning (MSB3644). -->
+    <_TargetFrameworkDirectories>$(MSBuildThisFileDirectory)/Documentation</_TargetFrameworkDirectories>
+    <_FullFrameworkReferenceAssemblyPaths>$(MSBuildThisFileDirectory)/Documentation</_FullFrameworkReferenceAssemblyPaths>
+    <!-- We do not want to target a portable profile.
+         TODO: Make this the default in buildtools so this is not necessary. -->
+    <TargetFrameworkProfile></TargetFrameworkProfile>
+    <!-- We set this property to avoid MSBuild errors regarding not setting TargetFrameworkProfile (see above line) -->
+    <PortableNuGetMode>true</PortableNuGetMode>
+  </PropertyGroup>
 </Project>

--- a/pkg/pack.cmd
+++ b/pkg/pack.cmd
@@ -16,8 +16,10 @@ popd
 :: Clean up existing nupkgs
 if exist "%__ProjectDir%\bin" (rmdir /s /q "%__ProjectDir%\bin")
 
-:: Package the assets using Tools
+"%__DotNet%" "%__MSBuild%" "%__ProjectDir%\tasks\core-setup.tasks.builds" /verbosity:minimal /flp:logfile=tools.log;v=diag
+if not ERRORLEVEL 0 goto :Error
 
+:: Package the assets using Tools
 "%__DotNet%" "%__MSBuild%" "%__ProjectDir%\projects\packages.builds" /p:TargetsWindows=true /verbosity:minimal
 
 if not ERRORLEVEL 0 goto :Error

--- a/pkg/pack.sh
+++ b/pkg/pack.sh
@@ -69,6 +69,8 @@ fi
 
 __common_parameters="/p:$__targets_param /p:DistroRid=$__distro_rid /verbosity:minimal"
 
+$__msbuild $__project_dir/tasks/core-setup.tasks.builds $__common_parameters || exit 1
+
 $__msbuild $__project_dir/projects/packages.builds $__common_parameters || exit 1
 
 exit 0

--- a/pkg/projects/Microsoft.NETCore.App/Microsoft.NETCore.App.pkgproj
+++ b/pkg/projects/Microsoft.NETCore.App/Microsoft.NETCore.App.pkgproj
@@ -6,11 +6,14 @@
     <IsLineupPackage Condition="'$(PackageTargetRuntime)' == ''">true</IsLineupPackage>
     <PreventImplementationReference Condition="'$(PackageTargetRuntime)' != ''">true</PreventImplementationReference>
     <Version>$(NetCoreAppVersion)</Version>
+    <NETCoreAppFramework>netcoreapp$([System.Version]::Parse('$(NetCoreAppVersion)').ToString(2))</NETCoreAppFramework>
     <PackagePlatform>AnyCPU</PackagePlatform>
     <SkipPackageFileCheck>true</SkipPackageFileCheck>
     <OmitDependencies>true</OmitDependencies>
     <SkipValidatePackage>true</SkipValidatePackage>
     <ShouldCreateLayout>false</ShouldCreateLayout>
+    <PropsFile>$(IntermediateOutputPath)$(MSBuildProjectName).props</PropsFile>
+    <PlatformManifestFile>$(IntermediateOutputPath)$(MSBuildProjectName).PlatformManifest.txt</PlatformManifestFile>
   </PropertyGroup>
   
   <Choose>
@@ -59,7 +62,14 @@
     <!-- Add a placeholder to make sure NuGet understands we still support older versions,
          even though they don't have ref-assets -->
     <File Include="$(PlaceHolderFile)">
-      <TargetPath>.NETCoreApp</TargetPath>
+      <TargetPath>ref/netcoreapp</TargetPath>
+    </File>
+    
+    <File Include="$(PropsFile)">
+      <TargetPath>build/$(NETCoreAppFramework)</TargetPath>
+    </File>
+    <File Include="$(PlatformManifestFile)">
+      <TargetPath>build/$(NETCoreAppFramework)</TargetPath>
     </File>
   </ItemGroup>
 
@@ -91,6 +101,23 @@
       <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
     </File>
   </ItemGroup>
+
+  <UsingTask TaskName="GenerateFileVersionProps" AssemblyFile="$(BuildToolsTaskDir)core-setup.tasks.dll"/>
+  <Target Name="GenerateFileVersionProps" BeforeTargets="GenerateNuSpec" Condition="'$(PackageTargetRuntime)' == ''">
+    <MSBuild Projects="@(ProjectReference)"
+             Condition="'%(ProjectReference.PackageTargetRuntime)' == '$(PackageRID)' OR 
+                        '%(ProjectReference.BuidOnRID)' == '$(PackageRID)' OR 
+                        ('$(IncludeAllPackages)' == 'true' AND '%(ProjectReference.PackageTargetRuntime)' != '')"
+             Targets="GetPackageFiles">
+      <Output TaskParameter="TargetOutputs" ItemName="SharedFrameworkRuntimeFiles" />
+    </MSBuild>
+    
+    <GenerateFileVersionProps Files="@(SharedFrameworkRuntimeFiles)"
+                              PackageId="$(Id)"
+                              PlatformManifestFile="$(PlatformManifestFile)"
+                              PropsFile="$(PropsFile)"
+                              PreferredPackages="$(Id);@(RuntimeDependency)" />
+  </Target>
 
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
   

--- a/pkg/projects/Microsoft.NETCore.App/project.json.template
+++ b/pkg/projects/Microsoft.NETCore.App/project.json.template
@@ -14,7 +14,7 @@
     "Libuv": "1.10.0-preview1-22033",
 
     "Microsoft.NETCore.Platforms": "1.2.0-beta-24912-52",
-    "NETStandard.Library": "2.0.0-beta-24909-0"
+    "NETStandard.Library": "2.0.0-beta-24913-0"
   },
   "frameworks": {
     "netcoreapp2.0": { }

--- a/pkg/tasks/BuildTask.cs
+++ b/pkg/tasks/BuildTask.cs
@@ -1,0 +1,37 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+
+namespace Microsoft.DotNet.Build.Tasks
+{
+    public abstract partial class BuildTask : ITask
+    {
+        private TaskLoggingHelper _log = null;
+
+        internal TaskLoggingHelper Log
+        {
+            get { return _log ?? (_log = new TaskLoggingHelper(this)); }
+        }
+
+        public BuildTask()
+        {
+        }
+
+        public IBuildEngine BuildEngine
+        {
+            get;
+            set;
+        }
+
+        public ITaskHost HostObject
+        {
+            get;
+            set;
+        }
+
+        public abstract bool Execute();
+    }
+}

--- a/pkg/tasks/FileUtilities.cs
+++ b/pkg/tasks/FileUtilities.cs
@@ -1,0 +1,35 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+
+namespace Microsoft.DotNet.Build.Tasks
+{
+    static partial class FileUtilities
+    {
+        public static Version GetFileVersion(string sourcePath)
+        {
+            var fvi = FileVersionInfo.GetVersionInfo(sourcePath);
+
+            if (fvi != null)
+            {
+                return new Version(fvi.FileMajorPart, fvi.FileMinorPart, fvi.FileBuildPart, fvi.FilePrivatePart);
+            }
+
+            return null;
+        }
+
+        static readonly HashSet<string> s_assemblyExtensions = new HashSet<string>(new[] { ".dll", ".exe", ".winmd" }, StringComparer.OrdinalIgnoreCase);
+        public static Version TryGetAssemblyVersion(string sourcePath)
+        {
+            var extension = Path.GetExtension(sourcePath);
+
+            return s_assemblyExtensions.Contains(extension) ? GetAssemblyVersion(sourcePath) : null;
+        }
+
+    }
+}

--- a/pkg/tasks/FileUtilities.net45.cs
+++ b/pkg/tasks/FileUtilities.net45.cs
@@ -1,0 +1,24 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Reflection;
+
+namespace Microsoft.DotNet.Build.Tasks
+{
+    static partial class FileUtilities
+    {
+        private static Version GetAssemblyVersion(string sourcePath)
+        {
+            try
+            {
+                return AssemblyName.GetAssemblyName(sourcePath)?.Version;
+            }
+            catch (BadImageFormatException)
+            {
+                return null;
+            }
+        }
+    }
+}

--- a/pkg/tasks/FileUtilities.netstandard.cs
+++ b/pkg/tasks/FileUtilities.netstandard.cs
@@ -1,0 +1,43 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Build.Utilities;
+using System;
+using System.IO;
+using System.Reflection.Metadata;
+using System.Reflection.PortableExecutable;
+
+namespace Microsoft.DotNet.Build.Tasks
+{
+    static partial class FileUtilities
+    {
+        private static Version GetAssemblyVersion(string sourcePath)
+        {
+            using (var assemblyStream = new FileStream(sourcePath, FileMode.Open, FileAccess.Read, FileShare.Delete | FileShare.Read))
+            {
+                Version result = null;
+                try
+                {
+                    using (PEReader peReader = new PEReader(assemblyStream, PEStreamOptions.LeaveOpen))
+                    {
+                        if (peReader.HasMetadata)
+                        {
+                            MetadataReader reader = peReader.GetMetadataReader();
+                            if (reader.IsAssembly)
+                            {
+                                result = reader.GetAssemblyDefinition().Version;
+                            }
+                        }
+                    }
+                }
+                catch (BadImageFormatException)
+                {
+                    // not a PE
+                }
+
+                return result;
+            }
+        }
+    }
+}

--- a/pkg/tasks/GenerateFileVersionProps.cs
+++ b/pkg/tasks/GenerateFileVersionProps.cs
@@ -1,0 +1,129 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using Microsoft.Build.Framework;
+using System.IO;
+using System.Collections.Generic;
+using Microsoft.Build.Construction;
+
+namespace Microsoft.DotNet.Build.Tasks
+{
+    public partial class GenerateFileVersionProps : BuildTask
+    {
+        const string PlatformManifestsItem = "PackageConflictPlatformManifests";
+        const string PreferredPackagesProperty = "PackageConflictPreferredPackages";
+
+        [Required]
+        public ITaskItem[] Files { get; set; }
+
+        [Required]
+        public string PackageId { get; set; }
+
+        [Required]
+        public string PlatformManifestFile { get; set; }
+
+        [Required]
+        public string PropsFile { get; set; }
+
+        [Required]
+        public string PreferredPackages { get; set; }
+
+        public override bool Execute()
+        {
+            var fileVersions = new Dictionary<string, FileVersionData>(StringComparer.OrdinalIgnoreCase);
+            foreach(var file in Files)
+            {
+                var targetPath = file.GetMetadata("TargetPath");
+
+                if (!targetPath.StartsWith("runtimes/"))
+                {
+                    continue;
+                }
+
+                if (file.GetMetadata("IsSymbolFile").Equals("true", StringComparison.OrdinalIgnoreCase))
+                {
+                    continue;
+                }
+
+                var filePath = file.GetMetadata("FullPath");
+                var fileName = Path.GetFileName(filePath);
+
+                var current = GetFileVersionData(filePath);
+
+                FileVersionData existing;
+
+                if (fileVersions.TryGetValue(fileName, out existing))
+                {
+                    if (current.AssemblyVersion != null &&
+                        existing.AssemblyVersion != null &&
+                        current.AssemblyVersion != existing.AssemblyVersion)
+                    {
+                        if (current.AssemblyVersion > existing.AssemblyVersion)
+                        {
+                            fileVersions[fileName] = current;
+                        }
+                        continue;
+                    }
+
+                    if (current.FileVersion != null && 
+                        existing.FileVersion != null)
+                    {
+                        if (current.FileVersion > existing.FileVersion)
+                        {
+                            fileVersions[fileName] = current;
+                        }
+                    }
+                }
+                else
+                {
+                    fileVersions[fileName] = current;
+                }
+            }
+
+            var props = ProjectRootElement.Create();
+            var itemGroup = props.AddItemGroup();
+            itemGroup.Condition = "'$(RuntimeIdentifer)' == '' AND '$(RuntimeIdentifiers)' == ''";
+
+            var manifestFileName = Path.GetFileName(PlatformManifestFile);
+            itemGroup.AddItem(PlatformManifestsItem, $"$(MSBuildThisFileDirectory){manifestFileName}");
+
+            using (var manifestWriter = File.CreateText(PlatformManifestFile))
+            {
+                foreach (var fileData in fileVersions)
+                {
+                    var name = fileData.Key;
+                    var versions = fileData.Value;
+                    var assemblyVersion = versions.AssemblyVersion?.ToString() ?? String.Empty;
+                    var fileVersion = versions.FileVersion?.ToString() ?? String.Empty;
+
+                    manifestWriter.WriteLine($"{name}|{PackageId}|{assemblyVersion}|{fileVersion}");
+                }
+            }
+
+            var propertyGroup = props.AddPropertyGroup();
+            propertyGroup.AddProperty(PreferredPackagesProperty, PreferredPackages);
+
+
+            props.Save(PropsFile);
+
+            return !Log.HasLoggedErrors;
+        }
+
+        FileVersionData GetFileVersionData(string filePath)
+        {
+            return new FileVersionData()
+            {
+                AssemblyVersion = FileUtilities.TryGetAssemblyVersion(filePath),
+                FileVersion = FileUtilities.GetFileVersion(filePath)
+            };
+        }
+
+        class FileVersionData
+        {
+            public Version AssemblyVersion { get; set; }
+            public Version FileVersion { get; set; }
+        }
+    }
+}

--- a/pkg/tasks/core-setup.tasks.builds
+++ b/pkg/tasks/core-setup.tasks.builds
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <ItemGroup>
+    <Project Include="$(MSBuildThisFileDirectory)$(MSBuildProjectName).csproj" />
+    <Project Include="$(MSBuildThisFileDirectory)$(MSBuildProjectName).csproj">
+      <AdditionalProperties>TargetGroup=net45</AdditionalProperties>
+    </Project>
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
+</Project>

--- a/pkg/tasks/core-setup.tasks.csproj
+++ b/pkg/tasks/core-setup.tasks.csproj
@@ -1,0 +1,36 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <OutputType>Library</OutputType>
+    <NuGetTargetMoniker>.NETStandard,Version=v1.5</NuGetTargetMoniker>
+    <NuGetTargetMoniker Condition="'$(TargetGroup)' == 'net45'">.NETFramework,Version=v4.5</NuGetTargetMoniker>
+    <CLSCompliant>false</CLSCompliant>
+    <ProjectGuid>{360F25FA-3CD9-4338-B961-A4F3122B88B2}</ProjectGuid>
+    <OutputPath Condition="'$(TargetGroup)' != 'net45'">$(ToolRuntimePath)</OutputPath>
+    <IntermediateOutputPath Condition="'$(TargetGroup)' == 'net45'">$(IntermediateOutputPath)\net45</IntermediateOutputPath>
+    <OutputPath Condition="'$(TargetGroup)' == 'net45'">$(ToolRuntimePath)\net45</OutputPath>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)' == 'netstandard1.5_Debug'" />
+  <PropertyGroup Condition="'$(Configuration)' == 'net45_Debug'" />
+  <ItemGroup>
+    <Compile Include="BuildTask.cs" />
+    <Compile Include="GenerateFileVersionProps.cs" />
+    <Compile Include="FileUtilities.cs" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetGroup)' != 'net45'">
+    <Compile Include="FileUtilities.netstandard.cs" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetGroup)' == 'net45'">
+    <Compile Include="FileUtilities.net45.cs" />
+    <TargetingPackReference Include="System" />
+    <TargetingPackReference Include="System.Core" />
+    <TargetingPackReference Include="Microsoft.Build" />
+    <TargetingPackReference Include="Microsoft.Build.Framework" />
+    <TargetingPackReference Include="Microsoft.Build.Utilities.v4.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="project.json" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/pkg/tasks/project.json
+++ b/pkg/tasks/project.json
@@ -1,0 +1,30 @@
+{
+  "dependencies": {
+    "System.Reflection.Metadata": "1.3.0"
+  },
+  "frameworks": {
+    "netstandard1.5": {
+      "dependencies": {
+        "Microsoft.Build": "0.1.0-preview-00022",
+        "Microsoft.Build.Framework": "0.1.0-preview-00022",
+        "Microsoft.Build.Tasks.Core": "0.1.0-preview-00022",
+        "Microsoft.Build.Utilities.Core": "0.1.0-preview-00022",
+        "Microsoft.Tpl.Dataflow": {
+          "version": "4.5.24",
+          "exclude": "all"
+        },
+        "NETStandard.Library": "1.6.0",
+        "System.Diagnostics.FileVersionInfo": "4.0.0"
+      },
+      "imports": [
+        "dnxcore50",
+        "portable-net45+win8+wpa81"
+      ]
+    },
+    "net45": {
+      "dependencies": {
+        "Microsoft.TargetingPack.NETFramework.v4.5": "1.0.1"
+      }
+    }
+  }
+}


### PR DESCRIPTION
This data informs the conflict resolution task what files make up the
shared framework, and what their versions are.  This is used to
determine if files from packages should be copied local or not.

/cc @weshaggard @terrajobst @eerhardt 