### PR TITLE
Treat negative test failures as success

### DIFF
--- a/build_projects/Microsoft.DotNet.Cli.Build.Framework/Command.cs
+++ b/build_projects/Microsoft.DotNet.Cli.Build.Framework/Command.cs
@@ -162,6 +162,11 @@ namespace Microsoft.DotNet.Cli.Build.Framework
 
         public CommandResult Execute()
         {
+            return Execute(false);
+        }
+
+        public CommandResult Execute(bool fExpectedToFail)
+        {
             ThrowIfRunning();
             _running = true;
 
@@ -202,7 +207,7 @@ namespace Microsoft.DotNet.Cli.Build.Framework
 
             var exitCode = _process.ExitCode;
 
-            ReportExecEnd(exitCode);
+            ReportExecEnd(exitCode, fExpectedToFail);
 
             return new CommandResult(
                 _process.StartInfo,
@@ -315,13 +320,19 @@ namespace Microsoft.DotNet.Cli.Build.Framework
             }
         }
 
-        private void ReportExecEnd(int exitCode)
+        private void ReportExecEnd(int exitCode, bool fExpectedToFail)
         {
             if (!_quietBuildReporter)
             {
                 bool success = exitCode == 0;
+                string msgExpectedToFail = "";
 
-                var message = $"{FormatProcessInfo(_process.StartInfo, includeWorkingDirectory: !success)} exited with {exitCode}";
+                if (fExpectedToFail) {
+                    success = !success;
+                    msgExpectedToFail = "failed as expected and ";
+                }
+
+                var message = $"{FormatProcessInfo(_process.StartInfo, includeWorkingDirectory: !success)} {msgExpectedToFail}exited with {exitCode}";
 
                 BuildReporter.EndSection(
                     "EXEC",

--- a/test/HostActivationTests/GivenThatICareAboutPortableAppActivation.cs
+++ b/test/HostActivationTests/GivenThatICareAboutPortableAppActivation.cs
@@ -74,7 +74,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.PortableApp
             dotnet.Exec("exec", "--runtimeconfig", runtimeConfig, appDll)
                 .CaptureStdErr()
                 .CaptureStdOut()
-                .Execute()
+                .Execute(fExpectedToFail:true)
                 .Should()
                 .Fail();
         }
@@ -195,7 +195,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.PortableApp
             dotnet.Exec("exec", "--depsfile", depsJson, appDll)
                 .CaptureStdErr()
                 .CaptureStdOut()
-                .Execute()
+                .Execute(fExpectedToFail:true)
                 .Should()
                 .Fail();
         }

--- a/test/HostActivationTests/GivenThatICareAboutStandaloneAppActivation.cs
+++ b/test/HostActivationTests/GivenThatICareAboutStandaloneAppActivation.cs
@@ -92,7 +92,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.StandaloneApp
             int exitCode = Command.Create(appExe)
                 .CaptureStdErr()
                 .CaptureStdOut()
-                .Execute()
+                .Execute(fExpectedToFail:true)
                 .ExitCode;
 
             if (CurrentPlatform.IsWindows)


### PR DESCRIPTION
Core-Setup repo has bunch of negative tests that are expected to fail. However, in the console output, they come across as failed, per the logging infrastructure, even though their failing implies passing. As a result, it is difficult to distinguish between a real failure and negative test failure.

This change will enable negative tests to pass a flag to the test infrastructure (by invoke the Execute method with true bool as argument) to indicate that they are negative tests, so that they can be marked as passed, if they fail!

@ramarag PTAL

CC @cakine 