### PR TITLE
Add uniform docker init and cleanup as well as VSTS Agent cleanup

### DIFF
--- a/buildpipeline/Core-Setup-CrossBuild.json
+++ b/buildpipeline/Core-Setup-CrossBuild.json
@@ -58,7 +58,27 @@
       "enabled": true,
       "continueOnError": false,
       "alwaysRun": false,
-      "displayName": "Start detached container",
+      "displayName": "Create host machine tools sandbox",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "5bfb729a-a7c8-4a78-a7c3-8d717bb7c13c",
+        "versionSpec": "2.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "SourceFolder": "pkg",
+        "Contents": "**",
+        "TargetFolder": "$(DockerHost_Sandbox)",
+        "CleanTargetFolder": "false",
+        "OverWrite": "false",
+        "flattenFolders": "false"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Initialize tools for host machine",
       "timeoutInMinutes": 0,
       "task": {
         "id": "6c731c3c-3c68-459a-a5c9-bde6e6595b5b",
@@ -66,81 +86,7 @@
         "definitionType": "task"
       },
       "inputs": {
-        "scriptPath": "$(PB_RepoName)/scripts/docker-as-current-user.sh",
-        "args": "run --privileged -d -w $(PB_GitDirectory) -v $(System.DefaultWorkingDirectory)/$(PB_RepoName):$(PB_GitDirectory) --name $(PB_DockerContainerName) $(PB_DockerImageName) sleep 7200",
-        "disableAutoCwd": "false",
-        "cwd": "",
-        "failOnStandardError": "false"
-      }
-    },
-    {
-      "enabled": true,
-      "continueOnError": false,
-      "alwaysRun": false,
-      "displayName": "Exec build",
-      "timeoutInMinutes": 0,
-      "task": {
-        "id": "6c731c3c-3c68-459a-a5c9-bde6e6595b5b",
-        "versionSpec": "2.*",
-        "definitionType": "task"
-      },
-      "inputs": {
-        "scriptPath": "$(PB_RepoName)/scripts/docker-as-current-user.sh",
-        "args": "exec --privileged -e HOME -e ROOTFS_DIR -e PUBLISH_TO_AZURE_BLOB -e CONNECTION_STRING -e CLI_NUGET_FEED_URL -e CLI_NUGET_API_KEY -e NUGET_FEED_URL -e NUGET_API_KEY -e GITHUB_PASSWORD $(PB_DockerContainerName) $(PB_GitDirectory)/build.sh $(CommonArguments) $(BuildArguments) $(portableLinux) --env-vars \"DISABLE_CROSSGEN=1,TARGETPLATFORM=$(PB_Architecture),TARGETRID=$(TargetRid),CROSS=1\"",
-        "disableAutoCwd": "false",
-        "cwd": "",
-        "failOnStandardError": "false"
-      }
-    },
-    {
-      "enabled": true,
-      "continueOnError": false,
-      "alwaysRun": false,
-      "displayName": "Stop Container",
-      "timeoutInMinutes": 0,
-      "task": {
-        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
-        "versionSpec": "1.*",
-        "definitionType": "task"
-      },
-      "inputs": {
-        "filename": "docker",
-        "arguments": "stop $(PB_DockerContainerName)",
-        "workingFolder": "",
-        "failOnStandardError": "false"
-      }
-    },
-    {
-      "enabled": true,
-      "continueOnError": false,
-      "alwaysRun": false,
-      "displayName": "Remove Container",
-      "timeoutInMinutes": 0,
-      "task": {
-        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
-        "versionSpec": "1.*",
-        "definitionType": "task"
-      },
-      "inputs": {
-        "filename": "docker",
-        "arguments": "rm $(PB_DockerContainerName)",
-        "workingFolder": "",
-        "failOnStandardError": "false"
-      }
-    },
-    {
-      "enabled": true,
-      "continueOnError": true,
-      "alwaysRun": true,
-      "displayName": "Initialize tools",
-      "timeoutInMinutes": 0,
-      "task": {
-        "id": "6c731c3c-3c68-459a-a5c9-bde6e6595b5b",
-        "versionSpec": "2.*",
-        "definitionType": "task"
-      },
-      "inputs": {
-        "scriptPath": "pkg/init-tools.sh",
+        "scriptPath": "$(DockerHost_Sandbox)/init-tools.sh",
         "args": "",
         "disableAutoCwd": "false",
         "cwd": "",
@@ -149,9 +95,47 @@
     },
     {
       "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Initialize Docker",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "6c731c3c-3c68-459a-a5c9-bde6e6595b5b",
+        "versionSpec": "2.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "scriptPath": "$(DockerHost_ToolsDirectory)/scripts/docker/init-docker.sh",
+        "args": "$(PB_DockerImageName)",
+        "disableAutoCwd": "false",
+        "cwd": "",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Run build in Docker container",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "6c731c3c-3c68-459a-a5c9-bde6e6595b5b",
+        "versionSpec": "2.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "scriptPath": "$(PB_RepoName)/scripts/docker-as-current-user.sh",
+        "args": "run --name $(PB_DockerContainerName) --rm --privileged -v $(System.DefaultWorkingDirectory)/$(PB_RepoName):$(PB_GitDirectory) -w $(PB_GitDirectory) -e HOME -e ROOTFS_DIR -e PUBLISH_TO_AZURE_BLOB -e CONNECTION_STRING -e CLI_NUGET_FEED_URL -e CLI_NUGET_API_KEY -e NUGET_FEED_URL -e NUGET_API_KEY -e GITHUB_PASSWORD $(PB_DockerImageName) ./build.sh $(CommonArguments) $(BuildArguments) $(portableLinux) --env-vars \"DISABLE_CROSSGEN=1,TARGETPLATFORM=$(PB_Architecture),TARGETRID=$(TargetRid),CROSS=1\"",
+        "disableAutoCwd": "false",
+        "cwd": "",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "enabled": true,
       "continueOnError": true,
       "alwaysRun": true,
-      "displayName": "Clean up Docker images and containers",
+      "displayName": "Cleanup Docker",
       "timeoutInMinutes": 0,
       "task": {
         "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
@@ -160,8 +144,26 @@
       },
       "inputs": {
         "filename": "perl",
-        "arguments": "pkg/Tools/scripts/docker/cleanup-docker.sh",
+        "arguments": "$(DockerHost_ToolsDirectory)/scripts/docker/cleanup-docker.sh",
         "workingFolder": "",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": true,
+      "alwaysRun": true,
+      "displayName": "Cleanup VSTS Agent",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "filename": "$(DockerHost_ToolsDirectory)/msbuild.sh",
+        "arguments": "cleanupagent.proj /p:AgentDirectory=$(Agent.HomeDirectory) /p:DoClean=$(PB_CleanAgent)",
+        "workingFolder": "$(DockerHost_ToolsDirectory)/scripts/vstsagent/",
         "failOnStandardError": "false"
       }
     }
@@ -252,7 +254,7 @@
       "value": "/opt/code/core-setup"
     },
     "PB_DockerContainerName": {
-      "value": "$(Build.BuildId)"
+      "value": "core-setup-cross-$(Build.BuildId)"
     },
     "PB_DockerRepository": {
       "value": "microsoft/dotnet-buildtools-prereqs"
@@ -286,6 +288,15 @@
     "SourceVersion": {
       "value": "",
       "allowOverride": true
+    },
+    "DockerHost_Sandbox": {
+      "value": "$(build.artifactstagingdirectory)/HostSandbox"
+    },
+    "DockerHost_ToolsDirectory": {
+      "value": "$(DockerHost_Sandbox)/Tools"
+    },
+    "PB_CleanAgent": {
+      "value": "true"
     }
   },
   "demands": [

--- a/buildpipeline/Core-Setup-CrossBuild.json
+++ b/buildpipeline/Core-Setup-CrossBuild.json
@@ -290,7 +290,7 @@
       "allowOverride": true
     },
     "DockerHost_Sandbox": {
-      "value": "$(build.artifactstagingdirectory)/HostSandbox"
+      "value": "$(Build.StagingDirectory)/HostSandbox"
     },
     "DockerHost_ToolsDirectory": {
       "value": "$(DockerHost_Sandbox)/Tools"

--- a/buildpipeline/Core-Setup-Linux.json
+++ b/buildpipeline/Core-Setup-Linux.json
@@ -22,7 +22,65 @@
       "enabled": true,
       "continueOnError": false,
       "alwaysRun": false,
-      "displayName": "Shell Script build.sh",
+      "displayName": "Create host machine tools sandbox",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "5bfb729a-a7c8-4a78-a7c3-8d717bb7c13c",
+        "versionSpec": "2.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "SourceFolder": "pkg",
+        "Contents": "**",
+        "TargetFolder": "$(DockerHost_Sandbox)",
+        "CleanTargetFolder": "false",
+        "OverWrite": "false",
+        "flattenFolders": "false"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Initialize tools for host machine",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "6c731c3c-3c68-459a-a5c9-bde6e6595b5b",
+        "versionSpec": "2.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "scriptPath": "$(DockerHost_Sandbox)/init-tools.sh",
+        "args": "",
+        "disableAutoCwd": "false",
+        "cwd": "",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Initialize Docker",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "6c731c3c-3c68-459a-a5c9-bde6e6595b5b",
+        "versionSpec": "2.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "scriptPath": "$(DockerHost_ToolsDirectory)/scripts/docker/init-docker.sh",
+        "args": "",
+        "disableAutoCwd": "false",
+        "cwd": "",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Run build in Docker container",
       "timeoutInMinutes": 0,
       "task": {
         "id": "6c731c3c-3c68-459a-a5c9-bde6e6595b5b",
@@ -41,26 +99,7 @@
       "enabled": true,
       "continueOnError": true,
       "alwaysRun": true,
-      "displayName": "Initialize tools",
-      "timeoutInMinutes": 0,
-      "task": {
-        "id": "6c731c3c-3c68-459a-a5c9-bde6e6595b5b",
-        "versionSpec": "2.*",
-        "definitionType": "task"
-      },
-      "inputs": {
-        "scriptPath": "pkg/init-tools.sh",
-        "args": "",
-        "disableAutoCwd": "false",
-        "cwd": "",
-        "failOnStandardError": "false"
-      }
-    },
-    {
-      "enabled": true,
-      "continueOnError": true,
-      "alwaysRun": true,
-      "displayName": "Clean up Docker images and containers",
+      "displayName": "Cleanup Docker",
       "timeoutInMinutes": 0,
       "task": {
         "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
@@ -69,7 +108,7 @@
       },
       "inputs": {
         "filename": "perl",
-        "arguments": "pkg/Tools/scripts/docker/cleanup-docker.sh",
+        "arguments": "$(DockerHost_ToolsDirectory)/scripts/docker/cleanup-docker.sh",
         "workingFolder": "",
         "failOnStandardError": "false"
       }
@@ -91,6 +130,24 @@
         "ArtifactName": "Build Logs",
         "ArtifactType": "Container",
         "TargetPath": "\\\\my\\share\\$(Build.DefinitionName)\\$(Build.BuildNumber)"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": true,
+      "alwaysRun": true,
+      "displayName": "Cleanup VSTS Agent",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "filename": "$(DockerHost_ToolsDirectory)/msbuild.sh",
+        "arguments": "cleanupagent.proj /p:AgentDirectory=$(Agent.HomeDirectory) /p:DoClean=$(PB_CleanAgent)",
+        "workingFolder": "$(DockerHost_ToolsDirectory)/scripts/vstsagent/",
+        "failOnStandardError": "false"
       }
     }
   ],
@@ -162,9 +219,21 @@
     "GITHUB_PASSWORD": {
       "value": "PassedViaPipeBuild"
     },
+    "DOTNET_BUILD_CONTAINER_TAG": {
+      "value": "core-setup-$(PB_DockerOS)-$(Build.BuildId)"
+    },
     "PB_DockerOS": {
       "value": "debian8",
       "allowOverride": true
+    },
+    "PB_CleanAgent": {
+      "value": "true"
+    },
+    "DockerHost_Sandbox": {
+      "value": "$(build.artifactstagingdirectory)/HostSandbox"
+    },
+    "DockerHost_ToolsDirectory": {
+      "value": "$(DockerHost_Sandbox)/Tools"
     }
   },
   "demands": [

--- a/buildpipeline/Core-Setup-Linux.json
+++ b/buildpipeline/Core-Setup-Linux.json
@@ -230,7 +230,7 @@
       "value": "true"
     },
     "DockerHost_Sandbox": {
-      "value": "$(build.artifactstagingdirectory)/HostSandbox"
+      "value": "$(Build.StagingDirectory)/HostSandbox"
     },
     "DockerHost_ToolsDirectory": {
       "value": "$(DockerHost_Sandbox)/Tools"

--- a/buildpipeline/Core-Setup-PortableLinux-x64.json
+++ b/buildpipeline/Core-Setup-PortableLinux-x64.json
@@ -211,7 +211,7 @@
       "value": "true"
     },
     "DockerHost_Sandbox": {
-      "value": "$(build.artifactstagingdirectory)/HostSandbox"
+      "value": "$(Build.StagingDirectory)/HostSandbox"
     },
     "DockerHost_ToolsDirectory": {
       "value": "$(DockerHost_Sandbox)/Tools"

--- a/buildpipeline/Core-Setup-PortableLinux-x64.json
+++ b/buildpipeline/Core-Setup-PortableLinux-x64.json
@@ -22,17 +22,57 @@
       "enabled": true,
       "continueOnError": false,
       "alwaysRun": false,
-      "displayName": "Docker cleanup",
+      "displayName": "Create host machine tools sandbox",
       "timeoutInMinutes": 0,
       "task": {
-        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
-        "versionSpec": "1.*",
+        "id": "5bfb729a-a7c8-4a78-a7c3-8d717bb7c13c",
+        "versionSpec": "2.*",
         "definitionType": "task"
       },
       "inputs": {
-        "filename": "bash",
-        "arguments": "-c \"docker ps -a -q --filter name=$(DockerContainerName) | xargs --no-run-if-empty docker rm -f -v\"",
-        "workingFolder": "",
+        "SourceFolder": "pkg",
+        "Contents": "**",
+        "TargetFolder": "$(DockerHost_Sandbox)",
+        "CleanTargetFolder": "false",
+        "OverWrite": "false",
+        "flattenFolders": "false"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Initialize tools for host machine",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "6c731c3c-3c68-459a-a5c9-bde6e6595b5b",
+        "versionSpec": "2.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "scriptPath": "$(DockerHost_Sandbox)/init-tools.sh",
+        "args": "",
+        "disableAutoCwd": "false",
+        "cwd": "",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Initialize Docker",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "6c731c3c-3c68-459a-a5c9-bde6e6595b5b",
+        "versionSpec": "2.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "scriptPath": "$(DockerHost_ToolsDirectory)/scripts/docker/init-docker.sh",
+        "args": "$(DockerImageName)",
+        "disableAutoCwd": "false",
+        "cwd": "",
         "failOnStandardError": "false"
       }
     },
@@ -49,7 +89,7 @@
       },
       "inputs": {
         "scriptPath": "scripts/dockerrun-as-current-user.sh",
-        "args": "-t --rm --sig-proxy=true --name $(DockerContainerName) -v $(Build.SourcesDirectory):/opt/code -w /opt/code -e CONNECTION_STRING -e PUBLISH_TO_AZURE_BLOB microsoft/dotnet-buildtools-prereqs:rhel7_prereqs_2 /bin/bash -c \"HOME=/opt/code; git clean -X -d -f; ./build.sh $(BuildArguments)\"",
+        "args": "-t --rm --sig-proxy=true --name $(DockerContainerName) -v $(Build.SourcesDirectory):/opt/code -w /opt/code -e CONNECTION_STRING -e PUBLISH_TO_AZURE_BLOB $(DockerImageName) /bin/bash -c \"HOME=/opt/code; git clean -X -d -f; ./build.sh $(BuildArguments)\"",
         "disableAutoCwd": "false",
         "cwd": "",
         "failOnStandardError": "false"
@@ -59,26 +99,7 @@
       "enabled": true,
       "continueOnError": true,
       "alwaysRun": true,
-      "displayName": "Initialize tools",
-      "timeoutInMinutes": 0,
-      "task": {
-        "id": "6c731c3c-3c68-459a-a5c9-bde6e6595b5b",
-        "versionSpec": "2.*",
-        "definitionType": "task"
-      },
-      "inputs": {
-        "scriptPath": "pkg/init-tools.sh",
-        "args": "",
-        "disableAutoCwd": "false",
-        "cwd": "",
-        "failOnStandardError": "false"
-      }
-    },
-    {
-      "enabled": true,
-      "continueOnError": true,
-      "alwaysRun": true,
-      "displayName": "Clean up Docker images and containers",
+      "displayName": "Cleanup Docker",
       "timeoutInMinutes": 0,
       "task": {
         "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
@@ -87,8 +108,26 @@
       },
       "inputs": {
         "filename": "perl",
-        "arguments": "pkg/Tools/scripts/docker/cleanup-docker.sh",
+        "arguments": "$(DockerHost_ToolsDirectory)/scripts/docker/cleanup-docker.sh",
         "workingFolder": "",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": true,
+      "alwaysRun": true,
+      "displayName": "Cleanup VSTS Agent",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "filename": "$(DockerHost_ToolsDirectory)/msbuild.sh",
+        "arguments": "cleanupagent.proj /p:AgentDirectory=$(Agent.HomeDirectory) /p:DoClean=$(PB_CleanAgent)",
+        "workingFolder": "$(DockerHost_ToolsDirectory)/scripts/vstsagent/",
         "failOnStandardError": "false"
       }
     }
@@ -145,8 +184,11 @@
       "value": "--skip-prereqs --configuration $(BuildConfiguration) --targets Default --portableLinux",
       "allowOverride": true
     },
+    "DockerImageName": {
+      "value": "microsoft/dotnet-buildtools-prereqs:rhel7_prereqs_2"
+    },
     "DockerContainerName": {
-      "value": "dotnetcore-setup-build-container-portablelinux",
+      "value": "core-setup-portablelinux-$(Build.BuildId)",
       "allowOverride": true
     },
     "CONNECTION_STRING": {
@@ -164,6 +206,15 @@
     },
     "GITHUB_PASSWORD": {
       "value": "PassedViaPipeBuild"
+    },
+    "PB_CleanAgent": {
+      "value": "true"
+    },
+    "DockerHost_Sandbox": {
+      "value": "$(build.artifactstagingdirectory)/HostSandbox"
+    },
+    "DockerHost_ToolsDirectory": {
+      "value": "$(DockerHost_Sandbox)/Tools"
     }
   },
   "demands": [

--- a/buildpipeline/Core-Setup-RHEL7-x64.json
+++ b/buildpipeline/Core-Setup-RHEL7-x64.json
@@ -211,7 +211,7 @@
       "value": "true"
     },
     "DockerHost_Sandbox": {
-      "value": "$(build.artifactstagingdirectory)/HostSandbox"
+      "value": "$(Build.StagingDirectory)/HostSandbox"
     },
     "DockerHost_ToolsDirectory": {
       "value": "$(DockerHost_Sandbox)/Tools"

--- a/buildpipeline/Core-Setup-RHEL7-x64.json
+++ b/buildpipeline/Core-Setup-RHEL7-x64.json
@@ -20,9 +20,29 @@
     },
     {
       "enabled": true,
-      "continueOnError": true,
-      "alwaysRun": true,
-      "displayName": "Initialize tools",
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Create host machine tools sandbox",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "5bfb729a-a7c8-4a78-a7c3-8d717bb7c13c",
+        "versionSpec": "2.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "SourceFolder": "pkg",
+        "Contents": "**",
+        "TargetFolder": "$(DockerHost_Sandbox)",
+        "CleanTargetFolder": "false",
+        "OverWrite": "false",
+        "flattenFolders": "false"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Initialize tools for host machine",
       "timeoutInMinutes": 0,
       "task": {
         "id": "6c731c3c-3c68-459a-a5c9-bde6e6595b5b",
@@ -30,7 +50,7 @@
         "definitionType": "task"
       },
       "inputs": {
-        "scriptPath": "pkg/init-tools.sh",
+        "scriptPath": "$(DockerHost_Sandbox)/init-tools.sh",
         "args": "",
         "disableAutoCwd": "false",
         "cwd": "",
@@ -49,7 +69,7 @@
         "definitionType": "task"
       },
       "inputs": {
-        "scriptPath": "pkg/Tools/scripts/docker/init-docker.sh",
+        "scriptPath": "$(DockerHost_ToolsDirectory)/scripts/docker/init-docker.sh",
         "args": "$(DockerImageName)",
         "disableAutoCwd": "false",
         "cwd": "",
@@ -79,7 +99,7 @@
       "enabled": true,
       "continueOnError": true,
       "alwaysRun": true,
-      "displayName": "Clean up Docker images and containers",
+      "displayName": "Cleanup Docker",
       "timeoutInMinutes": 0,
       "task": {
         "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
@@ -88,8 +108,26 @@
       },
       "inputs": {
         "filename": "perl",
-        "arguments": "pkg/Tools/scripts/docker/cleanup-docker.sh",
+        "arguments": "$(DockerHost_ToolsDirectory)/scripts/docker/cleanup-docker.sh",
         "workingFolder": "",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": true,
+      "alwaysRun": true,
+      "displayName": "Cleanup VSTS Agent",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "filename": "$(DockerHost_ToolsDirectory)/msbuild.sh",
+        "arguments": "cleanupagent.proj /p:AgentDirectory=$(Agent.HomeDirectory) /p:DoClean=$(PB_CleanAgent)",
+        "workingFolder": "$(DockerHost_ToolsDirectory)/scripts/vstsagent/",
         "failOnStandardError": "false"
       }
     }
@@ -146,8 +184,11 @@
       "value": "--skip-prereqs --configuration $(BuildConfiguration) --targets Default",
       "allowOverride": true
     },
+    "DockerImageName": {
+      "value": "microsoft/dotnet-buildtools-prereqs:rhel7_prereqs_2"
+    },
     "DockerContainerName": {
-      "value": "dotnetcore-setup-build-container-rhel",
+      "value": "core-setup-rhel-$(Build.BuildId)",
       "allowOverride": true
     },
     "CONNECTION_STRING": {
@@ -166,8 +207,14 @@
     "GITHUB_PASSWORD": {
       "value": "PassedViaPipeBuild"
     },
-    "DockerImageName": {
-      "value": "microsoft/dotnet-buildtools-prereqs:rhel7_prereqs_2"
+    "PB_CleanAgent": {
+      "value": "true"
+    },
+    "DockerHost_Sandbox": {
+      "value": "$(build.artifactstagingdirectory)/HostSandbox"
+    },
+    "DockerHost_ToolsDirectory": {
+      "value": "$(DockerHost_Sandbox)/Tools"
     }
   },
   "demands": [


### PR DESCRIPTION
Fixes #1816 
Related dotnet/core-eng#589

Modified the cross build, rhel, portable linux, and linux build definitions to do the following:

1. Setup a sandbox location to run init-tools on the host machine at the beginning of each build.  The sandbox location is used so that it does not interfere with the build within a container step that volume maps in the repo.  The sandbox location also allows the post build cleanup logic to reference the tools.
2. Run Init-Docker at the beginning of all builds.
3. Created a VSTS Agent cleanup step at the end of the build.
4. Refactored the cross build definition to use a simpler Docker pattern for building.
5. Renamed all of the containers to indicate which build definition they are for.  This helps in tracking down any resources left behind on the build machines.