### PR TITLE
Custom deps feature implemented [IN PROGRESS].

### DIFF
--- a/src/corehost/cli/deps_resolver.cpp
+++ b/src/corehost/cli/deps_resolver.cpp
@@ -369,6 +369,18 @@ bool deps_resolver_t::resolve_tpa_list(
         }
     }
 
+    for (const auto& custom_deps : m_custom_deps)
+    {
+        auto custom_deps_entries = custom_deps->get_entries(deps_entry_t::asset_types::runtime);
+        for (auto entry : custom_deps_entries)
+        {
+            if (!process_entry(m_app_dir, custom_deps.get(), entry))
+            {
+                return false;
+            }
+        }
+    }
+
     // Probe FX deps entries after app assemblies are added.
     const auto& fx_entries = m_portable ? m_fx_deps->get_entries(deps_entry_t::asset_types::runtime) : empty;
     for (const auto& entry : fx_entries)
@@ -400,6 +412,66 @@ void deps_resolver_t::init_known_entry_path(const deps_entry_t& entry, const pal
     {
         m_clrjit_path = path;
         return;
+    }
+}
+
+void deps_resolver_t::resolve_custom_deps(const hostpolicy_init_t& init)
+{
+    pal::string_t custom_deps_serialized = init.custom_deps_serialized;
+    pal::string_t fx_name = init.fx_name;
+    pal::string_t fx_ver = init.fx_ver;
+
+    if (custom_deps_serialized.empty())
+    {
+        return;
+    }
+
+    pal::string_t custom_deps_path;
+    pal::stringstream_t ss(custom_deps_serialized);
+    while (std::getline(ss, custom_deps_path, PATH_SEPARATOR))
+    {
+        // If it's a single deps file, insert it in 'm_custom_deps_files'
+        if (ends_with(custom_deps_path, _X(".deps.json"), false))
+        {
+            if (pal::file_exists(custom_deps_path))
+            {
+                m_custom_deps_files.push_back(custom_deps_path);
+            }
+        }
+        // If it's not a single deps file, we'll assume it's a directory
+        else
+        {
+            // We'll search deps files in 'base_dir'/shared/fx_name/fx_ver
+            append_path(&custom_deps_path, _X("shared"));
+            append_path(&custom_deps_path, fx_name.c_str());
+            append_path(&custom_deps_path, fx_ver.c_str());
+
+            // The resulting list will be empty if 'custom_deps_path' is not a valid directory path
+            std::vector<pal::string_t> list;
+            pal::readdir(custom_deps_path, _X("*.deps.json"), &list);
+            for (pal::string_t json_file : list)
+            {
+                pal::string_t json_full_path = custom_deps_path;
+                append_path(&json_full_path, json_file.c_str());
+                m_custom_deps_files.push_back(json_full_path);
+            }
+        }
+    }
+    if (m_portable)
+    {
+        for (pal::string_t json_file : m_custom_deps_files)
+        {
+            m_custom_deps.push_back(std::unique_ptr<deps_json_t>(
+                new deps_json_t(true, json_file, m_fx_deps->get_rid_fallback_graph())));
+        }
+    }
+    else
+    {
+        for (pal::string_t json_file : m_custom_deps_files)
+        {
+            m_custom_deps.push_back(std::unique_ptr<deps_json_t>(
+                new deps_json_t(false, json_file)));
+        }
     }
 }
 
@@ -507,6 +579,18 @@ bool deps_resolver_t::resolve_probe_dirs(
         (void) library_exists_in_dir(m_app_dir, LIBCORECLR_NAME, &m_coreclr_path);
 
         (void) library_exists_in_dir(m_app_dir, LIBCLRJIT_NAME, &m_clrjit_path);
+    }
+
+    for (const auto& custom_deps : m_custom_deps)
+    {
+        auto custom_deps_entries = custom_deps->get_entries(deps_entry_t::asset_types::runtime);
+        for (auto entry : custom_deps_entries)
+        {
+            if (!add_package_cache_entry(entry, m_app_dir))
+            {
+                return false;
+            }
+        }
     }
     
     for (const auto& entry : fx_entries)

--- a/src/corehost/cli/deps_resolver.h
+++ b/src/corehost/cli/deps_resolver.h
@@ -49,6 +49,8 @@ public:
             m_deps = std::unique_ptr<deps_json_t>(new deps_json_t(false, m_deps_file));
         }
 
+        resolve_custom_deps(init);
+
         setup_additional_probes(args.probe_paths);
         setup_probe_config(init, args);
     }
@@ -92,6 +94,9 @@ public:
     void init_known_entry_path(
         const deps_entry_t& entry,
         const pal::string_t& path);
+
+    void resolve_custom_deps(
+        const hostpolicy_init_t& init);
 
     const pal::string_t& get_fx_deps_file() const
     {
@@ -171,6 +176,9 @@ private:
 
     // The filepath for the app deps
     pal::string_t m_deps_file;
+
+    // The filepaths for the app custom deps
+    std::vector<pal::string_t> m_custom_deps_files;
     
     // The filepath for the fx deps
     pal::string_t m_fx_deps_file;
@@ -180,6 +188,9 @@ private:
 
     // Deps files for the app
     std::unique_ptr<deps_json_t>  m_deps;
+
+    // Custom deps files for the app
+    std::vector< std::unique_ptr<deps_json_t> > m_custom_deps;
 
     // Various probe configurations.
     std::vector<probe_config_t> m_probes;

--- a/src/corehost/cli/libhost.h
+++ b/src/corehost/cli/libhost.h
@@ -49,6 +49,8 @@ struct host_interface_t
     size_t prerelease_roll_forward;
     size_t host_mode;
     const pal::char_t* tfm;
+    const pal::char_t* custom_deps_serialized;
+    const pal::char_t* fx_ver;
     // !! WARNING / WARNING / WARNING / WARNING / WARNING / WARNING / WARNING / WARNING / WARNING
     // !! 1. Only append to this structure to maintain compat.
     // !! 2. Any nested structs should not use compiler specific padding (pack with _HOST_INTERFACE_PACK)
@@ -72,7 +74,9 @@ static_assert(offsetof(host_interface_t, patch_roll_forward) == 12 * sizeof(size
 static_assert(offsetof(host_interface_t, prerelease_roll_forward) == 13 * sizeof(size_t), "Struct offset breaks backwards compatibility");
 static_assert(offsetof(host_interface_t, host_mode) == 14 * sizeof(size_t), "Struct offset breaks backwards compatibility");
 static_assert(offsetof(host_interface_t, tfm) == 15 * sizeof(size_t), "Struct offset breaks backwards compatibility");
-static_assert(sizeof(host_interface_t) == 16 * sizeof(size_t), "Did you add static asserts for the newly added fields?");
+static_assert(offsetof(host_interface_t, custom_deps_serialized) == 16 * sizeof(size_t), "Struct offset breaks backwards compatibility");
+static_assert(offsetof(host_interface_t, fx_ver) == 17 * sizeof(size_t), "Struct offset breaks backwards compatibility");
+static_assert(sizeof(host_interface_t) == 18 * sizeof(size_t), "Did you add static asserts for the newly added fields?");
 
 #define HOST_INTERFACE_LAYOUT_VERSION_HI 0x16041101 // YYMMDD:nn always increases when layout breaks compat.
 #define HOST_INTERFACE_LAYOUT_VERSION_LO sizeof(host_interface_t)
@@ -88,6 +92,7 @@ private:
     const pal::string_t m_fx_dir;
     const pal::string_t m_fx_name;
     const pal::string_t m_deps_file;
+    const pal::string_t m_custom_deps_serialized;
     bool m_portable;
     std::vector<pal::string_t> m_probe_paths;
     std::vector<const pal::char_t*> m_probe_paths_cstr;
@@ -99,6 +104,7 @@ private:
 public:
     corehost_init_t(
         const pal::string_t& deps_file,
+        const pal::string_t& custom_deps_serialized,
         const std::vector<pal::string_t>& probe_paths,
         const pal::string_t& fx_dir,
         const host_mode_t mode,
@@ -106,6 +112,7 @@ public:
         : m_fx_dir(fx_dir)
         , m_fx_name(runtime_config.get_fx_name())
         , m_deps_file(deps_file)
+        , m_custom_deps_serialized(custom_deps_serialized)
         , m_portable(runtime_config.get_portable())
         , m_probe_paths(probe_paths)
         , m_patch_roll_forward(runtime_config.get_patch_roll_fwd())
@@ -156,7 +163,9 @@ public:
 
         hi.fx_dir = m_fx_dir.c_str();
         hi.fx_name = m_fx_name.c_str();
+        hi.fx_ver = m_fx_ver.c_str();
         hi.deps_file = m_deps_file.c_str();
+        hi.custom_deps_serialized = m_custom_deps_serialized.c_str();
         hi.is_portable = m_portable;
 
         hi.probe_paths.len = m_probe_paths_cstr.size();
@@ -189,10 +198,12 @@ struct hostpolicy_init_t
     std::vector<std::vector<char>> cfg_keys;
     std::vector<std::vector<char>> cfg_values;
     pal::string_t deps_file;
+    pal::string_t custom_deps_serialized;
     std::vector<pal::string_t> probe_paths;
     pal::string_t tfm;
     pal::string_t fx_dir;
     pal::string_t fx_name;
+    pal::string_t fx_ver;
     host_mode_t host_mode;
     bool patch_roll_forward;
     bool prerelease_roll_forward;
@@ -217,8 +228,10 @@ struct hostpolicy_init_t
             make_clrstr_arr(input->config_values.len, input->config_values.arr, &init->cfg_values);
 
             init->fx_dir = input->fx_dir;
+            init->fx_ver = input->fx_ver;
             init->fx_name = input->fx_name;
             init->deps_file = input->deps_file;
+            init->custom_deps_serialized = input->custom_deps_serialized;
             init->is_portable = input->is_portable;
 
             make_palstr_arr(input->probe_paths.len, input->probe_paths.arr, &init->probe_paths);


### PR DESCRIPTION
It's now possible to inject packages at runtime through custom .deps.json files. The files must be specified through DOTNET_CUSTOM_DEPS environment variable or through --custom-deps command line argument. It's important to notice that the command line argument overwrites the environment variable value.

For instance, if we wanted to load AppB during AppA execution:
dotnet --custom-deps ...\AppB.deps.json AppA.dll

It's possible to specify multiple files:
dotnet --custom-deps ...\AppB.deps.json;...\AppC.deps.json;...\AppD.deps.json AppA.dll

A directory path can be specified:
dotnet --custom-deps base_dir AppA.dll
Every .deps.json file contained in base_dir\shared\fx_name\fx_version will be picked.

It's also possible to mix directory and file paths:
dotnet --custom-deps base_dir1;...\AppB.deps.json;base_dir2 AppA.dll

The changes were manually tested, but it's still necessary to add unit tests to ensure that the new feature correctly follows the expected behavior.

Fixes dotnet/core-setup#1597
