### PR TITLE
Remove corehost executable.

### DIFF
--- a/build_projects/shared-build-targets-utils/Utils/SharedFrameworkPublisher.cs
+++ b/build_projects/shared-build-targets-utils/Utils/SharedFrameworkPublisher.cs
@@ -191,9 +191,6 @@ namespace Microsoft.DotNet.Cli.Build
                 Path.Combine(_corehostLockedDirectory, HostArtifactNames.DotnetHostBaseName),
                 Path.Combine(sharedFrameworkNameAndVersionRoot, HostArtifactNames.DotnetHostBaseName), true);
             File.Copy(
-               Path.Combine(_corehostLockedDirectory, HostArtifactNames.DotnetHostBaseName),
-               Path.Combine(sharedFrameworkNameAndVersionRoot, $"corehost{Constants.ExeSuffix}"), true);
-            File.Copy(
                Path.Combine(_corehostLockedDirectory, HostArtifactNames.DotnetHostFxrBaseName),
                Path.Combine(sharedFrameworkNameAndVersionRoot, HostArtifactNames.DotnetHostFxrBaseName), true);
 

--- a/src/corehost/common/pal.h
+++ b/src/corehost/common/pal.h
@@ -35,7 +35,6 @@
 #include <cstdlib>
 #include <libgen.h>
 
-#define HOST_EXE_NAME "corehost"
 #define xerr std::cerr
 #define xout std::cout
 #define DIR_SEPARATOR '/'


### PR DESCRIPTION
This executable was used in the project.json based CLI.  But it is no longer used with the new MSBuild based tools.  We should remove it in 2.0.

@gkhanna79 @ramarag 

/cc @livarcocc 