### PR TITLE
Fix yum package conflict in Docker image

### DIFF
--- a/scripts/docker/centos.7/Dockerfile
+++ b/scripts/docker/centos.7/Dockerfile
@@ -6,6 +6,10 @@
 # Dockerfile that creates a container suitable to build dotnet-cli
 FROM centos:7.1.1503
 
+# Swap the "fakesystemd" package with the real "systemd" package, because fakesystemd conflicts with openssl-devel.
+# The CentOS Docker image uses fakesystemd instead of systemd to reduce disk space.
+RUN yum -q -y swap -- remove fakesystemd -- install systemd systemd-libs
+
 RUN yum -q -y install deltarpm
 RUN yum -q -y install epel-release
 # RUN yum -y update


### PR DESCRIPTION
When running the Core-Setup builds on the new build agents, the CentOS
build failed with the following error:

2017-01-11T18:41:24.6447580Z Step 4 : RUN yum -q -y install unzip libunwind gettext libcurl-devel openssl-devel zlib libicu-devel
2017-01-11T18:41:24.7898330Z  ---> Running in cb2648bea479
2017-01-11T18:41:32.7647660Z  You could try using --skip-broken to work around the problem
2017-01-11T18:41:32.7663610Z _[91mError: libselinux conflicts with fakesystemd-1-17.el7.centos.noarch

Swapping the the "fakesystemd" package with the real "systemd" package
fixed the issue, which was recommended in http://stackoverflow.com/a/36632668.

This issue hasn't been seen on the official builds because the build
agents in that pool have the Docker image cached, and they are using an
older version of the centos:7.1.1503 image which appears not to have
this issue.