### PR TITLE
Fix bug when parsing arguments in build.sh

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -24,20 +24,17 @@ if [ -z "$HOME" ]; then
     mkdir -p $HOME
 fi
 
-args=( "$@" )
-
 while [[ $# > 0 ]]; do
     lowerI="$(echo $1 | awk '{print tolower($0)}')"
     case $lowerI in
         --docker)
             export BUILD_IN_DOCKER=1
             export DOCKER_IMAGENAME=$2
-            # remove docker args
-            args=( "${args[@]/$1}" )
-            args=( "${args[@]/$2}" )
             shift
             ;;
         *)
+            args+=( $1 )
+            ;;
     esac
     shift
 done


### PR DESCRIPTION
All arguments that match the docker argument were removed by https://github.com/dotnet/core-setup/blob/master/build.sh#L36L37 lines.
```
./build.sh --docker ubuntu.16.04 --env-vars "DISABLE_CROSSGEN=1,TARGETPLATFORM=arm,TARGETRID=ubuntu.16.04-arm,CROSS=1,ROOTFS_DIR=/opt/code/cross/rootfs/arm"
->
Argumtens~~~~:--env-vars DISABLE_CROSSGEN=1,TARGETPLATFORM=arm,TARGETRID=-arm,CROSS=1,ROOTFS_DIR=/opt/code/cross/rootfs/arm
```

Related issue: #725 #1400 