### PR TITLE
[release/1.1.0] Add retry on Docker image pull step in build

### DIFF
--- a/buildpipeline/Core-Setup-RHEL7-x64.json
+++ b/buildpipeline/Core-Setup-RHEL7-x64.json
@@ -22,6 +22,25 @@
       "enabled": true,
       "continueOnError": false,
       "alwaysRun": false,
+      "displayName": "Initialize Docker",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "6c731c3c-3c68-459a-a5c9-bde6e6595b5b",
+        "versionSpec": "2.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "scriptPath": "scripts/init-docker.sh",
+        "args": "$(PB_DockerImageName)",
+        "disableAutoCwd": "false",
+        "cwd": "",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
       "displayName": "Docker cleanup",
       "timeoutInMinutes": 0,
       "task": {
@@ -164,6 +183,9 @@
     },
     "GITHUB_PASSWORD": {
       "value": "PassedViaPipeBuild"
+    },
+    "PB_DockerImageName": {
+      "value": "microsoft/dotnet-buildtools-prereqs:rhel7_prereqs_2"
     }
   },
   "demands": [
@@ -174,7 +196,7 @@
       "branches": [
         "+refs/heads/*"
       ],
-      "artifacts": [ ],
+      "artifacts": [],
       "artifactTypesToDelete": [
         "FilePath",
         "SymbolStore"
@@ -197,13 +219,15 @@
       "cloneUrl": "https://github.com/dotnet/core-setup.git",
       "refsUrl": "https://api.github.com/repos/dotnet/core-setup/git/refs",
       "gitLfsSupport": "false",
-      "fetchDepth": "0"
+      "skipSyncSource": "false",
+      "fetchDepth": "0",
+      "cleanOptions": "0"
     },
     "id": "https://github.com/dotnet/core-setup.git",
     "type": "GitHub",
     "name": "dotnet/core-setup",
     "url": "https://github.com/dotnet/core-setup.git",
-    "defaultBranch": "release/build_defs_1.1.0",
+    "defaultBranch": "BuildConfigurations",
     "clean": "true",
     "checkoutSubmodules": false
   },
@@ -226,6 +250,6 @@
     "description": "Visual Studio and DevDiv team project for git source code repositories.  Work items will be added for Adams, Dev14 work items are tracked in vstfdevdiv.  ",
     "url": "https://devdiv.visualstudio.com/DefaultCollection/_apis/projects/0bdbc590-a062-4c3f-b0f6-9383f67865ee",
     "state": "wellFormed",
-    "revision": 418097459
+    "revision": 418097568
   }
 }

--- a/buildpipeline/Core-Setup-RHEL7-x64.json
+++ b/buildpipeline/Core-Setup-RHEL7-x64.json
@@ -30,8 +30,12 @@
         "definitionType": "task"
       },
       "inputs": {
+        // init-docker.sh was manually copied from dotnet/buildtools, as opposed to restoring buildtools package.
+        // Copying the script was a safer approach since:
+        //  1. Version of buildtools used in this branch does not have init-docker.sh
+        //  2. This is a service branch. Upgrading to a newer version of buildtools has a greater chance for regressions.
         "scriptPath": "scripts/init-docker.sh",
-        "args": "$(PB_DockerImageName)",
+        "args": "$(DockerImageName)",
         "disableAutoCwd": "false",
         "cwd": "",
         "failOnStandardError": "false"
@@ -68,7 +72,7 @@
       },
       "inputs": {
         "scriptPath": "scripts/dockerrun-as-current-user.sh",
-        "args": "-t --rm --sig-proxy=true --name $(DockerContainerName) -v $(Build.SourcesDirectory):/opt/code -w /opt/code -e CONNECTION_STRING -e PUBLISH_TO_AZURE_BLOB -e NUGET_FEED_URL -e NUGET_API_KEY -e GITHUB_PASSWORD $(PB_DockerImageName) /bin/bash -c \"HOME=/opt/code; git clean -X -d -f; ./build.sh $(BuildArguments)\"",
+        "args": "-t --rm --sig-proxy=true --name $(DockerContainerName) -v $(Build.SourcesDirectory):/opt/code -w /opt/code -e CONNECTION_STRING -e PUBLISH_TO_AZURE_BLOB -e NUGET_FEED_URL -e NUGET_API_KEY -e GITHUB_PASSWORD $(DockerImageName) /bin/bash -c \"HOME=/opt/code; git clean -X -d -f; ./build.sh $(BuildArguments)\"",
         "disableAutoCwd": "false",
         "cwd": "",
         "failOnStandardError": "false"
@@ -184,7 +188,7 @@
     "GITHUB_PASSWORD": {
       "value": "PassedViaPipeBuild"
     },
-    "PB_DockerImageName": {
+    "DockerImageName": {
       "value": "microsoft/dotnet-buildtools-prereqs:rhel7_prereqs_2"
     }
   },

--- a/buildpipeline/Core-Setup-RHEL7-x64.json
+++ b/buildpipeline/Core-Setup-RHEL7-x64.json
@@ -68,7 +68,7 @@
       },
       "inputs": {
         "scriptPath": "scripts/dockerrun-as-current-user.sh",
-        "args": "-t --rm --sig-proxy=true --name $(DockerContainerName) -v $(Build.SourcesDirectory):/opt/code -w /opt/code -e CONNECTION_STRING -e PUBLISH_TO_AZURE_BLOB -e NUGET_FEED_URL -e NUGET_API_KEY -e GITHUB_PASSWORD microsoft/dotnet-buildtools-prereqs:rhel7_prereqs_2 /bin/bash -c \"HOME=/opt/code; git clean -X -d -f; ./build.sh $(BuildArguments)\"",
+        "args": "-t --rm --sig-proxy=true --name $(DockerContainerName) -v $(Build.SourcesDirectory):/opt/code -w /opt/code -e CONNECTION_STRING -e PUBLISH_TO_AZURE_BLOB -e NUGET_FEED_URL -e NUGET_API_KEY -e GITHUB_PASSWORD $(PB_DockerImageName) /bin/bash -c \"HOME=/opt/code; git clean -X -d -f; ./build.sh $(BuildArguments)\"",
         "disableAutoCwd": "false",
         "cwd": "",
         "failOnStandardError": "false"

--- a/buildpipeline/Core-Setup-RHEL7-x64.json
+++ b/buildpipeline/Core-Setup-RHEL7-x64.json
@@ -30,10 +30,6 @@
         "definitionType": "task"
       },
       "inputs": {
-        // init-docker.sh was manually copied from dotnet/buildtools, as opposed to restoring buildtools package.
-        // Copying the script was a safer approach since:
-        //  1. Version of buildtools used in this branch does not have init-docker.sh
-        //  2. This is a service branch. Upgrading to a newer version of buildtools has a greater chance for regressions.
         "scriptPath": "scripts/init-docker.sh",
         "args": "$(DockerImageName)",
         "disableAutoCwd": "false",

--- a/buildpipeline/Core-Setup-RHEL7-x64.json
+++ b/buildpipeline/Core-Setup-RHEL7-x64.json
@@ -227,7 +227,7 @@
     "type": "GitHub",
     "name": "dotnet/core-setup",
     "url": "https://github.com/dotnet/core-setup.git",
-    "defaultBranch": "BuildConfigurations",
+    "defaultBranch": "release/build_defs_1.1.0",
     "clean": "true",
     "checkoutSubmodules": false
   },

--- a/scripts/cleanup-docker.sh
+++ b/scripts/cleanup-docker.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/perl
+
+#
+# ./cleanup-docker.sh 
+#
+
+# cleanup containers
+my $psList = `docker ps -a`;
+my @psItems = split /\n/, $psList;
+foreach(@psItems) {
+  # match 'docker ps' output to capture the container name
+  if($_ =~ /.*\s+([^\s]+)$/ig) {
+    my $containerName = $1;
+    if($containerName !~ /NAME/ig) {
+      printf "delete container $containerName\n";
+      my $deleteOutput = `docker rm -f $1`;
+      print "$deleteOutput\n";
+    }
+  }
+}
+
+#cleanup images
+my $imageList = `docker images`;
+@imageItems = split /\n/, $imageList;
+foreach(@imageItems) {
+  # match 'docker images' output to capture the image id
+  if($_ =~ /([^\s]+)\s+([^\s]+)\s+([^\s]+)\s+.*/ig) {
+    my $imageId = $3;
+    if($imageId !~ /IMAGE/ig) {
+      printf "delete image ID $imageId\n";
+      my $deleteImageOutput = `docker rmi -f $imageId`;
+      printf "$deleteImageOutput\n";
+    }
+  }
+}

--- a/scripts/dockerrun.sh
+++ b/scripts/dockerrun.sh
@@ -94,6 +94,7 @@ fi
 execute() {
     local count=0
     local retries=5
+    local waitFactor=6
     until "$@"; do
         local exit=$?
         count=$(( $count + 1 ))

--- a/scripts/dockerrun.sh
+++ b/scripts/dockerrun.sh
@@ -87,8 +87,40 @@ fi
 #  VSO
 [ ! -z "$BUILD_BUILDID" ] && DOTNET_BUILD_CONTAINER_NAME="${BUILD_BUILDID}-${BUILD_BUILDNUMBER}"
 
+# Executes a command and retries if it fails.
+# NOTE: This function is the exact copy from init-docker.sh.
+# Reason for not invoking init.docker.sh directly is since that script 
+# also performs cleanup, which we do not want in this case.
+execute() {
+    local count=0
+    local retries=5
+    until "$@"; do
+        local exit=$?
+        count=$(( $count + 1 ))
+        if [ $count -lt $retries ]; then
+            local wait=$(( waitFactor ** (( count - 1 )) ))
+            echo "Retry $count/$retries exited $exit, retrying in $wait seconds..."
+            sleep $wait
+        else    
+            say_err "Retry $count/$retries exited $exit, no more retries left."
+            return $exit
+        fi
+    done
+
+    return 0
+}
+
 # Build the docker container (will be fast if it is already built)
 echo "Building Docker Container using Dockerfile: $DOCKERFILE"
+
+# Get the name of Docker image.
+image=$(grep -i "^FROM " "$DOCKERFILE" | awk '{ print $2 }')
+
+if [ ! -z "$image" ]; then
+    echo "Pulling Docker image $image"
+    execute docker pull $image
+fi
+
 docker build --build-arg USER_ID=$(id -u) -t $DOTNET_BUILD_CONTAINER_TAG $DOCKERFILE
 
 # Run the build in the container

--- a/scripts/dockerrun.sh
+++ b/scripts/dockerrun.sh
@@ -117,9 +117,8 @@ echo "Building Docker Container using Dockerfile: $DOCKERFILE"
 # Get the name of Docker image.
 image=$(grep -i "^FROM " "$DOCKERFILE" | awk '{ print $2 }')
 
-# Core-Setup uses a predefined image for RHEL.  For all other Linux platforms, 
-# a Dockerfile specifies the Docker image to be built as part of the build.
-# Image name stated in the Dockerfile is pulled on behalf of the build.
+# Explicitly pull the base image with retry logic. 
+# This eliminates intermittent failures during docker build caused by failing to retrieve the base image.
 if [ ! -z "$image" ]; then
     echo "Pulling Docker image $image"
     execute docker pull $image

--- a/scripts/dockerrun.sh
+++ b/scripts/dockerrun.sh
@@ -117,6 +117,9 @@ echo "Building Docker Container using Dockerfile: $DOCKERFILE"
 # Get the name of Docker image.
 image=$(grep -i "^FROM " "$DOCKERFILE" | awk '{ print $2 }')
 
+# Core-Setup uses a predefined image for RHEL.  For all other Linux platforms, 
+# a Dockerfile specifies the Docker image to be built as part of the build.
+# Image name stated in the Dockerfile is pulled on behalf of the build.
 if [ ! -z "$image" ]; then
     echo "Pulling Docker image $image"
     execute docker pull $image

--- a/scripts/init-docker.sh
+++ b/scripts/init-docker.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+
+# Stop script on NZEC
+set -e
+# Stop script if unbound variable found (use ${var:-} if intentional)
+set -u
+
+say_err() {
+    printf "%b\n" "Error: $1" >&2
+}
+
+showHelp() {
+    echo "Usage: $scriptName [OPTIONS] [IMAGE_NAME[:TAG|@DIGEST]]"
+    echo
+    echo "Initializes Docker by:"
+    echo "  - Emitting the version of Docker that is being used"
+    echo "  - Removing all containers and images that exist on the machine"
+    echo "  - Ensuring the latest copy of the specified image exists on the machine"
+    echo
+    echo "Options:"
+    echo "  -r, --retryCount    Number of times to retry pulling image on error"
+    echo "  -w, --waitFactor    Time (seconds) to wait between pulls (time is multiplied each iteration)"
+}
+
+# Executes a command and retries if it fails.
+execute() {
+    local count=0
+    until "$@"; do
+        local exit=$?
+        count=$(( $count + 1 ))
+        if [ $count -lt $retries ]; then
+            local wait=$(( waitFactor ** (( count - 1 )) ))
+            echo "Retry $count/$retries exited $exit, retrying in $wait seconds..."
+            sleep $wait
+        else    
+            say_err "Retry $count/$retries exited $exit, no more retries left."
+            return $exit
+        fi
+    done
+
+    return 0
+}
+
+scriptName=$0
+retries=5
+waitFactor=6
+image=
+
+while [ $# -ne 0 ]; do
+    name=$1
+    case $name in
+        -h|--help)
+            showHelp
+            exit 0
+            ;;
+        -r|--retryCount)
+            shift
+            retries=$1
+            ;;
+        -w|--waitFactor)
+            shift
+            waitFactor=$1
+            ;;
+        -*)
+            say_err "Unknown option: $1"
+            exit 1
+            ;;
+        *)
+            if [ ! -z "$image" ]; then
+                say_err "Unknown argument: \`$name\`"
+                exit 1
+            fi
+
+            image="$1"
+            ;;
+    esac
+
+    shift
+done
+
+# Capture Docker version for diagnostic purposes
+docker --version
+echo
+
+echo "Cleaning Docker Artifacts"
+sourceDir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+"$sourceDir/cleanup-docker.sh"
+echo
+
+if [ ! -z "$image" ]; then
+    echo "Pulling Docker image $image"
+    execute docker pull $image
+fi

--- a/scripts/init-docker.sh
+++ b/scripts/init-docker.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+# Version of the script copied was - 
+#   https://github.com/dotnet/buildtools/blob/b5cc6e6ab5f71f6c0be7b730058b426e92528479/src/Microsoft.DotNet.Build.Tasks/PackageFiles/scripts/docker/init-docker.sh
+
 # Stop script on NZEC
 set -e
 # Stop script if unbound variable found (use ${var:-} if intentional)


### PR DESCRIPTION
Similar to #1701 But this one is for release/1.1.0

Builds for Linux platforms attempt to pull the corresponding Docker image. If an attempt fails then, there is no retry. This can cause build failure.

[BuildTools ](https://github.com/dotnet/buildtools) offers `init-docker.sh` script that can retry Docker image pull step. Hence introducing this script in this branch.

Note that RHEL has a limitation that requires a RHEL image, and cannot be built using a Dockerfile.

`init-docker.sh` was manually copied, as opposed to restoring buildtools package. Copying the script was a safer approach since:
1. Version of buildtools used in this branch does not have init-docker.sh
2. This is a service branch. Upgrading to a newer version of buildtools has a greater chance for regressions.

@MichaelSimons @chcosta @gkhanna79 please review.
