### PR TITLE
Switch Docker Hub repo being used to microsoft/dotnet-buildtools-prereqs

### DIFF
--- a/buildpipeline/Core-Setup-CrossBuild.json
+++ b/buildpipeline/Core-Setup-CrossBuild.json
@@ -216,7 +216,7 @@
       "value": "$(Build.BuildId)"
     },
     "PB_DockerRepository": {
-      "value": "chcosta/dotnetcore"
+      "value": "microsoft/dotnet-buildtools-prereqs"
     },
     "PB_DockerTag": {
       "value": "ubuntu1404_cross_prereqs_v2",

--- a/buildpipeline/Core-Setup-PortableLinux-x64.json
+++ b/buildpipeline/Core-Setup-PortableLinux-x64.json
@@ -31,7 +31,7 @@
       },
       "inputs": {
         "scriptPath": "scripts/dockerrun-as-current-user.sh",
-        "args": "-t --rm --sig-proxy=true --name $(DockerContainerName) -v $(Build.SourcesDirectory):/opt/code -w /opt/code -e CONNECTION_STRING -e PUBLISH_TO_AZURE_BLOB chcosta/dotnetcore:rhel7_prereqs /bin/bash -c \"HOME=/opt/code; git clean -X -d -f; ./build.sh $(BuildArguments)\"",
+        "args": "-t --rm --sig-proxy=true --name $(DockerContainerName) -v $(Build.SourcesDirectory):/opt/code -w /opt/code -e CONNECTION_STRING -e PUBLISH_TO_AZURE_BLOB microsoft/dotnet-buildtools-prereqs:rhel7_prereqs /bin/bash -c \"HOME=/opt/code; git clean -X -d -f; ./build.sh $(BuildArguments)\"",
         "disableAutoCwd": "false",
         "cwd": "",
         "failOnStandardError": "false"

--- a/buildpipeline/Core-Setup-RHEL7-x64.json
+++ b/buildpipeline/Core-Setup-RHEL7-x64.json
@@ -31,7 +31,7 @@
       },
       "inputs": {
         "scriptPath": "scripts/dockerrun-as-current-user.sh",
-        "args": "-t --rm --sig-proxy=true --name $(DockerContainerName) -v $(Build.SourcesDirectory):/opt/code -w /opt/code -e CONNECTION_STRING -e PUBLISH_TO_AZURE_BLOB chcosta/dotnetcore:rhel7_prereqs /bin/bash -c \"HOME=/opt/code; git clean -X -d -f; ./build.sh $(BuildArguments)\"",
+        "args": "-t --rm --sig-proxy=true --name $(DockerContainerName) -v $(Build.SourcesDirectory):/opt/code -w /opt/code -e CONNECTION_STRING -e PUBLISH_TO_AZURE_BLOB microsoft/dotnet-buildtools-prereqs:rhel7_prereqs /bin/bash -c \"HOME=/opt/code; git clean -X -d -f; ./build.sh $(BuildArguments)\"",
         "disableAutoCwd": "false",
         "cwd": "",
         "failOnStandardError": "false"

--- a/scripts/arm32_ci_script.sh
+++ b/scripts/arm32_ci_script.sh
@@ -174,11 +174,11 @@ function cross_build_core_setup_with_docker {
         # TODO: For arm, we are going to embed RootFS inside Docker image.
         case $__linuxCodeName in
         trusty)
-            __dockerImage=" chcosta/dotnetcore:ubuntu1404_cross_prereqs_v1"
+            __dockerImage=" microsoft/dotnet-buildtools-prereqs:ubuntu1404_cross_prereqs_v1"
             __runtimeOS="ubuntu.14.04"
         ;;
         xenial)
-            __dockerImage=" chcosta/dotnetcore:ubuntu1604_cross_prereqs_v1"
+            __dockerImage=" microsoft/dotnet-buildtools-prereqs:ubuntu1604_cross_prereqs_v1"
             __runtimeOS="ubuntu.16.04"
         ;;
         *)


### PR DESCRIPTION
We want to stop using the chcosta/dotnetcore Docker Hub repo and use the microsoft/dotnet-buildtools-prereqs repo.  All of the images from chcosta/dotnetcore have been copied over to the new repo.