### PR TITLE
Issue #1574: Enable new MSI upgrade code to support proper ref counting for SxS install of HostFxr (1.0)

### DIFF
--- a/build_projects/dotnet-host-build/CompileTargets.cs
+++ b/build_projects/dotnet-host-build/CompileTargets.cs
@@ -364,9 +364,6 @@ namespace Microsoft.DotNet.Host.Build
             var dotnetCli = DotNetCli.Stage0;
             var hostVersion = c.BuildContext.Get<HostVersion>("HostVersion");
             var sharedFrameworkNugetVersion = c.BuildContext.Get<string>("SharedFrameworkNugetVersion");
-
-            // For Windows (MSI) we want to pick the MSI version of LockedHostFxrVersion till the time we do not ship an updated hostfxr (to 1.0.1) (#1574)
-            //var hostFxrVersion = hostVersion.LockedHostFxrVersion.ToString();
             var hostFxrVersion = (CurrentPlatform.Current == BuildPlatform.Windows) ? hostVersion.LockedHostFxrMSIVersion.ToString() : hostVersion.LockedHostFxrVersion.ToString();
             var commitHash = c.BuildContext.Get<string>("CommitHash");
 

--- a/build_projects/dotnet-host-build/CompileTargets.cs
+++ b/build_projects/dotnet-host-build/CompileTargets.cs
@@ -364,8 +364,7 @@ namespace Microsoft.DotNet.Host.Build
             var dotnetCli = DotNetCli.Stage0;
             var hostVersion = c.BuildContext.Get<HostVersion>("HostVersion");
             var sharedFrameworkNugetVersion = c.BuildContext.Get<string>("SharedFrameworkNugetVersion");
-            //We provide a different locked hostFxr version for Windows (MSIs) instead of LockedHostFxrVersion for issue #1574. This we can update when we have the next binary change for the hostfxr.dll (from 1.0.1)
-            var hostFxrVersion = (CurrentPlatform.Current == BuildPlatform.Windows) ? hostVersion.LockedHostFxrMSIVersion.ToString() : hostVersion.LockedHostFxrVersion.ToString();
+            var hostFxrVersion = hostVersion.GetLockedPlatformInstallerVersion().ToString();
             var commitHash = c.BuildContext.Get<string>("CommitHash");
 
             var sharedFrameworkPublisher = new SharedFrameworkPublisher(

--- a/build_projects/dotnet-host-build/CompileTargets.cs
+++ b/build_projects/dotnet-host-build/CompileTargets.cs
@@ -364,7 +364,7 @@ namespace Microsoft.DotNet.Host.Build
             var dotnetCli = DotNetCli.Stage0;
             var hostVersion = c.BuildContext.Get<HostVersion>("HostVersion");
             var sharedFrameworkNugetVersion = c.BuildContext.Get<string>("SharedFrameworkNugetVersion");
-            var hostFxrVersion = hostVersion.GetLockedPlatformInstallerVersion().ToString();
+            var hostFxrVersion = hostVersion.GetLockedHostFXRPlatformInstallerVersion().ToString();
             var commitHash = c.BuildContext.Get<string>("CommitHash");
 
             var sharedFrameworkPublisher = new SharedFrameworkPublisher(

--- a/build_projects/dotnet-host-build/CompileTargets.cs
+++ b/build_projects/dotnet-host-build/CompileTargets.cs
@@ -364,6 +364,7 @@ namespace Microsoft.DotNet.Host.Build
             var dotnetCli = DotNetCli.Stage0;
             var hostVersion = c.BuildContext.Get<HostVersion>("HostVersion");
             var sharedFrameworkNugetVersion = c.BuildContext.Get<string>("SharedFrameworkNugetVersion");
+            //We provide a different locked hostFxr version for Windows (MSIs) instead of LockedHostFxrVersion for issue #1574. This we can update when we have the next binary change for the hostfxr.dll (from 1.0.1)
             var hostFxrVersion = (CurrentPlatform.Current == BuildPlatform.Windows) ? hostVersion.LockedHostFxrMSIVersion.ToString() : hostVersion.LockedHostFxrVersion.ToString();
             var commitHash = c.BuildContext.Get<string>("CommitHash");
 

--- a/build_projects/dotnet-host-build/CompileTargets.cs
+++ b/build_projects/dotnet-host-build/CompileTargets.cs
@@ -364,7 +364,10 @@ namespace Microsoft.DotNet.Host.Build
             var dotnetCli = DotNetCli.Stage0;
             var hostVersion = c.BuildContext.Get<HostVersion>("HostVersion");
             var sharedFrameworkNugetVersion = c.BuildContext.Get<string>("SharedFrameworkNugetVersion");
-            var hostFxrVersion = hostVersion.LockedHostFxrVersion.ToString();
+
+            // For Windows (MSI) we want to pick the MSI version of LockedHostFxrVersion till the time we do not ship an updated hostfxr (to 1.0.1) (#1574)
+            //var hostFxrVersion = hostVersion.LockedHostFxrVersion.ToString();
+            var hostFxrVersion = (CurrentPlatform.Current == BuildPlatform.Windows) ? hostVersion.LockedHostFxrMSIVersion.ToString() : hostVersion.LockedHostFxrVersion.ToString();
             var commitHash = c.BuildContext.Get<string>("CommitHash");
 
             var sharedFrameworkPublisher = new SharedFrameworkPublisher(

--- a/build_projects/dotnet-host-build/MsiTargets.cs
+++ b/build_projects/dotnet-host-build/MsiTargets.cs
@@ -139,8 +139,8 @@ namespace Microsoft.DotNet.Host.Build
         public static BuildTargetResult GenerateDotnetHostFxrMsi(BuildTargetContext c)
         {
             var hostVersion = c.BuildContext.Get<HostVersion>("HostVersion");
-            var hostFxrMsiVersion = hostVersion.LockedHostFxrVersion.GenerateMsiVersion();            
-            var hostFxrNugetVersion = hostVersion.LockedHostFxrVersion.ToString();
+            var hostFxrInternalMsiVersion = hostVersion.LockedHostFxrMSIVersion.GenerateMsiVersion();
+            var hostFxrMSIVersion = hostVersion.LockedHostFxrMSIVersion.ToString();
             var inputDir = c.BuildContext.Get<string>("HostFxrPublishRoot");
             var wixObjRoot = Path.Combine(Dirs.Output, "obj", "wix", "hostfxr");
             var hostFxrBrandName = $"'{Monikers.HostFxrBrandName}'";
@@ -154,7 +154,7 @@ namespace Microsoft.DotNet.Host.Build
 
             Cmd("powershell", "-NoProfile", "-NoLogo",
                 Path.Combine(Dirs.RepoRoot, "packaging", "windows", "hostfxr", "generatemsi.ps1"),
-                inputDir, HostFxrMsi, WixRoot, hostFxrBrandName, hostFxrMsiVersion, hostFxrNugetVersion, Arch, wixObjRoot, upgradeCode)
+                inputDir, HostFxrMsi, WixRoot, hostFxrBrandName, hostFxrInternalMsiVersion, hostFxrMSIVersion, Arch, wixObjRoot, upgradeCode)
                     .Execute()
                     .EnsureSuccessful();
             return c.Success();

--- a/build_projects/dotnet-host-build/MsiTargets.cs
+++ b/build_projects/dotnet-host-build/MsiTargets.cs
@@ -139,9 +139,8 @@ namespace Microsoft.DotNet.Host.Build
         public static BuildTargetResult GenerateDotnetHostFxrMsi(BuildTargetContext c)
         {
             var hostVersion = c.BuildContext.Get<HostVersion>("HostVersion");
-            //We provide a different locked hostFxr version for Windows (MSIs) instead of LockedHostFxrVersion for issue #1574. This we can update when we have the next binary change for the hostfxr.dll (from 1.0.1)
-            var hostFxrInternalMsiVersion = hostVersion.LockedHostFxrMSIVersion.GenerateMsiVersion();
-            var hostFxrMSIVersion = hostVersion.LockedHostFxrMSIVersion.ToString();
+            var hostFxrInternalMsiVersion = hostVersion.GetLockedPlatformInstallerVersion().GenerateMsiVersion();
+            var hostFxrMSIVersion = hostVersion.GetLockedPlatformInstallerVersion().ToString();
             var inputDir = c.BuildContext.Get<string>("HostFxrPublishRoot");
             var wixObjRoot = Path.Combine(Dirs.Output, "obj", "wix", "hostfxr");
             var hostFxrBrandName = $"'{Monikers.HostFxrBrandName}'";

--- a/build_projects/dotnet-host-build/MsiTargets.cs
+++ b/build_projects/dotnet-host-build/MsiTargets.cs
@@ -144,6 +144,7 @@ namespace Microsoft.DotNet.Host.Build
             var inputDir = c.BuildContext.Get<string>("HostFxrPublishRoot");
             var wixObjRoot = Path.Combine(Dirs.Output, "obj", "wix", "hostfxr");
             var hostFxrBrandName = $"'{Monikers.HostFxrBrandName}'";
+            var upgradeCode = Utils.GenerateGuidFromName(HostFxrMsi).ToString().ToUpper(); 
 
             if (Directory.Exists(wixObjRoot))
             {
@@ -153,7 +154,7 @@ namespace Microsoft.DotNet.Host.Build
 
             Cmd("powershell", "-NoProfile", "-NoLogo",
                 Path.Combine(Dirs.RepoRoot, "packaging", "windows", "hostfxr", "generatemsi.ps1"),
-                inputDir, HostFxrMsi, WixRoot, hostFxrBrandName, hostFxrMsiVersion, hostFxrNugetVersion, Arch, wixObjRoot)
+                inputDir, HostFxrMsi, WixRoot, hostFxrBrandName, hostFxrMsiVersion, hostFxrNugetVersion, Arch, wixObjRoot, upgradeCode)
                     .Execute()
                     .EnsureSuccessful();
             return c.Success();

--- a/build_projects/dotnet-host-build/MsiTargets.cs
+++ b/build_projects/dotnet-host-build/MsiTargets.cs
@@ -139,6 +139,7 @@ namespace Microsoft.DotNet.Host.Build
         public static BuildTargetResult GenerateDotnetHostFxrMsi(BuildTargetContext c)
         {
             var hostVersion = c.BuildContext.Get<HostVersion>("HostVersion");
+            //We provide a different locked hostFxr version for Windows (MSIs) instead of LockedHostFxrVersion for issue #1574. This we can update when we have the next binary change for the hostfxr.dll (from 1.0.1)
             var hostFxrInternalMsiVersion = hostVersion.LockedHostFxrMSIVersion.GenerateMsiVersion();
             var hostFxrMSIVersion = hostVersion.LockedHostFxrMSIVersion.ToString();
             var inputDir = c.BuildContext.Get<string>("HostFxrPublishRoot");

--- a/build_projects/dotnet-host-build/MsiTargets.cs
+++ b/build_projects/dotnet-host-build/MsiTargets.cs
@@ -139,8 +139,8 @@ namespace Microsoft.DotNet.Host.Build
         public static BuildTargetResult GenerateDotnetHostFxrMsi(BuildTargetContext c)
         {
             var hostVersion = c.BuildContext.Get<HostVersion>("HostVersion");
-            var hostFxrInternalMsiVersion = hostVersion.GetLockedPlatformInstallerVersion().GenerateMsiVersion();
-            var hostFxrMSIVersion = hostVersion.GetLockedPlatformInstallerVersion().ToString();
+            var hostFxrInternalMsiVersion = hostVersion.GetLockedHostFXRPlatformInstallerVersion().GenerateMsiVersion();
+            var hostFxrMSIVersion = hostVersion.GetLockedHostFXRPlatformInstallerVersion().ToString();
             var inputDir = c.BuildContext.Get<string>("HostFxrPublishRoot");
             var wixObjRoot = Path.Combine(Dirs.Output, "obj", "wix", "hostfxr");
             var hostFxrBrandName = $"'{Monikers.HostFxrBrandName}'";

--- a/build_projects/dotnet-host-build/PrepareTargets.cs
+++ b/build_projects/dotnet-host-build/PrepareTargets.cs
@@ -169,8 +169,7 @@ namespace Microsoft.DotNet.Host.Build
 
             var sharedFrameworkVersion = c.BuildContext.Get<string>("SharedFrameworkNugetVersion");
             var hostVersion = c.BuildContext.Get<HostVersion>("HostVersion").LockedHostVersion.ToString();
-            //We provide a different locked hostFxr version for Windows (MSIs) instead of LockedHostFxrVersion for issue #1574. This we can update when we have the next binary change for the hostfxr.dll (from 1.0.1)
-            var hostFxrVersion = (CurrentPlatform.Current == BuildPlatform.Windows) ? c.BuildContext.Get<HostVersion>("HostVersion").LockedHostFxrMSIVersion.ToString() : c.BuildContext.Get<HostVersion>("HostVersion").LockedHostFxrVersion.ToString();
+            var hostFxrVersion = c.BuildContext.Get<HostVersion>("HostVersion").GetLockedPlatformInstallerVersion().ToString();
 
             AddInstallerArtifactToContext(c, "dotnet-host", "SharedHost", hostVersion);
             AddInstallerArtifactToContext(c, "dotnet-hostfxr", "HostFxr", hostFxrVersion);

--- a/build_projects/dotnet-host-build/PrepareTargets.cs
+++ b/build_projects/dotnet-host-build/PrepareTargets.cs
@@ -169,8 +169,16 @@ namespace Microsoft.DotNet.Host.Build
 
             var sharedFrameworkVersion = c.BuildContext.Get<string>("SharedFrameworkNugetVersion");
             var hostVersion = c.BuildContext.Get<HostVersion>("HostVersion").LockedHostVersion.ToString();
-            var hostFxrVersion = c.BuildContext.Get<HostVersion>("HostVersion").LockedHostFxrVersion.ToString();
-
+            var hostFxrVersion = "";
+            if (CurrentPlatform.Current == BuildPlatform.Windows)
+            {
+                hostFxrVersion = c.BuildContext.Get<HostVersion>("HostVersion").LockedHostFxrMSIVersion.ToString();
+            }
+            else
+            {
+                hostFxrVersion = c.BuildContext.Get<HostVersion>("HostVersion").LockedHostFxrVersion.ToString();
+            }
+            
             AddInstallerArtifactToContext(c, "dotnet-host", "SharedHost", hostVersion);
             AddInstallerArtifactToContext(c, "dotnet-hostfxr", "HostFxr", hostFxrVersion);
             AddInstallerArtifactToContext(c, "dotnet-sharedframework", "SharedFramework", sharedFrameworkVersion);

--- a/build_projects/dotnet-host-build/PrepareTargets.cs
+++ b/build_projects/dotnet-host-build/PrepareTargets.cs
@@ -169,7 +169,7 @@ namespace Microsoft.DotNet.Host.Build
 
             var sharedFrameworkVersion = c.BuildContext.Get<string>("SharedFrameworkNugetVersion");
             var hostVersion = c.BuildContext.Get<HostVersion>("HostVersion").LockedHostVersion.ToString();
-            var hostFxrVersion = c.BuildContext.Get<HostVersion>("HostVersion").GetLockedPlatformInstallerVersion().ToString();
+            var hostFxrVersion = c.BuildContext.Get<HostVersion>("HostVersion").GetLockedHostFXRPlatformInstallerVersion().ToString();
 
             AddInstallerArtifactToContext(c, "dotnet-host", "SharedHost", hostVersion);
             AddInstallerArtifactToContext(c, "dotnet-hostfxr", "HostFxr", hostFxrVersion);

--- a/build_projects/dotnet-host-build/PrepareTargets.cs
+++ b/build_projects/dotnet-host-build/PrepareTargets.cs
@@ -169,6 +169,7 @@ namespace Microsoft.DotNet.Host.Build
 
             var sharedFrameworkVersion = c.BuildContext.Get<string>("SharedFrameworkNugetVersion");
             var hostVersion = c.BuildContext.Get<HostVersion>("HostVersion").LockedHostVersion.ToString();
+            //We provide a different locked hostFxr version for Windows (MSIs) instead of LockedHostFxrVersion for issue #1574. This we can update when we have the next binary change for the hostfxr.dll (from 1.0.1)
             var hostFxrVersion = (CurrentPlatform.Current == BuildPlatform.Windows) ? c.BuildContext.Get<HostVersion>("HostVersion").LockedHostFxrMSIVersion.ToString() : c.BuildContext.Get<HostVersion>("HostVersion").LockedHostFxrVersion.ToString();
 
             AddInstallerArtifactToContext(c, "dotnet-host", "SharedHost", hostVersion);

--- a/build_projects/dotnet-host-build/PrepareTargets.cs
+++ b/build_projects/dotnet-host-build/PrepareTargets.cs
@@ -169,16 +169,8 @@ namespace Microsoft.DotNet.Host.Build
 
             var sharedFrameworkVersion = c.BuildContext.Get<string>("SharedFrameworkNugetVersion");
             var hostVersion = c.BuildContext.Get<HostVersion>("HostVersion").LockedHostVersion.ToString();
-            var hostFxrVersion = "";
-            if (CurrentPlatform.Current == BuildPlatform.Windows)
-            {
-                hostFxrVersion = c.BuildContext.Get<HostVersion>("HostVersion").LockedHostFxrMSIVersion.ToString();
-            }
-            else
-            {
-                hostFxrVersion = c.BuildContext.Get<HostVersion>("HostVersion").LockedHostFxrVersion.ToString();
-            }
-            
+            var hostFxrVersion = (CurrentPlatform.Current == BuildPlatform.Windows) ? c.BuildContext.Get<HostVersion>("HostVersion").LockedHostFxrMSIVersion.ToString() : c.BuildContext.Get<HostVersion>("HostVersion").LockedHostFxrVersion.ToString();
+
             AddInstallerArtifactToContext(c, "dotnet-host", "SharedHost", hostVersion);
             AddInstallerArtifactToContext(c, "dotnet-hostfxr", "HostFxr", hostFxrVersion);
             AddInstallerArtifactToContext(c, "dotnet-sharedframework", "SharedFramework", sharedFrameworkVersion);

--- a/build_projects/dotnet-host-build/PublishTargets.cs
+++ b/build_projects/dotnet-host-build/PublishTargets.cs
@@ -40,7 +40,7 @@ namespace Microsoft.DotNet.Host.Build
             DebRepoPublisherTool = new DebRepoPublisher(Dirs.Packages);
             SharedFrameworkNugetVersion = c.BuildContext.Get<string>("SharedFrameworkNugetVersion");
             SharedHostNugetVersion = c.BuildContext.Get<HostVersion>("HostVersion").LockedHostVersion.ToString();
-            HostFxrNugetVersion = (CurrentPlatform.Current == BuildPlatform.Windows) ? c.BuildContext.Get<HostVersion>("HostVersion").LockedHostFxrMSIVersion.ToString() : c.BuildContext.Get<HostVersion>("HostVersion").LockedHostFxrVersion.ToString();
+            HostFxrNugetVersion = c.BuildContext.Get<HostVersion>("HostVersion").LockedHostFxrVersion.ToString();
             Channel = c.BuildContext.Get<string>("Channel");
             BranchName = c.BuildContext.Get<string>("BranchName");
             CommitHash = c.BuildContext.Get<string>("CommitHash");

--- a/build_projects/dotnet-host-build/PublishTargets.cs
+++ b/build_projects/dotnet-host-build/PublishTargets.cs
@@ -40,14 +40,7 @@ namespace Microsoft.DotNet.Host.Build
             DebRepoPublisherTool = new DebRepoPublisher(Dirs.Packages);
             SharedFrameworkNugetVersion = c.BuildContext.Get<string>("SharedFrameworkNugetVersion");
             SharedHostNugetVersion = c.BuildContext.Get<HostVersion>("HostVersion").LockedHostVersion.ToString();
-            if (CurrentPlatform.Current == BuildPlatform.Windows)
-            {
-                HostFxrNugetVersion = c.BuildContext.Get<HostVersion>("HostVersion").LockedHostFxrMSIVersion.ToString();
-            }
-            else
-            {
-                HostFxrNugetVersion = c.BuildContext.Get<HostVersion>("HostVersion").LockedHostFxrVersion.ToString();
-            }
+            HostFxrNugetVersion = (CurrentPlatform.Current == BuildPlatform.Windows) ? c.BuildContext.Get<HostVersion>("HostVersion").LockedHostFxrMSIVersion.ToString() : c.BuildContext.Get<HostVersion>("HostVersion").LockedHostFxrVersion.ToString();
             Channel = c.BuildContext.Get<string>("Channel");
             BranchName = c.BuildContext.Get<string>("BranchName");
             CommitHash = c.BuildContext.Get<string>("CommitHash");

--- a/build_projects/dotnet-host-build/PublishTargets.cs
+++ b/build_projects/dotnet-host-build/PublishTargets.cs
@@ -40,7 +40,14 @@ namespace Microsoft.DotNet.Host.Build
             DebRepoPublisherTool = new DebRepoPublisher(Dirs.Packages);
             SharedFrameworkNugetVersion = c.BuildContext.Get<string>("SharedFrameworkNugetVersion");
             SharedHostNugetVersion = c.BuildContext.Get<HostVersion>("HostVersion").LockedHostVersion.ToString();
-            HostFxrNugetVersion = c.BuildContext.Get<HostVersion>("HostVersion").LockedHostFxrVersion.ToString();
+            if (CurrentPlatform.Current == BuildPlatform.Windows)
+            {
+                HostFxrNugetVersion = c.BuildContext.Get<HostVersion>("HostVersion").LockedHostFxrMSIVersion.ToString();
+            }
+            else
+            {
+                HostFxrNugetVersion = c.BuildContext.Get<HostVersion>("HostVersion").LockedHostFxrVersion.ToString();
+            }
             Channel = c.BuildContext.Get<string>("Channel");
             BranchName = c.BuildContext.Get<string>("BranchName");
             CommitHash = c.BuildContext.Get<string>("CommitHash");

--- a/build_projects/shared-build-targets-utils/Utils/HostVersion.cs
+++ b/build_projects/shared-build-targets-utils/Utils/HostVersion.cs
@@ -1,6 +1,6 @@
+using Microsoft.DotNet.Cli.Build.Framework;
 using System;
 using System.Collections.Generic;
-using Microsoft.DotNet.Cli.Build.Framework;
 
 namespace Microsoft.DotNet.Cli.Build
 {
@@ -100,6 +100,7 @@ namespace Microsoft.DotNet.Cli.Build
             { "hostfxr", LatestHostFxrVersion },
             { "hostpolicy", LatestHostPolicyVersion }
         };
+
         //
         // Locked muxer for consumption in CLI.
         //

--- a/build_projects/shared-build-targets-utils/Utils/HostVersion.cs
+++ b/build_projects/shared-build-targets-utils/Utils/HostVersion.cs
@@ -108,7 +108,8 @@ namespace Microsoft.DotNet.Cli.Build
         public bool IsLocked = true; // Set this variable to toggle muxer locking.
         public VerInfo LockedHostFxrVersion => IsLocked ? new VerInfo(1, 0, 1, "", "", "", CommitCountString) : LatestHostFxrVersion;
         //We add a different LockedHostFxrVersion for the MSI as the package needs to deviate for issue #1574. This we can update or remove when we have a binary change for the hostfxr.dll (from 1.0.1)
-        public VerInfo LockedHostFxrMSIVersion => new VerInfo(1, 0, 5, "", "", "", CommitCountString);
+        public bool fExplicitHostFXRMSIVersion = true; // Set this variable to override LatestHostFxrVersion for MSI packages only. This can be set to false when we fall back to using just LockedHostFxrVersion for all.
+        public VerInfo LockedHostFxrMSIVersion => fExplicitHostFXRMSIVersion ? new VerInfo(1, 0, 5, "", "", "", CommitCountString) : LockedHostFxrVersion;
         public VerInfo LockedHostVersion    => IsLocked ? new VerInfo(1, 0, 1, "", "", "", CommitCountString) : LatestHostVersion;
     }
 }

--- a/build_projects/shared-build-targets-utils/Utils/HostVersion.cs
+++ b/build_projects/shared-build-targets-utils/Utils/HostVersion.cs
@@ -72,7 +72,7 @@ namespace Microsoft.DotNet.Cli.Build
         // These versions should only be incremented in a servicing release if the package in question
         // is being updated.
         public VerInfo LatestHostVersion => new VerInfo(1, 0, 1, "", "", "", CommitCountString);
-        public VerInfo LatestHostFxrVersion => new VerInfo(1, 0, 1, "", "", "", CommitCountString);
+        public VerInfo LatestHostFxrVersion => new VerInfo(1, 0, 2, "", "", "", CommitCountString);
         public VerInfo LatestHostPolicyVersion => new VerInfo(1, 0, 3, "", "", "", CommitCountString);
   
         public Dictionary<string, VerInfo> LatestHostPackages => new Dictionary<string, VerInfo>()
@@ -106,7 +106,7 @@ namespace Microsoft.DotNet.Cli.Build
         // These versions are used when generating platform installers.
         //
         public bool IsLocked = true; // Set this variable to toggle muxer locking.
-        public VerInfo LockedHostFxrVersion => IsLocked ? new VerInfo(1, 0, 1, "", "", "", CommitCountString) : LatestHostFxrVersion;
+        public VerInfo LockedHostFxrVersion => IsLocked ? new VerInfo(1, 0, 2, "", "", "", CommitCountString) : LatestHostFxrVersion;
         public VerInfo LockedHostVersion    => IsLocked ? new VerInfo(1, 0, 1, "", "", "", CommitCountString) : LatestHostVersion;
     }
 }

--- a/build_projects/shared-build-targets-utils/Utils/HostVersion.cs
+++ b/build_projects/shared-build-targets-utils/Utils/HostVersion.cs
@@ -107,7 +107,7 @@ namespace Microsoft.DotNet.Cli.Build
         //
         public bool IsLocked = true; // Set this variable to toggle muxer locking.
         public VerInfo LockedHostFxrVersion => IsLocked ? new VerInfo(1, 0, 1, "", "", "", CommitCountString) : LatestHostFxrVersion;
-        //We add a different LockedHostFxrVersion for the MSI as the package needs to deviate for issue #1574. This we can reconcile and remove when we have a binary change for the hostfxr.dll
+        //We add a different LockedHostFxrVersion for the MSI as the package needs to deviate for issue #1574. This we can update or remove when we have a binary change for the hostfxr.dll (from 1.0.1)
         public VerInfo LockedHostFxrMSIVersion => new VerInfo(1, 0, 5, "", "", "", CommitCountString);
         public VerInfo LockedHostVersion    => IsLocked ? new VerInfo(1, 0, 1, "", "", "", CommitCountString) : LatestHostVersion;
     }

--- a/build_projects/shared-build-targets-utils/Utils/HostVersion.cs
+++ b/build_projects/shared-build-targets-utils/Utils/HostVersion.cs
@@ -113,7 +113,7 @@ namespace Microsoft.DotNet.Cli.Build
 
         // This method returns the locked hostfxr version based on the flag fExplicitHostFXRMSIVersion and the current platform. 
         // For MSI (Windows) generation we specify a newer version for handling issue #1574 and for non-Windows platform we return the LockedHostFxrVersion.
-        public VerInfo GetLockedPlatformInstallerVersion()
+        public VerInfo GetLockedHostFXRPlatformInstallerVersion()
         {
             VerInfo version = LockedHostFxrVersion;
 

--- a/build_projects/shared-build-targets-utils/Utils/HostVersion.cs
+++ b/build_projects/shared-build-targets-utils/Utils/HostVersion.cs
@@ -100,7 +100,6 @@ namespace Microsoft.DotNet.Cli.Build
             { "hostfxr", LatestHostFxrVersion },
             { "hostpolicy", LatestHostPolicyVersion }
         };
-        
         //
         // Locked muxer for consumption in CLI.
         //

--- a/build_projects/shared-build-targets-utils/Utils/HostVersion.cs
+++ b/build_projects/shared-build-targets-utils/Utils/HostVersion.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using Microsoft.DotNet.Cli.Build.Framework;
 
 namespace Microsoft.DotNet.Cli.Build
 {
@@ -99,7 +100,7 @@ namespace Microsoft.DotNet.Cli.Build
             { "hostfxr", LatestHostFxrVersion },
             { "hostpolicy", LatestHostPolicyVersion }
         };
-
+        
         //
         // Locked muxer for consumption in CLI.
         //
@@ -107,9 +108,21 @@ namespace Microsoft.DotNet.Cli.Build
         //
         public bool IsLocked = true; // Set this variable to toggle muxer locking.
         public VerInfo LockedHostFxrVersion => IsLocked ? new VerInfo(1, 0, 1, "", "", "", CommitCountString) : LatestHostFxrVersion;
-        //We add a different LockedHostFxrVersion for the MSI as the package needs to deviate for issue #1574. This we can update or remove when we have a binary change for the hostfxr.dll (from 1.0.1)
-        public bool fExplicitHostFXRMSIVersion = true; // Set this variable to override LatestHostFxrVersion for MSI packages only. This can be set to false when we fall back to using just LockedHostFxrVersion for all.
-        public VerInfo LockedHostFxrMSIVersion => fExplicitHostFXRMSIVersion ? new VerInfo(1, 0, 5, "", "", "", CommitCountString) : LockedHostFxrVersion;
         public VerInfo LockedHostVersion    => IsLocked ? new VerInfo(1, 0, 1, "", "", "", CommitCountString) : LatestHostVersion;
+        public bool fExplicitHostFXRMSIVersion = true; //This should be set to false when we no longer need to override the MSI version to be different from the HostFXR nuget package version".
+
+        // This method returns the locked hostfxr version based on the flag fExplicitHostFXRMSIVersion and the current platform. 
+        // For MSI (Windows) generation we specify a newer version for handling issue #1574 and for non-Windows platform we return the LockedHostFxrVersion.
+        public VerInfo GetLockedPlatformInstallerVersion()
+        {
+            VerInfo version = LockedHostFxrVersion;
+
+            if (fExplicitHostFXRMSIVersion && CurrentPlatform.Current == BuildPlatform.Windows)
+            {
+                version = new VerInfo(1, 0, 5, "", "", "", CommitCountString);
+            }
+
+            return version;
+        }
     }
 }

--- a/build_projects/shared-build-targets-utils/Utils/HostVersion.cs
+++ b/build_projects/shared-build-targets-utils/Utils/HostVersion.cs
@@ -72,7 +72,7 @@ namespace Microsoft.DotNet.Cli.Build
         // These versions should only be incremented in a servicing release if the package in question
         // is being updated.
         public VerInfo LatestHostVersion => new VerInfo(1, 0, 1, "", "", "", CommitCountString);
-        public VerInfo LatestHostFxrVersion => new VerInfo(1, 0, 5, "", "", "", CommitCountString);
+        public VerInfo LatestHostFxrVersion => new VerInfo(1, 0, 1, "", "", "", CommitCountString);
         public VerInfo LatestHostPolicyVersion => new VerInfo(1, 0, 3, "", "", "", CommitCountString);
   
         public Dictionary<string, VerInfo> LatestHostPackages => new Dictionary<string, VerInfo>()
@@ -107,6 +107,8 @@ namespace Microsoft.DotNet.Cli.Build
         //
         public bool IsLocked = true; // Set this variable to toggle muxer locking.
         public VerInfo LockedHostFxrVersion => IsLocked ? new VerInfo(1, 0, 1, "", "", "", CommitCountString) : LatestHostFxrVersion;
+        //We add a different LockedHostFxrVersion for the MSI as the package needs to deviate for issue #1574. This we can reconcile and remove when we have a binary change for the hostfxr.dll
+        public VerInfo LockedHostFxrMSIVersion => new VerInfo(1, 0, 5, "", "", "", CommitCountString);
         public VerInfo LockedHostVersion    => IsLocked ? new VerInfo(1, 0, 1, "", "", "", CommitCountString) : LatestHostVersion;
     }
 }

--- a/build_projects/shared-build-targets-utils/Utils/HostVersion.cs
+++ b/build_projects/shared-build-targets-utils/Utils/HostVersion.cs
@@ -72,7 +72,7 @@ namespace Microsoft.DotNet.Cli.Build
         // These versions should only be incremented in a servicing release if the package in question
         // is being updated.
         public VerInfo LatestHostVersion => new VerInfo(1, 0, 1, "", "", "", CommitCountString);
-        public VerInfo LatestHostFxrVersion => new VerInfo(1, 0, 2, "", "", "", CommitCountString);
+        public VerInfo LatestHostFxrVersion => new VerInfo(1, 0, 5, "", "", "", CommitCountString);
         public VerInfo LatestHostPolicyVersion => new VerInfo(1, 0, 3, "", "", "", CommitCountString);
   
         public Dictionary<string, VerInfo> LatestHostPackages => new Dictionary<string, VerInfo>()
@@ -106,7 +106,7 @@ namespace Microsoft.DotNet.Cli.Build
         // These versions are used when generating platform installers.
         //
         public bool IsLocked = true; // Set this variable to toggle muxer locking.
-        public VerInfo LockedHostFxrVersion => IsLocked ? new VerInfo(1, 0, 2, "", "", "", CommitCountString) : LatestHostFxrVersion;
+        public VerInfo LockedHostFxrVersion => IsLocked ? new VerInfo(1, 0, 1, "", "", "", CommitCountString) : LatestHostFxrVersion;
         public VerInfo LockedHostVersion    => IsLocked ? new VerInfo(1, 0, 1, "", "", "", CommitCountString) : LatestHostVersion;
     }
 }

--- a/packaging/windows/hostfxr/generatemsi.ps1
+++ b/packaging/windows/hostfxr/generatemsi.ps1
@@ -6,8 +6,8 @@ param(
     [Parameter(Mandatory=$true)][string]$HostFxrMSIOutput,
     [Parameter(Mandatory=$true)][string]$WixRoot,
     [Parameter(Mandatory=$true)][string]$ProductMoniker,
+    [Parameter(Mandatory=$true)][string]$HostFxrInternalMSIVersion,
     [Parameter(Mandatory=$true)][string]$HostFxrMSIVersion,
-    [Parameter(Mandatory=$true)][string]$HostFxrNugetVersion,
     [Parameter(Mandatory=$true)][string]$Architecture,
     [Parameter(Mandatory=$true)][string]$WixObjRoot,
     [Parameter(Mandatory=$true)][string]$HostFxrUpgradeCode 
@@ -54,15 +54,15 @@ function RunCandle
     Write-Host Running candle..
     $AuthWsxRoot =  Join-Path $RepoRoot "packaging\windows\hostfxr"
 
-    $ComponentVersion = $HostFxrNugetVersion.Replace('-', '_');
+    $ComponentVersion = $HostFxrMSIVersion.Replace('-', '_');
 
     .\candle.exe -nologo `
         -out "$WixObjRoot\" `
         -dHostFxrSrc="$HostFxrPublishRoot" `
         -dMicrosoftEula="$RepoRoot\packaging\osx\hostfxr\resources\en.lproj\eula.rtf" `
         -dProductMoniker="$ProductMoniker" `
-        -dBuildVersion="$HostFxrMSIVersion" `
-        -dNugetVersion="$HostFxrNugetVersion" `
+        -dBuildVersion="$HostFxrInternalMSIVersion" `
+        -dNugetVersion="$HostFxrMSIVersion" `
         -dComponentVersion="$ComponentVersion" `
         -dUpgradeCode="$HostFxrUpgradeCode" `
         -arch $Architecture `

--- a/packaging/windows/hostfxr/generatemsi.ps1
+++ b/packaging/windows/hostfxr/generatemsi.ps1
@@ -9,7 +9,8 @@ param(
     [Parameter(Mandatory=$true)][string]$HostFxrMSIVersion,
     [Parameter(Mandatory=$true)][string]$HostFxrNugetVersion,
     [Parameter(Mandatory=$true)][string]$Architecture,
-    [Parameter(Mandatory=$true)][string]$WixObjRoot
+    [Parameter(Mandatory=$true)][string]$WixObjRoot,
+    [Parameter(Mandatory=$true)][string]$HostFxrUpgradeCode 
 )
 
 . "$PSScriptRoot\..\..\..\scripts\common\_common.ps1"
@@ -63,6 +64,7 @@ function RunCandle
         -dBuildVersion="$HostFxrMSIVersion" `
         -dNugetVersion="$HostFxrNugetVersion" `
         -dComponentVersion="$ComponentVersion" `
+        -dUpgradeCode="$HostFxrUpgradeCode" `
         -arch $Architecture `
         -ext WixDependencyExtension.dll `
         "$AuthWsxRoot\hostfxr.wxs" `

--- a/packaging/windows/hostfxr/variables.wxi
+++ b/packaging/windows/hostfxr/variables.wxi
@@ -18,11 +18,9 @@
   <?if $(var.Platform)=x86?>
   <?define Program_Files="ProgramFilesFolder"?>
   <?define Win64AttributeValue=no?>
-  <?define UpgradeCode="CAA1E417-96A8-4560-A0E4-98E329E20A8B"?>
   <?elseif $(var.Platform)=x64?>
   <?define Program_Files="ProgramFiles64Folder"?>
   <?define Win64AttributeValue=yes?>
-  <?define UpgradeCode="6B33D104-1681-4382-8D4C-25CC69C1CFB9"?>
   <?else?>
   <?error Invalid Platform ($(var.Platform))?>
   <?endif?>


### PR DESCRIPTION
- Enable HostFxrMsi to install side by side between releases and build-to-build. This fix is for 1.0.
- This change will now enable the HostFxrMsi to be generated with a new upgrade code with every build.

- Reference Issue: #1574  
