### PR TITLE
Relax Debian Installer generation

### DIFF
--- a/build_projects/dotnet-host-build/DebTargets.cs
+++ b/build_projects/dotnet-host-build/DebTargets.cs
@@ -17,7 +17,6 @@ namespace Microsoft.DotNet.Host.Build
                 nameof(GenerateHostFxrDeb),
                 nameof(GenerateSharedFrameworkDeb))]
         [BuildPlatforms(BuildPlatform.Ubuntu, BuildPlatform.Debian)]
-        [BuildArchitectures(BuildArchitecture.x64)]
         public static BuildTargetResult GenerateDebs(BuildTargetContext c)
         {
             return c.Success();
@@ -162,7 +161,6 @@ namespace Microsoft.DotNet.Host.Build
         [Target(nameof(InstallSharedFramework),
                 nameof(RemovePackages))]
         [BuildPlatforms(BuildPlatform.Ubuntu, BuildPlatform.Debian)]
-        [BuildArchitectures(BuildArchitecture.x64)]
         public static BuildTargetResult TestDebInstaller(BuildTargetContext c)
         {
             return c.Success();


### PR DESCRIPTION
Allow generation of Debian packages for other architectures besides x64.