### PR TITLE
Update dotnet-install script to 'dotnet/cli/master'.

### DIFF
--- a/build_projects/dotnet-host-build/build.ps1
+++ b/build_projects/dotnet-host-build/build.ps1
@@ -102,7 +102,7 @@ if (!(Test-Path "$RepoRoot\artifacts"))
 }
 
 # Install a stage 0
-$DOTNET_INSTALL_SCRIPT_URL="https://raw.githubusercontent.com/dotnet/cli/rel/1.0.0/scripts/obtain/dotnet-install.ps1"
+$DOTNET_INSTALL_SCRIPT_URL="https://raw.githubusercontent.com/dotnet/cli/master/scripts/obtain/dotnet-install.ps1"
 Invoke-WebRequest $DOTNET_INSTALL_SCRIPT_URL -OutFile "$RepoRoot\artifacts\dotnet-install.ps1"
 
 & "$RepoRoot\artifacts\dotnet-install.ps1" -Version 1.0.0-preview3-003886 -Architecture $Architecture -Verbose

--- a/build_projects/dotnet-host-build/build.sh
+++ b/build_projects/dotnet-host-build/build.sh
@@ -141,7 +141,7 @@ done < "$REPOROOT/branchinfo.txt"
 [ -z "$DOTNET_INSTALL_DIR" ] && export DOTNET_INSTALL_DIR=$REPOROOT/.dotnet_stage0/$(uname)
 [ -d "$DOTNET_INSTALL_DIR" ] || mkdir -p $DOTNET_INSTALL_DIR
 
-DOTNET_INSTALL_SCRIPT_URL="https://raw.githubusercontent.com/dotnet/cli/rel/1.0.0/scripts/obtain/dotnet-install.sh"
+DOTNET_INSTALL_SCRIPT_URL="https://raw.githubusercontent.com/dotnet/cli/master/scripts/obtain/dotnet-install.sh"
 curl -sSL "$DOTNET_INSTALL_SCRIPT_URL" | bash /dev/stdin --version 1.0.0-preview3-003886 --verbose
 
 # Put stage 0 on the PATH (for this shell only)


### PR DESCRIPTION
There have been bug fixes in the dotnet-install script in the CLI master branch that we should take advantage of.

For example:

https://github.com/dotnet/cli/pull/5850

@gkhanna79 @ramarag 

/cc @am11