### PR TITLE
Fix OSX RID.

### DIFF
--- a/src/corehost/common/pal.unix.cpp
+++ b/src/corehost/common/pal.unix.cpp
@@ -296,7 +296,7 @@ pal::string_t pal::get_current_os_rid_platform()
                 minorVersion = 10;
             }
 
-            ridOS.append(_X("10."));
+            ridOS.append(_X("osx.10."));
             ridOS.append(std::to_string(minorVersion));
         }
     }


### PR DESCRIPTION
The RID on OSX is incorrect.  It is missing the os name.

@gkhanna79 @ramarag

I plan on adding tests for this, but I don't have time right now and I need to get this bug fixed.  So a follow-up PR will be made to add tests.