### PR TITLE
Dynamic host rid

### DIFF
--- a/build_projects/dotnet-host-build/CompileTargets.cs
+++ b/build_projects/dotnet-host-build/CompileTargets.cs
@@ -170,7 +170,6 @@ namespace Microsoft.DotNet.Host.Build
         {
             var hostVersion = c.BuildContext.Get<HostVersion>("HostVersion");
             var configuration = c.BuildContext.Get<string>("Configuration");
-            string rid = c.BuildContext.Get<string>("TargetRID");
             string platform = c.BuildContext.Get<string>("Platform");
             string crossEnv = c.BuildContext.Get<string>("Cross");
             bool linkPortable = c.BuildContext.Get<bool>("LinkPortable");
@@ -201,7 +200,6 @@ namespace Microsoft.DotNet.Host.Build
                 List<string> cmakeArgList = new List<string>();
 
                 string cmakeBaseRid, visualStudio, archMacro, arch;
-                string ridMacro = $"-DCLI_CMAKE_RUNTIME_ID:STRING=win10-{platform.ToLower()}";
                 string cmakeHostVer = $"-DCLI_CMAKE_HOST_VER:STRING={hostVersion.LatestHostVersion.ToString()}";
                 string cmakeAppHostVer = $"-DCLI_CMAKE_APPHOST_VER:STRING={hostVersion.LatestAppHostVersion.ToString()}";
                 string cmakeHostPolicyVer = $"-DCLI_CMAKE_HOST_POLICY_VER:STRING={hostVersion.LatestHostPolicyVersion.ToString()}";
@@ -247,7 +245,6 @@ namespace Microsoft.DotNet.Host.Build
 
                 cmakeArgList.Add(corehostSrcDir);
                 cmakeArgList.Add(archMacro);
-                cmakeArgList.Add(ridMacro);
                 cmakeArgList.Add(cmakeHostVer);
                 cmakeArgList.Add(cmakeAppHostVer);
                 cmakeArgList.Add(cmakeHostFxrVer);
@@ -310,6 +307,8 @@ namespace Microsoft.DotNet.Host.Build
                 List<string> buildScriptArgList = new List<string>();
                 string buildScriptFile  = Path.Combine(corehostSrcDir, "build.sh");
 
+                buildScriptArgList.Add("--configuration");
+                buildScriptArgList.Add(configuration);
                 buildScriptArgList.Add("--arch");
                 buildScriptArgList.Add(arch);
                 buildScriptArgList.Add("--hostver");
@@ -320,8 +319,6 @@ namespace Microsoft.DotNet.Host.Build
                 buildScriptArgList.Add(hostVersion.LatestHostFxrVersion.ToString());
                 buildScriptArgList.Add("--policyver");
                 buildScriptArgList.Add(hostVersion.LatestHostPolicyVersion.ToString());
-                buildScriptArgList.Add("--rid");
-                buildScriptArgList.Add(rid);
                 buildScriptArgList.Add("--commithash");
                 buildScriptArgList.Add(commitHash);
 

--- a/src/Microsoft.DotNet.PlatformAbstractions/RuntimeEnvironment.cs
+++ b/src/Microsoft.DotNet.PlatformAbstractions/RuntimeEnvironment.cs
@@ -80,7 +80,7 @@ namespace Microsoft.DotNet.PlatformAbstractions
             }
             else if (ver.Major >= 10)
             {
-                // Use Win10-* RID even for newer platforms we do not know for so that existing Win10 assets can be used
+                // Use Win10-* RID even for newer platforms we do not know for, so that existing Win10 assets can be used
                 // to keep apps working.
                 return "10";
             }

--- a/src/Microsoft.DotNet.PlatformAbstractions/RuntimeEnvironment.cs
+++ b/src/Microsoft.DotNet.PlatformAbstractions/RuntimeEnvironment.cs
@@ -78,9 +78,10 @@ namespace Microsoft.DotNet.PlatformAbstractions
                     return "81";
                 }
             }
-            else if (ver.Major == 10 && ver.Minor == 0)
+            else if (ver.Major >= 10)
             {
-                // Not sure if there will be  10.x (where x > 0) or even 11, so let's be defensive.
+                // Use Win10-* RID even for newer platforms we do not know for so that existing Win10 assets can be used
+                // to keep apps working.
                 return "10";
             }
             return string.Empty; // Unknown version

--- a/src/corehost/cli/deps_format.cpp
+++ b/src/corehost/cli/deps_format.cpp
@@ -132,7 +132,7 @@ pal::string_t get_current_rid()
         currentRid = pal::get_current_os_rid_platform();
         if (!currentRid.empty())
         {
-        currentRid = currentRid + pal::string_t(_X("-")) + get_arch();
+            currentRid = currentRid + pal::string_t(_X("-")) + get_arch();
         }
     }
     

--- a/src/corehost/cli/setup.cmake
+++ b/src/corehost/cli/setup.cmake
@@ -96,12 +96,6 @@ if (WIN32 AND CLI_CMAKE_PLATFORM_ARCH_ARM)
       endif()
 endif ()
 
-if("${CLI_CMAKE_RUNTIME_ID}" STREQUAL "")
-    message(FATAL_ERROR "Runtime ID not specified")
-else()
-    add_definitions(-DTARGET_RUNTIME_ID="${CLI_CMAKE_RUNTIME_ID}")
-endif()
-
 if("${CLI_CMAKE_HOST_POLICY_VER}" STREQUAL "")
     message(FATAL_ERROR "Host policy version is not specified")
 else()

--- a/src/corehost/common/pal.h
+++ b/src/corehost/common/pal.h
@@ -193,6 +193,9 @@ namespace pal
     inline void err_flush() { std::fflush(stderr); }
     inline void out_flush() { std::fflush(stdout); }
 
+    // Based upon https://github.com/dotnet/core-setup/blob/master/src/Microsoft.DotNet.PlatformAbstractions/Native/PlatformApis.cs
+    pal::string_t get_current_os_rid_platform();
+        
     bool touch_file(const pal::string_t& path);
     bool realpath(string_t* path);
     bool file_exists(const string_t& path);

--- a/src/corehost/common/pal.unix.cpp
+++ b/src/corehost/common/pal.unix.cpp
@@ -249,7 +249,7 @@ bool pal::get_local_dotnet_dir(pal::string_t* recv)
 
 pal::string_t trim_quotes(pal::string_t stringToCleanup)
 {
-    char_t quote_array[2] = {'\"', '\''};
+    pal::char_t quote_array[2] = {'\"', '\''};
     for(int index = 0; index < sizeof(quote_array)/sizeof(quote_array[0]); index++)
     {
         size_t pos = stringToCleanup.find(quote_array[index]);


### PR DESCRIPTION
Today, the host uses a static RID hard-coded into it, at the time of build, to determine where to start the RID fallback from. This requires updating the host everytime a new RID is required to be supported and requires the host to be built on the OS corresponding to the RID.

With this change, we will compute the RID for the host at execution time, using the same approach as implemented in https://github.com/dotnet/core-setup/blob/master/src/Microsoft.DotNet.PlatformAbstractions/Native/PlatformApis.cs.

I also fixed an issue to specify the CMAKE_BUILD_TYPE to fix the broken debugging experience (basically source file mapping for busted).