### PR TITLE
Do not require unzip to be present to build

### DIFF
--- a/build_projects/shared-build-targets-utils/PackageDependencies.cs
+++ b/build_projects/shared-build-targets-utils/PackageDependencies.cs
@@ -81,7 +81,6 @@ namespace Microsoft.DotNet.Cli.Build
             {
                return new string[]
                {
-                    "unzip",
                     "libunwind",
                     "gettext",
                     "libcurl-devel",


### PR DESCRIPTION
`unzip` is not a dependency necessary to build.  While some parts of CoreFX will have a dependency on parts of zlib, we don't need the unzip binary itself.

I validated a build without unzip being present and everything worked.