### PR TITLE
Remove Linux distro-specific dependencies

### DIFF
--- a/pkg/projects/dir.props
+++ b/pkg/projects/dir.props
@@ -57,19 +57,11 @@
 
   <ItemGroup>
     <OfficialBuildRID Include="alpine.3.4.3-x64" />
-    <OfficialBuildRID Include="debian.8-x64" />
     <OfficialBuildRid Include="debian.8-armel">
       <Platform>armel</Platform>
     </OfficialBuildRid>
-    <OfficialBuildRID Include="fedora.23-x64" />
-    <OfficialBuildRID Include="fedora.24-x64" />
     <OfficialBuildRID Include="linux-x64" />
-    <OfficialBuildRID Include="opensuse.42.1-x64" />
     <OfficialBuildRID Include="osx.10.12-x64" />
-    <OfficialBuildRID Include="rhel.7-x64" />
-    <OfficialBuildRID Include="ubuntu.14.04-x64" />
-    <OfficialBuildRID Include="ubuntu.16.04-x64" />
-    <OfficialBuildRID Include="ubuntu.16.10-x64" />
     <OfficialBuildRID Include="win7-x86">
       <BuidOnRID>win10-x86</BuidOnRID>
       <Platform>x86</Platform>


### PR DESCRIPTION
Removing the Linux distros from the runtime.json dependency list. This will cause anyone using self-contained applications to use the portable linux assets by default.
