### PR TITLE
Upgrade NuGet version for push timeout fix

### DIFF
--- a/build_projects/dotnet-host-build/project.json
+++ b/build_projects/dotnet-host-build/project.json
@@ -13,7 +13,7 @@
     "System.Runtime.Serialization.Primitives": "4.1.1",
     "System.Xml.XmlSerializer": "4.0.11",
     "WindowsAzure.Storage": "6.2.2-preview",
-    "NuGet.CommandLine.XPlat": "3.5.0-rc-1285",
+    "NuGet.CommandLine.XPlat": "4.0.0-rc3-2140",
     "Microsoft.DotNet.Cli.Build.Framework": {
       "target": "project"
     },


### PR DESCRIPTION
Takes fix for https://github.com/NuGet/Home/issues/2785, so that package pushes have an hour-long timeout rather than three tries of 100s each.

I picked `4.0.0-rc3-2140` specifically because that's the version the CoreFX/CoreCLR/WCF builds use.