### PR TITLE
Change dotnet-deb-tool to prefercliruntime.

### DIFF
--- a/buildpipeline/Core-Setup-Ubuntu14.04-x64.json
+++ b/buildpipeline/Core-Setup-Ubuntu14.04-x64.json
@@ -101,7 +101,7 @@
       "value": "PassedViaPipeBuild"
     },
     "CLI_NUGET_FEED_URL": {
-      "value": "https://www.myget.org/F/core-setup-testing"
+      "value": "https://dotnet.myget.org/F/cli-deps"
     },
     "CLI_NUGET_API_KEY": {
       "value": "PassedViaPipeBuild"

--- a/setuptools/dotnet-deb-tool/project.json
+++ b/setuptools/dotnet-deb-tool/project.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.1-t-*",
+  "version": "2.0.0-beta-*",
   "buildOptions": {
     "emitEntryPoint": true,
     "compile": {
@@ -16,6 +16,7 @@
 
   "packOptions": {
     "files": {
+      "include": "prefercliruntime",
       "mappings":{
         "lib/netcoreapp1.0/tool/": {
           "include": "tool/**/*"


### PR DESCRIPTION
Also, fixing it to start publishing deb-tool to the cli-deps feed again.

We need deb-tool to prefercliruntime, so it can be ran on either 1.0 or 1.1 depending on what the CLI is running.  That way it can be invoked on distros that don't support 1.0.

@naamunds @gkhanna79 @wtgodbe @ravimeda 
