### PR TITLE
Remove win10 specific runtime packages

### DIFF
--- a/pkg/projects/dir.props
+++ b/pkg/projects/dir.props
@@ -52,7 +52,9 @@
   <PropertyGroup Condition="'$(PackageRID)' == ''">
     <PackageRID>$(DistroRid)</PackageRID>
     <PackageRID Condition="'$(OSEnvironment)' == 'OSX'">osx.10.12-$(Platform)</PackageRID>
-    <PackageRID Condition="'$(OSEnvironment)' == 'Windows_NT'">win10-$(Platform)</PackageRID>
+    <PackageRID Condition="'$(OSEnvironment)' == 'Windows_NT'">win7-$(Platform)</PackageRID>
+    <PackageRID Condition="'$(OSEnvironment)' == 'Windows_NT' AND '$(Platform)' =='arm'">win8-$(Platform)</PackageRID>
+    <PackageRID Condition="'$(OSEnvironment)' == 'Windows_NT' AND '$(Platform)' =='arm64'">win10-$(Platform)</PackageRID>
   </PropertyGroup>
 
   <ItemGroup>
@@ -71,21 +73,10 @@
     <OfficialBuildRID Include="ubuntu.16.04-x64" />
     <OfficialBuildRID Include="ubuntu.16.10-x64" />
     <OfficialBuildRID Include="win7-x86">
-      <BuidOnRID>win10-x86</BuidOnRID>
       <Platform>x86</Platform>
     </OfficialBuildRID>
-    <OfficialBuildRID Include="win7-x64">
-      <BuidOnRID>win10-x64</BuidOnRID>
-    </OfficialBuildRID>
+    <OfficialBuildRID Include="win7-x64"/>
     <OfficialBuildRID Include="win8-arm">
-      <BuidOnRID>win10-arm</BuidOnRID>
-      <Platform>arm</Platform>
-    </OfficialBuildRID>
-    <OfficialBuildRID Include="win10-x86">
-      <Platform>x86</Platform>
-    </OfficialBuildRID>
-    <OfficialBuildRID Include="win10-x64" />
-    <OfficialBuildRID Include="win10-arm">
       <Platform>arm</Platform>
     </OfficialBuildRID>
     <OfficialBuildRID Include="win10-arm64">


### PR DESCRIPTION
Previously I was building a different Core.App on win10 in order to
reduce the size of the package and therefore standalone apps, since we
had API-sets that were specific to older versions of windows.

We no longer have that dependency so removing the unnecessary
additional packages.

Fixes #1825.

This was a quick and dirty change.  @chcosta feel free to cherry-pick and polish if you'd like this to be different.

/cc @eerhardt @gkhanna79 