### PR TITLE
Git checkout task should be a command and not shell script - 1.1.0

### DIFF
--- a/buildpipeline/Core-Setup-CentOS-x64.json
+++ b/buildpipeline/Core-Setup-CentOS-x64.json
@@ -7,15 +7,14 @@
       "displayName": "git checkout",
       "timeoutInMinutes": 0,
       "task": {
-        "id": "6c731c3c-3c68-459a-a5c9-bde6e6595b5b",
-        "versionSpec": "2.*",
+        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
+        "versionSpec": "1.*",
         "definitionType": "task"
       },
       "inputs": {
-        "scriptPath": "git",
-        "args": "checkout $(SourceVersion)",
-        "disableAutoCwd": "false",
-        "cwd": "",
+        "filename": "git",
+        "arguments": "checkout $(SourceVersion)",
+        "workingFolder": "",
         "failOnStandardError": "false"
       }
     },

--- a/buildpipeline/Core-Setup-Debian8-x64.json
+++ b/buildpipeline/Core-Setup-Debian8-x64.json
@@ -7,15 +7,14 @@
       "displayName": "git checkout",
       "timeoutInMinutes": 0,
       "task": {
-        "id": "6c731c3c-3c68-459a-a5c9-bde6e6595b5b",
-        "versionSpec": "2.*",
+        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
+        "versionSpec": "1.*",
         "definitionType": "task"
       },
       "inputs": {
-        "scriptPath": "git",
-        "args": "checkout $(SourceVersion)",
-        "disableAutoCwd": "false",
-        "cwd": "",
+        "filename": "git",
+        "arguments": "checkout $(SourceVersion)",
+        "workingFolder": "",
         "failOnStandardError": "false"
       }
     },

--- a/buildpipeline/Core-Setup-Fedora23-x64.json
+++ b/buildpipeline/Core-Setup-Fedora23-x64.json
@@ -7,15 +7,14 @@
       "displayName": "git checkout",
       "timeoutInMinutes": 0,
       "task": {
-        "id": "6c731c3c-3c68-459a-a5c9-bde6e6595b5b",
-        "versionSpec": "2.*",
+        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
+        "versionSpec": "1.*",
         "definitionType": "task"
       },
       "inputs": {
-        "scriptPath": "git",
-        "args": "checkout $(SourceVersion)",
-        "disableAutoCwd": "false",
-        "cwd": "",
+        "filename": "git",
+        "arguments": "checkout $(SourceVersion)",
+        "workingFolder": "",
         "failOnStandardError": "false"
       }
     },

--- a/buildpipeline/Core-Setup-Fedora24-x64.json
+++ b/buildpipeline/Core-Setup-Fedora24-x64.json
@@ -7,15 +7,14 @@
       "displayName": "git checkout",
       "timeoutInMinutes": 0,
       "task": {
-        "id": "6c731c3c-3c68-459a-a5c9-bde6e6595b5b",
-        "versionSpec": "2.*",
+        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
+        "versionSpec": "1.*",
         "definitionType": "task"
       },
       "inputs": {
-        "scriptPath": "git",
-        "args": "checkout $(SourceVersion)",
-        "disableAutoCwd": "false",
-        "cwd": "",
+        "filename": "git",
+        "arguments": "checkout $(SourceVersion)",
+        "workingFolder": "",
         "failOnStandardError": "false"
       }
     },

--- a/buildpipeline/Core-Setup-OSX-x64.json
+++ b/buildpipeline/Core-Setup-OSX-x64.json
@@ -7,15 +7,14 @@
       "displayName": "git checkout",
       "timeoutInMinutes": 0,
       "task": {
-        "id": "6c731c3c-3c68-459a-a5c9-bde6e6595b5b",
-        "versionSpec": "2.*",
+        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
+        "versionSpec": "1.*",
         "definitionType": "task"
       },
       "inputs": {
-        "scriptPath": "git",
-        "args": "checkout $(SourceVersion)",
-        "disableAutoCwd": "false",
-        "cwd": "",
+        "filename": "git",
+        "arguments": "checkout $(SourceVersion)",
+        "workingFolder": "",
         "failOnStandardError": "false"
       }
     },

--- a/buildpipeline/Core-Setup-OpenSuse13.2-x64.json
+++ b/buildpipeline/Core-Setup-OpenSuse13.2-x64.json
@@ -7,15 +7,14 @@
       "displayName": "git checkout",
       "timeoutInMinutes": 0,
       "task": {
-        "id": "6c731c3c-3c68-459a-a5c9-bde6e6595b5b",
-        "versionSpec": "2.*",
+        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
+        "versionSpec": "1.*",
         "definitionType": "task"
       },
       "inputs": {
-        "scriptPath": "git",
-        "args": "checkout $(SourceVersion)",
-        "disableAutoCwd": "false",
-        "cwd": "",
+        "filename": "git",
+        "arguments": "checkout $(SourceVersion)",
+        "workingFolder": "",
         "failOnStandardError": "false"
       }
     },

--- a/buildpipeline/Core-Setup-OpenSuse42.1-x64.json
+++ b/buildpipeline/Core-Setup-OpenSuse42.1-x64.json
@@ -7,15 +7,14 @@
       "displayName": "git checkout",
       "timeoutInMinutes": 0,
       "task": {
-        "id": "6c731c3c-3c68-459a-a5c9-bde6e6595b5b",
-        "versionSpec": "2.*",
+        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
+        "versionSpec": "1.*",
         "definitionType": "task"
       },
       "inputs": {
-        "scriptPath": "git",
-        "args": "checkout $(SourceVersion)",
-        "disableAutoCwd": "false",
-        "cwd": "",
+        "filename": "git",
+        "arguments": "checkout $(SourceVersion)",
+        "workingFolder": "",
         "failOnStandardError": "false"
       }
     },

--- a/buildpipeline/Core-Setup-RHEL7-x64.json
+++ b/buildpipeline/Core-Setup-RHEL7-x64.json
@@ -7,15 +7,14 @@
       "displayName": "git checkout",
       "timeoutInMinutes": 0,
       "task": {
-        "id": "6c731c3c-3c68-459a-a5c9-bde6e6595b5b",
-        "versionSpec": "2.*",
+        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
+        "versionSpec": "1.*",
         "definitionType": "task"
       },
       "inputs": {
-        "scriptPath": "git",
-        "args": "checkout $(SourceVersion)",
-        "disableAutoCwd": "false",
-        "cwd": "",
+        "filename": "git",
+        "arguments": "checkout $(SourceVersion)",
+        "workingFolder": "",
         "failOnStandardError": "false"
       }
     },

--- a/buildpipeline/Core-Setup-Ubuntu14.04-x64.json
+++ b/buildpipeline/Core-Setup-Ubuntu14.04-x64.json
@@ -7,15 +7,14 @@
       "displayName": "git checkout",
       "timeoutInMinutes": 0,
       "task": {
-        "id": "6c731c3c-3c68-459a-a5c9-bde6e6595b5b",
-        "versionSpec": "2.*",
+        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
+        "versionSpec": "1.*",
         "definitionType": "task"
       },
       "inputs": {
-        "scriptPath": "git",
-        "args": "checkout $(SourceVersion)",
-        "disableAutoCwd": "false",
-        "cwd": "",
+        "filename": "git",
+        "arguments": "checkout $(SourceVersion)",
+        "workingFolder": "",
         "failOnStandardError": "false"
       }
     },

--- a/buildpipeline/Core-Setup-Ubuntu16.04-x64.json
+++ b/buildpipeline/Core-Setup-Ubuntu16.04-x64.json
@@ -7,15 +7,14 @@
       "displayName": "git checkout",
       "timeoutInMinutes": 0,
       "task": {
-        "id": "6c731c3c-3c68-459a-a5c9-bde6e6595b5b",
-        "versionSpec": "2.*",
+        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
+        "versionSpec": "1.*",
         "definitionType": "task"
       },
       "inputs": {
-        "scriptPath": "git",
-        "args": "checkout $(SourceVersion)",
-        "disableAutoCwd": "false",
-        "cwd": "",
+        "filename": "git",
+        "arguments": "checkout $(SourceVersion)",
+        "workingFolder": "",
         "failOnStandardError": "false"
       }
     },

--- a/buildpipeline/Core-Setup-Ubuntu16.10-x64.json
+++ b/buildpipeline/Core-Setup-Ubuntu16.10-x64.json
@@ -7,15 +7,14 @@
       "displayName": "git checkout",
       "timeoutInMinutes": 0,
       "task": {
-        "id": "6c731c3c-3c68-459a-a5c9-bde6e6595b5b",
-        "versionSpec": "2.*",
+        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
+        "versionSpec": "1.*",
         "definitionType": "task"
       },
       "inputs": {
-        "scriptPath": "git",
-        "args": "checkout $(SourceVersion)",
-        "disableAutoCwd": "false",
-        "cwd": "",
+        "filename": "git",
+        "arguments": "checkout $(SourceVersion)",
+        "workingFolder": "",
         "failOnStandardError": "false"
       }
     },


### PR DESCRIPTION
Git checkout task introduced through #1685 should be a VSTS Run Command and not Run Shell Script. type. Updated non-Windows definitions accordingly.

@gkhanna79 @dagood @chcosta please review.