### PR TITLE
Run CrossBuild as agent user to avoid creating undeletable files

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -17,7 +17,7 @@ done
 DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
 
 # Some things depend on HOME and it may not be set. We should fix those things, but until then, we just patch a value in
-if [ -z "$HOME" ]; then
+if [ -z "$HOME" ] || [ ! -d "$HOME" ]; then
     export HOME=$DIR/artifacts/home
 
     [ ! -d "$HOME" ] || rm -Rf $HOME

--- a/buildpipeline/Core-Setup-CrossBuild.json
+++ b/buildpipeline/Core-Setup-CrossBuild.json
@@ -61,14 +61,15 @@
       "displayName": "Start detached container",
       "timeoutInMinutes": 0,
       "task": {
-        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
-        "versionSpec": "1.*",
+        "id": "6c731c3c-3c68-459a-a5c9-bde6e6595b5b",
+        "versionSpec": "2.*",
         "definitionType": "task"
       },
       "inputs": {
-        "filename": "docker",
-        "arguments": "run --privileged -d -w $(PB_GitDirectory) -v $(System.DefaultWorkingDirectory)/$(PB_RepoName):$(PB_GitDirectory) --name $(PB_DockerContainerName) $(PB_DockerImageName) sleep 7200",
-        "workingFolder": "",
+        "scriptPath": "$(PB_RepoName)/scripts/docker-as-current-user.sh",
+        "args": "run --privileged -d -w $(PB_GitDirectory) -v $(System.DefaultWorkingDirectory)/$(PB_RepoName):$(PB_GitDirectory) --name $(PB_DockerContainerName) $(PB_DockerImageName) sleep 7200",
+        "disableAutoCwd": "false",
+        "cwd": "",
         "failOnStandardError": "false"
       }
     },
@@ -76,17 +77,18 @@
       "enabled": true,
       "continueOnError": false,
       "alwaysRun": false,
-      "displayName": "Run Build",
+      "displayName": "Exec build",
       "timeoutInMinutes": 0,
       "task": {
-        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
-        "versionSpec": "1.*",
+        "id": "6c731c3c-3c68-459a-a5c9-bde6e6595b5b",
+        "versionSpec": "2.*",
         "definitionType": "task"
       },
       "inputs": {
-        "filename": "docker",
-        "arguments": "exec --privileged -e ROOTFS_DIR -e PUBLISH_TO_AZURE_BLOB -e CONNECTION_STRING -e CLI_NUGET_FEED_URL -e CLI_NUGET_API_KEY -e NUGET_FEED_URL -e NUGET_API_KEY -e GITHUB_PASSWORD $(PB_DockerContainerName) $(PB_GitDirectory)/build.sh $(CommonArguments) $(BuildArguments) $(portableLinux) --env-vars \"DISABLE_CROSSGEN=1,TARGETPLATFORM=$(PB_Architecture),TARGETRID=$(TargetRid),CROSS=1\"",
-        "workingFolder": "",
+        "scriptPath": "$(PB_RepoName)/scripts/docker-as-current-user.sh",
+        "args": "exec --privileged -e HOME -e ROOTFS_DIR -e PUBLISH_TO_AZURE_BLOB -e CONNECTION_STRING -e CLI_NUGET_FEED_URL -e CLI_NUGET_API_KEY -e NUGET_FEED_URL -e NUGET_API_KEY -e GITHUB_PASSWORD $(PB_DockerContainerName) $(PB_GitDirectory)/build.sh $(CommonArguments) $(BuildArguments) $(portableLinux) --env-vars \"DISABLE_CROSSGEN=1,TARGETPLATFORM=$(PB_Architecture),TARGETRID=$(TargetRid),CROSS=1\"",
+        "disableAutoCwd": "false",
+        "cwd": "",
         "failOnStandardError": "false"
       }
     },
@@ -247,7 +249,7 @@
       "value": "core-setup"
     },
     "PB_GitDirectory": {
-      "value": "/root/core-setup"
+      "value": "/opt/code/core-setup"
     },
     "PB_DockerContainerName": {
       "value": "$(Build.BuildId)"

--- a/scripts/docker-as-current-user.sh
+++ b/scripts/docker-as-current-user.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) .NET Foundation and contributors. All rights reserved.
+# Licensed under the MIT license. See LICENSE file in the project root for full license information.
+#
+
+set -e
+
+command="$1"
+shift
+docker "$command" -u="$(id -u):$(id -g)" "$@"

--- a/scripts/dockerrun-as-current-user.sh
+++ b/scripts/dockerrun-as-current-user.sh
@@ -6,4 +6,12 @@
 
 set -e
 
-docker run -u="$(id -u):$(id -g)" "$@"
+SOURCE="${BASH_SOURCE[0]}"
+while [ -h "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symlink
+  DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
+  SOURCE="$(readlink "$SOURCE")"
+  [[ "$SOURCE" != /* ]] && SOURCE="$DIR/$SOURCE" # if $SOURCE was a relative symlink, we need to resolve it relative to the path where the symlink file was located
+done
+DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
+
+"$DIR/docker-as-current-user.sh" run "$@"


### PR DESCRIPTION
Create `docker-as-current-user.sh` for both `run` and `exec`. Use this script in the CrossBuild so that files created in the mapped volume are owned by the agent user. This allows VSTS to clean up.

Since the user isn't root anymore, I had to set `HOME` to something other than `/`. `export`ing the agent account's home into the container results in a `HOME` that doesn't exist, so I added that as another condition to use the custom `HOME` code in build.sh. (Trying to simply clear `HOME` to activate the custom code results in `/` being set, and I didn't want to use the workaround of sending a random garbage value.)

I also moved the mapped container git dir from `/root/...` to `/opt/code/...` for permissions.

@MichaelSimons @gkhanna79 PTAL

I noticed when I was testing that this def doesn't have any pull-retry logic, so it failed to pull the image quite often in my test runs. Created https://github.com/dotnet/core-setup/issues/1816 for this, but it might be tracked somewhere else, too. /cc @ravimeda 