### PR TITLE
Add URL for dotnet/standard auto-updates

### DIFF
--- a/build_projects/update-dependencies/Config.cs
+++ b/build_projects/update-dependencies/Config.cs
@@ -40,7 +40,7 @@ namespace Microsoft.DotNet.Scripts
         private Lazy<string> _coreFxVersionUrl = new Lazy<string>(() => GetEnvironmentVariable("COREFX_VERSION_URL", "https://raw.githubusercontent.com/dotnet/versions/master/build-info/dotnet/corefx/master/Latest_Packages.txt"));
         private Lazy<string> _coreClrVersionUrl = new Lazy<string>(() => GetEnvironmentVariable("CORECLR_VERSION_URL", "https://raw.githubusercontent.com/dotnet/versions/master/build-info/dotnet/coreclr/master/Latest_Packages.txt"));
         private Lazy<string> _roslynVersionUrl = new Lazy<string>(() => GetEnvironmentVariable("ROSLYN_VERSION_URL", "https://raw.githubusercontent.com/dotnet/versions/master/build-info/dotnet/roslyn/netcore1.0/Latest_Packages.txt"));
-        private Lazy<string> _standardVersionUrl = new Lazy<string>(() => GetEnvironmentVariable("STANDARD_VERSION_URL", string.Empty));
+        private Lazy<string> _standardVersionUrl = new Lazy<string>(() => GetEnvironmentVariable("STANDARD_VERSION_URL", "https://raw.githubusercontent.com/dotnet/versions/master/build-info/dotnet/standard/master/Latest_Packages.txt"));
         private Lazy<string> _libuvVersionUrl = new Lazy<string>(() => GetEnvironmentVariable("LIBUV_VERSION_URL", string.Empty));
         private Lazy<string> _gitHubOriginOwner;
         private Lazy<string> _gitHubUpstreamOwner = new Lazy<string>(() => GetEnvironmentVariable("GITHUB_UPSTREAM_OWNER", "dotnet"));


### PR DESCRIPTION
Plugs the auto-update URL into the property introduced in https://github.com/dotnet/core-setup/pull/1347. Uses trigger added by https://github.com/dotnet/versions/pull/124.

Example: https://github.com/dagood/core-setup/commit/770309e814f1272e390803dd984c7ef23b99cda3

@ellismg @gkhanna79 @weshaggard 
FYI @eerhardt 