### PR TITLE
[WIP][DO NOT MERGE] Enable building corehost for Debug and Release

### DIFF
--- a/src/corehost/build.sh
+++ b/src/corehost/build.sh
@@ -184,6 +184,13 @@ else
     exit 1
 fi
 
+if [ -z $CONFIGURATION ]; then
+    export CONFIGURATION=Debug
+fi
+echo "CONFIGURATION=$CONFIGURATION"
+
+__cmake_defines="-DCMAKE_BUILD_TYPE=${CONFIGURATION} ${__cmake_defines}"
+
 echo "Building Corehost from $DIR to $(pwd)"
 set -x # turn on trace
 if [ $__CrossBuild == 1 ]; then


### PR DESCRIPTION
Fix #1386 

This enables corehost to be built for Debug and Release with different optimization level.
This PR should be merged **after** stable version of clang is introduced for arm32 cross compilation.

## Example
When build for x64,

For Debug, `-g` option is added when compiling `corehost`.

```
$ ./build.sh --configuration Debug
...
cd /home/hk0110/work/dxl/dotnet/github/dotnet/core-setup/artifacts/ubuntu.14.04-x64/corehost/cmake/cli/exe/dotnet && /usr/bin/clang++-3.5   -DAPPHOST_PKG_VER=\"2.0.0-beta-001479-00\" -DHOST_FXR_PKG_VER=\"2.0.0-beta-001479-00\" -DHOST_PKG_VER=\"2.0.0-beta-001479-00\" -DHOST_POLICY_PKG_NAME=\"runtime.ubuntu.14.04-x64.Microsoft.NETCore.DotNetHostPolicy\" -DHOST_POLICY_PKG_REL_DIR=\"runtimes/ubuntu.14.04-x64/native\" -DHOST_POLICY_PKG_VER=\"2.0.0-beta-001479-00\" -DREPO_COMMIT_HASH=\"c7af9c45878fc1e30290b185f5bb19366a725740\" -DTARGET_RUNTIME_ID=\"ubuntu.14.04-x64\" -D_NO_ASYNCRTIMP -D_NO_PPLXIMP -D_TARGET_AMD64_=1 -D__LINUX__ -std=c++11 -g -I/home/hk0110/work/dxl/dotnet/github/dotnet/core-setup/src/corehost/cli/exe/dotnet/../../.. -I/home/hk0110/work/dxl/dotnet/github/dotnet/core-setup/src/corehost/cli/exe/dotnet/../../../common -I/home/hk0110/work/dxl/dotnet/github/dotnet/core-setup/src/corehost/cli/exe/dotnet/../.. -I/home/hk0110/work/dxl/dotnet/github/dotnet/core-setup/src/corehost/cli/exe/dotnet/../../fxr    -fPIE -Wno-unused-local-typedef -fstack-protector-strong -o CMakeFiles/dotnet.dir/__/__/__/corehost.cpp.o -c /home/hk0110/work/dxl/dotnet/github/dotnet/core-setup/src/corehost/corehost.cpp
```

For Release, `-O3 -DNDEBUG` option is added when compiling `corehost`.
```
./build.sh --configuration Release
...
cd /home/hk0110/work/dxl/dotnet/github/dotnet/core-setup/artifacts/ubuntu.14.04-x64/corehost/cmake/cli/exe/dotnet && /usr/bin/clang++-3.5   -DAPPHOST_PKG_VER=\"2.0.0-beta-001479-00\" -DHOST_FXR_PKG_VER=\"2.0.0-beta-001479-00\" -DHOST_PKG_VER=\"2.0.0-beta-001479-00\" -DHOST_POLICY_PKG_NAME=\"runtime.ubuntu.14.04-x64.Microsoft.NETCore.DotNetHostPolicy\" -DHOST_POLICY_PKG_REL_DIR=\"runtimes/ubuntu.14.04-x64/native\" -DHOST_POLICY_PKG_VER=\"2.0.0-beta-001479-00\" -DREPO_COMMIT_HASH=\"c7af9c45878fc1e30290b185f5bb19366a725740\" -DTARGET_RUNTIME_ID=\"ubuntu.14.04-x64\" -D_NO_ASYNCRTIMP -D_NO_PPLXIMP -D_TARGET_AMD64_=1 -D__LINUX__ -std=c++11 -O3 -DNDEBUG -I/home/hk0110/work/dxl/dotnet/github/dotnet/core-setup/src/corehost/cli/exe/dotnet/../../.. -I/home/hk0110/work/dxl/dotnet/github/dotnet/core-setup/src/corehost/cli/exe/dotnet/../../../common -I/home/hk0110/work/dxl/dotnet/github/dotnet/core-setup/src/corehost/cli/exe/dotnet/../.. -I/home/hk0110/work/dxl/dotnet/github/dotnet/core-setup/src/corehost/cli/exe/dotnet/../../fxr    -fPIE -Wno-unused-local-typedef -fstack-protector-strong -o CMakeFiles/dotnet.dir/__/__/__/corehost.cpp.o -c /home/hk0110/work/dxl/dotnet/github/dotnet/core-setup/src/corehost/corehost.cpp
```