### PR TITLE
Enable HostFxrMsi to install side by side between releases and build-to-build.

### DIFF
--- a/build_projects/dotnet-host-build/MsiTargets.cs
+++ b/build_projects/dotnet-host-build/MsiTargets.cs
@@ -162,7 +162,7 @@ namespace Microsoft.DotNet.Host.Build
             var inputDir = c.BuildContext.Get<string>("HostFxrPublishRoot");
             var wixObjRoot = Path.Combine(Dirs.Output, "obj", "wix", "hostfxr");
             var hostFxrBrandName = $"'{Monikers.GetHostFxrBrandName(c)}'";
-			var upgradeCode = Utils.GenerateGuidFromName(HostFxrMsi).ToString().ToUpper();
+            var upgradeCode = Utils.GenerateGuidFromName(HostFxrMsi).ToString().ToUpper();
 
             if (Directory.Exists(wixObjRoot))
             {

--- a/build_projects/dotnet-host-build/MsiTargets.cs
+++ b/build_projects/dotnet-host-build/MsiTargets.cs
@@ -172,7 +172,7 @@ namespace Microsoft.DotNet.Host.Build
 
             Cmd("powershell", "-NoProfile", "-NoLogo",
                 Path.Combine(Dirs.RepoRoot, "packaging", "windows", "hostfxr", "generatemsi.ps1"),
-                inputDir, HostFxrMsi, WixRoot, hostFxrBrandName, hostFxrMsiVersion, hostFxrNugetVersion, MSIBuildArch, TargetArch, wixObjRoot,upgradeCode)
+                inputDir, HostFxrMsi, WixRoot, hostFxrBrandName, hostFxrMsiVersion, hostFxrNugetVersion, MSIBuildArch, TargetArch, wixObjRoot, upgradeCode)
                     .Execute()
                     .EnsureSuccessful();
             return c.Success();

--- a/build_projects/dotnet-host-build/MsiTargets.cs
+++ b/build_projects/dotnet-host-build/MsiTargets.cs
@@ -162,6 +162,7 @@ namespace Microsoft.DotNet.Host.Build
             var inputDir = c.BuildContext.Get<string>("HostFxrPublishRoot");
             var wixObjRoot = Path.Combine(Dirs.Output, "obj", "wix", "hostfxr");
             var hostFxrBrandName = $"'{Monikers.GetHostFxrBrandName(c)}'";
+			var upgradeCode = Utils.GenerateGuidFromName(HostFxrMsi).ToString().ToUpper();
 
             if (Directory.Exists(wixObjRoot))
             {
@@ -171,7 +172,7 @@ namespace Microsoft.DotNet.Host.Build
 
             Cmd("powershell", "-NoProfile", "-NoLogo",
                 Path.Combine(Dirs.RepoRoot, "packaging", "windows", "hostfxr", "generatemsi.ps1"),
-                inputDir, HostFxrMsi, WixRoot, hostFxrBrandName, hostFxrMsiVersion, hostFxrNugetVersion, MSIBuildArch, TargetArch, wixObjRoot)
+                inputDir, HostFxrMsi, WixRoot, hostFxrBrandName, hostFxrMsiVersion, hostFxrNugetVersion, MSIBuildArch, TargetArch, wixObjRoot,upgradeCode)
                     .Execute()
                     .EnsureSuccessful();
             return c.Success();

--- a/packaging/windows/hostfxr/generatemsi.ps1
+++ b/packaging/windows/hostfxr/generatemsi.ps1
@@ -10,7 +10,8 @@ param(
     [Parameter(Mandatory=$true)][string]$HostFxrNugetVersion,
     [Parameter(Mandatory=$true)][string]$Architecture,
     [Parameter(Mandatory=$true)][string]$TargetArchitecture,
-    [Parameter(Mandatory=$true)][string]$WixObjRoot
+    [Parameter(Mandatory=$true)][string]$WixObjRoot,
+	[Parameter(Mandatory=$true)][string]$HostFxrUpgradeCode
 )
 
 . "$PSScriptRoot\..\..\..\scripts\common\_common.ps1"
@@ -65,6 +66,7 @@ function RunCandle
         -dNugetVersion="$HostFxrNugetVersion" `
         -dComponentVersion="$ComponentVersion" `
         -dTargetArchitecture="$TargetArchitecture" `
+		-dUpgradeCode="$HostFxrUpgradeCode" `
         -arch $Architecture `
         -ext WixDependencyExtension.dll `
         "$AuthWsxRoot\hostfxr.wxs" `

--- a/packaging/windows/hostfxr/generatemsi.ps1
+++ b/packaging/windows/hostfxr/generatemsi.ps1
@@ -11,7 +11,7 @@ param(
     [Parameter(Mandatory=$true)][string]$Architecture,
     [Parameter(Mandatory=$true)][string]$TargetArchitecture,
     [Parameter(Mandatory=$true)][string]$WixObjRoot,
-	[Parameter(Mandatory=$true)][string]$HostFxrUpgradeCode
+    [Parameter(Mandatory=$true)][string]$HostFxrUpgradeCode
 )
 
 . "$PSScriptRoot\..\..\..\scripts\common\_common.ps1"
@@ -66,7 +66,7 @@ function RunCandle
         -dNugetVersion="$HostFxrNugetVersion" `
         -dComponentVersion="$ComponentVersion" `
         -dTargetArchitecture="$TargetArchitecture" `
-		-dUpgradeCode="$HostFxrUpgradeCode" `
+        -dUpgradeCode="$HostFxrUpgradeCode" `
         -arch $Architecture `
         -ext WixDependencyExtension.dll `
         "$AuthWsxRoot\hostfxr.wxs" `

--- a/packaging/windows/hostfxr/variables.wxi
+++ b/packaging/windows/hostfxr/variables.wxi
@@ -18,11 +18,9 @@
   <?if $(var.Platform)=x86?>
   <?define Program_Files="ProgramFilesFolder"?>
   <?define Win64AttributeValue=no?>
-  <?define UpgradeCode="CAA1E417-96A8-4560-A0E4-98E329E20A8B"?>
   <?elseif $(var.Platform)=x64?>
   <?define Program_Files="ProgramFiles64Folder"?>
   <?define Win64AttributeValue=yes?>
-  <?define UpgradeCode="6B33D104-1681-4382-8D4C-25CC69C1CFB9"?>
   <?else?>
   <?error Invalid Platform ($(var.Platform))?>
   <?endif?>


### PR DESCRIPTION
Enable HostFxrMsi to install side by side between releases and build-to-build. This fix is for 2.0 and will need similar fix for LTS branches.

Reference Issue:
https://github.com/dotnet/core-setup/issues/572

