### PR TITLE
Remove the Roslyn VB support from shared framework

### DIFF
--- a/TestAssets/TestProjects/PortableApp/project.json
+++ b/TestAssets/TestProjects/PortableApp/project.json
@@ -28,10 +28,6 @@
           "version": "1.3.0",
           "exclude": "all"
         },
-        "Microsoft.CodeAnalysis.VisualBasic": {
-          "version": "1.3.0",
-          "exclude": "all"
-        },
         "Microsoft.CSharp": {
           "version": "4.3.0",
           "exclude": "all"

--- a/TestAssets/TestProjects/PortableTestApp/project.json
+++ b/TestAssets/TestProjects/PortableTestApp/project.json
@@ -35,10 +35,6 @@
           "version": "1.3.0",
           "exclude": "all"
         },
-        "Microsoft.CodeAnalysis.VisualBasic": {
-          "version": "1.3.0",
-          "exclude": "all"
-        },
         "Microsoft.CSharp": {
           "version": "4.3.0",
           "exclude": "all"

--- a/TestAssets/TestProjects/SharedFxLookupPortableApp/project.json
+++ b/TestAssets/TestProjects/SharedFxLookupPortableApp/project.json
@@ -28,10 +28,6 @@
           "version": "1.3.0",
           "exclude": "all"
         },
-        "Microsoft.CodeAnalysis.VisualBasic": {
-          "version": "1.3.0",
-          "exclude": "all"
-        },
         "Microsoft.CSharp": {
           "version": "4.3.0",
           "exclude": "all"

--- a/TestAssets/TestProjects/StandaloneApp/project.json.template
+++ b/TestAssets/TestProjects/StandaloneApp/project.json.template
@@ -24,10 +24,6 @@
           "version": "1.3.0",
           "exclude": "all"
         },
-        "Microsoft.CodeAnalysis.VisualBasic": {
-          "version": "1.3.0",
-          "exclude": "all"
-        },
         "Microsoft.CSharp": {
           "version": "4.3.0",
           "exclude": "all"

--- a/TestAssets/TestProjects/StandaloneTestApp/project.json.template
+++ b/TestAssets/TestProjects/StandaloneTestApp/project.json.template
@@ -31,10 +31,6 @@
           "version": "1.3.0",
           "exclude": "all"
         },
-        "Microsoft.CodeAnalysis.VisualBasic": {
-          "version": "1.3.0",
-          "exclude": "all"
-        },
         "Microsoft.CSharp": {
           "version": "4.3.0",
           "exclude": "all"

--- a/pkg/projects/Microsoft.NETCore.App/project.json.template
+++ b/pkg/projects/Microsoft.NETCore.App/project.json.template
@@ -4,10 +4,6 @@
       "version": "1.3.0",
       "exclude": "compile"
     },
-    "Microsoft.CodeAnalysis.VisualBasic": {
-      "version": "1.3.0",
-      "exclude": "compile"
-    },
     "Microsoft.Private.CoreFx.NETCoreApp": "4.4.0-beta-25011-01",
     "Microsoft.NETCore.Runtime.CoreCLR": "2.0.0-beta-25013-01",
     "Microsoft.DiaSymReader.Native": "1.4.0",


### PR DESCRIPTION
VB support for Roslyn is a pretty large assembly which we don't
need for the mainline scenarios so we are removing from the
shared framework.

cc @ericstj @jaredpar @Petermarcu 