### PR TITLE
Fix pkg and packaging targets

### DIFF
--- a/packaging/windows/package.targets
+++ b/packaging/windows/package.targets
@@ -10,7 +10,11 @@
       
       <Exec Command="powershell -NoProfile -NoLogo $(GetWixScript) -WixVersion $(WixVersion) -OutputDir $(WixToolsDir)" />
 
-      <GenerateGuidFromName Name="$(PackagesOutputDir)$(SharedFrameworkInstallerFile)">
+      <GenerateGuidFromName Name="$(PackagesOutputDir)$(SharedHostInstallerFile)">
+        <Output TaskParameter="GeneratedGui" PropertyName="SharedHostUpgradeCode" />
+      </GenerateGuidFromName>
+
+      <GenerateGuidFromName Name="$(PackagesOutputDir)$(HostFxrInstallerFile)">
         <Output TaskParameter="GeneratedGui" PropertyName="HostFxrUpgradeCode" />
       </GenerateGuidFromName>
 
@@ -19,7 +23,7 @@
             <InputDir>$(SharedHostPublishRoot)</InputDir>
             <BrandName>$(SharedHostBrandName)</BrandName>
             <InstallerName>$(PackagesOutputDir)$(SharedHostInstallerFile)</InstallerName>
-            <UpgradeCode></UpgradeCode>
+            <UpgradeCode>$(SharedHostUpgradeCode)</UpgradeCode>
         </WixOutputs>
         <WixOutputs Include="$(WixObjRoot)hostfxr">
             <InputDir>$(HostFxrPublishRoot)</InputDir>

--- a/pkg/projects/dir.targets
+++ b/pkg/projects/dir.targets
@@ -18,11 +18,11 @@
     <!-- Update project.json template -->
     <MakeDir Directories="$([System.IO.Path]::GetDirectoryName('$(ProjectJson)'))" />
 
-    <ReplaceFileContents
-      InputFile="project.json.template"
-      DestinationFile="$(ProjectJson)"
-      ReplacementPatterns="{RID};{TFM}"
-      ReplacementStrings="$(TargetRid);$(NuGetTargetMoniker)" />
+    <WriteLinesToFile
+      File="$(ProjectJson)"
+      Lines="$([System.IO.File]::ReadAllText('project.json.template').Replace('{RID}', $(NuGetRuntimeIdentifier)).Replace('{TFM}', $(NuGetTargetMoniker)))"
+      Overwrite="true"
+                      />
 
     <ItemGroup>
       <FileWrites Include="$(ProjectJson)" />


### PR DESCRIPTION
-Fix pkgbuild: The issue was using the new replace file contents target instead of string.Replace this is because an empty property won't work with the custom target.

-Add missing upgrade codes when generating Msi

whit this running .\build.cmd -SkipTests=true runs succesfully to completion in a freshly clone repo.