### PR TITLE
Mark XUnit negative test failure as success

### DIFF
--- a/test/HostActivationTests/GivenThatICareAboutDotnetTestXunitScenarios.cs
+++ b/test/HostActivationTests/GivenThatICareAboutDotnetTestXunitScenarios.cs
@@ -61,7 +61,7 @@ namespace Microsoft.DotNet.Tools.Publish.Tests
                     appDll)
                 .CaptureStdErr()
                 .CaptureStdOut()
-                .Execute()
+                .Execute(fExpectedToFail:true)
                 .Should()
                 .Fail()
                 .And


### PR DESCRIPTION
Mark an additional negative test failure as success.

CC @ramarag 