### PR TITLE
Update NETStandard.Library to 2.0.0-beta-24918-03

### DIFF
--- a/pkg/projects/Microsoft.NETCore.App/project.json.template
+++ b/pkg/projects/Microsoft.NETCore.App/project.json.template
@@ -13,7 +13,7 @@
     "Microsoft.DiaSymReader.Native": "1.4.0",
     "Libuv": "1.10.0-preview1-22036",
     "Microsoft.NETCore.Platforms": "2.0.0-beta-24918-07",
-    "NETStandard.Library": "2.0.0-beta-24918-02"
+    "NETStandard.Library": "2.0.0-beta-24918-03"
   },
   "frameworks": {
     "netcoreapp2.0": {}


### PR DESCRIPTION
/cc @weshaggard @eerhardt 

With this we should be good to start moving the CLI/SDK to target this version.