### PR TITLE
Add Ubuntu 16.04 ARM CI script for cross build

### DIFF
--- a/scripts/arm32_ci_script.sh
+++ b/scripts/arm32_ci_script.sh
@@ -264,6 +264,12 @@ do
     esac
 done
 
+if [[ $__linuxCodeName == "xenial" || $__linuxCodeName == "tizen" ]]; then
+    # This case does not support CI build yet.
+    # Will be enabled ASAP.
+    exit 0
+fi
+
 #Check if there are any uncommited changes in the source directory as git adds and removes patches
 if [[ $(git status -s) != "" ]]; then
    echo 'ERROR: There are some uncommited changes. To avoid losing these changes commit them and try again.'


### PR DESCRIPTION

It adds Ubuntu16.04:arm:Release CI job only.
The arm32 script is temporarily disabled so it does nothing.
I will be enable the job soon.

Related issues: #1512, #1572 