### PR TITLE
Build NuGet packages on non windows systems

### DIFF
--- a/build_projects/dotnet-host-build/PublishTargets.cs
+++ b/build_projects/dotnet-host-build/PublishTargets.cs
@@ -313,7 +313,10 @@ namespace Microsoft.DotNet.Host.Build
         [Target]
         public static BuildTargetResult PublishManagedPackages(BuildTargetContext c)
         {
-            if (EnvVars.Signed)
+            // When building on non windows platforms, we don't compile the full set of
+            // tfms a package targets (to prevent the need of having mono and the reference
+            // assemblies installed. So we shouldn't publish these packages.
+            if (EnvVars.Signed && CurrentPlatform.IsWindows)
             {
                 foreach (var file in Directory.GetFiles(Dirs.Packages, "*.nupkg"))
                 {


### PR DESCRIPTION
Because some of the projects cross-compile for full framework TFMs,
the build process on non windows doesn't work (unless you have mono
and the reference assembly packages installed).

To work around this, I just build netstandard and netcoreapp TFMs when
you are not on *nix.