### PR TITLE
Lookup correct RID for restore during test run

### DIFF
--- a/test/TestUtils/RepoDirectoriesProvider.cs
+++ b/test/TestUtils/RepoDirectoriesProvider.cs
@@ -18,6 +18,9 @@ namespace Microsoft.DotNet.CoreSetup.Test
         private string _corehostPackages;
         private string _corehostDummyPackages;
 
+        private string _targetRID;
+
+        public string TargetRID => _targetRID;
         public string RepoRoot => _repoRoot;
         public string Artifacts => _artifacts;
         public string HostArtifacts => _hostArtifacts;
@@ -38,9 +41,9 @@ namespace Microsoft.DotNet.CoreSetup.Test
             
             string baseArtifactsFolder = artifacts ?? Path.Combine(_repoRoot, "artifacts");
 
-            var targetRID = Environment.GetEnvironmentVariable("TEST_TARGETRID");
+            _targetRID = Environment.GetEnvironmentVariable("TEST_TARGETRID");
 
-            _artifacts = Path.Combine(baseArtifactsFolder, targetRID);
+            _artifacts = Path.Combine(baseArtifactsFolder, _targetRID);
 
             _hostArtifacts = artifacts ?? Path.Combine(_artifacts, "corehost");
             _nugetPackages = nugetPackages ?? Path.Combine(_repoRoot, ".nuget", "packages");

--- a/test/TestUtils/TestProjectFixture.cs
+++ b/test/TestUtils/TestProjectFixture.cs
@@ -70,7 +70,7 @@ namespace Microsoft.DotNet.CoreSetup.Test
                 ?? Path.Combine(AppContext.BaseDirectory, s_testArtifactDirectoryEnvironmentVariable);
 
             _sdkDotnet = new DotNetCli(dotnetInstallPath ?? DotNetCli.GetStage0Path(repoDirectoriesProvider.RepoRoot));
-            _currentRid = repoDirectoriesProvider.TargetRID;
+            _currentRid = currentRid ?? repoDirectoriesProvider.TargetRID;
 
             _builtDotnet = new DotNetCli(repoDirectoriesProvider.BuiltDotnet);
 

--- a/test/TestUtils/TestProjectFixture.cs
+++ b/test/TestUtils/TestProjectFixture.cs
@@ -70,7 +70,7 @@ namespace Microsoft.DotNet.CoreSetup.Test
                 ?? Path.Combine(AppContext.BaseDirectory, s_testArtifactDirectoryEnvironmentVariable);
 
             _sdkDotnet = new DotNetCli(dotnetInstallPath ?? DotNetCli.GetStage0Path(repoDirectoriesProvider.RepoRoot));
-            _currentRid = currentRid ?? _sdkDotnet.GetRuntimeId();
+            _currentRid = repoDirectoriesProvider.TargetRID;
 
             _builtDotnet = new DotNetCli(repoDirectoriesProvider.BuiltDotnet);
 


### PR DESCRIPTION
@ramarag @naamunds PTAL

This fixes the issue of restoring the packages for incorrect RID, post the recent dev-eng RI. 