### PR TITLE
Include base branch in auto-update PR title

### DIFF
--- a/build_projects/update-dependencies/PushPRTargets.cs
+++ b/build_projects/update-dependencies/PushPRTargets.cs
@@ -98,7 +98,7 @@ namespace Microsoft.DotNet.Scripts
             string commitMessage = c.GetCommitMessage();
 
             NewPullRequest prInfo = new NewPullRequest(
-                commitMessage,
+                $"[{s_config.GitHubUpstreamBranch}] {commitMessage}",
                 s_config.GitHubOriginOwner + ":" + remoteBranchName,
                 s_config.GitHubUpstreamBranch);
 


### PR DESCRIPTION
For example, in master, prefixes the PR title with `[master] `. This will make it easier to look through Core-Setup auto-PRs while they're noisy. See https://github.com/dotnet/core-setup/pull/1194.