### PR TITLE
Remove libuv and roslyn from update-dependencies

### DIFF
--- a/build_projects/update-dependencies/Config.cs
+++ b/build_projects/update-dependencies/Config.cs
@@ -21,7 +21,6 @@ namespace Microsoft.DotNet.Scripts
     /// 
     /// COREFX_VERSION_URL - The Url to get the current CoreFx version. (ex. "https://raw.githubusercontent.com/dotnet/versions/master/build-info/dotnet/corefx/master/Latest_Packages.txt")
     /// CORECLR_VERSION_URL - The Url to get the current CoreCLR version. (ex. "https://raw.githubusercontent.com/dotnet/versions/master/build-info/dotnet/coreclr/master/Latest_Packages.txt")
-    /// ROSLYN_VERSION_URL - The Url to get the current Roslyn version. (ex. "https://raw.githubusercontent.com/dotnet/versions/master/build-info/dotnet/roslyn/netcore1.0/Latest_Packages.txt")
     /// GITHUB_ORIGIN_OWNER - The owner of the GitHub fork to push the commit and create the PR from. (ex. "dotnet-bot")
     /// GITHUB_UPSTREAM_OWNER - The owner of the GitHub base repo to create the PR to. (ex. "dotnet")
     /// GITHUB_PROJECT - The repo name under the ORIGIN and UPSTREAM owners. (ex. "cli")
@@ -39,9 +38,7 @@ namespace Microsoft.DotNet.Scripts
         private Lazy<string> _password = new Lazy<string>(() => GetEnvironmentVariable("GITHUB_PASSWORD"));
         private Lazy<string> _coreFxVersionUrl = new Lazy<string>(() => GetEnvironmentVariable("COREFX_VERSION_URL", "https://raw.githubusercontent.com/dotnet/versions/master/build-info/dotnet/corefx/master/Latest_Packages.txt"));
         private Lazy<string> _coreClrVersionUrl = new Lazy<string>(() => GetEnvironmentVariable("CORECLR_VERSION_URL", "https://raw.githubusercontent.com/dotnet/versions/master/build-info/dotnet/coreclr/master/Latest_Packages.txt"));
-        private Lazy<string> _roslynVersionUrl = new Lazy<string>(() => GetEnvironmentVariable("ROSLYN_VERSION_URL", "https://raw.githubusercontent.com/dotnet/versions/master/build-info/dotnet/roslyn/netcore1.0/Latest_Packages.txt"));
         private Lazy<string> _standardVersionUrl = new Lazy<string>(() => GetEnvironmentVariable("STANDARD_VERSION_URL", "https://raw.githubusercontent.com/dotnet/versions/master/build-info/dotnet/standard/master/Latest_Packages.txt"));
-        private Lazy<string> _libuvVersionUrl = new Lazy<string>(() => GetEnvironmentVariable("LIBUV_VERSION_URL", string.Empty));
         private Lazy<string> _gitHubOriginOwner;
         private Lazy<string> _gitHubUpstreamOwner = new Lazy<string>(() => GetEnvironmentVariable("GITHUB_UPSTREAM_OWNER", "dotnet"));
         private Lazy<string> _gitHubProject = new Lazy<string>(() => GetEnvironmentVariable("GITHUB_PROJECT", "core-setup"));
@@ -60,9 +57,7 @@ namespace Microsoft.DotNet.Scripts
         public string Password => _password.Value;
         public string CoreFxVersionUrl => _coreFxVersionUrl.Value;
         public string CoreClrVersionUrl => _coreClrVersionUrl.Value;
-        public string RoslynVersionUrl => _roslynVersionUrl.Value;
         public string StandardVersionUrl => _standardVersionUrl.Value;
-        public string LibuvVersionUrl => _libuvVersionUrl.Value;
         public string GitHubOriginOwner => _gitHubOriginOwner.Value;
         public string GitHubUpstreamOwner => _gitHubUpstreamOwner.Value;
         public string GitHubProject => _gitHubProject.Value;

--- a/build_projects/update-dependencies/UpdateFilesTargets.cs
+++ b/build_projects/update-dependencies/UpdateFilesTargets.cs
@@ -34,17 +34,7 @@ namespace Microsoft.DotNet.Scripts
 
             dependencyInfos.Add(CreateDependencyInfo("CoreFx", Config.Instance.CoreFxVersionUrl).Result);
             dependencyInfos.Add(CreateDependencyInfo("CoreClr", Config.Instance.CoreClrVersionUrl).Result);
-            dependencyInfos.Add(CreateDependencyInfo("Roslyn", Config.Instance.RoslynVersionUrl).Result);
-
-            if (Config.Instance.StandardVersionUrl != string.Empty)
-            {
-                dependencyInfos.Add(CreateDependencyInfo("Standard", Config.Instance.StandardVersionUrl).Result);
-            }
-
-            if (Config.Instance.LibuvVersionUrl != string.Empty)
-            {
-                dependencyInfos.Add(CreateDependencyInfo("Libuv", Config.Instance.LibuvVersionUrl).Result);
-            }
+            dependencyInfos.Add(CreateDependencyInfo("Standard", Config.Instance.StandardVersionUrl).Result);
 
             return c.Success();
         }


### PR DESCRIPTION
The shared framework no longer depends on packages from either
dotnet/roslyn or aspnet/libuv-package so we can remove these from our
updater scripts.
