### PR TITLE
Add assemblies which are not getting signed

### DIFF
--- a/build_projects/dotnet-host-build/sign.proj
+++ b/build_projects/dotnet-host-build/sign.proj
@@ -47,6 +47,18 @@
       <FilesToSign Include="$(IntermediateOutputPath)sharedFrameworkPublish/shared/**/Microsoft.*.dll">
         <Authenticode>$(CertificateId)</Authenticode>
       </FilesToSign>
+      <FilesToSign Include="$(IntermediateOutputPath)sharedFrameworkPublish/shared/**/mscorlib.dll">
+        <Authenticode>$(CertificateId)</Authenticode>
+      </FilesToSign>
+      <FilesToSign Include="$(IntermediateOutputPath)sharedFrameworkPublish/shared/**/netstandard.dll">
+        <Authenticode>$(CertificateId)</Authenticode>
+      </FilesToSign>
+      <FilesToSign Include="$(IntermediateOutputPath)sharedFrameworkPublish/shared/**/SOS.NETCore.dll">
+        <Authenticode>$(CertificateId)</Authenticode>
+      </FilesToSign>
+      <FilesToSign Include="$(IntermediateOutputPath)sharedFrameworkPublish/shared/**/System.dll">
+        <Authenticode>$(CertificateId)</Authenticode>
+      </FilesToSign>
       <FilesToSign Include="$(IntermediateOutputPath)sharedFrameworkPublish/shared/**/System.*.dll">
         <Authenticode>$(CertificateId)</Authenticode>
       </FilesToSign>


### PR DESCRIPTION
Fixes https://github.com/dotnet/core-setup/issues/1801

I don't have a good way to validate this, but looking at the code, it seems reasonable that this was the cause of these assemblies not getting signed.  

/cc @livarcocc @eerhardt @dagood @gkhanna79 