### PR TITLE
Enable fallback to base host RID

### DIFF
--- a/src/Microsoft.DotNet.PlatformAbstractions/RuntimeEnvironment.cs
+++ b/src/Microsoft.DotNet.PlatformAbstractions/RuntimeEnvironment.cs
@@ -80,9 +80,8 @@ namespace Microsoft.DotNet.PlatformAbstractions
             }
             else if (ver.Major >= 10)
             {
-                // Use Win10-* RID even for newer platforms we do not know for, so that existing Win10 assets can be used
-                // to keep apps working.
-                return "10";
+                // Return the major version for use in RID computation without applying any cap.
+                return ver.Major.ToString();
             }
             return string.Empty; // Unknown version
         }

--- a/src/corehost/cli/deps_format.cpp
+++ b/src/corehost/cli/deps_format.cpp
@@ -122,8 +122,8 @@ void deps_json_t::reconcile_libraries_with_targets(
     }
 }
 
-// Returns the RID for the platform the host is running on.
-pal::string_t get_current_rid()
+// Returns the RID determined (computed or fallback) for the platform the host is running on.
+pal::string_t deps_json_t::get_current_rid(const rid_fallback_graph_t& rid_fallback_graph)
 {
     
     pal::string_t currentRid;
@@ -136,14 +136,26 @@ pal::string_t get_current_rid()
         }
     }
     
-    trace::info(_X("Host RID is %s"), currentRid.empty()? _X("not available"): currentRid.c_str());
+    trace::info(_X("HostRID is %s"), currentRid.empty()? _X("not available"): currentRid.c_str());
+
+    // If the current RID is not present in the RID fallback graph, then the platform
+    // is unknown to us. At this point, we will fallback to using the base RIDs and attempt
+    // asset lookup using them.
+    //
+    // We do the same even when the RID is empty.
+    if (currentRid.empty() || (rid_fallback_graph.count(currentRid) == 0))
+    {
+        currentRid = pal::get_current_os_fallback_rid() + pal::string_t(_X("-")) + get_arch();
+
+        trace::info(_X("Falling back to base HostRID: %s"), currentRid.c_str());
+    }
 
     return currentRid;
 }
 
 bool deps_json_t::perform_rid_fallback(rid_specific_assets_t* portable_assets, const rid_fallback_graph_t& rid_fallback_graph)
 {
-    pal::string_t host_rid = get_current_rid();
+    pal::string_t host_rid = get_current_rid(rid_fallback_graph);
     
     for (auto& package : portable_assets->libs)
     {

--- a/src/corehost/cli/deps_format.h
+++ b/src/corehost/cli/deps_format.h
@@ -83,6 +83,7 @@ private:
 
     pal::string_t get_optional_path(const json_object& properties, const pal::string_t& key) const;
 
+    pal::string_t get_current_rid(const rid_fallback_graph_t& rid_fallback_graph);
     bool perform_rid_fallback(rid_specific_assets_t* portable_assets, const rid_fallback_graph_t& rid_fallback_graph);
 
     std::vector<deps_entry_t> m_deps_entries[deps_entry_t::asset_types::count];

--- a/src/corehost/common/pal.h
+++ b/src/corehost/common/pal.h
@@ -50,16 +50,26 @@
 
 #endif
 
-
+// When running on a platform that is not supported in RID fallback graph (because it was unknown
+// at the time the SharedFX in question was built), we need to use a reasonable fallback RID to allow
+// consuming the native assets.
+//
+// For Windows and OSX, we will maintain the last highest RID-Platform we are known to support for them as the 
+// degree of compat across their respective releases is usually high.
+//
+// We cannot maintain the same (compat) invariant for linux and thus, we will fallback to using lowest RID-Plaform.
 #if defined(_WIN32)
 #define LIB_PREFIX
 #define MAKE_LIBNAME(NAME) (_X(NAME) _X(".dll"))
+#define FALLBACK_HOST_RID _X("win10")
 #elif defined(__APPLE__)
 #define LIB_PREFIX _X("lib")
 #define MAKE_LIBNAME(NAME) (LIB_PREFIX _X(NAME) _X(".dylib"))
+#define FALLBACK_HOST_RID _X("osx.10.12")
 #else
 #define LIB_PREFIX _X("lib")
 #define MAKE_LIBNAME(NAME) (LIB_PREFIX _X(NAME) _X(".so"))
+#define FALLBACK_HOST_RID _X("linux")
 #endif
 
 #define LIBCLRJIT_NAME MAKE_LIBNAME("clrjit")
@@ -180,21 +190,17 @@ namespace pal
 
 #endif
 
-#if defined(__APPLE__)
-    enum os_moniker_t
-    {
-        sierra = 16,
-        el_capitan = 15,
-    };
-
-    bool get_os_moniker(os_moniker_t* moniker);
-#endif
-
     inline void err_flush() { std::fflush(stderr); }
     inline void out_flush() { std::fflush(stdout); }
 
     // Based upon https://github.com/dotnet/core-setup/blob/master/src/Microsoft.DotNet.PlatformAbstractions/Native/PlatformApis.cs
     pal::string_t get_current_os_rid_platform();
+    inline pal::string_t get_current_os_fallback_rid()
+    {
+        pal::string_t fallbackRid(FALLBACK_HOST_RID);
+
+        return fallbackRid;
+    }
         
     bool touch_file(const pal::string_t& path);
     bool realpath(string_t* path);

--- a/src/corehost/common/pal.unix.cpp
+++ b/src/corehost/common/pal.unix.cpp
@@ -297,7 +297,7 @@ pal::string_t pal::get_current_os_rid_platform()
             }
 
             ridOS.append(_X("osx.10."));
-            ridOS.append(std::to_string(minorVersion));
+            ridOS.append(pal::to_string(minorVersion));
         }
     }
 

--- a/src/corehost/common/pal.windows.cpp
+++ b/src/corehost/common/pal.windows.cpp
@@ -272,15 +272,9 @@ pal::string_t pal::get_current_os_rid_platform()
                 }
                 else if (majorVer >= 10)
                 {
-                    switch(minorVer)
-                    {
-                        case 0:
-                        default: 
-                            // Use Win10-* RID even for newer platforms we do not know for so that existing Win10 assets can be used
-                            // to keep apps working.
-                            ridOS.append(_X("win10"));
-                            break;
-                    }
+                    // Return the major version for use in RID computation without applying any cap.
+                    ridOS.append(_X("win"));
+                    ridOS.append(pal::to_string(majorVer));
                 }
             }
         }


### PR DESCRIPTION
Fixes https://github.com/dotnet/core-setup/issues/1620 based upon the comments at https://github.com/dotnet/core-setup/issues/1620#issuecomment-285226279.

I have also removed the capping from RID computation for Windows so that it is in sync with what we do for OSX and Linux (return what was computed without cap).

@eerhardt PTAL