### PR TITLE
Fix run of App spec'ing RIDs without RID

### DIFF
--- a/pkg/tasks/GenerateFileVersionProps.cs
+++ b/pkg/tasks/GenerateFileVersionProps.cs
@@ -84,7 +84,8 @@ namespace Microsoft.DotNet.Build.Tasks
 
             var props = ProjectRootElement.Create();
             var itemGroup = props.AddItemGroup();
-            itemGroup.Condition = "'$(RuntimeIdentifer)' == '' AND '$(RuntimeIdentifiers)' == ''";
+            // only set the platform manifest when our RID-specific packages aren't in scope
+            itemGroup.Condition = "'$(RuntimeIdentifer)' == ''";
 
             var manifestFileName = Path.GetFileName(PlatformManifestFile);
             itemGroup.AddItem(PlatformManifestsItem, $"$(MSBuildThisFileDirectory){manifestFileName}");


### PR DESCRIPTION
Just because an app sets the RuntimeIdentifiers property doesn't mean it
will always be standalone.  RuntimeIdentifiers just communicates to
NuGet to restore for those RIDs (analgous to the runtime section of
project.json).  The RuntimeIdentifier property is what actually
determines if an app will run / publish standalone.

Fixes https://github.com/dotnet/standard/issues/184

/cc @eerhardt 