### PR TITLE
Run Docker as current user in official builds

### DIFF
--- a/buildpipeline/Core-Setup-PortableLinux-x64.json
+++ b/buildpipeline/Core-Setup-PortableLinux-x64.json
@@ -22,17 +22,18 @@
       "enabled": true,
       "continueOnError": false,
       "alwaysRun": false,
-      "displayName": "Run build.sh in Docker container",
+      "displayName": "Run build in Docker container",
       "timeoutInMinutes": 0,
       "task": {
-        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
-        "versionSpec": "1.*",
+        "id": "6c731c3c-3c68-459a-a5c9-bde6e6595b5b",
+        "versionSpec": "2.*",
         "definitionType": "task"
       },
       "inputs": {
-        "filename": "docker",
-        "arguments": "run -t --rm --sig-proxy=true --name $(DockerContainerName) -v $(Build.SourcesDirectory):/opt/code -w /opt/code -e CONNECTION_STRING -e PUBLISH_TO_AZURE_BLOB chcosta/dotnetcore:rhel7_prereqs /bin/bash -c \"git clean -X -d -f; ./build.sh $(BuildArguments)\"",
-        "workingFolder": "",
+        "scriptPath": "scripts/dockerrun-as-current-user.sh",
+        "args": "-t --rm --sig-proxy=true --name $(DockerContainerName) -v $(Build.SourcesDirectory):/opt/code -w /opt/code -e CONNECTION_STRING -e PUBLISH_TO_AZURE_BLOB chcosta/dotnetcore:rhel7_prereqs /bin/bash -c \"HOME=/opt/code; git clean -X -d -f; ./build.sh $(BuildArguments)\"",
+        "disableAutoCwd": "false",
+        "cwd": "",
         "failOnStandardError": "false"
       }
     }

--- a/buildpipeline/Core-Setup-RHEL7-x64.json
+++ b/buildpipeline/Core-Setup-RHEL7-x64.json
@@ -22,17 +22,18 @@
       "enabled": true,
       "continueOnError": false,
       "alwaysRun": false,
-      "displayName": "Run build.sh in Docker container",
+      "displayName": "Run build in Docker container",
       "timeoutInMinutes": 0,
       "task": {
-        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
-        "versionSpec": "1.*",
+        "id": "6c731c3c-3c68-459a-a5c9-bde6e6595b5b",
+        "versionSpec": "2.*",
         "definitionType": "task"
       },
       "inputs": {
-        "filename": "docker",
-        "arguments": "run -t --rm --sig-proxy=true --name $(DockerContainerName) -v $(Build.SourcesDirectory):/opt/code -w /opt/code -e CONNECTION_STRING -e PUBLISH_TO_AZURE_BLOB chcosta/dotnetcore:rhel7_prereqs /bin/bash -c \"git clean -X -d -f; ./build.sh $(BuildArguments)\"",
-        "workingFolder": "",
+        "scriptPath": "scripts/dockerrun-as-current-user.sh",
+        "args": "-t --rm --sig-proxy=true --name $(DockerContainerName) -v $(Build.SourcesDirectory):/opt/code -w /opt/code -e CONNECTION_STRING -e PUBLISH_TO_AZURE_BLOB chcosta/dotnetcore:rhel7_prereqs /bin/bash -c \"HOME=/opt/code; git clean -X -d -f; ./build.sh $(BuildArguments)\"",
+        "disableAutoCwd": "false",
+        "cwd": "",
         "failOnStandardError": "false"
       }
     }

--- a/scripts/dockerrun-as-current-user.sh
+++ b/scripts/dockerrun-as-current-user.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) .NET Foundation and contributors. All rights reserved.
+# Licensed under the MIT license. See LICENSE file in the project root for full license information.
+#
+
+set -e
+
+docker run -u="$(id -u):$(id -g)" "$@"


### PR DESCRIPTION
In the PortableLinux and RHEL build definitions, "docker run" is called
directly, without specifying the user as which to run.  This means that
the build artifacts which are mapped to the host have "root" as their
owner, because "root" as the default Docker user.  This prevents the
build agent's user from being able to delete those files in subsequent
builds, causing official builds to fail.

This fix runs the Docker container as the same user ID and group ID as
the host, which causes the build artifacts to have that same owner so
that they can be deleted later. This is done in a new script because
invoking the "id" command to get the user ID within the build
definition is not trivial, so this is the simplest implementation.

This is a short-term fix to unblock the builds; I am considering
removing the volume-mapping and instead copying in the files for a
longer-term solution.

/cc @gkhanna79 @wtgodbe @dagood @MichaelSimons @chcosta 