### PR TITLE
Support for Linux Arm32 builds

### DIFF
--- a/build_projects/dotnet-host-build/PrepareTargets.cs
+++ b/build_projects/dotnet-host-build/PrepareTargets.cs
@@ -43,15 +43,9 @@ namespace Microsoft.DotNet.Host.Build
             nameof(PackDotnetDebTool))]
         public static BuildTargetResult Init(BuildTargetContext c)
         {
-            var configEnv = Environment.GetEnvironmentVariable("CONFIGURATION");
             string platformEnv = c.BuildContext.Get<string>("Platform");
             
             string targetFramework = Environment.GetEnvironmentVariable("TARGETFRAMEWORK") ?? "netcoreapp2.0";
-
-            if (string.IsNullOrEmpty(configEnv))
-            {
-                configEnv = "Debug";
-            }
 
             string crossEnv = Environment.GetEnvironmentVariable("CROSS") ?? "0";
             if (string.Equals(crossEnv, "1"))
@@ -64,7 +58,6 @@ namespace Microsoft.DotNet.Host.Build
                 }
             }
 
-            c.BuildContext["Configuration"] = configEnv;
             c.BuildContext["Channel"] = Environment.GetEnvironmentVariable("CHANNEL");
             
             c.BuildContext["TargetFramework"] = targetFramework;
@@ -88,6 +81,13 @@ namespace Microsoft.DotNet.Host.Build
         public static BuildTargetResult CommonInit(BuildTargetContext c)
         {
             string platformEnv = Environment.GetEnvironmentVariable("TARGETPLATFORM") ?? RuntimeEnvironment.RuntimeArchitecture.ToString();
+            
+            var configEnv = Environment.GetEnvironmentVariable("CONFIGURATION");
+            if (string.IsNullOrEmpty(configEnv))
+            {
+                configEnv = "Debug";
+            }
+            c.BuildContext["Configuration"] = configEnv;
             
             string targetRID = Environment.GetEnvironmentVariable("TARGETRID");
             string realTargetRID = targetRID;
@@ -245,8 +245,8 @@ namespace Microsoft.DotNet.Host.Build
         [Target]
         public static BuildTargetResult ExpectedBuildArtifacts(BuildTargetContext c)
         {
-            var config = Environment.GetEnvironmentVariable("CONFIGURATION");
-            var versionBadgeName = $"sharedfx_{Monikers.GetBadgeMoniker()}_{config}_version_badge.svg";
+            var config = c.BuildContext.Get<string>("Configuration");
+            var versionBadgeName = $"sharedfx_{Monikers.GetBadgeMoniker(c)}_{config}_version_badge.svg";
             c.BuildContext["VersionBadge"] = Path.Combine(Dirs.Output, versionBadgeName);
 
             var sharedFrameworkVersion = c.BuildContext.Get<string>("SharedFrameworkNugetVersion");

--- a/build_projects/dotnet-host-build/PublishTargets.cs
+++ b/build_projects/dotnet-host-build/PublishTargets.cs
@@ -72,7 +72,7 @@ namespace Microsoft.DotNet.Host.Build
         [Target]
         public static BuildTargetResult FinalizeBuild(BuildTargetContext c)
         {
-            if (CheckIfAllBuildsHavePublished())
+            if (CheckIfAllBuildsHavePublished(c))
             {
                 string targetContainer = $"{Channel}/Binaries/Latest/";
                 string targetVersionFile = $"{targetContainer}{CommitHash}";
@@ -185,7 +185,7 @@ namespace Microsoft.DotNet.Host.Build
             repoUpdater.UpdatePublishedVersions(Dirs.PackagesNoRID, $"build-info/dotnet/core-setup/{Channel}/Latest").Wait();
         }
 
-        private static bool CheckIfAllBuildsHavePublished()
+        private static bool CheckIfAllBuildsHavePublished(BuildTargetContext c)
         {
             Dictionary<string, bool> badges = new Dictionary<string, bool>()
              {
@@ -195,9 +195,9 @@ namespace Microsoft.DotNet.Host.Build
                  { "sharedfx_Windows_arm64", false },
                  { "sharedfx_Linux_x64", false },
                  { "sharedfx_Ubuntu_x64", false },
-                 // { "sharedfx_Ubuntu_14_04_arm", false },
+                 { "sharedfx_Ubuntu_14_04_arm", false },
                  { "sharedfx_Ubuntu_16_04_x64", false },
-                 // { "sharedfx_Ubuntu_16_04_arm", false },
+                 { "sharedfx_Ubuntu_16_04_arm", false },
                  { "sharedfx_Ubuntu_16_10_x64", false },
                  { "sharedfx_RHEL_x64", false },
                  { "sharedfx_OSX_x64", false },
@@ -212,7 +212,7 @@ namespace Microsoft.DotNet.Host.Build
 
             List<string> blobs = new List<string>(AzurePublisherTool.ListBlobs($"{Channel}/Binaries/{SharedFrameworkNugetVersion}/"));
 
-            var versionBadgeName = $"sharedfx_{Monikers.GetBadgeMoniker()}";
+            var versionBadgeName = $"sharedfx_{Monikers.GetBadgeMoniker(c)}";
             if (badges.ContainsKey(versionBadgeName) == false)
             {
                 throw new ArgumentException($"A new OS build ({versionBadgeName}) was added without adding the moniker to the {nameof(badges)} lookup");

--- a/build_projects/shared-build-targets-utils/Utils/Monikers.cs
+++ b/build_projects/shared-build-targets-utils/Utils/Monikers.cs
@@ -38,7 +38,7 @@ namespace Microsoft.DotNet.Cli.Build
             string rid = Environment.GetEnvironmentVariable("TARGETRID") ?? RuntimeEnvironment.GetRuntimeIdentifier();
 
             // Look for expected RIDs, including Portable one, for Linux
-            if (rid.StartsWith("linux-") || rid == "ubuntu.16.04-x64" || rid == "ubuntu.16.10-x64" || rid == "fedora.23-x64" || rid == "fedora.24-x64" || rid == "opensuse.13.2-x64" || rid == "opensuse.42.1-x64" || rid == "debian.8-armel" || rid == "tizen.4.0.0-armel")
+            if (rid.StartsWith("linux-") || rid == "ubuntu.16.04-x64" || rid == "ubuntu.16.04-arm" || rid == "ubuntu.16.10-x64" || rid == "fedora.23-x64" || rid == "fedora.24-x64" || rid == "opensuse.13.2-x64" || rid == "opensuse.42.1-x64" || rid == "debian.8-armel" || rid == "tizen.4.0.0-armel")
             {
                 return $"{artifactPrefix}-{rid}.{version}";
             }
@@ -50,19 +50,20 @@ namespace Microsoft.DotNet.Cli.Build
             }
         }
 
-        public static string GetBadgeMoniker()
+        public static string GetBadgeMoniker(BuildTargetContext c)
         {
-            string rid = Environment.GetEnvironmentVariable("TARGETRID") ?? RuntimeEnvironment.GetRuntimeIdentifier();
-
+            string rid = c.BuildContext.Get<string>("TargetRID");
             if (rid.StartsWith("linux-"))
             {
-                return $"Linux_{Environment.GetEnvironmentVariable("TARGETPLATFORM") ?? CurrentArchitecture.Current.ToString()}";
+                return $"Linux_{c.BuildContext.Get<string>("Platform")}";
             }
 
             switch (rid)
             {
                 case "ubuntu.16.04-x64":
                      return "Ubuntu_16_04_x64";
+                case "ubuntu.16.04-arm":
+                     return "Ubuntu_16_04_arm";
                 case "ubuntu.16.10-x64":
                      return "Ubuntu_16_10_x64";
                 case "fedora.23-x64":
@@ -79,7 +80,7 @@ namespace Microsoft.DotNet.Cli.Build
                      return "Tizen_4_0_0_armel";
             }
 
-            return $"{CurrentPlatform.Current}_{Environment.GetEnvironmentVariable("TARGETPLATFORM") ?? CurrentArchitecture.Current.ToString()}";
+            return $"{CurrentPlatform.Current}_{c.BuildContext.Get<string>("Platform")}";
         }
 
         public static string GetDebianHostFxrPackageName(string hostfxrNugetVersion)

--- a/buildpipeline/Core-Setup-CrossBuild.json
+++ b/buildpipeline/Core-Setup-CrossBuild.json
@@ -4,95 +4,7 @@
       "enabled": true,
       "continueOnError": false,
       "alwaysRun": false,
-      "displayName": "Delete files from $(Build.SourcesDirectory)",
-      "timeoutInMinutes": 0,
-      "task": {
-        "id": "b7e8b412-0437-4065-9371-edc5881de25b",
-        "versionSpec": "1.*",
-        "definitionType": "task"
-      },
-      "inputs": {
-        "SourceFolder": "$(Build.SourcesDirectory)",
-        "Contents": "**\n.gitignore"
-      }
-    },
-    {
-      "enabled": false,
-      "continueOnError": false,
-      "alwaysRun": false,
-      "displayName": "git clone",
-      "timeoutInMinutes": 0,
-      "task": {
-        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
-        "versionSpec": "1.*",
-        "definitionType": "task"
-      },
-      "inputs": {
-        "filename": "git",
-        "arguments": "clone $(PB_RepoUrl) core-setup",
-        "workingFolder": "",
-        "failOnStandardError": "false"
-      }
-    },
-    {
-      "enabled": false,
-      "continueOnError": false,
-      "alwaysRun": false,
-      "displayName": "git checkout",
-      "timeoutInMinutes": 0,
-      "task": {
-        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
-        "versionSpec": "1.*",
-        "definitionType": "task"
-      },
-      "inputs": {
-        "filename": "git",
-        "arguments": "checkout $(SourceVersion)",
-        "workingFolder": "$(Build.SourcesDirectory)/corefx",
-        "failOnStandardError": "false"
-      }
-    },
-    {
-      "enabled": false,
-      "continueOnError": false,
-      "alwaysRun": true,
-      "displayName": "Initialize tools",
-      "timeoutInMinutes": 0,
-      "task": {
-        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
-        "versionSpec": "1.*",
-        "definitionType": "task"
-      },
-      "inputs": {
-        "filename": "$(Build.SourcesDirectory)/core-setup/init-tools.sh",
-        "arguments": "",
-        "workingFolder": "",
-        "failOnStandardError": "false"
-      }
-    },
-    {
-      "enabled": false,
-      "continueOnError": false,
-      "alwaysRun": false,
-      "displayName": "Docker cleanup",
-      "timeoutInMinutes": 0,
-      "task": {
-        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
-        "versionSpec": "1.*",
-        "definitionType": "task"
-      },
-      "inputs": {
-        "filename": "$(Build.SourcesDirectory)/core-setup/Tools/scripts/docker/cleanup-docker.sh",
-        "arguments": "",
-        "workingFolder": "",
-        "failOnStandardError": "false"
-      }
-    },
-    {
-      "enabled": true,
-      "continueOnError": false,
-      "alwaysRun": false,
-      "displayName": "Start detached docker container",
+      "displayName": "Start detached container",
       "timeoutInMinutes": 0,
       "task": {
         "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
@@ -110,7 +22,7 @@
       "enabled": true,
       "continueOnError": false,
       "alwaysRun": false,
-      "displayName": "Clone repository",
+      "displayName": "Clone Repository",
       "timeoutInMinutes": 0,
       "task": {
         "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
@@ -128,7 +40,7 @@
       "enabled": true,
       "continueOnError": false,
       "alwaysRun": false,
-      "displayName": "Check out the specified commit",
+      "displayName": "Checkout commit",
       "timeoutInMinutes": 0,
       "task": {
         "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
@@ -146,7 +58,7 @@
       "enabled": true,
       "continueOnError": false,
       "alwaysRun": false,
-      "displayName": "Run build-rootfs.sh",
+      "displayName": "Build RootFS",
       "timeoutInMinutes": 0,
       "task": {
         "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
@@ -164,7 +76,7 @@
       "enabled": true,
       "continueOnError": false,
       "alwaysRun": false,
-      "displayName": "Run build.sh",
+      "displayName": "Run Build",
       "timeoutInMinutes": 0,
       "task": {
         "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
@@ -173,7 +85,7 @@
       },
       "inputs": {
         "filename": "docker",
-        "arguments": "exec $(PB_DockerContainerName) $(PB_GitDirectory)/build.sh --skip-prereqs --configuration $(PB_ConfigurationGroup) --targets Default $(portableLinux) --env-vars \"DISABLE_CROSSGEN=1,TARGETPLATFORM=$(PB_Architecture),TARGETRID=$(TargetRid)\"",
+        "arguments": "exec $(PB_DockerContainerName) $(PB_GitDirectory)/build.sh $(BuildArguments) $(portableLinux) --env-vars \"DISABLE_CROSSGEN=1,TARGETPLATFORM=$(PB_Architecture),TARGETRID=$(TargetRid)\"",
         "workingFolder": "",
         "failOnStandardError": "false"
       }
@@ -197,62 +109,10 @@
       }
     },
     {
-      "enabled": false,
-      "continueOnError": false,
-      "alwaysRun": false,
-      "displayName": "Run publish-packages.sh",
-      "timeoutInMinutes": 0,
-      "task": {
-        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
-        "versionSpec": "1.*",
-        "definitionType": "task"
-      },
-      "inputs": {
-        "filename": "docker",
-        "arguments": "exec $(PB_DockerContainerName) $(PB_GitDirectory)/publish-packages.sh -AzureAccount=$(PB_CloudDropAccountName) -AzureToken=$(CloudDropAccessToken) -Container=$(PB_Label) -verbose -- /p:OverwriteOnPublish=true",
-        "workingFolder": "",
-        "failOnStandardError": "false"
-      }
-    },
-    {
       "enabled": true,
       "continueOnError": false,
       "alwaysRun": false,
-      "displayName": "Delete files from $(PB_DockerCopyDest)",
-      "timeoutInMinutes": 0,
-      "task": {
-        "id": "b7e8b412-0437-4065-9371-edc5881de25b",
-        "versionSpec": "1.*",
-        "definitionType": "task"
-      },
-      "inputs": {
-        "SourceFolder": "$(PB_DockerCopyDest)",
-        "Contents": "*"
-      }
-    },
-    {
-      "enabled": true,
-      "continueOnError": true,
-      "alwaysRun": true,
-      "displayName": "Expose docker repo for publishing",
-      "timeoutInMinutes": 0,
-      "task": {
-        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
-        "versionSpec": "1.*",
-        "definitionType": "task"
-      },
-      "inputs": {
-        "filename": "docker",
-        "arguments": "cp $(PB_DockerContainerName):$(PB_GitDirectory) $(PB_DockerCopyDest)",
-        "workingFolder": "",
-        "failOnStandardError": "false"
-      }
-    },
-    {
-      "enabled": true,
-      "continueOnError": false,
-      "alwaysRun": false,
-      "displayName": "Stop docker",
+      "displayName": "Stop Container",
       "timeoutInMinutes": 0,
       "task": {
         "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
@@ -270,7 +130,7 @@
       "enabled": true,
       "continueOnError": false,
       "alwaysRun": false,
-      "displayName": "Remove container",
+      "displayName": "Remove Container",
       "timeoutInMinutes": 0,
       "task": {
         "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
@@ -280,43 +140,6 @@
       "inputs": {
         "filename": "docker",
         "arguments": "rm $(PB_DockerContainerName)",
-        "workingFolder": "",
-        "failOnStandardError": "false"
-      }
-    },
-    {
-      "enabled": true,
-      "continueOnError": true,
-      "alwaysRun": true,
-      "displayName": "Copy Publish Artifact: BuildLogs",
-      "timeoutInMinutes": 0,
-      "task": {
-        "id": "1d341bb0-2106-458c-8422-d00bcea6512a",
-        "versionSpec": "1.*",
-        "definitionType": "task"
-      },
-      "inputs": {
-        "CopyRoot": "$(PB_DockerCopyDest)/corefx",
-        "Contents": "**/*.log",
-        "ArtifactName": "BuildLogs",
-        "ArtifactType": "Container",
-        "TargetPath": "\\\\my\\share\\$(Build.DefinitionName)\\$(Build.BuildNumber)"
-      }
-    },
-    {
-      "enabled": true,
-      "continueOnError": true,
-      "alwaysRun": true,
-      "displayName": "Run docker version",
-      "timeoutInMinutes": 0,
-      "task": {
-        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
-        "versionSpec": "1.*",
-        "definitionType": "task"
-      },
-      "inputs": {
-        "filename": "docker",
-        "arguments": "version",
         "workingFolder": "",
         "failOnStandardError": "false"
       }
@@ -341,7 +164,7 @@
         "id": "a9db38f9-9fdc-478c-b0f9-464221e58316"
       },
       "inputs": {
-        "workItemType": "234347",
+        "workItemType": "4777",
         "assignToRequestor": "true",
         "additionalFields": "{}"
       }
@@ -357,24 +180,53 @@
     }
   ],
   "variables": {
-    "system.debug": {
-      "value": "false",
+    "BuildConfiguration": {
+      "value": "Release",
       "allowOverride": true
     },
-    "PB_ConfigurationGroup": {
-      "value": "Release"
+    "BuildArguments": {
+      "value": "--skip-prereqs --configuration $(BuildConfiguration) --targets Default",
+      "allowOverride": true
     },
-    "PB_RepoUrl": {
-      "value": "http://github.com/dotnet/core-setup.git"
+    "CONNECTION_STRING": {
+      "value": "PassedViaPipeBuild"
+    },
+    "PUBLISH_TO_AZURE_BLOB": {
+      "value": "true",
+      "allowOverride": true
+    },
+    "REPO_ID": {
+      "value": "562fbfe0b2d7d0e0a43780c4"
+    },
+    "REPO_USER": {
+      "value": "dotnet"
+    },
+    "REPO_PASS": {
+      "value": "PassedViaPipeBuild"
+    },
+    "REPO_SERVER": {
+      "value": "azure-apt-cat.cloudapp.net"
+    },
+    "NUGET_FEED_URL": {
+      "value": "https://dotnet.myget.org/F/dotnet-core"
+    },
+    "NUGET_API_KEY": {
+      "value": "PassedViaPipeBuild"
+    },
+    "GITHUB_PASSWORD": {
+      "value": "PassedViaPipeBuild"
+    },
+    "CLI_NUGET_FEED_URL": {
+      "value": "https://www.myget.org/F/core-setup-testing"
+    },
+    "CLI_NUGET_API_KEY": {
+      "value": "PassedViaPipeBuild"
     },
     "PB_GitDirectory": {
       "value": "/root/core-setup"
     },
     "PB_DockerContainerName": {
       "value": "$(Build.BuildId)"
-    },
-    "PB_DockerImageName": {
-      "value": "$(PB_DockerRepository):$(PB_DockerTag)"
     },
     "PB_DockerRepository": {
       "value": "chcosta/dotnetcore"
@@ -383,34 +235,15 @@
       "value": "ubuntu1404_cross_prereqs_v1",
       "allowOverride": true
     },
-    "PB_CloudDropAccountName": {
-      "value": "dotnetbuildoutput"
-    },
-    "CloudDropAccessToken": {
-      "value": null,
-      "isSecret": true
-    },
-    "OfficialBuildId": {
-      "value": "$(Build.BuildNumber)"
-    },
-    "PB_Label": {
-      "value": "$(Build.BuildNumber)"
-    },
-    "GitHubBranch": {
-      "value": "sni_plus_latestbuildtools"
+    "PB_DockerImageName": {
+      "value": "$(PB_DockerRepository):$(PB_DockerTag)"
     },
     "PB_Architecture": {
       "value": "arm"
     },
-    "SourceVersion": {
-      "value": "HEAD",
-      "allowOverride": true
-    },
-    "PB_DockerCopyDest": {
-      "value": "$(Build.BinariesDirectory)/docker_repo"
-    },
     "portableLinux": {
-      "value": ""
+      "value": "",
+      "allowOverride": true
     },
     "CrossToolsetVersion": {
       "value": "",
@@ -421,6 +254,14 @@
     },
     "TargetRid": {
       "value": "ubuntu.14.04-arm",
+      "allowOverride": true
+    },
+    "PB_RepoUrl": {
+      "value": "https://github.com/dotnet/core-setup.git",
+      "allowOverride": true
+    },
+    "SourceVersion": {
+      "value": "",
       "allowOverride": true
     }
   },
@@ -443,23 +284,27 @@
       "deleteTestResults": true
     }
   ],
-  "buildNumberFormat": "$(date:yyyyMMdd)$(rev:-rr)",
+  "buildNumberFormat": "$(Date:yyyMMdd)$(Rev:.r)",
   "jobAuthorizationScope": "projectCollection",
   "jobTimeoutInMinutes": 90,
+  "badgeEnabled": true,
   "repository": {
     "properties": {
-      "labelSources": "0",
-      "reportBuildStatus": "true",
-      "fetchDepth": "0",
+      "connectedServiceId": "f4c31735-42d2-4c3a-bc47-7ac06fd0dccc",
+      "apiUrl": "https://api.github.com/repos/dotnet/core-setup",
+      "branchesUrl": "https://api.github.com/repos/dotnet/core-setup/branches",
+      "cloneUrl": "https://github.com/dotnet/core-setup.git",
+      "refsUrl": "https://api.github.com/repos/dotnet/core-setup/git/refs",
       "gitLfsSupport": "false",
       "skipSyncSource": "false",
+      "fetchDepth": "0",
       "cleanOptions": "0"
     },
-    "id": "58fa2458-e392-4373-ba2b-dd3ef0c2d7ce",
-    "type": "TfsGit",
-    "name": "DotNet-CoreFX-Trusted",
-    "url": "https://devdiv.visualstudio.com/DevDiv/_git/DotNet-CoreFX-Trusted",
-    "defaultBranch": "refs/heads/master",
+    "id": "https://github.com/dotnet/core-setup.git",
+    "type": "GitHub",
+    "name": "dotnet/core-setup",
+    "url": "https://github.com/dotnet/core-setup.git",
+    "defaultBranch": "master",
     "clean": "true",
     "checkoutSubmodules": false
   },
@@ -474,9 +319,8 @@
   },
   "path": "\\",
   "type": "build",
-  "id": 5267,
-  "name": "CoreSetup-CrossBuild",
-  "url": "https://devdiv.visualstudio.com/DefaultCollection/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_apis/build/Definitions/5267",
+  "id": 5272,
+  "name": "Core-Setup-CrossBuild",
   "project": {
     "id": "0bdbc590-a062-4c3f-b0f6-9383f67865ee",
     "name": "DevDiv",

--- a/buildpipeline/Core-Setup-CrossBuild.json
+++ b/buildpipeline/Core-Setup-CrossBuild.json
@@ -1,0 +1,488 @@
+{
+  "build": [
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Delete files from $(Build.SourcesDirectory)",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "b7e8b412-0437-4065-9371-edc5881de25b",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "SourceFolder": "$(Build.SourcesDirectory)",
+        "Contents": "**\n.gitignore"
+      }
+    },
+    {
+      "enabled": false,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "git clone",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "filename": "git",
+        "arguments": "clone $(PB_RepoUrl) core-setup",
+        "workingFolder": "",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "enabled": false,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "git checkout",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "filename": "git",
+        "arguments": "checkout $(SourceVersion)",
+        "workingFolder": "$(Build.SourcesDirectory)/corefx",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "enabled": false,
+      "continueOnError": false,
+      "alwaysRun": true,
+      "displayName": "Initialize tools",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "filename": "$(Build.SourcesDirectory)/core-setup/init-tools.sh",
+        "arguments": "",
+        "workingFolder": "",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "enabled": false,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Docker cleanup",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "filename": "$(Build.SourcesDirectory)/core-setup/Tools/scripts/docker/cleanup-docker.sh",
+        "arguments": "",
+        "workingFolder": "",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Start detached docker container",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "filename": "docker",
+        "arguments": "run --privileged -d -w $(PB_GitDirectory) --name $(PB_DockerContainerName) $(PB_DockerImageName) sleep 7200",
+        "workingFolder": "",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Clone repository",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "filename": "docker",
+        "arguments": "exec $(PB_DockerContainerName) git clone $(PB_RepoUrl) $(PB_GitDirectory)",
+        "workingFolder": "",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Check out the specified commit",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "filename": "docker",
+        "arguments": "exec $(PB_DockerContainerName) git checkout $(SourceVersion)",
+        "workingFolder": "",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Run build-rootfs.sh",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "filename": "sudo",
+        "arguments": "docker exec --privileged $(PB_DockerContainerName) $(PB_GitDirectory)/cross/build-rootfs.sh $(PB_Architecture) $(CrossToolsetVersion) $(SkipUnmount)",
+        "workingFolder": "",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Run build.sh",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "filename": "docker",
+        "arguments": "exec $(PB_DockerContainerName) $(PB_GitDirectory)/build.sh --skip-prereqs --configuration $(PB_ConfigurationGroup) --targets Default $(portableLinux) --env-vars \"DISABLE_CROSSGEN=1,TARGETPLATFORM=$(PB_Architecture),TARGETRID=$(TargetRid)\"",
+        "workingFolder": "",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Cleanup RootFS",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "filename": "sudo",
+        "arguments": "docker exec --privileged $(PB_DockerContainerName) git clean -xdf $(PB_GitDirectory)/cross/",
+        "workingFolder": "",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "enabled": false,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Run publish-packages.sh",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "filename": "docker",
+        "arguments": "exec $(PB_DockerContainerName) $(PB_GitDirectory)/publish-packages.sh -AzureAccount=$(PB_CloudDropAccountName) -AzureToken=$(CloudDropAccessToken) -Container=$(PB_Label) -verbose -- /p:OverwriteOnPublish=true",
+        "workingFolder": "",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Delete files from $(PB_DockerCopyDest)",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "b7e8b412-0437-4065-9371-edc5881de25b",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "SourceFolder": "$(PB_DockerCopyDest)",
+        "Contents": "*"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": true,
+      "alwaysRun": true,
+      "displayName": "Expose docker repo for publishing",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "filename": "docker",
+        "arguments": "cp $(PB_DockerContainerName):$(PB_GitDirectory) $(PB_DockerCopyDest)",
+        "workingFolder": "",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Stop docker",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "filename": "docker",
+        "arguments": "stop $(PB_DockerContainerName)",
+        "workingFolder": "",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Remove container",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "filename": "docker",
+        "arguments": "rm $(PB_DockerContainerName)",
+        "workingFolder": "",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": true,
+      "alwaysRun": true,
+      "displayName": "Copy Publish Artifact: BuildLogs",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "1d341bb0-2106-458c-8422-d00bcea6512a",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "CopyRoot": "$(PB_DockerCopyDest)/corefx",
+        "Contents": "**/*.log",
+        "ArtifactName": "BuildLogs",
+        "ArtifactType": "Container",
+        "TargetPath": "\\\\my\\share\\$(Build.DefinitionName)\\$(Build.BuildNumber)"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": true,
+      "alwaysRun": true,
+      "displayName": "Run docker version",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "filename": "docker",
+        "arguments": "version",
+        "workingFolder": "",
+        "failOnStandardError": "false"
+      }
+    }
+  ],
+  "options": [
+    {
+      "enabled": false,
+      "definition": {
+        "id": "7c555368-ca64-4199-add6-9ebaf0b0137d"
+      },
+      "inputs": {
+        "multipliers": "[]",
+        "parallel": "false",
+        "continueOnError": "true",
+        "additionalFields": "{}"
+      }
+    },
+    {
+      "enabled": false,
+      "definition": {
+        "id": "a9db38f9-9fdc-478c-b0f9-464221e58316"
+      },
+      "inputs": {
+        "workItemType": "234347",
+        "assignToRequestor": "true",
+        "additionalFields": "{}"
+      }
+    },
+    {
+      "enabled": false,
+      "definition": {
+        "id": "57578776-4c22-4526-aeb0-86b6da17ee9c"
+      },
+      "inputs": {
+        "additionalFields": "{}"
+      }
+    }
+  ],
+  "variables": {
+    "system.debug": {
+      "value": "false",
+      "allowOverride": true
+    },
+    "PB_ConfigurationGroup": {
+      "value": "Release"
+    },
+    "PB_RepoUrl": {
+      "value": "http://github.com/dotnet/core-setup.git"
+    },
+    "PB_GitDirectory": {
+      "value": "/root/core-setup"
+    },
+    "PB_DockerContainerName": {
+      "value": "$(Build.BuildId)"
+    },
+    "PB_DockerImageName": {
+      "value": "$(PB_DockerRepository):$(PB_DockerTag)"
+    },
+    "PB_DockerRepository": {
+      "value": "chcosta/dotnetcore"
+    },
+    "PB_DockerTag": {
+      "value": "ubuntu1404_cross_prereqs_v1",
+      "allowOverride": true
+    },
+    "PB_CloudDropAccountName": {
+      "value": "dotnetbuildoutput"
+    },
+    "CloudDropAccessToken": {
+      "value": null,
+      "isSecret": true
+    },
+    "OfficialBuildId": {
+      "value": "$(Build.BuildNumber)"
+    },
+    "PB_Label": {
+      "value": "$(Build.BuildNumber)"
+    },
+    "GitHubBranch": {
+      "value": "sni_plus_latestbuildtools"
+    },
+    "PB_Architecture": {
+      "value": "arm"
+    },
+    "SourceVersion": {
+      "value": "HEAD",
+      "allowOverride": true
+    },
+    "PB_DockerCopyDest": {
+      "value": "$(Build.BinariesDirectory)/docker_repo"
+    },
+    "portableLinux": {
+      "value": ""
+    },
+    "CrossToolsetVersion": {
+      "value": "",
+      "allowOverride": true
+    },
+    "SkipUnmount": {
+      "value": "--SkipUnmount"
+    },
+    "TargetRid": {
+      "value": "ubuntu.14.04-arm",
+      "allowOverride": true
+    }
+  },
+  "demands": [
+    "Agent.OS -equals linux"
+  ],
+  "retentionRules": [
+    {
+      "branches": [
+        "+refs/heads/*"
+      ],
+      "artifacts": [],
+      "artifactTypesToDelete": [
+        "FilePath",
+        "SymbolStore"
+      ],
+      "daysToKeep": 10,
+      "minimumToKeep": 1,
+      "deleteBuildRecord": true,
+      "deleteTestResults": true
+    }
+  ],
+  "buildNumberFormat": "$(date:yyyyMMdd)$(rev:-rr)",
+  "jobAuthorizationScope": "projectCollection",
+  "jobTimeoutInMinutes": 90,
+  "repository": {
+    "properties": {
+      "labelSources": "0",
+      "reportBuildStatus": "true",
+      "fetchDepth": "0",
+      "gitLfsSupport": "false",
+      "skipSyncSource": "false",
+      "cleanOptions": "0"
+    },
+    "id": "58fa2458-e392-4373-ba2b-dd3ef0c2d7ce",
+    "type": "TfsGit",
+    "name": "DotNet-CoreFX-Trusted",
+    "url": "https://devdiv.visualstudio.com/DevDiv/_git/DotNet-CoreFX-Trusted",
+    "defaultBranch": "refs/heads/master",
+    "clean": "true",
+    "checkoutSubmodules": false
+  },
+  "quality": "definition",
+  "queue": {
+    "pool": {
+      "id": 39,
+      "name": "DotNet-Build"
+    },
+    "id": 36,
+    "name": "DotNet-Build"
+  },
+  "path": "\\",
+  "type": "build",
+  "id": 5267,
+  "name": "CoreSetup-CrossBuild",
+  "url": "https://devdiv.visualstudio.com/DefaultCollection/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_apis/build/Definitions/5267",
+  "project": {
+    "id": "0bdbc590-a062-4c3f-b0f6-9383f67865ee",
+    "name": "DevDiv",
+    "description": "Visual Studio and DevDiv team project for git source code repositories.  Work items will be added for Adams, Dev14 work items are tracked in vstfdevdiv.  ",
+    "url": "https://devdiv.visualstudio.com/DefaultCollection/_apis/projects/0bdbc590-a062-4c3f-b0f6-9383f67865ee",
+    "state": "wellFormed",
+    "revision": 418097529
+  }
+}

--- a/buildpipeline/pipeline.json
+++ b/buildpipeline/pipeline.json
@@ -130,6 +130,29 @@
           }
         },
         {
+          "Name": "Core-Setup-CrossBuild",
+          "Parameters": {
+            "PB_Architecture": "arm"
+          },
+          "ReportingParameters": {
+            "OperatingSystem": "Ubuntu 14.04",
+            "Type": "build/product/",
+          }
+        },
+        {
+          "Name": "Core-Setup-CrossBuild",
+          "Parameters": {
+            "PB_DockerTag": "ubuntu1604_cross_prereqs_v1",
+            "PB_Architecture": "arm",
+            "CrossToolsetVersion": "xenial",
+            "TargetRid": "ubuntu.16.04-arm"
+          },
+          "ReportingParameters": {
+            "OperatingSystem": "Ubuntu 16.04",
+            "Type": "build/product/",
+          }
+        },
+        {
           "Name": "Core-Setup-Windows-arm32",
           "ReportingParameters": {
             "OperatingSystem": "Windows",

--- a/buildpipeline/pipeline.json
+++ b/buildpipeline/pipeline.json
@@ -132,7 +132,10 @@
         {
           "Name": "Core-Setup-CrossBuild",
           "Parameters": {
-            "PB_Architecture": "arm"
+            "PB_DockerTag": "ubuntu1404_cross_prereqs_v1",
+            "PB_Architecture": "arm",
+            "CrossToolsetVersion": "trusty",
+            "TargetRid": "ubuntu.14.04-arm"
           },
           "ReportingParameters": {
             "OperatingSystem": "Ubuntu 14.04",


### PR DESCRIPTION
This change enables building for Ubuntu 14.04 and 16.04 for Arm32. Once this is merged, we can enable pipeline builds.

I also made few cleanup fixes to add more reliability to the build.

@ramarag @wtgodbe PTAL