### PR TITLE
Fix intermediate path for package projects

### DIFF
--- a/pkg/projects/dir.props
+++ b/pkg/projects/dir.props
@@ -3,7 +3,6 @@
   <Import Project="..\dir.props" />
   <PropertyGroup>
     <PackagePlatform>AnyCPU</PackagePlatform>
-    <Configuration Condition="'$(Configuration)' == ''">Debug</Configuration>
     <IntermediateOutputPath Condition="'$(IntermediateOutputPath)' == ''">obj/$(Configuration)/</IntermediateOutputPath>
     <IntermediateOutputPath Condition="'$(NuGetRuntimeIdentifier)' != ''">$(IntermediateOutputPath)$(NuGetRuntimeIdentifier)/</IntermediateOutputPath>
     

--- a/pkg/projects/dir.props
+++ b/pkg/projects/dir.props
@@ -3,6 +3,10 @@
   <Import Project="..\dir.props" />
   <PropertyGroup>
     <PackagePlatform>AnyCPU</PackagePlatform>
+    <Configuration Condition="'$(Configuration)' == ''">Debug</Configuration>
+    <IntermediateOutputPath Condition="'$(IntermediateOutputPath)' == ''">obj/$(Configuration)/</IntermediateOutputPath>
+    <IntermediateOutputPath Condition="'$(NuGetRuntimeIdentifier)' != ''">$(IntermediateOutputPath)$(NuGetRuntimeIdentifier)/</IntermediateOutputPath>
+    
     <ProjectJsonTemplate>$(MSBuildThisProjectDirectory)project.json.template</ProjectJsonTemplate>
     <ProjectJson Condition="Exists('$(ProjectJsonTemplate)')">$(IntermediateOutputPath)project.json</ProjectJson>
     <ProjectLockJson Condition="Exists('$(ProjectJsonTemplate)')">$(IntermediateOutputPath)project.lock.json</ProjectLockJson>


### PR DESCRIPTION
win10 assets were not getting packaged because the intermediate path was not getting set correctly

/cc @ericstj @weshaggard 