### PR TITLE
Fix build break by only publishing dotnet-deb-tool for ubuntu.14.04-x64.

### DIFF
--- a/build_projects/dotnet-host-build/PublishTargets.cs
+++ b/build_projects/dotnet-host-build/PublishTargets.cs
@@ -60,6 +60,7 @@ namespace Microsoft.DotNet.Host.Build
 
         [Target]
         [BuildPlatforms(BuildPlatform.Ubuntu, "14.04")]
+        [BuildArchitectures(BuildArchitecture.x64)]
         public static BuildTargetResult PublishDotnetDebToolPackage(BuildTargetContext c)
         {
             string nugetFeedUrl = EnvVars.EnsureVariable("CLI_NUGET_FEED_URL");

--- a/buildpipeline/Core-Setup-CrossBuild.json
+++ b/buildpipeline/Core-Setup-CrossBuild.json
@@ -242,12 +242,6 @@
     "GITHUB_PASSWORD": {
       "value": "PassedViaPipeBuild"
     },
-    "CLI_NUGET_FEED_URL": {
-      "value": "https://www.myget.org/F/core-setup-testing"
-    },
-    "CLI_NUGET_API_KEY": {
-      "value": "PassedViaPipeBuild"
-    },
     "PB_RepoName": {
       "value": "core-setup"
     },

--- a/setuptools/dotnet-deb-tool/project.json
+++ b/setuptools/dotnet-deb-tool/project.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.0.0-beta-*",
+  "version": "2.0.0-*",
   "buildOptions": {
     "emitEntryPoint": true,
     "compile": {


### PR DESCRIPTION
Fix #1570

@naamunds @dagood @gkhanna79