### PR TITLE
Update Microsoft.DiaSymReader.Native version to 1.4.1

### DIFF
--- a/pkg/projects/Microsoft.NETCore.App/project.json
+++ b/pkg/projects/Microsoft.NETCore.App/project.json
@@ -39,7 +39,7 @@
     "System.Threading.Tasks.Parallel": "4.3.0",
     "System.Threading.Thread": "4.3.0",
     "System.Threading.ThreadPool": "4.3.0",
-    "Microsoft.DiaSymReader.Native": "1.4.0",
+    "Microsoft.DiaSymReader.Native": "1.4.1",
     "Libuv": "1.9.1"
   },
   "frameworks": {


### PR DESCRIPTION
Fixes #14627

The new package contains the same binaries as 1.4.0 and a fixed .props file.

This is the actual change in the props file: https://github.com/dotnet/roslyn-internal/commit/b9fc00eb6b5f2a9f918b1a21fbefcd6db68feec1 -- the only difference between 1.4.0 and 1.4.1