### PR TITLE
Retry Docker image pull, and cleanup - master

### DIFF
--- a/buildpipeline/Core-Setup-RHEL7-x64.json
+++ b/buildpipeline/Core-Setup-RHEL7-x64.json
@@ -20,6 +20,44 @@
     },
     {
       "enabled": true,
+      "continueOnError": true,
+      "alwaysRun": true,
+      "displayName": "Initialize tools",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "6c731c3c-3c68-459a-a5c9-bde6e6595b5b",
+        "versionSpec": "2.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "scriptPath": "pkg/init-tools.sh",
+        "args": "",
+        "disableAutoCwd": "false",
+        "cwd": "",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Initialize Docker",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "6c731c3c-3c68-459a-a5c9-bde6e6595b5b",
+        "versionSpec": "2.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "scriptPath": "pkg/Tools/scripts/docker/init-docker.sh",
+        "args": "$(DockerImageName)",
+        "disableAutoCwd": "false",
+        "cwd": "",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "enabled": true,
       "continueOnError": false,
       "alwaysRun": false,
       "displayName": "Docker cleanup",
@@ -49,26 +87,7 @@
       },
       "inputs": {
         "scriptPath": "scripts/dockerrun-as-current-user.sh",
-        "args": "-t --rm --sig-proxy=true --name $(DockerContainerName) -v $(Build.SourcesDirectory):/opt/code -w /opt/code -e CONNECTION_STRING -e PUBLISH_TO_AZURE_BLOB microsoft/dotnet-buildtools-prereqs:rhel7_prereqs_2 /bin/bash -c \"HOME=/opt/code; git clean -X -d -f; ./build.sh $(BuildArguments)\"",
-        "disableAutoCwd": "false",
-        "cwd": "",
-        "failOnStandardError": "false"
-      }
-    },
-    {
-      "enabled": true,
-      "continueOnError": true,
-      "alwaysRun": true,
-      "displayName": "Initialize tools",
-      "timeoutInMinutes": 0,
-      "task": {
-        "id": "6c731c3c-3c68-459a-a5c9-bde6e6595b5b",
-        "versionSpec": "2.*",
-        "definitionType": "task"
-      },
-      "inputs": {
-        "scriptPath": "pkg/init-tools.sh",
-        "args": "",
+        "args": "-t --rm --sig-proxy=true --name $(DockerContainerName) -v $(Build.SourcesDirectory):/opt/code -w /opt/code -e CONNECTION_STRING -e PUBLISH_TO_AZURE_BLOB $(DockerImageName) /bin/bash -c \"HOME=/opt/code; git clean -X -d -f; ./build.sh $(BuildArguments)\"",
         "disableAutoCwd": "false",
         "cwd": "",
         "failOnStandardError": "false"
@@ -164,6 +183,9 @@
     },
     "GITHUB_PASSWORD": {
       "value": "PassedViaPipeBuild"
+    },
+    "DockerImageName": {
+      "value": "microsoft/dotnet-buildtools-prereqs:rhel7_prereqs_2"
     }
   },
   "demands": [
@@ -197,7 +219,9 @@
       "cloneUrl": "https://github.com/dotnet/core-setup.git",
       "refsUrl": "https://api.github.com/repos/dotnet/core-setup/git/refs",
       "gitLfsSupport": "false",
-      "fetchDepth": "0"
+      "skipSyncSource": "false",
+      "fetchDepth": "0",
+      "cleanOptions": "0"
     },
     "id": "https://github.com/dotnet/core-setup.git",
     "type": "GitHub",
@@ -226,6 +250,6 @@
     "description": "Visual Studio and DevDiv team project for git source code repositories.  Work items will be added for Adams, Dev14 work items are tracked in vstfdevdiv.  ",
     "url": "https://devdiv.visualstudio.com/DefaultCollection/_apis/projects/0bdbc590-a062-4c3f-b0f6-9383f67865ee",
     "state": "wellFormed",
-    "revision": 418097459
+    "revision": 418097568
   }
 }

--- a/buildpipeline/Core-Setup-RHEL7-x64.json
+++ b/buildpipeline/Core-Setup-RHEL7-x64.json
@@ -92,6 +92,24 @@
         "cwd": "",
         "failOnStandardError": "false"
       }
+    },
+    {
+      "enabled": true,
+      "continueOnError": true,
+      "alwaysRun": true,
+      "displayName": "Clean up Docker images and containers",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "filename": "perl",
+        "arguments": "pkg/Tools/scripts/docker/cleanup-docker.sh",
+        "workingFolder": "",
+        "failOnStandardError": "false"
+      }
     }
   ],
   "options": [

--- a/buildpipeline/Core-Setup-RHEL7-x64.json
+++ b/buildpipeline/Core-Setup-RHEL7-x64.json
@@ -60,24 +60,6 @@
       "enabled": true,
       "continueOnError": false,
       "alwaysRun": false,
-      "displayName": "Docker cleanup",
-      "timeoutInMinutes": 0,
-      "task": {
-        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
-        "versionSpec": "1.*",
-        "definitionType": "task"
-      },
-      "inputs": {
-        "filename": "bash",
-        "arguments": "-c \"docker ps -a -q --filter name=$(DockerContainerName) | xargs --no-run-if-empty docker rm -f -v\"",
-        "workingFolder": "",
-        "failOnStandardError": "false"
-      }
-    },
-    {
-      "enabled": true,
-      "continueOnError": false,
-      "alwaysRun": false,
       "displayName": "Run build in Docker container",
       "timeoutInMinutes": 0,
       "task": {

--- a/buildpipeline/Core-Setup-RHEL7-x64.json
+++ b/buildpipeline/Core-Setup-RHEL7-x64.json
@@ -92,24 +92,6 @@
         "cwd": "",
         "failOnStandardError": "false"
       }
-    },
-    {
-      "enabled": true,
-      "continueOnError": true,
-      "alwaysRun": true,
-      "displayName": "Clean up Docker images and containers",
-      "timeoutInMinutes": 0,
-      "task": {
-        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
-        "versionSpec": "1.*",
-        "definitionType": "task"
-      },
-      "inputs": {
-        "filename": "perl",
-        "arguments": "pkg/Tools/scripts/docker/cleanup-docker.sh",
-        "workingFolder": "",
-        "failOnStandardError": "false"
-      }
     }
   ],
   "options": [

--- a/scripts/dockerrun.sh
+++ b/scripts/dockerrun.sh
@@ -87,8 +87,43 @@ fi
 #  VSO
 [ ! -z "$BUILD_BUILDID" ] && DOTNET_BUILD_CONTAINER_NAME="${BUILD_BUILDID}-${BUILD_BUILDNUMBER}"
 
+# Executes a command and retries if it fails.
+# NOTE: This function is the exact copy from init-docker.sh.
+# Reason for not invoking init.docker.sh directly is since that script 
+# also performs cleanup, which we do not want in this case.
+execute() {
+    local count=0
+    local retries=5
+    local waitFactor=6
+    until "$@"; do
+        local exit=$?
+        count=$(( $count + 1 ))
+        if [ $count -lt $retries ]; then
+            local wait=$(( waitFactor ** (( count - 1 )) ))
+            echo "Retry $count/$retries exited $exit, retrying in $wait seconds..."
+            sleep $wait
+        else    
+            say_err "Retry $count/$retries exited $exit, no more retries left."
+            return $exit
+        fi
+    done
+
+    return 0
+}
+
 # Build the docker container (will be fast if it is already built)
 echo "Building Docker Container using Dockerfile: $DOCKERFILE"
+
+# Get the name of Docker image.
+image=$(grep -i "^FROM " "$DOCKERFILE" | awk '{ print $2 }')
+
+# Explicitly pull the base image with retry logic. 
+# This eliminates intermittent failures during docker build caused by failing to retrieve the base image.
+if [ ! -z "$image" ]; then
+    echo "Pulling Docker image $image"
+    execute docker pull $image
+fi
+
 docker build --build-arg USER_ID=$(id -u) -t $DOTNET_BUILD_CONTAINER_TAG $DOCKERFILE
 
 # Run the build in the container


### PR DESCRIPTION
Recent build failures happened either due to -

1. Attempt to pull Docker image fails, and there is no retry.
2. Low disk space likely because Docker images were not cleaned up by earlier builds.

This fix attempts to add a retry on Docker image pull step. In case of RHEL, which requires a predefined image, `init-docker.sh` script is used to reliably pull down the image on behalf of the build. `init-tools.sh` task restores BuildTools package that brings in `init-docker.sh`.  Hence the task is moved up in the `Core-Setup-RHEL7-x64.json`

@MichaelSimons @dagood @chcosta @gkhanna79 please review.
