### PR TITLE
Teach update-versions how to update libuv packages

### DIFF
--- a/build_projects/update-dependencies/Config.cs
+++ b/build_projects/update-dependencies/Config.cs
@@ -41,6 +41,7 @@ namespace Microsoft.DotNet.Scripts
         private Lazy<string> _coreClrVersionUrl = new Lazy<string>(() => GetEnvironmentVariable("CORECLR_VERSION_URL", "https://raw.githubusercontent.com/dotnet/versions/master/build-info/dotnet/coreclr/master/Latest_Packages.txt"));
         private Lazy<string> _roslynVersionUrl = new Lazy<string>(() => GetEnvironmentVariable("ROSLYN_VERSION_URL", "https://raw.githubusercontent.com/dotnet/versions/master/build-info/dotnet/roslyn/netcore1.0/Latest_Packages.txt"));
         private Lazy<string> _standardVersionUrl = new Lazy<string>(() => GetEnvironmentVariable("STANDARD_VERSION_URL", string.Empty));
+        private Lazy<string> _libuvVersionUrl = new Lazy<string>(() => GetEnvironmentVariable("LIBUV_VERSION_URL", string.Empty));
         private Lazy<string> _gitHubOriginOwner;
         private Lazy<string> _gitHubUpstreamOwner = new Lazy<string>(() => GetEnvironmentVariable("GITHUB_UPSTREAM_OWNER", "dotnet"));
         private Lazy<string> _gitHubProject = new Lazy<string>(() => GetEnvironmentVariable("GITHUB_PROJECT", "core-setup"));
@@ -61,6 +62,7 @@ namespace Microsoft.DotNet.Scripts
         public string CoreClrVersionUrl => _coreClrVersionUrl.Value;
         public string RoslynVersionUrl => _roslynVersionUrl.Value;
         public string StandardVersionUrl => _standardVersionUrl.Value;
+        public string LibuvVersionUrl => _libuvVersionUrl.Value;
         public string GitHubOriginOwner => _gitHubOriginOwner.Value;
         public string GitHubUpstreamOwner => _gitHubUpstreamOwner.Value;
         public string GitHubProject => _gitHubProject.Value;

--- a/build_projects/update-dependencies/UpdateFilesTargets.cs
+++ b/build_projects/update-dependencies/UpdateFilesTargets.cs
@@ -41,6 +41,11 @@ namespace Microsoft.DotNet.Scripts
                 dependencyInfos.Add(CreateDependencyInfo("Standard", Config.Instance.StandardVersionUrl).Result);
             }
 
+            if (Config.Instance.LibuvVersionUrl != string.Empty)
+            {
+                dependencyInfos.Add(CreateDependencyInfo("Libuv", Config.Instance.LibuvVersionUrl).Result);
+            }
+
             return c.Success();
         }
 


### PR DESCRIPTION
We don't yet have versions information being written for libuv, so we
don't actually update anything unless a URL is provided via an
environment variable.