### PR TITLE
Update UWP MP dependency on Microsoft.Net.Native.Compiler to version 1.6.0

### DIFF
--- a/pkg/projects/Microsoft.NETCore.UniversalWindowsPlatform/project.json
+++ b/pkg/projects/Microsoft.NETCore.UniversalWindowsPlatform/project.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "Microsoft.Net.Native.Compiler": "1.5.0",
+    "Microsoft.Net.Native.Compiler": "1.6.0",
     "Microsoft.NETCore.Portable.Compatibility": "1.0.2",
     "Microsoft.NETCore.Runtime.CoreCLR": "1.0.3",
     "Microsoft.NETCore.Targets": "1.0.2",


### PR DESCRIPTION
This dependency existed in MP 5.3.0 that we shipped with Visual Studio 2017 RC 3, so I'm retroactively updating our package here.