### PR TITLE
Remove unnecessary Docker version demand

### DIFF
--- a/buildpipeline/Core-Setup-CrossBuild.json
+++ b/buildpipeline/Core-Setup-CrossBuild.json
@@ -300,8 +300,7 @@
     }
   },
   "demands": [
-    "Agent.OS -equals linux",
-    "Docker -equals 1.13.1"
+    "Agent.OS -equals linux"
   ],
   "retentionRules": [
     {


### PR DESCRIPTION
With the [recent changes I made](https://github.com/dotnet/core-setup/commit/7dd80454d42262f83ada2d3e636710d781e07eb6) to cleanup the Docker usage pattern in the build definitions for cross build, there is no longer a need for the Docker demand.  This demand was needed because the previous Docker usage pattern required support for the `--priviliged` option on `docker exec`.  This option is not available on Docker 1.12.5 which is the version on all but one of the build agents.  Removing this demand is a good practice so that when we migrate to newer versions of Docker in the future, this build will not fail to find an agent that satisfies its demands.