### PR TITLE
Fixing a small spelling error in an MSBuild property name.

### DIFF
--- a/pkg/tasks/GenerateFileVersionProps.cs
+++ b/pkg/tasks/GenerateFileVersionProps.cs
@@ -85,7 +85,7 @@ namespace Microsoft.DotNet.Build.Tasks
             var props = ProjectRootElement.Create();
             var itemGroup = props.AddItemGroup();
             // only set the platform manifest when our RID-specific packages aren't in scope
-            itemGroup.Condition = "'$(RuntimeIdentifer)' == ''";
+            itemGroup.Condition = "'$(RuntimeIdentifier)' == ''";
 
             var manifestFileName = Path.GetFileName(PlatformManifestFile);
             itemGroup.AddItem(PlatformManifestsItem, $"$(MSBuildThisFileDirectory){manifestFileName}");


### PR DESCRIPTION
@weshaggard @ericstj 

When publishing a self-contained application, none of the framework assemblies are being published.

I'm not sure where the best place to test all this build logic is, but fixing the error for now.

/cc @erozenfeld 