### PR TITLE
Switch dependency of NewtonSoft.Json to 6.0.4 for .NET Framework build of DependencyModel

### DIFF
--- a/src/Microsoft.Extensions.DependencyModel/DependencyContextJsonReader.cs
+++ b/src/Microsoft.Extensions.DependencyModel/DependencyContextJsonReader.cs
@@ -727,4 +727,21 @@ namespace Microsoft.Extensions.DependencyModel
             public string HashPath;
         }
     }
+    
+#if NET451
+    static class JsonExtensions
+    {
+        public static bool? ReadAsBoolean(this JsonReader r)
+        {
+            string s = r.ReadAsString();
+            if (string.IsNullOrEmpty(s))
+            {
+                return null;
+            }
+
+            return bool.Parse(s);
+            
+        }
+    }
+#endif
 }

--- a/src/Microsoft.Extensions.DependencyModel/project.json
+++ b/src/Microsoft.Extensions.DependencyModel/project.json
@@ -8,17 +8,21 @@
   "dependencies": {
     "Microsoft.DotNet.PlatformAbstractions": {
       "target": "project"
-    },
-    "Newtonsoft.Json": "9.0.1"
+    }
   },
   "frameworks": {
-    "net451": {},
+    "net451": {
+      "dependencies": {
+        "Newtonsoft.Json": "6.0.4"        
+      }
+    },
     "netstandard1.3": {
       "imports": "portable-net45+wp80+win8+wpa81+dnxcore50",
       "dependencies": {
         "System.Diagnostics.Debug": "4.0.11",
         "System.Dynamic.Runtime": "4.0.11",
-        "System.Linq": "4.1.0"
+        "System.Linq": "4.1.0",
+        "Newtonsoft.Json": "9.0.1"
       }
     },
     "netstandard1.6": {
@@ -26,7 +30,8 @@
       "dependencies": {
         "System.Diagnostics.Debug": "4.0.11",
         "System.Dynamic.Runtime": "4.0.11",
-        "System.Linq": "4.1.0"
+        "System.Linq": "4.1.0",
+        "Newtonsoft.Json": "9.0.1"
       }
     }
   },


### PR DESCRIPTION
Pre-emptively submitting this PR, we will discuss whether to move forward with it.

This switches the .NET Framework build of Microsoft.Extensions.DependencyModel to depend on version 6.0.4 of NewtonSoft.Json, instead of version 9.0.1.  This should help with assembly load conflicts we are having between the .NET SDK tasks and NuGet APIs.