### PR TITLE
Remove Linux distro-specific dependencies

### DIFF
--- a/build_projects/shared-build-targets-utils/Utils/SharedFrameworkPublisher.cs
+++ b/build_projects/shared-build-targets-utils/Utils/SharedFrameworkPublisher.cs
@@ -263,10 +263,8 @@ namespace Microsoft.DotNet.Cli.Build
             string templateFile = Path.Combine(sharedFrameworkProjectPath, "project.json.template");
             JObject sharedFrameworkProject = JsonUtils.ReadProject(templateFile);
 
-            string netCoreAppDependencyName = GetNetCoreAppDependencyName(rid);
+            AddSharedFrameworkDependencies(sharedFrameworkProject, sharedFrameworkNugetVersion, rid);
 
-            ((JObject)sharedFrameworkProject["dependencies"]).RemoveAll();
-            sharedFrameworkProject["dependencies"][netCoreAppDependencyName] = sharedFrameworkNugetVersion;
             ((JObject)sharedFrameworkProject["runtimes"]).RemoveAll();
             sharedFrameworkProject["runtimes"][rid] = new JObject();
             ((JObject)sharedFrameworkProject["frameworks"]).RemoveAll();
@@ -280,14 +278,19 @@ namespace Microsoft.DotNet.Cli.Build
             return sharedFrameworkProjectPath;
         }
 
-        private static string GetNetCoreAppDependencyName(string rid)
+        private static void AddSharedFrameworkDependencies(
+            JObject sharedFrameworkProject,
+            string sharedFrameworkNugetVersion,
+            string rid)
         {
+            ((JObject)sharedFrameworkProject["dependencies"]).RemoveAll();
+
             if (NeedsToUseRuntimeSpecificDependency(rid))
             {
-                return $"runtime.{rid}.Microsoft.NETCore.App";
+                sharedFrameworkProject["dependencies"][$"runtime.{rid}.Microsoft.NETCore.App"] = sharedFrameworkNugetVersion;
             }
 
-            return "Microsoft.NETCore.App";
+            sharedFrameworkProject["dependencies"]["Microsoft.NETCore.App"] = sharedFrameworkNugetVersion;
         }
 
         private static bool NeedsToUseRuntimeSpecificDependency(string rid)

--- a/pkg/projects/dir.props
+++ b/pkg/projects/dir.props
@@ -108,6 +108,20 @@
     </BuildRID>
   </ItemGroup>
 
+  <!-- RIDs to remove from the runtime dependencies, so the lineup packages don't have distro specific dependencies.
+       Instead, the linux-x64 runtime will be used on all linux distros by default. 
+       NOTE: There isn't a linux-arm build yet, so we can't remove any arm RIDs. -->
+  <ItemGroup>
+    <LinuxDistroRIDNonDependency Include="debian.8-x64" />
+    <LinuxDistroRIDNonDependency Include="fedora.23-x64" />
+    <LinuxDistroRIDNonDependency Include="fedora.24-x64" />
+    <LinuxDistroRIDNonDependency Include="opensuse.42.1-x64" />
+    <LinuxDistroRIDNonDependency Include="rhel.7-x64" />
+    <LinuxDistroRIDNonDependency Include="ubuntu.14.04-x64" />
+    <LinuxDistroRIDNonDependency Include="ubuntu.16.04-x64" />
+    <LinuxDistroRIDNonDependency Include="ubuntu.16.10-x64" />
+  </ItemGroup>
+
   <ItemGroup Condition="'$(HasRuntimePackages)' != 'false'">
     <_project Include="@(BuildRID)">
       <Platform Condition="'%(Platform)' == ''">x64</Platform>

--- a/pkg/projects/dir.props
+++ b/pkg/projects/dir.props
@@ -5,7 +5,7 @@
     <PackagePlatform>AnyCPU</PackagePlatform>
     <IntermediateOutputPath Condition="'$(IntermediateOutputPath)' == ''">obj/$(Configuration)/</IntermediateOutputPath>
     <IntermediateOutputPath Condition="'$(NuGetRuntimeIdentifier)' != ''">$(IntermediateOutputPath)$(NuGetRuntimeIdentifier)/</IntermediateOutputPath>
-    
+
     <ProjectJsonTemplate>$(MSBuildThisProjectDirectory)project.json.template</ProjectJsonTemplate>
     <ProjectJson Condition="Exists('$(ProjectJsonTemplate)')">$(IntermediateOutputPath)project.json</ProjectJson>
     <ProjectLockJson Condition="Exists('$(ProjectJsonTemplate)')">$(IntermediateOutputPath)project.lock.json</ProjectLockJson>
@@ -108,18 +108,24 @@
     </BuildRID>
   </ItemGroup>
 
-  <!-- RIDs to remove from the runtime dependencies, so the lineup packages don't have distro specific dependencies.
+  <!-- RIDs to keep in the runtime dependencies, so the lineup packages don't have linux distro specific dependencies.
        Instead, the linux-x64 runtime will be used on all linux distros by default. 
        NOTE: There isn't a linux-arm build yet, so we can't remove any arm RIDs. -->
   <ItemGroup>
-    <LinuxDistroRIDNonDependency Include="debian.8-x64" />
-    <LinuxDistroRIDNonDependency Include="fedora.23-x64" />
-    <LinuxDistroRIDNonDependency Include="fedora.24-x64" />
-    <LinuxDistroRIDNonDependency Include="opensuse.42.1-x64" />
-    <LinuxDistroRIDNonDependency Include="rhel.7-x64" />
-    <LinuxDistroRIDNonDependency Include="ubuntu.14.04-x64" />
-    <LinuxDistroRIDNonDependency Include="ubuntu.16.04-x64" />
-    <LinuxDistroRIDNonDependency Include="ubuntu.16.10-x64" />
+    <ValidLineupDependency Include="alpine.3.4.3-x64" />
+    <ValidLineupDependency Include="debian.8-armel" />
+    <ValidLineupDependency Include="linux-x64" />
+    <ValidLineupDependency Include="osx.10.10-x64" />
+    <ValidLineupDependency Include="win7-x86" />
+    <ValidLineupDependency Include="win7-x64" />
+    <ValidLineupDependency Include="win8-arm" />
+    <ValidLineupDependency Include="win10-x86" />
+    <ValidLineupDependency Include="win10-x64" />
+    <ValidLineupDependency Include="win10-arm" />
+    <ValidLineupDependency Include="win10-arm64" />
+    <ValidLineupDependency Include="ubuntu.14.04-arm" />
+    <ValidLineupDependency Include="ubuntu.16.04-arm" />
+    <ValidLineupDependency Include="tizen.4.0.0-armel" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(HasRuntimePackages)' != 'false'">
@@ -134,5 +140,5 @@
 
   <ItemGroup Condition="'$(PackageTargetRuntime)' == '' and '$(HasRuntimePackages)' != 'false'">
     <ProjectReference Include="@(Project)" />
-  </ItemGroup>  
+  </ItemGroup>
 </Project>

--- a/pkg/projects/dir.targets
+++ b/pkg/projects/dir.targets
@@ -90,19 +90,43 @@
     </MSBuild>
   </Target>
 
-  <!-- Remove the linux distro specific dependencies so the portable linux RID is used by default. -->
+  <!-- Remove the specific linux distro dependencies so the portable linux RID is used by default. -->
   <Target Name="RemoveLinuxDistroDependencies"
-          Condition="'@(RuntimeDependency)' != ''"
-          AfterTargets="DetermineRuntimeDependencies"
-          Outputs="%(LinuxDistroRIDNonDependency.Identity)">
-    <PropertyGroup>
-      <CurrentLinuxDistroRID>%(LinuxDistroRIDNonDependency.Identity)</CurrentLinuxDistroRID>
-    </PropertyGroup>
+          Condition="'$(PackageTargetRuntime)' == '' And '@(RuntimeDependency)' != ''"
+          DependsOnTargets="CalculateValidLineupDependencies"
+          AfterTargets="DetermineRuntimeDependencies">
 
     <ItemGroup>
       <_RuntimeDependencyToRemove Include="@(RuntimeDependency)"
-                                  Condition="'%(RuntimeDependency.TargetRuntime)' == '$(CurrentLinuxDistroRID)'" />
+                                  Condition="!$(ValidLineupDependencies.Contains(';%(RuntimeDependency.TargetRuntime);'))" />
       <RuntimeDependency Remove="@(_RuntimeDependencyToRemove)" />
     </ItemGroup>
+  </Target>
+
+  <!-- For runtime packages on specific linux distros, add the RuntimeDependency between the current RID and the Base package.
+       This way, consumers can use the distro-specific package and get the correct assets. -->
+  <Target Name="AddLinuxDistroDependency"
+          Condition="'$(PackageTargetRuntime)' != ''"
+          DependsOnTargets="CalculatePackageVersion;CalculateValidLineupDependencies"
+          AfterTargets="DetermineRuntimeDependencies">
+
+    <PropertyGroup>
+      <ShouldAddRuntimeDependency>!$(ValidLineupDependencies.Contains(';$(PackageTargetRuntime);'))</ShouldAddRuntimeDependency>
+      <IncludeRuntimeJson Condition="'$(ShouldAddRuntimeDependency)' == 'true'">true</IncludeRuntimeJson>
+    </PropertyGroup>
+
+    <ItemGroup Condition="'$(ShouldAddRuntimeDependency)' == 'true'">
+      <RuntimeDependency Include="$(Id)"
+                         TargetRuntime="$(PackageTargetRuntime)"
+                         TargetPackage="$(BaseId)"
+                         Version="$(PackageVersion)" />
+    </ItemGroup>
+
+  </Target>
+
+  <Target Name="CalculateValidLineupDependencies">
+    <PropertyGroup>
+      <ValidLineupDependencies>;@(ValidLineupDependency);</ValidLineupDependencies>
+    </PropertyGroup>
   </Target>
 </Project>

--- a/pkg/projects/dir.targets
+++ b/pkg/projects/dir.targets
@@ -89,4 +89,20 @@
               ItemName="Dependency" />
     </MSBuild>
   </Target>
+
+  <!-- Remove the linux distro specific dependencies so the portable linux RID is used by default. -->
+  <Target Name="RemoveLinuxDistroDependencies"
+          Condition="'@(RuntimeDependency)' != ''"
+          AfterTargets="DetermineRuntimeDependencies"
+          Outputs="%(LinuxDistroRIDNonDependency.Identity)">
+    <PropertyGroup>
+      <CurrentLinuxDistroRID>%(LinuxDistroRIDNonDependency.Identity)</CurrentLinuxDistroRID>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <_RuntimeDependencyToRemove Include="@(RuntimeDependency)"
+                                  Condition="'%(RuntimeDependency.TargetRuntime)' == '$(CurrentLinuxDistroRID)'" />
+      <RuntimeDependency Remove="@(_RuntimeDependencyToRemove)" />
+    </ItemGroup>
+  </Target>
 </Project>

--- a/src/sharedframework/framework/project.json.template
+++ b/src/sharedframework/framework/project.json.template
@@ -4,7 +4,7 @@
     "emitEntryPoint": true
   },
   "dependencies": {
-    "Microsoft.NETCore.App": "$(NetCoreAppVersion)"
+    "$(MicrosoftNETCoreAppName)": "$(NetCoreAppVersion)"
   },
   "runtimes": {
     "$(RID)": {}


### PR DESCRIPTION
Removing the Linux distros from the runtime.json dependency list. This will cause anyone using self-contained applications to use the portable linux assets by default.

@weshaggard @gkhanna79 @ericstj 

/cc @Petermarcu 