### PR TITLE
Use latest stable version of clang and llvm-devel

### DIFF
--- a/scripts/docker/fedora.24/Dockerfile
+++ b/scripts/docker/fedora.24/Dockerfile
@@ -1,6 +1,6 @@
 FROM fedora:24
 
-RUN dnf install -y bash git cmake wget which python clang-3.8.1-1.fc24.x86_64 llvm-devel-3.8.1-2.fc24.x86_64 make libicu-devel lldb-devel.x86_64 \
+RUN dnf install -y bash git cmake wget which python clang-3.8.0-1.fc24.x86_64 llvm-devel-3.8.0-1.fc24.x86_64 make libicu-devel lldb-devel.x86_64 \
                    libunwind-devel.x86_64 lttng-ust-devel.x86_64 uuid-devel libuuid-devel tar glibc-locale-source zlib-devel libcurl-devel \
                    krb5-devel openssl-devel autoconf libtool hostname
 


### PR DESCRIPTION
As per the discussion on #1383, we should be using the stable versions of clang and llvm-devel, i.e. from the "fedora" package repository instead of the "updates" package repository.  I hadn't yet pushed the update to that PR when it was merged.

The stable version for clang and llvm-devel is 3.8.0-1.  With this change, compared to before #1383, the only change is from clang 3.8.0-2 to 3.8.0-1.

/cc @gkhanna79 @janvorli 