### PR TITLE
Provide a switch to skip building debian packages

### DIFF
--- a/build_projects/dotnet-host-build/DebTargets.cs
+++ b/build_projects/dotnet-host-build/DebTargets.cs
@@ -30,7 +30,7 @@ namespace Microsoft.DotNet.Host.Build
             // Ubuntu 16.04 Jenkins Machines don't have docker or debian package build tools
             // So we need to skip this target if the tools aren't present.
             // https://github.com/dotnet/core-setup/issues/167
-            if (DebuildNotPresent())
+            if (ShouldSkipBuildDebPackages() || DebuildNotPresent())
             {
                 c.Info("Debuild not present, skipping target: {nameof(GenerateSharedHostDeb)}");
                 return c.Success();
@@ -72,7 +72,7 @@ namespace Microsoft.DotNet.Host.Build
             // Ubuntu 16.04 Jenkins Machines don't have docker or debian package build tools
             // So we need to skip this target if the tools aren't present.
             // https://github.com/dotnet/core-setup/issues/167
-            if (DebuildNotPresent())
+            if (ShouldSkipBuildDebPackages() || DebuildNotPresent())
             {
                 c.Info("Debuild not present, skipping target: {nameof(GenerateHostFxrDeb)}");
                 return c.Success();
@@ -116,7 +116,7 @@ namespace Microsoft.DotNet.Host.Build
             // Ubuntu 16.04 Jenkins Machines don't have docker or debian package build tools
             // So we need to skip this target if the tools aren't present.
             // https://github.com/dotnet/core-setup/issues/167
-            if (DebuildNotPresent())
+            if (ShouldSkipBuildDebPackages() || DebuildNotPresent())
             {
                 c.Info("Debuild not present, skipping target: {nameof(GenerateSharedFrameworkDeb)}");
                 return c.Success();
@@ -174,7 +174,7 @@ namespace Microsoft.DotNet.Host.Build
             // Ubuntu 16.04 Jenkins Machines don't have docker or debian package build tools
             // So we need to skip this target if the tools aren't present.
             // https://github.com/dotnet/core-setup/issues/167
-            if (DebuildNotPresent())
+            if (ShouldSkipBuildDebPackages() || DebuildNotPresent())
             {
                 c.Info("Debuild not present, skipping target: {nameof(InstallSharedHost)}");
                 return c.Success();
@@ -191,7 +191,7 @@ namespace Microsoft.DotNet.Host.Build
             // Ubuntu 16.04 Jenkins Machines don't have docker or debian package build tools
             // So we need to skip this target if the tools aren't present.
             // https://github.com/dotnet/core-setup/issues/167
-            if (DebuildNotPresent())
+            if (ShouldSkipBuildDebPackages() || DebuildNotPresent())
             {
                 c.Info("Debuild not present, skipping target: {nameof(InstallHostFxr)}");
                 return c.Success();
@@ -208,7 +208,7 @@ namespace Microsoft.DotNet.Host.Build
             // Ubuntu 16.04 Jenkins Machines don't have docker or debian package build tools
             // So we need to skip this target if the tools aren't present.
             // https://github.com/dotnet/core-setup/issues/167
-            if (DebuildNotPresent())
+            if (ShouldSkipBuildDebPackages() || DebuildNotPresent())
             {
                 c.Info("Debuild not present, skipping target: {nameof(InstallSharedFramework)}");
                 return c.Success();
@@ -225,7 +225,7 @@ namespace Microsoft.DotNet.Host.Build
             // Ubuntu 16.04 Jenkins Machines don't have docker or debian package build tools
             // So we need to skip this target if the tools aren't present.
             // https://github.com/dotnet/core-setup/issues/167
-            if (DebuildNotPresent())
+            if (ShouldSkipBuildDebPackages() || DebuildNotPresent())
             {
                 c.Info("Debuild not present, skipping target: {nameof(RemovePackages)}");
                 return c.Success();
@@ -266,6 +266,11 @@ namespace Microsoft.DotNet.Host.Build
         private static bool DebuildNotPresent()
         {
             return Cmd("/usr/bin/env", "debuild", "-h").Execute().ExitCode != 0;
+        }
+
+        private static bool ShouldSkipBuildDebPackages()
+        {
+            return Environment.GetEnvironmentVariable("DOTNET_BUILD_SKIP_DEB_PACKAGING") == "1";
         }
     }
 }

--- a/build_projects/dotnet-host-build/build.sh
+++ b/build_projects/dotnet-host-build/build.sh
@@ -93,6 +93,9 @@ while [[ $# > 0 ]]; do
             # Allow CI to disable prereqs check since the CI has the pre-reqs but not ldconfig it seems
             export DOTNET_INSTALL_SKIP_PREREQS=1
             ;;
+        --skip-deb-package-build)
+            export DOTNET_BUILD_SKIP_DEB_PACKAGING=1
+            ;;
         --build-driver-only)
             __BuildDriverOnly=1
             ;;


### PR DESCRIPTION
When the "Package" target is selected, we try to build the relevant
installers as well as the tarballs. On Debian, doing so requires root
because of how we factor our packages (since we have to install some
packages before building others so our dependency stuff works out).

While the package building is already somewhat conditional (you need
`debuild` installed in order to do it) we should have finer grained
switches so you can opt out of building the debs and still get
tarballs. As part of the overall source build effort and move to
buildtools we should make this whole interaction less hacky and more
configurable.