### PR TITLE
Remove unneccessary 1.0 compat keys from 2.0

### DIFF
--- a/packaging/windows/sharedframework/registrykeys.wxs
+++ b/packaging/windows/sharedframework/registrykeys.wxs
@@ -8,11 +8,6 @@
           <RegistryValue Action="write" Name="$(var.FrameworkDisplayVersion)" Type="integer" Value="1" KeyPath="yes"/>
         </RegistryKey>
       </Component>
-      <Component Id="SetupRegistry_x86_RC2_Compat_Key" Directory="TARGETDIR" Win64="no">
-        <RegistryKey Root="HKLM" Key="SOFTWARE\dotnet\Setup\InstalledVersions\$(var.Platform)\sharedfx\$(var.FrameworkName)">
-          <RegistryValue Action="write" Name="1.0.0-rc2" Type="integer" Value="1" KeyPath="yes"/>
-        </RegistryKey>
-      </Component>
     </ComponentGroup>
     
     <!-- Set registry keys to allow WER to genereate correct dumps-->


### PR DESCRIPTION
This key was there to deal with a backwards versioning problem in 1.0. Not needed in 2.0 anymore.