### PR TITLE
Use GetFileAttributesEx to determine presence of folder or file

### DIFF
--- a/src/corehost/common/pal.windows.cpp
+++ b/src/corehost/common/pal.windows.cpp
@@ -327,11 +327,15 @@ bool pal::file_exists(const string_t& path)
         return false;
     }
 
-    WIN32_FIND_DATAW data;
-    auto find_handle = ::FindFirstFileW(path.c_str(), &data);
-    bool found = find_handle != INVALID_HANDLE_VALUE;
-    ::FindClose(find_handle);
-    return found;
+
+    // We will attempt to fetch attributes for the file or folder in question that are
+    // returned only if they exist.
+    WIN32_FILE_ATTRIBUTE_DATA data;
+    if (GetFileAttributesExW(path.c_str(), GetFileExInfoStandard, &data) != 0) {
+        return true;
+    }
+    
+    return false;
 }
 
 void pal::readdir(const string_t& path, const string_t& pattern, std::vector<pal::string_t>* list)


### PR DESCRIPTION
This Windows specific issue happens since FindFirstFile , which is used to determine file/folder presence, cannot handle arguments that terminate with trailing slash without any file pattern arguments.

A more reliable way to do the same would be to use GetFileAttributesEx that can handle this case. Also, this aligns the Windows implementation of this PAL function with what is done on non-Windows using stat function.

@eerhardt @ramarag PTAL