### PR TITLE
Fix resource assembly path computation

### DIFF
--- a/src/corehost/cli/deps_entry.cpp
+++ b/src/corehost/cli/deps_entry.cpp
@@ -69,8 +69,19 @@ bool deps_entry_t::to_dir_path(const pal::string_t& base, pal::string_t* str) co
         {
             replace_char(&pal_relative_path, _X('/'), DIR_SEPARATOR);
         }
+
+        // Resources are represented as "<ietf-code>/<ResourceAssemblyName.dll>" in the deps.json.
+        // The <ietf-code> is the "directory" in the pal_relative_path below, so extract it.
         pal::string_t ietf_dir = get_directory(pal_relative_path);
-        pal::string_t ietf = get_filename(ietf_dir);
+        pal::string_t ietf = ietf_dir;
+
+        // get_directory returns with DIR_SEPERATOR appended that we need to remove.
+        auto sep_pos = ietf.find_last_of(DIR_SEPARATOR);
+        if (sep_pos != pal::string_t::npos)
+        {
+            ietf = ietf.erase(sep_pos, pal::string_t::npos);
+        }
+        
         pal::string_t base_ietf_dir = base;
         append_path(&base_ietf_dir, ietf.c_str());
         trace::verbose(_X("Detected a resource asset, will query dir/ietf-tag/resource base: %s asset: %s"), base_ietf_dir.c_str(), asset_name.c_str());


### PR DESCRIPTION
Fixes https://github.com/dotnet/core-setup/issues/1221

This is a regression introduced from https://github.com/dotnet/core-setup/pull/529 to fix https://github.com/dotnet/core-setup/issues/436, as a result of which extracting IETF code from resource relative path (in deps.json) would have an extra directory seperator appended.

The fix is to strip the separator out.

@ramarag PTAL.