### PR TITLE
Add ARM cross build dependency to Dockerfile

### DIFF
--- a/scripts/docker/ubuntu.14.04/Dockerfile
+++ b/scripts/docker/ubuntu.14.04/Dockerfile
@@ -42,6 +42,13 @@ RUN apt-get update && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
+# ARM cross build dependency
+RUN apt-get update && \
+    apt-get -qqy install \
+        binutils-arm-linux-gnueabihf && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
 # Use clang as c++ compiler
 RUN update-alternatives --install /usr/bin/c++ c++ /usr/bin/clang++-3.5 100
 RUN update-alternatives --set c++ /usr/bin/clang++-3.5

--- a/scripts/docker/ubuntu.16.04/Dockerfile
+++ b/scripts/docker/ubuntu.16.04/Dockerfile
@@ -42,6 +42,13 @@ RUN apt-get update && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
+# ARM cross build dependency
+RUN apt-get update && \
+    apt-get -qqy install \
+        binutils-arm-linux-gnueabihf && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
 # Use clang as c++ compiler
 RUN update-alternatives --install /usr/bin/c++ c++ /usr/bin/clang++-3.5 100
 RUN update-alternatives --set c++ /usr/bin/clang++-3.5


### PR DESCRIPTION
Add ARM cross build toolchain to Dockerfile.

build error like belows:
```
  /usr/bin/clang-3.5 -target arm-linux-gnueabihf -B
  /opt/code/cross/rootfs/arm/usr/lib/gcc/arm-linux-gnueabihf
  -L/opt/code/cross/rootfs/arm/lib/arm-linux-gnueabihf
  --sysroot=/opt/code/cross/rootfs/arm
  CMakeFiles/cmTC_71942.dir/testCCompiler.c.o -o cmTC_71942 -rdynamic

  /usr/bin/ld: unrecognised emulation mode: armelf_linux_eabi
```

Related issue: #725 #1400 