### PR TITLE
Set MACOSX_RPATH on hostfxr and hostpolicy

### DIFF
--- a/src/corehost/cli/dll/CMakeLists.txt
+++ b/src/corehost/cli/dll/CMakeLists.txt
@@ -59,6 +59,7 @@ if(WIN32)
     list(APPEND RESOURCES ../native.rc)
 endif()
 add_library(hostpolicy SHARED ${SOURCES} ${RESOURCES})
+set_target_properties(hostpolicy PROPERTIES MACOSX_RPATH TRUE)
 
 # Specify the import library to link against for Arm32 build since the default set is minimal
 if (WIN32 AND CLI_CMAKE_PLATFORM_ARCH_ARM)

--- a/src/corehost/cli/fxr/CMakeLists.txt
+++ b/src/corehost/cli/fxr/CMakeLists.txt
@@ -56,6 +56,7 @@ if(WIN32)
     list(APPEND RESOURCES ../native.rc)
 endif()
 add_library(hostfxr SHARED ${SOURCES} ${RESOURCES})
+set_target_properties(hostfxr PROPERTIES MACOSX_RPATH TRUE)
 
 # Specify the import library to link against for Arm32 build since the default set is minimal
 if (WIN32 AND CLI_CMAKE_PLATFORM_ARCH_ARM)


### PR DESCRIPTION
On my system (using CMake 3.5.2), CMake emits a configure-time warning because the `MACOSX_RPATH` property is not set on the targets `hostfxr` and `hostpolicy`. I have gone ahead and set this property. The `MACOSX_RPATH` property is documented (by `cmake --help-property MACOSX_RPATH`) as follows:

```
MACOSX_RPATH
------------

Whether this target on OS X or iOS is located at runtime using rpaths.

When this property is set to ``TRUE``, the directory portion of
the ``install_name`` field of this shared library will be ``@rpath``
unless overridden by ``INSTALL_NAME_DIR``.  This indicates
the shared library is to be found at runtime using runtime
paths (rpaths).

This property is initialized by the value of the variable
``CMAKE_MACOSX_RPATH`` if it is set when a target is
created.

Runtime paths will also be embedded in binaries using this target and
can be controlled by the ``INSTALL_RPATH`` target property on
the target linking to this target.

Policy ``CMP0042`` was introduced to change the default value of
``MACOSX_RPATH`` to ``TRUE``.  This is because use of ``@rpath`` is a
more flexible and powerful alternative to ``@executable_path`` and
``@loader_path``.
```

Seeing as how the `dotnet` executable opens this library using `pal::load_library` (which [resolves to `dlopen`](https://github.com/dotnet/core-setup/blob/master/src/corehost/common/pal.unix.cpp#L69-L78)), this should not prove an issue with the corehost as written. However, if the libraries affected were ever to be embedded inside of a GUI application on macOS (a `*.app` bundle), this change may well affect the GUI application for the better, as the files will no longer expect to be installed in a fixed location, instead being located at load time based on the file that links against them. This enables macOS applications to be moved around on disk without breaking.