### PR TITLE
Use same logic to prepare rootfs across dotnet if possible

### DIFF
--- a/cross/build-rootfs.sh
+++ b/cross/build-rootfs.sh
@@ -2,37 +2,48 @@
 
 usage()
 {
-    echo "Usage: $0 [BuildArch] [UbuntuCodeName] [lldbx.y] [--SkipUnmount]"
+    echo "Usage: $0 [BuildArch] [LinuxCodeName] [lldbx.y] [--skipunmount]"
     echo "BuildArch can be: arm(default), armel, x86"
-    echo "UbuntuCodeName - optional, Code name for Ubuntu, can be: trusty(default), vivid, wily, xenial. If BuildArch is armel, UbuntuCodeName is ignored."
+    echo "LinuxCodeName - optional, Code name for Linux, can be: trusty(default), vivid, wily, xenial. If BuildArch is armel, LinuxCodeName is jessie(default) or tizen."
     echo "lldbx.y - optional, LLDB version, can be: lldb3.6(default), lldb3.8"
-    echo "[--SkipUnmount] - do not unmount rootfs folders."
-
+    echo "--skipunmount - optional, will skip the unmount of rootfs folder."
     exit 1
 }
 
-__UbuntuCodeName=trusty
-
+__LinuxCodeName=trusty
 __CrossDir=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 __InitialDir=$PWD
 __BuildArch=arm
 __UbuntuArch=armhf
 __UbuntuRepo="http://ports.ubuntu.com/"
-__UbuntuPackagesBase="build-essential libunwind8-dev gettext symlinks liblttng-ust-dev libicu-dev"
 __LLDB_Package="lldb-3.6-dev"
-__UnprocessedBuildArgs=
 __SkipUnmount=0
 
-for i in "$@"
-    do
-        lowerI="$(echo $i | awk '{print tolower($0)}')"
-        case $lowerI in
+# base development support
+__UbuntuPackages="build-essential"
+
+# symlinks fixer
+__UbuntuPackages+=" symlinks"
+
+# CoreCLR and CoreFX dependencies
+__UbuntuPackages+=" gettext"
+__UbuntuPackages+=" libunwind8-dev"
+__UbuntuPackages+=" liblttng-ust-dev"
+__UbuntuPackages+=" libicu-dev"
+
+# CoreFX dependencies
+__UbuntuPackages+=" libcurl4-openssl-dev"
+__UbuntuPackages+=" libkrb5-dev"
+__UbuntuPackages+=" libssl-dev"
+__UbuntuPackages+=" zlib1g-dev"
+
+__UnprocessedBuildArgs=
+for i in "$@" ; do
+    lowerI="$(echo $i | awk '{print tolower($0)}')"
+    case $lowerI in
         -?|-h|--help)
             usage
             exit 1
-            ;;
-        --skipunmount)
-            __SkipUnmount=1
             ;;
         arm)
             __BuildArch=arm
@@ -42,7 +53,7 @@ for i in "$@"
             __BuildArch=armel
             __UbuntuArch=armel
             __UbuntuRepo="http://ftp.debian.org/debian/"
-            __UbuntuCodeName=jessie
+            __LinuxCodeName=jessie
             ;;
         x86)
             __BuildArch=x86
@@ -56,33 +67,36 @@ for i in "$@"
             __LLDB_Package="lldb-3.8-dev"
             ;;
         vivid)
-            if [ "$__UbuntuCodeName" != "jessie" ]; then
-                __UbuntuCodeName=vivid
+            if [ "$__LinuxCodeName" != "jessie" ]; then
+                __LinuxCodeName=vivid
             fi
             ;;
         wily)
-            if [ "$__UbuntuCodeName" != "jessie" ]; then
-                __UbuntuCodeName=wily
+            if [ "$__LinuxCodeName" != "jessie" ]; then
+                __LinuxCodeName=wily
             fi
             ;;
         xenial)
-            if [ "$__UbuntuCodeName" != "jessie" ]; then
-                __UbuntuCodeName=xenial
+            if [ "$__LinuxCodeName" != "jessie" ]; then
+                __LinuxCodeName=xenial
             fi
             ;;
         jessie)
-            __UbuntuCodeName=jessie
+            __LinuxCodeName=jessie
             __UbuntuRepo="http://ftp.debian.org/debian/"
             ;;
         tizen)
             if [ "$__BuildArch" != "armel" ]; then
-                echo "Tizen is available only for armel"
+                echo "Tizen is available only for armel."
                 usage;
                 exit 1;
             fi
-            __UbuntuCodeName=
+            __LinuxCodeName=
             __UbuntuRepo=
             __Tizen=tizen
+            ;;
+        --skipunmount)
+            __SkipUnmount=1
             ;;
         *)
             __UnprocessedBuildArgs="$__UnprocessedBuildArgs $i"
@@ -90,29 +104,31 @@ for i in "$@"
     esac
 done
 
+if [[ "$__BuildArch" == "arm" ]]; then
+    __UbuntuPackages+=" ${__LLDB_Package:-}"
+fi
+
 if [ "$__BuildArch" == "armel" ]; then
-     __LLDB_Package="lldb-3.5-dev"
+    __LLDB_Package="lldb-3.5-dev"
+    __UbuntuPackages+=" ${__LLDB_Package:-}"
 fi
 
 __RootfsDir="$__CrossDir/rootfs/$__BuildArch"
-__UbuntuPackages="$__UbuntuPackagesBase $__LLDB_Package"
 
 if [[ -n "$ROOTFS_DIR" ]]; then
     __RootfsDir=$ROOTFS_DIR
 fi
 
 if [ -d "$__RootfsDir" ]; then
-    
     if [ $__SkipUnmount == 0 ]; then
         umount $__RootfsDir/*
     fi
-
     rm -rf $__RootfsDir
 fi
 
-if [[ -n $__UbuntuCodeName ]]; then
-    qemu-debootstrap --arch $__UbuntuArch $__UbuntuCodeName $__RootfsDir $__UbuntuRepo
-    cp $__CrossDir/$__BuildArch/sources.list.$__UbuntuCodeName $__RootfsDir/etc/apt/sources.list
+if [[ -n $__LinuxCodeName ]]; then
+    qemu-debootstrap --arch $__UbuntuArch $__LinuxCodeName $__RootfsDir $__UbuntuRepo
+    cp $__CrossDir/$__BuildArch/sources.list.$__LinuxCodeName $__RootfsDir/etc/apt/sources.list
     chroot $__RootfsDir apt-get update
     chroot $__RootfsDir apt-get -f -y install
     chroot $__RootfsDir apt-get -y install $__UbuntuPackages
@@ -121,11 +137,10 @@ if [[ -n $__UbuntuCodeName ]]; then
     if [ $__SkipUnmount == 0 ]; then
         umount $__RootfsDir/*
     fi
-
 elif [ "$__Tizen" == "tizen" ]; then
     ROOTFS_DIR=$__RootfsDir $__CrossDir/$__BuildArch/tizen-build-rootfs.sh
 else
-    echo "Unsupported platform"
+    echo "Unsupported target platform."
     usage;
     exit 1
 fi


### PR DESCRIPTION
Refactoring code to make it as same as possible to coreclr.

The only remaining difference between core-setup and coreclr is supported architecture.

This is a follow-up PR of dotnet/coreclr/pull/9411 which also follows dotnet/corefx#15755 (merged).

Main issue for this: dotnet/core-setup#1432