### PR TITLE
Set CoreHost RID to the current RID, not the target RID

### DIFF
--- a/build_projects/dotnet-host-build/CompileTargets.cs
+++ b/build_projects/dotnet-host-build/CompileTargets.cs
@@ -202,7 +202,7 @@ namespace Microsoft.DotNet.Host.Build
                 List<string> cmakeArgList = new List<string>();
 
                 string cmakeBaseRid, visualStudio, archMacro, arch;
-                string ridMacro = $"-DCLI_CMAKE_RUNTIME_ID:STRING={rid}";
+                string ridMacro = $"-DCLI_CMAKE_RUNTIME_ID:STRING=win10-{platform.ToLower()}";
                 string cmakeHostVer = $"-DCLI_CMAKE_HOST_VER:STRING={hostVersion.LatestHostVersion.ToString()}";
                 string cmakeAppHostVer = $"-DCLI_CMAKE_APPHOST_VER:STRING={hostVersion.LatestAppHostVersion.ToString()}";
                 string cmakeHostPolicyVer = $"-DCLI_CMAKE_HOST_POLICY_VER:STRING={hostVersion.LatestHostPolicyVersion.ToString()}";


### PR DESCRIPTION
[My commit in August](https://github.com/dotnet/core-setup/commit/20600ceb2e8be73bf63e72341132cf8125c8fcdb#diff-ff058bba01b969c51b1b7f3b68cd9fe0) changed the value we were passing to `DCLI_CMAKE_RUNTIME_ID` to always be equal to the base RID instead of the current RID as a part of getting ARM64 up and running. This commit reverts that behavior as progress towards https://github.com/dotnet/core-setup/issues/1504