### PR TITLE
Fix typo in crossgen workaround

### DIFF
--- a/build_projects/shared-build-targets-utils/Utils/Crossgen.cs
+++ b/build_projects/shared-build-targets-utils/Utils/Crossgen.cs
@@ -55,8 +55,8 @@ namespace Microsoft.DotNet.Cli.Build
             else if (_targetRID == "win10-arm64")
             {
                 // workaround https://github.com/dotnet/coreclr/issues/9884
-                // ridCrossgen = Path.Combine(crossgenPackagePath, "tools", "x86_arm", $"crossgen{Constants.ExeSuffix}");
-                ridCrossgen = Path.Combine(crossgenPackagePath, "tools", "x86_AnyCPU", $"crossgen{Constants.ExeSuffix}");
+                // ridCrossgen = Path.Combine(crossgenPackagePath, "tools", "x64_arm", $"crossgen{Constants.ExeSuffix}");
+                ridCrossgen = Path.Combine(crossgenPackagePath, "tools", "x64_AnyCPU", $"crossgen{Constants.ExeSuffix}");
             }
             else
             {


### PR DESCRIPTION
I had a copy-paste typo and didn't catch the diff.

It made it through CI but broke official build, since CI doesn't run ARM64 but official does.