### PR TITLE
Fixes for Arm32 build

### DIFF
--- a/build_projects/dotnet-host-build/PublishTargets.cs
+++ b/build_projects/dotnet-host-build/PublishTargets.cs
@@ -268,6 +268,10 @@ namespace Microsoft.DotNet.Host.Build
             nameof(PublishTargets.PublishSharedFrameworkInstallerFileToAzure),
             nameof(PublishTargets.PublishCombinedMuxerHostFxrFrameworkInstallerFileToAzure))]
         [BuildPlatforms(BuildPlatform.Ubuntu, BuildPlatform.OSX, BuildPlatform.Windows, BuildPlatform.Debian)]
+
+        // We do not spport publishing platform installers for any other architecture on any supported platform
+        // yet.
+        [BuildArchitectures(BuildArchitecture.x64,BuildArchitecture.x86)]
         public static BuildTargetResult PublishInstallerFilesToAzure(BuildTargetContext c) => c.Success();
 
         [Target(
@@ -281,6 +285,9 @@ namespace Microsoft.DotNet.Host.Build
             nameof(PublishHostFxrDebToDebianRepo),
             nameof(PublishSharedHostDebToDebianRepo))]
         [BuildPlatforms(BuildPlatform.Ubuntu, BuildPlatform.Debian)]
+        // We do not spport publishing platform installers for any other architecture on any supported platform
+        // yet.
+        [BuildArchitectures(BuildArchitecture.x64)]
         public static BuildTargetResult PublishDebFilesToDebianRepo(BuildTargetContext c)
         {
             return c.Success();

--- a/buildpipeline/Core-Setup-CrossBuild.json
+++ b/buildpipeline/Core-Setup-CrossBuild.json
@@ -85,7 +85,7 @@
       },
       "inputs": {
         "filename": "docker",
-        "arguments": "exec -e PUBLISH_TO_AZURE_BLOB -e CONNECTION_STRING -e CLI_NUGET_FEED_URL -e CLI_NUGET_API_KEY -e NUGET_FEED_URL -e NUGET_API_KEY -e GITHUB_PASSWORD $(PB_DockerContainerName) $(PB_GitDirectory)/build.sh $(BuildArguments) $(portableLinux) --env-vars \"DISABLE_CROSSGEN=1,TARGETPLATFORM=$(PB_Architecture),TARGETRID=$(TargetRid)\"",
+        "arguments": "exec -e PUBLISH_TO_AZURE_BLOB -e CONNECTION_STRING -e CLI_NUGET_FEED_URL -e CLI_NUGET_API_KEY -e NUGET_FEED_URL -e NUGET_API_KEY -e GITHUB_PASSWORD $(PB_DockerContainerName) $(PB_GitDirectory)/build.sh $(BuildArguments) $(portableLinux) --env-vars \"DISABLE_CROSSGEN=1,TARGETPLATFORM=$(PB_Architecture),TARGETRID=$(TargetRid),CROSS=1\"",
         "workingFolder": "",
         "failOnStandardError": "false"
       }


### PR DESCRIPTION
Specify CROSS=1 for the cross build.

Ensure that platform installers are not attempted to be published for Arm32.