### PR TITLE
[release/1.1.0] Include base branch in auto-update PR title

### DIFF
--- a/build_projects/update-dependencies/PushPRTargets.cs
+++ b/build_projects/update-dependencies/PushPRTargets.cs
@@ -98,7 +98,7 @@ namespace Microsoft.DotNet.Scripts
             string commitMessage = c.GetCommitMessage();
 
             NewPullRequest prInfo = new NewPullRequest(
-                commitMessage,
+                $"[{s_config.GitHubUpstreamBranch}] {commitMessage}",
                 s_config.GitHubOriginOwner + ":" + remoteBranchName,
                 s_config.GitHubUpstreamBranch);
 


### PR DESCRIPTION
(cherry picked from commit 0300e0084eac1f71092a421746403f50484cac63)

Take https://github.com/dotnet/core-setup/pull/1200 so 1.1.0 auto-PRs are marked.

FYI @ericstj 