### PR TITLE
Push packages to full v2 feed url

### DIFF
--- a/buildpipeline/Core-Setup-CentOS-x64.json
+++ b/buildpipeline/Core-Setup-CentOS-x64.json
@@ -80,7 +80,7 @@
       "allowOverride": true
     },
     "NUGET_FEED_URL": {
-      "value": "https://dotnet.myget.org/F/dotnet-core"
+      "value": "https://dotnet.myget.org/F/dotnet-core/api/v2"
     },
     "NUGET_API_KEY": {
       "value": "PassedViaPipeBuild"

--- a/buildpipeline/Core-Setup-CrossBuild.json
+++ b/buildpipeline/Core-Setup-CrossBuild.json
@@ -234,7 +234,7 @@
       "value": "azure-apt-cat.cloudapp.net"
     },
     "NUGET_FEED_URL": {
-      "value": "https://dotnet.myget.org/F/dotnet-core"
+      "value": "https://dotnet.myget.org/F/dotnet-core/api/v2"
     },
     "NUGET_API_KEY": {
       "value": "PassedViaPipeBuild"

--- a/buildpipeline/Core-Setup-Debian8-x64.json
+++ b/buildpipeline/Core-Setup-Debian8-x64.json
@@ -80,7 +80,7 @@
       "allowOverride": true
     },
     "NUGET_FEED_URL": {
-      "value": "https://dotnet.myget.org/F/dotnet-core"
+      "value": "https://dotnet.myget.org/F/dotnet-core/api/v2"
     },
     "NUGET_API_KEY": {
       "value": "PassedViaPipeBuild"

--- a/buildpipeline/Core-Setup-Fedora23-x64.json
+++ b/buildpipeline/Core-Setup-Fedora23-x64.json
@@ -97,7 +97,7 @@
       "allowOverride": true
     },
     "NUGET_FEED_URL": {
-      "value": "https://dotnet.myget.org/F/dotnet-core"
+      "value": "https://dotnet.myget.org/F/dotnet-core/api/v2"
     },
     "NUGET_API_KEY": {
       "value": "PassedViaPipeBuild"

--- a/buildpipeline/Core-Setup-Fedora24-x64.json
+++ b/buildpipeline/Core-Setup-Fedora24-x64.json
@@ -78,7 +78,7 @@
       "allowOverride": true
     },
     "NUGET_FEED_URL": {
-      "value": "https://dotnet.myget.org/F/dotnet-core"
+      "value": "https://dotnet.myget.org/F/dotnet-core/api/v2"
     },
     "NUGET_API_KEY": {
       "value": "PassedViaPipeBuild"

--- a/buildpipeline/Core-Setup-OSX-x64.json
+++ b/buildpipeline/Core-Setup-OSX-x64.json
@@ -80,7 +80,7 @@
       "allowOverride": true
     },
     "NUGET_FEED_URL": {
-      "value": "https://dotnet.myget.org/F/dotnet-core"
+      "value": "https://dotnet.myget.org/F/dotnet-core/api/v2"
     },
     "NUGET_API_KEY": {
       "value": "PassedViaPipeBuild"

--- a/buildpipeline/Core-Setup-OpenSuse42.1-x64.json
+++ b/buildpipeline/Core-Setup-OpenSuse42.1-x64.json
@@ -78,7 +78,7 @@
       "allowOverride": true
     },
     "NUGET_FEED_URL": {
-      "value": "https://dotnet.myget.org/F/dotnet-core"
+      "value": "https://dotnet.myget.org/F/dotnet-core/api/v2"
     },
     "NUGET_API_KEY": {
       "value": "PassedViaPipeBuild"

--- a/buildpipeline/Core-Setup-PortableLinux-x64.json
+++ b/buildpipeline/Core-Setup-PortableLinux-x64.json
@@ -102,7 +102,7 @@
       "allowOverride": true
     },
     "NUGET_FEED_URL": {
-      "value": "https://dotnet.myget.org/F/dotnet-core"
+      "value": "https://dotnet.myget.org/F/dotnet-core/api/v2"
     },
     "NUGET_API_KEY": {
       "value": "PassedViaPipeBuild"

--- a/buildpipeline/Core-Setup-RHEL7-x64.json
+++ b/buildpipeline/Core-Setup-RHEL7-x64.json
@@ -102,7 +102,7 @@
       "allowOverride": true
     },
     "NUGET_FEED_URL": {
-      "value": "https://dotnet.myget.org/F/dotnet-core"
+      "value": "https://dotnet.myget.org/F/dotnet-core/api/v2"
     },
     "NUGET_API_KEY": {
       "value": "PassedViaPipeBuild"

--- a/buildpipeline/Core-Setup-Signing-Windows-x64.json
+++ b/buildpipeline/Core-Setup-Signing-Windows-x64.json
@@ -423,7 +423,7 @@
       "value": "true"
     },
     "NUGET_FEED_URL": {
-      "value": "https://dotnet.myget.org/F/dotnet-core"
+      "value": "https://dotnet.myget.org/F/dotnet-core/api/v2"
     },
     "NUGET_API_KEY": {
       "value": "PassedViaPipeBuild"

--- a/buildpipeline/Core-Setup-Signing-Windows-x86.json
+++ b/buildpipeline/Core-Setup-Signing-Windows-x86.json
@@ -396,7 +396,7 @@
       "value": "true"
     },
     "NUGET_FEED_URL": {
-      "value": "https://dotnet.myget.org/F/dotnet-core"
+      "value": "https://dotnet.myget.org/F/dotnet-core/api/v2"
     },
     "NUGET_API_KEY": {
       "value": "PassedViaPipeBuild"

--- a/buildpipeline/Core-Setup-Ubuntu14.04-x64.json
+++ b/buildpipeline/Core-Setup-Ubuntu14.04-x64.json
@@ -92,7 +92,7 @@
       "value": "azure-apt-cat.cloudapp.net"
     },
     "NUGET_FEED_URL": {
-      "value": "https://dotnet.myget.org/F/dotnet-core"
+      "value": "https://dotnet.myget.org/F/dotnet-core/api/v2"
     },
     "NUGET_API_KEY": {
       "value": "PassedViaPipeBuild"

--- a/buildpipeline/Core-Setup-Ubuntu16.04-x64.json
+++ b/buildpipeline/Core-Setup-Ubuntu16.04-x64.json
@@ -78,7 +78,7 @@
       "allowOverride": true
     },
     "NUGET_FEED_URL": {
-      "value": "https://dotnet.myget.org/F/dotnet-core"
+      "value": "https://dotnet.myget.org/F/dotnet-core/api/v2"
     },
     "NUGET_API_KEY": {
       "value": "PassedViaPipeBuild"

--- a/buildpipeline/Core-Setup-Ubuntu16.10-x64.json
+++ b/buildpipeline/Core-Setup-Ubuntu16.10-x64.json
@@ -78,7 +78,7 @@
       "allowOverride": true
     },
     "NUGET_FEED_URL": {
-      "value": "https://dotnet.myget.org/F/dotnet-core"
+      "value": "https://dotnet.myget.org/F/dotnet-core/api/v2"
     },
     "NUGET_API_KEY": {
       "value": "PassedViaPipeBuild"

--- a/buildpipeline/Core-Setup-Windows-arm32.json
+++ b/buildpipeline/Core-Setup-Windows-arm32.json
@@ -65,7 +65,7 @@
   ],
   "variables": {
     "NUGET_FEED_URL": {
-      "value": "https://dotnet.myget.org/F/dotnet-core"
+      "value": "https://dotnet.myget.org/F/dotnet-core/api/v2"
     },
     "NUGET_API_KEY": {
       "value": "PassedViaPipeBuild"

--- a/buildpipeline/Core-Setup-Windows-arm64.json
+++ b/buildpipeline/Core-Setup-Windows-arm64.json
@@ -65,7 +65,7 @@
   ],
   "variables": {
     "NUGET_FEED_URL": {
-      "value": "https://dotnet.myget.org/F/dotnet-core"
+      "value": "https://dotnet.myget.org/F/dotnet-core/api/v2"
     },
     "NUGET_API_KEY": {
       "value": "PassedViaPipeBuild"


### PR DESCRIPTION
Rather than using the abbreviated `F/dotnet-core` endpoint, use `F/dotnet-core/api/v2`. This is the current recommended push url for MyGet, and may help smooth out a publishing issue.