### PR TITLE
Roll Forward On No Candidate Fx implemented

### DIFF
--- a/TestAssets/TestUtils/SharedFxLookup/SharedFxLookupPortableApp_prerelease.runtimeconfig.json
+++ b/TestAssets/TestUtils/SharedFxLookup/SharedFxLookupPortableApp_prerelease.runtimeconfig.json
@@ -1,8 +1,0 @@
-{
-  "runtimeOptions": {
-    "framework": {
-      "name": "Microsoft.NETCore.App",
-      "version": "9999.0.0-dummy0"
-    }
-  }
-}

--- a/TestAssets/TestUtils/SharedFxLookup/SharedFxLookupPortableApp_production.runtimeconfig.json
+++ b/TestAssets/TestUtils/SharedFxLookup/SharedFxLookupPortableApp_production.runtimeconfig.json
@@ -1,8 +1,0 @@
-{
-  "runtimeOptions": {
-    "framework": {
-      "name": "Microsoft.NETCore.App",
-      "version": "9999.0.0"
-    }
-  }
-}

--- a/src/corehost/cli/fxr/fx_muxer.h
+++ b/src/corehost/cli/fxr/fx_muxer.h
@@ -33,8 +33,8 @@ private:
         const std::vector<pal::string_t>& probe_realpaths,
         const runtime_config_t& config,
         pal::string_t* impl_dir);
-    static void resolve_roll_forward(pal::string_t& fx_dir, const pal::string_t& fx_ver, const fx_ver_t& specified);
-    static pal::string_t resolve_fx_dir(host_mode_t mode, const pal::string_t& own_dir, const runtime_config_t& config, const pal::string_t& specified_fx_version);
+    static void resolve_roll_forward(pal::string_t& fx_dir, const pal::string_t& fx_ver, const fx_ver_t& specified, const bool& patch_roll_fwd, const int& roll_fwd_on_no_candidate_fx);
+    static pal::string_t resolve_fx_dir(host_mode_t mode, const pal::string_t& own_dir, const runtime_config_t& config, const pal::string_t& specified_fx_version, const int& roll_fwd_on_no_candidate_fx_val);
     static pal::string_t resolve_cli_version(const pal::string_t& global);
     static bool resolve_sdk_dotnet_path(const pal::string_t& own_dir, pal::string_t* cli_sdk);
 };

--- a/src/corehost/cli/fxr/fx_ver.cpp
+++ b/src/corehost/cli/fxr/fx_ver.cpp
@@ -44,6 +44,16 @@ bool fx_ver_t::operator >(const fx_ver_t& b) const
     return compare(*this, b) > 0;
 }
 
+bool fx_ver_t::operator <=(const fx_ver_t& b) const
+{
+    return compare(*this, b) <= 0;
+}
+
+bool fx_ver_t::operator >=(const fx_ver_t& b) const
+{
+    return compare(*this, b) >= 0;
+}
+
 pal::string_t fx_ver_t::as_str() const
 {
     pal::stringstream_t stream;

--- a/src/corehost/cli/fxr/fx_ver.h
+++ b/src/corehost/cli/fxr/fx_ver.h
@@ -32,6 +32,8 @@ struct fx_ver_t
     bool operator !=(const fx_ver_t& b) const;
     bool operator <(const fx_ver_t& b) const;
     bool operator >(const fx_ver_t& b) const;
+    bool operator <=(const fx_ver_t& b) const;
+    bool operator >=(const fx_ver_t& b) const;
 
     static bool parse(const pal::string_t& ver, fx_ver_t* fx_ver, bool parse_only_production = false);
 

--- a/src/corehost/cli/fxr/hostfxr.cpp
+++ b/src/corehost/cli/fxr/hostfxr.cpp
@@ -64,6 +64,9 @@ int execute_app(
         return code;
     }
 
+    // Previous hostfxr trace messages must be printed before calling trace::setup in hostpolicy
+    trace::flush();
+
     const host_interface_t& intf = init->get_host_init_data();
     if ((code = host_load(&intf)) == 0)
     {

--- a/src/corehost/cli/hostpolicy.cpp
+++ b/src/corehost/cli/hostpolicy.cpp
@@ -211,6 +211,9 @@ int run(const arguments_t& args)
     breadcrumb_writer_t writer(&breadcrumbs);
     writer.begin_write();
 
+    // Previous hostpolicy trace messages must be printed before executing assembly
+    trace::flush();
+
     // Execute the application
     unsigned int exit_code = 1;
     hr = coreclr::execute_assembly(

--- a/src/corehost/cli/runtime_config.cpp
+++ b/src/corehost/cli/runtime_config.cpp
@@ -11,6 +11,7 @@
 runtime_config_t::runtime_config_t(const pal::string_t& path, const pal::string_t& dev_path)
     : m_patch_roll_fwd(true)
     , m_prerelease_roll_fwd(false)
+    , m_roll_fwd_on_no_candidate_fx(0)
     , m_path(path)
     , m_dev_path(dev_path)
     , m_portable(false)
@@ -69,6 +70,20 @@ bool runtime_config_t::parse_opts(const json_value& opts)
     if (prerelease_roll_fwd != opts_obj.end())
     {
         m_prerelease_roll_fwd = prerelease_roll_fwd->second.as_bool();
+    }
+
+    auto roll_fwd_on_no_candidate_fx = opts_obj.find(_X("rollForwardOnNoCandidateFx"));
+    if (roll_fwd_on_no_candidate_fx != opts_obj.end())
+    {
+        m_roll_fwd_on_no_candidate_fx = roll_fwd_on_no_candidate_fx->second.as_integer();
+    }
+    else
+    {
+        pal::string_t env_no_candidate;
+        if (pal::getenv(_X("DOTNET_ROLL_FORWARD_ON_NO_CANDIDATE_FX"), &env_no_candidate))
+        {
+            m_roll_fwd_on_no_candidate_fx = pal::xtoi(env_no_candidate.c_str());
+        }
     }
 
     auto tfm = opts_obj.find(_X("tfm"));
@@ -210,6 +225,12 @@ bool runtime_config_t::get_prerelease_roll_fwd() const
 {
     assert(m_valid);
     return m_prerelease_roll_fwd;
+}
+
+int runtime_config_t::get_roll_fwd_on_no_candidate_fx() const
+{
+    assert(m_valid);
+    return m_roll_fwd_on_no_candidate_fx;
 }
 
 bool runtime_config_t::get_portable() const

--- a/src/corehost/cli/runtime_config.h
+++ b/src/corehost/cli/runtime_config.h
@@ -25,6 +25,7 @@ public:
     const std::list<pal::string_t>& get_probe_paths() const;
     bool get_patch_roll_fwd() const;
     bool get_prerelease_roll_fwd() const;
+    int get_roll_fwd_on_no_candidate_fx() const;
     bool get_portable() const;
     bool parse_opts(const json_value& opts);
     void config_kv(std::vector<pal::string_t>*, std::vector<pal::string_t>*) const;
@@ -42,6 +43,7 @@ private:
     pal::string_t m_fx_ver;
     bool m_patch_roll_fwd;
     bool m_prerelease_roll_fwd;
+    int m_roll_fwd_on_no_candidate_fx;
 
     pal::string_t m_dev_path;
     pal::string_t m_path;

--- a/src/corehost/common/pal.h
+++ b/src/corehost/common/pal.h
@@ -190,6 +190,9 @@ namespace pal
     bool get_os_moniker(os_moniker_t* moniker);
 #endif
 
+    inline void err_flush() { std::fflush(stderr); }
+    inline void out_flush() { std::fflush(stdout); }
+
     bool touch_file(const pal::string_t& path);
     bool realpath(string_t* path);
     bool file_exists(const string_t& path);

--- a/src/corehost/common/trace.cpp
+++ b/src/corehost/common/trace.cpp
@@ -89,3 +89,9 @@ void trace::warning(const pal::char_t* format, ...)
         va_end(args);
     }
 }
+
+void trace::flush()
+{
+    pal::err_flush();
+    pal::out_flush();
+}

--- a/src/corehost/common/trace.h
+++ b/src/corehost/common/trace.h
@@ -17,6 +17,7 @@ namespace trace
     void error(const pal::char_t* format, ...);
     void println(const pal::char_t* format, ...);
     void println();
+    void flush();
 };
 
 #endif // TRACE_H

--- a/src/corehost/corehost.cpp
+++ b/src/corehost/corehost.cpp
@@ -174,6 +174,9 @@ int run(const int argc, const pal::char_t* argv[])
         return StatusCode::CoreHostLibLoadFailure;
     }
 
+    // Previous corehost trace messages must be printed before calling trace::setup in hostfxr
+    trace::flush();
+
     // Obtain the entrypoints.
     hostfxr_main_fn main_fn = (hostfxr_main_fn) pal::get_symbol(fxr, "hostfxr_main");
     int code = main_fn(argc, argv);

--- a/test/HostActivationTests/GivenThatICareAboutMultilevelSharedFxLookup.cs
+++ b/test/HostActivationTests/GivenThatICareAboutMultilevelSharedFxLookup.cs
@@ -1,7 +1,8 @@
-﻿using System;
+﻿using Microsoft.DotNet.InternalAbstractions;
+using Newtonsoft.Json.Linq;
+using System;
 using System.IO;
 using Xunit;
-using Microsoft.DotNet.InternalAbstractions;
 
 namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.MultilevelSharedFxLookup
 {
@@ -90,7 +91,8 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.MultilevelSharedFxLooku
             var appDll = fixture.TestProject.AppDll;
 
             // Set desired version = 9999.0.0
-            SetProductionRuntimeConfig(fixture);
+            string runtimeConfig = Path.Combine(fixture.TestProject.OutputDirectory, "SharedFxLookupPortableApp.runtimeconfig.json");
+            SetRuntimeConfigJson(runtimeConfig, "9999.0.0");
 
             // Add a dummy version in the exe dir
             AddAvailableSharedFxVersions(_exeSharedFxBaseDir, "9999.0.0");
@@ -167,7 +169,8 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.MultilevelSharedFxLooku
             AddAvailableSharedFxVersions(_exeSharedFxBaseDir, "9999.0.0", "9999.0.0-dummy0");
 
             // Set desired version = 9999.0.0-dummy0
-            SetPrereleaseRuntimeConfig(fixture);
+            string runtimeConfig = Path.Combine(fixture.TestProject.OutputDirectory, "SharedFxLookupPortableApp.runtimeconfig.json");
+            SetRuntimeConfigJson(runtimeConfig, "9999.0.0-dummy0");
 
             // Version: 9999.0.0-dummy0
             // CWD: empty
@@ -205,7 +208,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.MultilevelSharedFxLooku
                 .HaveStdErrContaining(Path.Combine(_cwdSelectedMessage, "9999.0.0-dummy1"));
 
             // Set desired version = 9999.0.0
-            SetProductionRuntimeConfig(fixture);
+            SetRuntimeConfigJson(runtimeConfig, "9999.0.0");
 
             // Version: 9999.0.0
             // CWD: 9999.0.0-dummy1
@@ -296,6 +299,288 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.MultilevelSharedFxLooku
             DeleteAvailableSharedFxVersions(_userSharedFxBaseDir, "9999.0.2", "9999.0.0-dummy2");
         }
 
+        [Fact]
+        public void Roll_Forward_On_No_Candidate_Fx_Must_Happen_If_Compatible_Patch_Version_Is_Not_Available()
+        {
+            var fixture = PreviouslyBuiltAndRestoredPortableTestProjectFixture
+                .Copy();
+
+            var dotnet = fixture.BuiltDotnet;
+            var appDll = fixture.TestProject.AppDll;
+
+            // Set desired version = 9999.0.0
+            string runtimeConfig = Path.Combine(fixture.TestProject.OutputDirectory, "SharedFxLookupPortableApp.runtimeconfig.json");
+            SetRuntimeConfigJson(runtimeConfig, "9999.0.0");
+
+            // Add some dummy versions in the cwd
+            AddAvailableSharedFxVersions(_cwdSharedFxBaseDir, "10000.1.1", "10000.1.3");
+
+            // Version: 9999.0.0
+            // 'Roll forward on no candidate fx' enabled through env var
+            // CWD: 10000.1.1, 10000.1.3
+            // Expected: 10000.1.3 from cwd
+            dotnet.Exec(appDll)
+                .WorkingDirectory(_currentWorkingDir)
+                .EnvironmentVariable("DOTNET_ROLL_FORWARD_ON_NO_CANDIDATE_FX", "1")
+                .EnvironmentVariable("COREHOST_TRACE", "1")
+                .CaptureStdOut()
+                .CaptureStdErr()
+                .Execute()
+                .Should()
+                .Pass()
+                .And
+                .HaveStdErrContaining(Path.Combine(_cwdSelectedMessage, "10000.1.3"));
+
+            // Add a dummy version in the cwd
+            AddAvailableSharedFxVersions(_cwdSharedFxBaseDir, "9999.1.1");
+
+            // Version: 9999.0.0
+            // 'Roll forward on no candidate fx' enabled through env var
+            // CWD: 9999.1.1, 10000.1.1, 10000.1.3
+            // Expected: 9999.1.1 from cwd
+            dotnet.Exec(appDll)
+                .WorkingDirectory(_currentWorkingDir)
+                .EnvironmentVariable("DOTNET_ROLL_FORWARD_ON_NO_CANDIDATE_FX", "1")
+                .EnvironmentVariable("COREHOST_TRACE", "1")
+                .CaptureStdOut()
+                .CaptureStdErr()
+                .Execute()
+                .Should()
+                .Pass()
+                .And
+                .HaveStdErrContaining(Path.Combine(_cwdSelectedMessage, "9999.1.1"));
+        }
+
+        [Fact]
+        public void Roll_Forward_On_No_Candidate_Fx_Fails_If_No_Higher_Version_Is_Available()
+        {
+            var fixture = PreviouslyBuiltAndRestoredPortableTestProjectFixture
+                .Copy();
+
+            var dotnet = fixture.BuiltDotnet;
+            var appDll = fixture.TestProject.AppDll;
+
+            // Set desired version = 9999.1.1
+            string runtimeConfig = Path.Combine(fixture.TestProject.OutputDirectory, "SharedFxLookupPortableApp.runtimeconfig.json");
+            SetRuntimeConfigJson(runtimeConfig, "9999.1.1");
+
+            // Add some dummy versions in the cwd
+            AddAvailableSharedFxVersions(_cwdSharedFxBaseDir, "9998.0.1", "9998.1.0", "9999.0.0", "9999.0.1", "9999.1.0");
+
+            // Version: 9999.1.1
+            // 'Roll forward on no candidate fx' enabled through env var
+            // CWD: 9998.0.1, 9998.1.0, 9999.0.0, 9999.0.1, 9999.1.0
+            // Expected: no compatible version
+            dotnet.Exec(appDll)
+                .WorkingDirectory(_currentWorkingDir)
+                .EnvironmentVariable("DOTNET_ROLL_FORWARD_ON_NO_CANDIDATE_FX", "1")
+                .EnvironmentVariable("COREHOST_TRACE", "1")
+                .CaptureStdOut()
+                .CaptureStdErr()
+                .Execute(fExpectedToFail:true)
+                .Should()
+                .Fail()
+                .And
+                .HaveStdErrContaining("It was not possible to find any compatible framework version");
+        }
+
+        [Fact]
+        public void Roll_Forward_On_No_Candidate_Fx_Must_Look_Into_All_Lookup_Folders()
+        {
+            var fixture = PreviouslyBuiltAndRestoredPortableTestProjectFixture
+                .Copy();
+
+            var dotnet = fixture.BuiltDotnet;
+            var appDll = fixture.TestProject.AppDll;
+
+            // Set desired version = 9999.0.0
+            string runtimeConfig = Path.Combine(fixture.TestProject.OutputDirectory, "SharedFxLookupPortableApp.runtimeconfig.json");
+            SetRuntimeConfigJson(runtimeConfig, "9999.0.0");
+
+            // Add a dummy version in the exe dir
+            AddAvailableSharedFxVersions(_exeSharedFxBaseDir, "9999.1.0");
+
+            // Version: 9999.0.0
+            // 'Roll forward on no candidate fx' enabled through env var
+            // CWD: empty
+            // User: empty
+            // Exe: 9999.1.0
+            // Expected: 9999.1.0 from exe dir
+            dotnet.Exec(appDll)
+                .WorkingDirectory(_currentWorkingDir)
+                .EnvironmentVariable("DOTNET_ROLL_FORWARD_ON_NO_CANDIDATE_FX", "1")
+                .EnvironmentVariable("COREHOST_TRACE", "1")
+                .CaptureStdOut()
+                .CaptureStdErr()
+                .Execute()
+                .Should()
+                .Pass()
+                .And
+                .HaveStdErrContaining(_exeSelectedMessage);
+
+            // Add a dummy version in the user dir
+            AddAvailableSharedFxVersions(_userSharedFxBaseDir, "9999.1.1");
+
+            // Version: 9999.0.0
+            // 'Roll forward on no candidate fx' enabled through env var
+            // CWD: empty
+            // User: 9999.1.1
+            // Exe: 9999.1.0
+            // Expected: 9999.1.1 from user dir
+            dotnet.Exec(appDll)
+                .WorkingDirectory(_currentWorkingDir)
+                .EnvironmentVariable("DOTNET_ROLL_FORWARD_ON_NO_CANDIDATE_FX", "1")
+                .EnvironmentVariable("COREHOST_TRACE", "1")
+                .CaptureStdOut()
+                .CaptureStdErr()
+                .Execute()
+                .Should()
+                .Pass()
+                .And
+                .HaveStdErrContaining(_userSelectedMessage);
+
+            // Add a dummy version in the cwd
+            AddAvailableSharedFxVersions(_cwdSharedFxBaseDir, "10000.0.0");
+
+            // Version: 9999.0.0
+            // 'Roll forward on no candidate fx' enabled through env var
+            // CWD: 10000.0.0
+            // User: 9999.1.1
+            // Exe: 9999.1.0
+            // Expected: 10000.0.0 from cwd
+            dotnet.Exec(appDll)
+                .WorkingDirectory(_currentWorkingDir)
+                .EnvironmentVariable("DOTNET_ROLL_FORWARD_ON_NO_CANDIDATE_FX", "1")
+                .EnvironmentVariable("COREHOST_TRACE", "1")
+                .CaptureStdOut()
+                .CaptureStdErr()
+                .Execute()
+                .Should()
+                .Pass()
+                .And
+                .HaveStdErrContaining(_cwdSelectedMessage);
+
+            // Remove dummy folders from user dir
+            DeleteAvailableSharedFxVersions(_userSharedFxBaseDir, "9999.1.1");
+        }
+
+        [Fact]
+        public void Roll_Forward_On_No_Candidate_Fx_May_Be_Enabled_Through_Runtimeconfig_Json_File()
+        {
+            var fixture = PreviouslyBuiltAndRestoredPortableTestProjectFixture
+                .Copy();
+
+            var dotnet = fixture.BuiltDotnet;
+            var appDll = fixture.TestProject.AppDll;
+
+            // Set desired version = 9999.0.0
+            // Enable 'roll forward on no candidate fx' through runtimeconfig
+            string runtimeConfig = Path.Combine(fixture.TestProject.OutputDirectory, "SharedFxLookupPortableApp.runtimeconfig.json");
+            SetRuntimeConfigJson(runtimeConfig, "9999.0.0", 1);
+
+            // Add some dummy versions
+            AddAvailableSharedFxVersions(_cwdSharedFxBaseDir, "9999.1.0");
+            AddAvailableSharedFxVersions(_exeSharedFxBaseDir, "9999.0.0");
+
+            // Version: 9999.0.0
+            // 'Roll forward on no candidate fx' enabled through runtimeconfig
+            // CWD: 9999.1.0
+            // User: empty
+            // Exe: 9999.0.0
+            // Expected: 9999.1.0 from cwd
+            dotnet.Exec(appDll)
+                .WorkingDirectory(_currentWorkingDir)
+                .EnvironmentVariable("COREHOST_TRACE", "1")
+                .CaptureStdOut()
+                .CaptureStdErr()
+                .Execute()
+                .Should()
+                .Pass()
+                .And
+                .HaveStdErrContaining(_cwdSelectedMessage);
+
+            // Set desired version = 9999.0.0
+            // Disable 'roll forward on no candidate fx' through runtimeconfig
+            runtimeConfig = Path.Combine(fixture.TestProject.OutputDirectory, "SharedFxLookupPortableApp.runtimeconfig.json");
+            SetRuntimeConfigJson(runtimeConfig, "9999.0.0", 0);
+
+            // Version: 9999.0.0
+            // 'Roll forward on no candidate fx' disabled through runtimeconfig
+            // CWD: 9999.1.0
+            // User: empty
+            // Exe: 9999.0.0
+            // Expected: 9999.0.0 from exe dir
+            dotnet.Exec(appDll)
+                .WorkingDirectory(_currentWorkingDir)
+                .EnvironmentVariable("DOTNET_ROLL_FORWARD_ON_NO_CANDIDATE_FX", "1")
+                .EnvironmentVariable("COREHOST_TRACE", "1")
+                .CaptureStdOut()
+                .CaptureStdErr()
+                .Execute()
+                .Should()
+                .Pass()
+                .And
+                .HaveStdErrContaining(_exeSelectedMessage);
+        }
+
+        [Fact]
+        public void Roll_Forward_On_No_Candidate_Fx_May_Be_Enabled_Through_Argument()
+        {
+            var fixture = PreviouslyBuiltAndRestoredPortableTestProjectFixture
+                .Copy();
+
+            var dotnet = fixture.BuiltDotnet;
+            var appDll = fixture.TestProject.AppDll;
+
+            // Set desired version = 9999.0.0
+            // Disable 'roll forward on no candidate fx' through Runtimeconfig
+            string runtimeConfig = Path.Combine(fixture.TestProject.OutputDirectory, "SharedFxLookupPortableApp.runtimeconfig.json");
+            SetRuntimeConfigJson(runtimeConfig, "9999.0.0", 0);
+
+            // Add some dummy versions
+            AddAvailableSharedFxVersions(_cwdSharedFxBaseDir, "9999.1.0");
+            AddAvailableSharedFxVersions(_exeSharedFxBaseDir, "9999.0.0");
+
+            // Version: 9999.0.0
+            // 'Roll forward on no candidate fx' enabled through argument
+            // CWD: 9999.1.0
+            // User: empty
+            // Exe: 9999.0.0
+            // Expected: 9999.1.0 from cwd
+            dotnet.Exec("--roll-forward-on-no-candidate-fx", "1", appDll)
+                .WorkingDirectory(_currentWorkingDir)
+                .EnvironmentVariable("COREHOST_TRACE", "1")
+                .CaptureStdOut()
+                .CaptureStdErr()
+                .Execute()
+                .Should()
+                .Pass()
+                .And
+                .HaveStdErrContaining(_cwdSelectedMessage);
+
+            // Set desired version = 9999.0.0
+            // Enable 'roll forward on no candidate fx' through Runtimeconfig
+            SetRuntimeConfigJson(runtimeConfig, "9999.0.0", 1);
+
+            // Version: 9999.0.0
+            // 'Roll forward on no candidate fx' disabled through argument
+            // CWD: 9999.1.0
+            // User: empty
+            // Exe: 9999.0.0
+            // Expected: 9999.0.0 from exe dir
+            dotnet.Exec("--roll-forward-on-no-candidate-fx", "0", appDll)
+                .WorkingDirectory(_currentWorkingDir)
+                .EnvironmentVariable("DOTNET_ROLL_FORWARD_ON_NO_CANDIDATE_FX", "1")
+                .EnvironmentVariable("COREHOST_TRACE", "1")
+                .CaptureStdOut()
+                .CaptureStdErr()
+                .Execute()
+                .Should()
+                .Pass()
+                .And
+                .HaveStdErrContaining(_exeSelectedMessage);
+        }
+
         // This method adds a list of new framework version folders in the specified
         // sharedFxBaseDir. The files are copied from the _buildSharedFxDir.
         // Remarks:
@@ -384,24 +669,6 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.MultilevelSharedFxLooku
             }
         }
 
-        // Overwrites the fixture's runtimeconfig.json. The specified version is 9999.0.0-dummy0
-        private void SetPrereleaseRuntimeConfig(TestProjectFixture fixture)
-        {
-            string destFile = Path.Combine(fixture.TestProject.OutputDirectory, "SharedFxLookupPortableApp.runtimeconfig.json");
-            string srcFile = Path.Combine(RepoDirectories.RepoRoot, "TestAssets", "TestUtils",
-                "SharedFxLookup", "SharedFxLookupPortableApp_prerelease.runtimeconfig.json");
-            File.Copy(srcFile, destFile, true);
-        }
-
-        // Overwrites the fixture's runtimeconfig.json. The specified version is 9999.0.0
-        private void SetProductionRuntimeConfig(TestProjectFixture fixture)
-        {
-            string destFile = Path.Combine(fixture.TestProject.OutputDirectory, "SharedFxLookupPortableApp.runtimeconfig.json");
-            string srcFile = Path.Combine(RepoDirectories.RepoRoot, "TestAssets", "TestUtils",
-                "SharedFxLookup", "SharedFxLookupPortableApp_production.runtimeconfig.json");
-            File.Copy(srcFile, destFile, true);
-        }
-
         // MultilevelDirectory is %TEST_ARTIFACTS%\dotnetMultilevelSharedFxLookup\id.
         // We must locate the first non existing id.
         private string CalculateMultilevelDirectory(string baseMultilevelDir)
@@ -416,6 +683,40 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.MultilevelSharedFxLooku
             } while (Directory.Exists(multilevelDir));
 
             return multilevelDir;
+        }
+
+        // Generated json file:
+        /*
+         * {
+         *   "runtimeOptions": {
+         *     "framework": {
+         *       "name": "Microsoft.NETCore.App",
+         *       "version": {version}
+         *     },
+         *     "rollForwardOnNoCandidateFx": {rollFwdOnNoCandidateFx} <-- only if rollFwdOnNoCandidateFx is defined
+         *   }
+         * }
+        */
+        private void SetRuntimeConfigJson(string destFile, string version, int? rollFwdOnNoCandidateFx = null)
+        {
+            JObject runtimeOptions = new JObject(
+                new JProperty("framework",
+                    new JObject(
+                        new JProperty("name", "Microsoft.NETCore.App"),
+                        new JProperty("version", version)
+                    )
+                )
+            );
+
+            if (rollFwdOnNoCandidateFx.HasValue)
+            {
+                runtimeOptions.Add("rollForwardOnNoCandidateFx", rollFwdOnNoCandidateFx);
+            }
+
+            JObject json = new JObject();
+            json.Add("runtimeOptions", runtimeOptions);
+
+            File.WriteAllText(destFile, json.ToString());
         }
     }
 }


### PR DESCRIPTION
"Roll Forward On No Candidate Fx" is disabled by default. It can be enabled through:

1. Command line argument (--roll-forward-on-no-candidate-fx).
2. Runtimeconfig json file ('rollForwardOnNoCadidateFx' property).
3. DOTNET_ROLL_FORWARD_ON_NO_CANDIDATE_FX environment variable.

The conflicts will be resolved by following the priority rank described above (from 1 to 3).

If the patch roll forward we do today fails and "Roll Forward On No Candidate Fx" is set, we'll search for the next lowest production available and apply the patch roll forward again.

Fixes dotnet/core-setup#1565