### PR TITLE
Run Docker as current user in official builds

### DIFF
--- a/scripts/dockerrun-as-current-user.sh
+++ b/scripts/dockerrun-as-current-user.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) .NET Foundation and contributors. All rights reserved.
+# Licensed under the MIT license. See LICENSE file in the project root for full license information.
+#
+
+set -e
+
+docker run -u="$(id -u):$(id -g)" "$@"


### PR DESCRIPTION
In the PortableLinux and RHEL build definitions, "docker run" is called
directly, without specifying the user as which to run.  This means that
the build artifacts which are mapped to the host have "root" as their
owner, because "root" as the default Docker user.  This prevents the
build agent's user from being able to delete those files in subsequent
builds, causing official builds to fail.

This fix runs the Docker container as the same user ID and group ID as
the host, which causes the build artifacts to have that same owner so
that they can be deleted later. This is done in a new script because
invoking the "id" command to get the user ID within the build
definition is not trivial, so this is the simplest implementation.

This is a short-term fix to unblock the builds; I am considering
removing the volume-mapping and instead copying in the files for a
longer-term solution.