### PR TITLE
Include all RID-specific assets in platform manifest during official build

### DIFF
--- a/pkg/projects/Microsoft.NETCore.App/Microsoft.NETCore.App.pkgproj
+++ b/pkg/projects/Microsoft.NETCore.App/Microsoft.NETCore.App.pkgproj
@@ -14,6 +14,11 @@
     <ShouldCreateLayout>false</ShouldCreateLayout>
     <PropsFile>$(IntermediateOutputPath)$(MSBuildProjectName).props</PropsFile>
     <PlatformManifestFile>$(IntermediateOutputPath)$(MSBuildProjectName).PlatformManifest.txt</PlatformManifestFile>
+    <!-- During an official build when we can guarantee that all RID-specific dependencies have been built,
+         restore all of those dependencies and gather the prospective content of the RID-specific Core.App
+         packages.  This is needed so that we have a complete platform manifest in the shipping version of
+         the Microsoft.NETCore.App (RID-agnostic/identity package). -->
+    <IncludeAllRuntimePackagesInPlatformManifest Condition="'$(SIGNED_PACKAGES)' == 'true'">true</IncludeAllRuntimePackagesInPlatformManifest>
   </PropertyGroup>
   
   <Choose>
@@ -107,7 +112,7 @@
     <MSBuild Projects="@(ProjectReference)"
              Condition="'%(ProjectReference.PackageTargetRuntime)' == '$(PackageRID)' OR 
                         '%(ProjectReference.BuidOnRID)' == '$(PackageRID)' OR 
-                        ('$(IncludeAllPackages)' == 'true' AND '%(ProjectReference.PackageTargetRuntime)' != '')"
+                        ('$(IncludeAllRuntimePackagesInPlatformManifest)' == 'true' AND '%(ProjectReference.PackageTargetRuntime)' != '')"
              Targets="GetPackageFiles">
       <Output TaskParameter="TargetOutputs" ItemName="SharedFrameworkRuntimeFiles" />
     </MSBuild>


### PR DESCRIPTION
Previously I only included assets in the platform manifest for packages
being built on the current platform.

This is a problem because the platform manifest ships in a single
RID agnostic package so normally it would only have one set of files
that correspond to the RID-specific package that happened to be
built in the same build leg.

I foresaw this problem and made a switch to the package build that
would tell it to examine the assets from all RID specific packages.

This change uses that switch during the official build (identified
by environment SIGNED_PACKAGES=true).  This switch is only safe to
use in the official build where we've already built all RIDs for
dependencies since it will cause the build to download RID-specific
packages for all of its dependencies.  That would fail in a purely
vertical (RID-specific) end-to-end build, AKA: vertical build.

In the future we need to make sure that if we switch the official
build to be completely vertical we still have a build-leg that will
run after all verticals of dependencies are complete to build the
RID-less package for Microsoft.NETCore.App.

/cc @eerhardt @ellismg @dagood @chcosta @weshaggard 

Fixes https://github.com/dotnet/standard/issues/191