### PR TITLE
Export __base_rid to be recognized by toolchain.cmake

### DIFF
--- a/cross/armel/toolchain.cmake
+++ b/cross/armel/toolchain.cmake
@@ -16,7 +16,7 @@ add_compile_options(--sysroot=${CROSS_ROOTFS})
 set(CROSS_LINK_FLAGS "${CROSS_LINK_FLAGS} -target ${TOOLCHAIN}")
 set(CROSS_LINK_FLAGS "${CROSS_LINK_FLAGS} --sysroot=${CROSS_ROOTFS}")
 
-if("${CLI_CMAKE_RUNTIME_ID}" MATCHES "tizen.*")
+if("$ENV{__CrossToolChainTargetRID}" MATCHES "tizen.*")
     set(TIZEN_TOOLCHAIN "armv7l-tizen-linux-gnueabi/4.9.2")
     include_directories(${CROSS_ROOTFS}/usr/lib/gcc/${TIZEN_TOOLCHAIN}/include/c++/)
     include_directories(${CROSS_ROOTFS}/usr/lib/gcc/${TIZEN_TOOLCHAIN}/include/c++/armv7l-tizen-linux-gnueabi)

--- a/src/corehost/build.sh
+++ b/src/corehost/build.sh
@@ -167,6 +167,7 @@ fi
 
 __build_arch_lowcase=$(echo "$__build_arch" | tr '[:upper:]' '[:lower:]')
 __base_rid=$__rid_plat-$__build_arch_lowcase
+export __CrossToolChainTargetRID=$__base_rid
 
 # Set up the environment to be used for building with clang.
 if which "clang-3.5" > /dev/null 2>&1; then


### PR DESCRIPTION
In an environment without gcc-arm-linux-gnueabi (such as a docker),
clang does not find a toolchain for tizen by default, and
in this case it must set the exact library location.
The CLI_CMAKE_RUNTIME_ID that is passed as an argument is not passed at check time in the clang,
so __base_rid environment is exported and used.

Related issue : #725 