### PR TITLE
Git checkout the specific commit - 1.0.0

### DIFF
--- a/buildpipeline/Core-Setup-CentOS-x64.json
+++ b/buildpipeline/Core-Setup-CentOS-x64.json
@@ -4,6 +4,25 @@
       "enabled": true,
       "continueOnError": false,
       "alwaysRun": false,
+      "displayName": "git checkout",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "6c731c3c-3c68-459a-a5c9-bde6e6595b5b",
+        "versionSpec": "2.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "scriptPath": "git",
+        "args": "checkout $(SourceVersion)",
+        "disableAutoCwd": "false",
+        "cwd": "",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
       "displayName": "Shell Script build.sh",
       "timeoutInMinutes": 0,
       "task": {

--- a/buildpipeline/Core-Setup-CentOS-x64.json
+++ b/buildpipeline/Core-Setup-CentOS-x64.json
@@ -7,15 +7,14 @@
       "displayName": "git checkout",
       "timeoutInMinutes": 0,
       "task": {
-        "id": "6c731c3c-3c68-459a-a5c9-bde6e6595b5b",
-        "versionSpec": "2.*",
+        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
+        "versionSpec": "1.*",
         "definitionType": "task"
       },
       "inputs": {
-        "scriptPath": "git",
-        "args": "checkout $(SourceVersion)",
-        "disableAutoCwd": "false",
-        "cwd": "",
+        "filename": "git",
+        "arguments": "checkout $(SourceVersion)",
+        "workingFolder": "",
         "failOnStandardError": "false"
       }
     },

--- a/buildpipeline/Core-Setup-Debian8-x64.json
+++ b/buildpipeline/Core-Setup-Debian8-x64.json
@@ -4,6 +4,25 @@
       "enabled": true,
       "continueOnError": false,
       "alwaysRun": false,
+      "displayName": "git checkout",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "6c731c3c-3c68-459a-a5c9-bde6e6595b5b",
+        "versionSpec": "2.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "scriptPath": "git",
+        "args": "checkout $(SourceVersion)",
+        "disableAutoCwd": "false",
+        "cwd": "",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
       "displayName": "Shell Script build.sh",
       "timeoutInMinutes": 0,
       "task": {

--- a/buildpipeline/Core-Setup-Debian8-x64.json
+++ b/buildpipeline/Core-Setup-Debian8-x64.json
@@ -7,15 +7,14 @@
       "displayName": "git checkout",
       "timeoutInMinutes": 0,
       "task": {
-        "id": "6c731c3c-3c68-459a-a5c9-bde6e6595b5b",
-        "versionSpec": "2.*",
+        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
+        "versionSpec": "1.*",
         "definitionType": "task"
       },
       "inputs": {
-        "scriptPath": "git",
-        "args": "checkout $(SourceVersion)",
-        "disableAutoCwd": "false",
-        "cwd": "",
+        "filename": "git",
+        "arguments": "checkout $(SourceVersion)",
+        "workingFolder": "",
         "failOnStandardError": "false"
       }
     },

--- a/buildpipeline/Core-Setup-Fedora23-x64.json
+++ b/buildpipeline/Core-Setup-Fedora23-x64.json
@@ -4,6 +4,25 @@
       "enabled": true,
       "continueOnError": false,
       "alwaysRun": false,
+      "displayName": "git checkout",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "6c731c3c-3c68-459a-a5c9-bde6e6595b5b",
+        "versionSpec": "2.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "scriptPath": "git",
+        "args": "checkout $(SourceVersion)",
+        "disableAutoCwd": "false",
+        "cwd": "",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
       "displayName": "Shell Script build.sh",
       "timeoutInMinutes": 0,
       "task": {

--- a/buildpipeline/Core-Setup-Fedora23-x64.json
+++ b/buildpipeline/Core-Setup-Fedora23-x64.json
@@ -7,15 +7,14 @@
       "displayName": "git checkout",
       "timeoutInMinutes": 0,
       "task": {
-        "id": "6c731c3c-3c68-459a-a5c9-bde6e6595b5b",
-        "versionSpec": "2.*",
+        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
+        "versionSpec": "1.*",
         "definitionType": "task"
       },
       "inputs": {
-        "scriptPath": "git",
-        "args": "checkout $(SourceVersion)",
-        "disableAutoCwd": "false",
-        "cwd": "",
+        "filename": "git",
+        "arguments": "checkout $(SourceVersion)",
+        "workingFolder": "",
         "failOnStandardError": "false"
       }
     },

--- a/buildpipeline/Core-Setup-OSX-x64.json
+++ b/buildpipeline/Core-Setup-OSX-x64.json
@@ -4,6 +4,25 @@
       "enabled": true,
       "continueOnError": false,
       "alwaysRun": false,
+      "displayName": "git checkout",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "6c731c3c-3c68-459a-a5c9-bde6e6595b5b",
+        "versionSpec": "2.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "scriptPath": "git",
+        "args": "checkout $(SourceVersion)",
+        "disableAutoCwd": "false",
+        "cwd": "",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
       "displayName": "Shell Script build.sh",
       "timeoutInMinutes": 0,
       "task": {

--- a/buildpipeline/Core-Setup-OSX-x64.json
+++ b/buildpipeline/Core-Setup-OSX-x64.json
@@ -7,15 +7,14 @@
       "displayName": "git checkout",
       "timeoutInMinutes": 0,
       "task": {
-        "id": "6c731c3c-3c68-459a-a5c9-bde6e6595b5b",
-        "versionSpec": "2.*",
+        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
+        "versionSpec": "1.*",
         "definitionType": "task"
       },
       "inputs": {
-        "scriptPath": "git",
-        "args": "checkout $(SourceVersion)",
-        "disableAutoCwd": "false",
-        "cwd": "",
+        "filename": "git",
+        "arguments": "checkout $(SourceVersion)",
+        "workingFolder": "",
         "failOnStandardError": "false"
       }
     },

--- a/buildpipeline/Core-Setup-OpenSuse13.2-x64.json
+++ b/buildpipeline/Core-Setup-OpenSuse13.2-x64.json
@@ -4,6 +4,25 @@
       "enabled": true,
       "continueOnError": false,
       "alwaysRun": false,
+      "displayName": "git checkout",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "6c731c3c-3c68-459a-a5c9-bde6e6595b5b",
+        "versionSpec": "2.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "scriptPath": "git",
+        "args": "checkout $(SourceVersion)",
+        "disableAutoCwd": "false",
+        "cwd": "",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
       "displayName": "Shell Script build.sh",
       "timeoutInMinutes": 0,
       "task": {

--- a/buildpipeline/Core-Setup-OpenSuse13.2-x64.json
+++ b/buildpipeline/Core-Setup-OpenSuse13.2-x64.json
@@ -7,15 +7,14 @@
       "displayName": "git checkout",
       "timeoutInMinutes": 0,
       "task": {
-        "id": "6c731c3c-3c68-459a-a5c9-bde6e6595b5b",
-        "versionSpec": "2.*",
+        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
+        "versionSpec": "1.*",
         "definitionType": "task"
       },
       "inputs": {
-        "scriptPath": "git",
-        "args": "checkout $(SourceVersion)",
-        "disableAutoCwd": "false",
-        "cwd": "",
+        "filename": "git",
+        "arguments": "checkout $(SourceVersion)",
+        "workingFolder": "",
         "failOnStandardError": "false"
       }
     },

--- a/buildpipeline/Core-Setup-RHEL7-x64.json
+++ b/buildpipeline/Core-Setup-RHEL7-x64.json
@@ -4,6 +4,25 @@
       "enabled": true,
       "continueOnError": false,
       "alwaysRun": false,
+      "displayName": "git checkout",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "6c731c3c-3c68-459a-a5c9-bde6e6595b5b",
+        "versionSpec": "2.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "scriptPath": "git",
+        "args": "checkout $(SourceVersion)",
+        "disableAutoCwd": "false",
+        "cwd": "",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
       "displayName": "Docker cleanup",
       "timeoutInMinutes": 0,
       "task": {

--- a/buildpipeline/Core-Setup-RHEL7-x64.json
+++ b/buildpipeline/Core-Setup-RHEL7-x64.json
@@ -7,15 +7,14 @@
       "displayName": "git checkout",
       "timeoutInMinutes": 0,
       "task": {
-        "id": "6c731c3c-3c68-459a-a5c9-bde6e6595b5b",
-        "versionSpec": "2.*",
+        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
+        "versionSpec": "1.*",
         "definitionType": "task"
       },
       "inputs": {
-        "scriptPath": "git",
-        "args": "checkout $(SourceVersion)",
-        "disableAutoCwd": "false",
-        "cwd": "",
+        "filename": "git",
+        "arguments": "checkout $(SourceVersion)",
+        "workingFolder": "",
         "failOnStandardError": "false"
       }
     },

--- a/buildpipeline/Core-Setup-Signing-Windows-x64.json
+++ b/buildpipeline/Core-Setup-Signing-Windows-x64.json
@@ -4,6 +4,24 @@
       "enabled": true,
       "continueOnError": false,
       "alwaysRun": false,
+      "displayName": "git checkout",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "filename": "git",
+        "arguments": "checkout $(SourceVersion)",
+        "workingFolder": "",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
       "displayName": "Install Signing Plugin",
       "timeoutInMinutes": 0,
       "task": {
@@ -318,7 +336,7 @@
         "versionSpec": "1.*",
         "definitionType": "task"
       },
-      "inputs": { }
+      "inputs": {}
     },
     {
       "enabled": true,

--- a/buildpipeline/Core-Setup-Signing-Windows-x86.json
+++ b/buildpipeline/Core-Setup-Signing-Windows-x86.json
@@ -4,6 +4,24 @@
       "enabled": true,
       "continueOnError": false,
       "alwaysRun": false,
+      "displayName": "git checkout",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "filename": "git",
+        "arguments": "checkout $(SourceVersion)",
+        "workingFolder": "",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
       "displayName": "Install Signing Plugin",
       "timeoutInMinutes": 0,
       "task": {
@@ -318,7 +336,7 @@
         "versionSpec": "1.*",
         "definitionType": "task"
       },
-      "inputs": { }
+      "inputs": {}
     },
     {
       "enabled": true,

--- a/buildpipeline/Core-Setup-Ubuntu14.04-x64.json
+++ b/buildpipeline/Core-Setup-Ubuntu14.04-x64.json
@@ -4,6 +4,25 @@
       "enabled": true,
       "continueOnError": false,
       "alwaysRun": false,
+      "displayName": "git checkout",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "6c731c3c-3c68-459a-a5c9-bde6e6595b5b",
+        "versionSpec": "2.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "scriptPath": "git",
+        "args": "checkout $(SourceVersion)",
+        "disableAutoCwd": "false",
+        "cwd": "",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
       "displayName": "Shell Script build.sh",
       "timeoutInMinutes": 0,
       "task": {

--- a/buildpipeline/Core-Setup-Ubuntu14.04-x64.json
+++ b/buildpipeline/Core-Setup-Ubuntu14.04-x64.json
@@ -7,15 +7,14 @@
       "displayName": "git checkout",
       "timeoutInMinutes": 0,
       "task": {
-        "id": "6c731c3c-3c68-459a-a5c9-bde6e6595b5b",
-        "versionSpec": "2.*",
+        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
+        "versionSpec": "1.*",
         "definitionType": "task"
       },
       "inputs": {
-        "scriptPath": "git",
-        "args": "checkout $(SourceVersion)",
-        "disableAutoCwd": "false",
-        "cwd": "",
+        "filename": "git",
+        "arguments": "checkout $(SourceVersion)",
+        "workingFolder": "",
         "failOnStandardError": "false"
       }
     },

--- a/buildpipeline/Core-Setup-Ubuntu16.04-x64.json
+++ b/buildpipeline/Core-Setup-Ubuntu16.04-x64.json
@@ -4,6 +4,25 @@
       "enabled": true,
       "continueOnError": false,
       "alwaysRun": false,
+      "displayName": "git checkout",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "6c731c3c-3c68-459a-a5c9-bde6e6595b5b",
+        "versionSpec": "2.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "scriptPath": "git",
+        "args": "checkout $(SourceVersion)",
+        "disableAutoCwd": "false",
+        "cwd": "",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
       "displayName": "Shell Script build.sh",
       "timeoutInMinutes": 0,
       "task": {

--- a/buildpipeline/Core-Setup-Ubuntu16.04-x64.json
+++ b/buildpipeline/Core-Setup-Ubuntu16.04-x64.json
@@ -7,15 +7,14 @@
       "displayName": "git checkout",
       "timeoutInMinutes": 0,
       "task": {
-        "id": "6c731c3c-3c68-459a-a5c9-bde6e6595b5b",
-        "versionSpec": "2.*",
+        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
+        "versionSpec": "1.*",
         "definitionType": "task"
       },
       "inputs": {
-        "scriptPath": "git",
-        "args": "checkout $(SourceVersion)",
-        "disableAutoCwd": "false",
-        "cwd": "",
+        "filename": "git",
+        "arguments": "checkout $(SourceVersion)",
+        "workingFolder": "",
         "failOnStandardError": "false"
       }
     },

--- a/buildpipeline/Core-Setup-Windows-arm32.json
+++ b/buildpipeline/Core-Setup-Windows-arm32.json
@@ -4,6 +4,24 @@
       "enabled": true,
       "continueOnError": false,
       "alwaysRun": false,
+      "displayName": "git checkout",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "filename": "git",
+        "arguments": "checkout $(SourceVersion)",
+        "workingFolder": "",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
       "displayName": "Run script build.cmd",
       "timeoutInMinutes": 0,
       "task": {


### PR DESCRIPTION
Similar to #1685 But this one is for release 1.**0**.0.

In PipeBuild, build legs checkout master branch as default. This causes a problem in servicing branches. To address this behavior, build legs should checkout the specific commit. Hence adding a task to git checkout in each PipeBuild build definition.

@dagood @chcosta @gkhanna79 please review.