### PR TITLE
[release/1.1.0] Only publish when destination deliberately specified

### DIFF
--- a/build_projects/Microsoft.DotNet.Cli.Build.Framework/TargetConditions/EnvironmentAttribute.cs
+++ b/build_projects/Microsoft.DotNet.Cli.Build.Framework/TargetConditions/EnvironmentAttribute.cs
@@ -6,6 +6,7 @@ namespace Microsoft.DotNet.Cli.Build.Framework
     [AttributeUsage(AttributeTargets.Method, AllowMultiple = true, Inherited = false)]
     public class EnvironmentAttribute : TargetConditionAttribute
     {
+        private const string EnvVarEmptyWorkaround = "ENV_VAR_EMPTY_WORKAROUND";
         private string _envVar;
         private string[] _expectedVals;
 
@@ -34,7 +35,7 @@ namespace Microsoft.DotNet.Cli.Build.Framework
             }
             else
             {
-                return !string.IsNullOrEmpty(actualVal);
+                return actualVal != EnvVarEmptyWorkaround && !string.IsNullOrEmpty(actualVal);
             }
         }
     }

--- a/build_projects/dotnet-host-build/PublishTargets.cs
+++ b/build_projects/dotnet-host-build/PublishTargets.cs
@@ -60,6 +60,7 @@ namespace Microsoft.DotNet.Host.Build
 
         [Target]
         [BuildPlatforms(BuildPlatform.Ubuntu, "14.04")]
+        [Environment("CLI_NUGET_FEED_URL")]
         public static BuildTargetResult PublishDotnetDebToolPackage(BuildTargetContext c)
         {
             string nugetFeedUrl = EnvVars.EnsureVariable("CLI_NUGET_FEED_URL");
@@ -134,7 +135,8 @@ namespace Microsoft.DotNet.Host.Build
                         "opensuse.42.1.x64.version"
                     };
                     
-                    PublishCoreHostPackagesToFeed();
+                    c.BuildContext.RunTarget(nameof(PublishTargets.PublishCoreHostPackagesToFeed));
+                    c.BuildContext.RunTarget(nameof(PublishTargets.PublishCoreHostPackageVersionsToVersionsRepo));
 
                     string sfxVersion = Utils.GetSharedFrameworkVersionFileContent(c);
                     foreach (string version in versionFiles)
@@ -164,20 +166,39 @@ namespace Microsoft.DotNet.Host.Build
             }
         }
 
-        private static void PublishCoreHostPackagesToFeed()
+        [Target]
+        public static BuildTargetResult DownloadCoreHostPackagesToBuildDirectory(BuildTargetContext c)
         {
             var hostBlob = $"{Channel}/Binaries/{SharedFrameworkNugetVersion}";
 
             Directory.CreateDirectory(Dirs.PackagesNoRID);
             AzurePublisherTool.DownloadFilesWithExtension(hostBlob, ".nupkg", Dirs.PackagesNoRID);
 
+            return c.Success();
+        }
+
+        [Target(nameof(PublishTargets.DownloadCoreHostPackagesToBuildDirectory))]
+        [Environment("NUGET_FEED_URL")]
+        public static BuildTargetResult PublishCoreHostPackagesToFeed(BuildTargetContext c)
+        {
             string nugetFeedUrl = EnvVars.EnsureVariable("NUGET_FEED_URL");
             string apiKey = EnvVars.EnsureVariable("NUGET_API_KEY");
+
             NuGetUtil.PushPackages(Dirs.PackagesNoRID, nugetFeedUrl, apiKey, IncludeSymbolPackages);
 
+            return c.Success();
+        }
+
+        [Target(nameof(PublishTargets.DownloadCoreHostPackagesToBuildDirectory))]
+        [Environment("GITHUB_PASSWORD")]
+        public static BuildTargetResult PublishCoreHostPackageVersionsToVersionsRepo(BuildTargetContext c)
+        {
             string githubAuthToken = EnvVars.EnsureVariable("GITHUB_PASSWORD");
             VersionRepoUpdater repoUpdater = new VersionRepoUpdater(githubAuthToken);
+
             repoUpdater.UpdatePublishedVersions(Dirs.PackagesNoRID, $"build-info/dotnet/core-setup/{Channel}/Latest").Wait();
+
+            return c.Success();
         }
 
         private static bool CheckIfAllBuildsHavePublished()
@@ -260,6 +281,10 @@ namespace Microsoft.DotNet.Host.Build
             nameof(PublishHostFxrDebToDebianRepo),
             nameof(PublishSharedHostDebToDebianRepo))]
         [BuildPlatforms(BuildPlatform.Ubuntu, BuildPlatform.Debian)]
+        [Environment("REPO_SERVER")]
+        [Environment("REPO_ID")]
+        [Environment("REPO_USER")]
+        [Environment("REPO_PASS")]
         public static BuildTargetResult PublishDebFilesToDebianRepo(BuildTargetContext c)
         {
             return c.Success();

--- a/buildpipeline/Core-Setup-CentOS-x64.json
+++ b/buildpipeline/Core-Setup-CentOS-x64.json
@@ -128,20 +128,20 @@
       "allowOverride": true
     },
     "CONNECTION_STRING": {
-      "value": "PassedViaPipeBuild"
+      "value": "ENV_VAR_EMPTY_WORKAROUND"
     },
     "PUBLISH_TO_AZURE_BLOB": {
-      "value": "true",
+      "value": "false",
       "allowOverride": true
     },
     "NUGET_FEED_URL": {
-      "value": "https://dotnet.myget.org/F/dotnet-core"
+      "value": "ENV_VAR_EMPTY_WORKAROUND"
     },
     "NUGET_API_KEY": {
-      "value": "PassedViaPipeBuild"
+      "value": "ENV_VAR_EMPTY_WORKAROUND"
     },
     "GITHUB_PASSWORD": {
-      "value": "PassedViaPipeBuild"
+      "value": "ENV_VAR_EMPTY_WORKAROUND"
     }
   },
   "demands": [

--- a/buildpipeline/Core-Setup-Debian8-x64.json
+++ b/buildpipeline/Core-Setup-Debian8-x64.json
@@ -128,32 +128,32 @@
       "allowOverride": true
     },
     "CONNECTION_STRING": {
-      "value": "PassedViaPipeBuild"
+      "value": "ENV_VAR_EMPTY_WORKAROUND"
     },
     "PUBLISH_TO_AZURE_BLOB": {
-      "value": "true",
+      "value": "false",
       "allowOverride": true
     },
     "NUGET_FEED_URL": {
-      "value": "https://dotnet.myget.org/F/dotnet-core"
+      "value": "ENV_VAR_EMPTY_WORKAROUND"
     },
     "NUGET_API_KEY": {
-      "value": "PassedViaPipeBuild"
+      "value": "ENV_VAR_EMPTY_WORKAROUND"
     },
     "GITHUB_PASSWORD": {
-      "value": "PassedViaPipeBuild"
+      "value": "ENV_VAR_EMPTY_WORKAROUND"
     },
     "REPO_ID": {
-      "value": "579f8fb0fedca9aeeb399132"
+      "value": "ENV_VAR_EMPTY_WORKAROUND"
     },
     "REPO_USER": {
-      "value": "dotnet"
+      "value": "ENV_VAR_EMPTY_WORKAROUND"
     },
     "REPO_PASS": {
-      "value": "PassedViaPipeBuild"
+      "value": "ENV_VAR_EMPTY_WORKAROUND"
     },
     "REPO_SERVER": {
-      "value": "azure-apt-cat.cloudapp.net"
+      "value": "ENV_VAR_EMPTY_WORKAROUND"
     }
   },
   "demands": [

--- a/buildpipeline/Core-Setup-Debian8-x64.json
+++ b/buildpipeline/Core-Setup-Debian8-x64.json
@@ -144,7 +144,7 @@
       "value": "ENV_VAR_EMPTY_WORKAROUND"
     },
     "REPO_ID": {
-      "value": "ENV_VAR_EMPTY_WORKAROUND"
+      "value": "579f8fb0fedca9aeeb399132"
     },
     "REPO_USER": {
       "value": "ENV_VAR_EMPTY_WORKAROUND"

--- a/buildpipeline/Core-Setup-Fedora23-x64.json
+++ b/buildpipeline/Core-Setup-Fedora23-x64.json
@@ -145,20 +145,20 @@
       "value": "--skip-prereqs --configuration $(BuildConfiguration)  --docker fedora.23 --targets Default"
     },
     "CONNECTION_STRING": {
-      "value": "PassedViaPipeBuild"
+      "value": "ENV_VAR_EMPTY_WORKAROUND"
     },
     "PUBLISH_TO_AZURE_BLOB": {
-      "value": "true",
+      "value": "false",
       "allowOverride": true
     },
     "NUGET_FEED_URL": {
-      "value": "https://dotnet.myget.org/F/dotnet-core"
+      "value": "ENV_VAR_EMPTY_WORKAROUND"
     },
     "NUGET_API_KEY": {
-      "value": "PassedViaPipeBuild"
+      "value": "ENV_VAR_EMPTY_WORKAROUND"
     },
     "GITHUB_PASSWORD": {
-      "value": "PassedViaPipeBuild"
+      "value": "ENV_VAR_EMPTY_WORKAROUND"
     }
   },
   "demands": [

--- a/buildpipeline/Core-Setup-Fedora24-x64.json
+++ b/buildpipeline/Core-Setup-Fedora24-x64.json
@@ -126,20 +126,20 @@
       "value": "--skip-prereqs --configuration $(BuildConfiguration)  --docker fedora.24 --targets Default"
     },
     "CONNECTION_STRING": {
-      "value": "PassedViaPipeBuild"
+      "value": "ENV_VAR_EMPTY_WORKAROUND"
     },
     "PUBLISH_TO_AZURE_BLOB": {
-      "value": "true",
+      "value": "false",
       "allowOverride": true
     },
     "NUGET_FEED_URL": {
-      "value": "https://dotnet.myget.org/F/dotnet-core"
+      "value": "ENV_VAR_EMPTY_WORKAROUND"
     },
     "NUGET_API_KEY": {
-      "value": "PassedViaPipeBuild"
+      "value": "ENV_VAR_EMPTY_WORKAROUND"
     },
     "GITHUB_PASSWORD": {
-      "value": "PassedViaPipeBuild"
+      "value": "ENV_VAR_EMPTY_WORKAROUND"
     }
   },
   "demands": [

--- a/buildpipeline/Core-Setup-OSX-x64.json
+++ b/buildpipeline/Core-Setup-OSX-x64.json
@@ -128,20 +128,20 @@
       "allowOverride": true
     },
     "CONNECTION_STRING": {
-      "value": "PassedViaPipeBuild"
+      "value": "ENV_VAR_EMPTY_WORKAROUND"
     },
     "PUBLISH_TO_AZURE_BLOB": {
-      "value": "true",
+      "value": "false",
       "allowOverride": true
     },
     "NUGET_FEED_URL": {
-      "value": "https://dotnet.myget.org/F/dotnet-core"
+      "value": "ENV_VAR_EMPTY_WORKAROUND"
     },
     "NUGET_API_KEY": {
-      "value": "PassedViaPipeBuild"
+      "value": "ENV_VAR_EMPTY_WORKAROUND"
     },
     "GITHUB_PASSWORD": {
-      "value": "PassedViaPipeBuild"
+      "value": "ENV_VAR_EMPTY_WORKAROUND"
     }
   },
   "demands": [

--- a/buildpipeline/Core-Setup-OpenSuse13.2-x64.json
+++ b/buildpipeline/Core-Setup-OpenSuse13.2-x64.json
@@ -126,20 +126,20 @@
       "value": "--skip-prereqs --configuration $(BuildConfiguration)  --docker opensuse.13.2 --targets Default"
     },
     "CONNECTION_STRING": {
-      "value": "PassedViaPipeBuild"
+      "value": "ENV_VAR_EMPTY_WORKAROUND"
     },
     "PUBLISH_TO_AZURE_BLOB": {
-      "value": "true",
+      "value": "false",
       "allowOverride": true
     },
     "NUGET_FEED_URL": {
-      "value": "https://dotnet.myget.org/F/dotnet-core"
+      "value": "ENV_VAR_EMPTY_WORKAROUND"
     },
     "NUGET_API_KEY": {
-      "value": "PassedViaPipeBuild"
+      "value": "ENV_VAR_EMPTY_WORKAROUND"
     },
     "GITHUB_PASSWORD": {
-      "value": "PassedViaPipeBuild"
+      "value": "ENV_VAR_EMPTY_WORKAROUND"
     }
   },
   "demands": [

--- a/buildpipeline/Core-Setup-OpenSuse42.1-x64.json
+++ b/buildpipeline/Core-Setup-OpenSuse42.1-x64.json
@@ -126,20 +126,20 @@
       "value": "--skip-prereqs --configuration $(BuildConfiguration)  --docker opensuse.42.1 --targets Default"
     },
     "CONNECTION_STRING": {
-      "value": "PassedViaPipeBuild"
+      "value": "ENV_VAR_EMPTY_WORKAROUND"
     },
     "PUBLISH_TO_AZURE_BLOB": {
-      "value": "true",
+      "value": "false",
       "allowOverride": true
     },
     "NUGET_FEED_URL": {
-      "value": "https://dotnet.myget.org/F/dotnet-core"
+      "value": "ENV_VAR_EMPTY_WORKAROUND"
     },
     "NUGET_API_KEY": {
-      "value": "PassedViaPipeBuild"
+      "value": "ENV_VAR_EMPTY_WORKAROUND"
     },
     "GITHUB_PASSWORD": {
-      "value": "PassedViaPipeBuild"
+      "value": "ENV_VAR_EMPTY_WORKAROUND"
     }
   },
   "demands": [

--- a/buildpipeline/Core-Setup-RHEL7-x64.json
+++ b/buildpipeline/Core-Setup-RHEL7-x64.json
@@ -68,7 +68,7 @@
       },
       "inputs": {
         "scriptPath": "scripts/dockerrun-as-current-user.sh",
-        "args": "-t --rm --sig-proxy=true --name $(DockerContainerName) -v $(Build.SourcesDirectory):/opt/code -w /opt/code -e CONNECTION_STRING -e PUBLISH_TO_AZURE_BLOB -e NUGET_FEED_URL -e NUGET_API_KEY -e GITHUB_PASSWORD $(DockerImageName) /bin/bash -c \"HOME=/opt/code; git clean -X -d -f; ./build.sh $(BuildArguments)\"",
+        "args": "-t --rm --sig-proxy=true --name $(DockerContainerName) -v $(Build.SourcesDirectory):/opt/code -w /opt/code $(BuildEnvironmentVariables) $(DockerImageName) /bin/bash -c \"HOME=/opt/code; git clean -X -d -f; ./build.sh $(BuildArguments)\"",
         "disableAutoCwd": "false",
         "cwd": "",
         "failOnStandardError": "false"
@@ -164,25 +164,29 @@
       "value": "--skip-prereqs --configuration $(BuildConfiguration) --targets Default",
       "allowOverride": true
     },
+    "BuildEnvironmentVariables": {
+      "value": "-e CHANNEL -e CONNECTION_STRING -e REPO_ID -e REPO_USER -e REPO_PASS -e REPO_SERVER -e DOTNET_BUILD_SKIP_CROSSGEN -e PUBLISH_TO_AZURE_BLOB -e DOCKER_HUB_REPO -e DOCKER_HUB_TRIGGER_TOKEN -e NUGET_FEED_URL -e NUGET_API_KEY -e GITHUB_PASSWORD -e CLI_NUGET_FEED_URL -e CLI_NUGET_API_KEY",
+      "allowOverride": true
+    },
     "DockerContainerName": {
       "value": "dotnetcore-setup-build-container-rhel",
       "allowOverride": true
     },
     "CONNECTION_STRING": {
-      "value": "PassedViaPipeBuild"
+      "value": "ENV_VAR_EMPTY_WORKAROUND"
     },
     "PUBLISH_TO_AZURE_BLOB": {
-      "value": "true",
+      "value": "false",
       "allowOverride": true
     },
     "NUGET_FEED_URL": {
-      "value": "https://dotnet.myget.org/F/dotnet-core"
+      "value": "ENV_VAR_EMPTY_WORKAROUND"
     },
     "NUGET_API_KEY": {
-      "value": "PassedViaPipeBuild"
+      "value": "ENV_VAR_EMPTY_WORKAROUND"
     },
     "GITHUB_PASSWORD": {
-      "value": "PassedViaPipeBuild"
+      "value": "ENV_VAR_EMPTY_WORKAROUND"
     },
     "DockerImageName": {
       "value": "microsoft/dotnet-buildtools-prereqs:rhel7_prereqs_2"

--- a/buildpipeline/Core-Setup-Signing-Windows-x64.json
+++ b/buildpipeline/Core-Setup-Signing-Windows-x64.json
@@ -435,19 +435,20 @@
       "value": "dotnet"
     },
     "CONNECTION_STRING": {
-      "value": "PassedViaPipeBuild"
+      "value": "ENV_VAR_EMPTY_WORKAROUND"
     },
     "PUBLISH_TO_AZURE_BLOB": {
-      "value": "true"
+      "value": "false",
+      "allowOverride": true
     },
     "NUGET_FEED_URL": {
-      "value": "https://dotnet.myget.org/F/dotnet-core"
+      "value": "ENV_VAR_EMPTY_WORKAROUND"
     },
     "NUGET_API_KEY": {
-      "value": "PassedViaPipeBuild"
+      "value": "ENV_VAR_EMPTY_WORKAROUND"
     },
     "GITHUB_PASSWORD": {
-      "value": "PassedViaPipeBuild"
+      "value": "ENV_VAR_EMPTY_WORKAROUND"
     },
     "SIGNED_PACKAGES": {
       "value": "true"

--- a/buildpipeline/Core-Setup-Signing-Windows-x86.json
+++ b/buildpipeline/Core-Setup-Signing-Windows-x86.json
@@ -408,19 +408,20 @@
       "value": "dotnet"
     },
     "CONNECTION_STRING": {
-      "value": "PassedViaPipeBuild"
+      "value": "ENV_VAR_EMPTY_WORKAROUND"
     },
     "PUBLISH_TO_AZURE_BLOB": {
-      "value": "true"
+      "value": "false",
+      "allowOverride": true
     },
     "NUGET_FEED_URL": {
-      "value": "https://dotnet.myget.org/F/dotnet-core"
+      "value": "ENV_VAR_EMPTY_WORKAROUND"
     },
     "NUGET_API_KEY": {
-      "value": "PassedViaPipeBuild"
+      "value": "ENV_VAR_EMPTY_WORKAROUND"
     },
     "GITHUB_PASSWORD": {
-      "value": "PassedViaPipeBuild"
+      "value": "ENV_VAR_EMPTY_WORKAROUND"
     },
     "BuildArchitecture": {
       "value": "x86"

--- a/buildpipeline/Core-Setup-Ubuntu14.04-x64.json
+++ b/buildpipeline/Core-Setup-Ubuntu14.04-x64.json
@@ -135,7 +135,7 @@
       "allowOverride": true
     },
     "REPO_ID": {
-      "value": "ENV_VAR_EMPTY_WORKAROUND"
+      "value": "562fbfe0b2d7d0e0a43780c4"
     },
     "REPO_USER": {
       "value": "ENV_VAR_EMPTY_WORKAROUND"

--- a/buildpipeline/Core-Setup-Ubuntu14.04-x64.json
+++ b/buildpipeline/Core-Setup-Ubuntu14.04-x64.json
@@ -128,38 +128,38 @@
       "allowOverride": true
     },
     "CONNECTION_STRING": {
-      "value": "PassedViaPipeBuild"
+      "value": "ENV_VAR_EMPTY_WORKAROUND"
     },
     "PUBLISH_TO_AZURE_BLOB": {
-      "value": "true",
+      "value": "false",
       "allowOverride": true
     },
     "REPO_ID": {
-      "value": "562fbfe0b2d7d0e0a43780c4"
+      "value": "ENV_VAR_EMPTY_WORKAROUND"
     },
     "REPO_USER": {
-      "value": "dotnet"
+      "value": "ENV_VAR_EMPTY_WORKAROUND"
     },
     "REPO_PASS": {
-      "value": "PassedViaPipeBuild"
+      "value": "ENV_VAR_EMPTY_WORKAROUND"
     },
     "REPO_SERVER": {
-      "value": "azure-apt-cat.cloudapp.net"
+      "value": "ENV_VAR_EMPTY_WORKAROUND"
     },
     "NUGET_FEED_URL": {
-      "value": "https://dotnet.myget.org/F/dotnet-core"
+      "value": "ENV_VAR_EMPTY_WORKAROUND"
     },
     "NUGET_API_KEY": {
-      "value": "PassedViaPipeBuild"
+      "value": "ENV_VAR_EMPTY_WORKAROUND"
     },
     "GITHUB_PASSWORD": {
-      "value": "PassedViaPipeBuild"
+      "value": "ENV_VAR_EMPTY_WORKAROUND"
     },
     "CLI_NUGET_FEED_URL": {
-      "value": "https://www.myget.org/F/core-setup-testing"
+      "value": "ENV_VAR_EMPTY_WORKAROUND"
     },
     "CLI_NUGET_API_KEY": {
-      "value": "PassedViaPipeBuild"
+      "value": "ENV_VAR_EMPTY_WORKAROUND"
     }
   },
   "demands": [

--- a/buildpipeline/Core-Setup-Ubuntu16.04-x64.json
+++ b/buildpipeline/Core-Setup-Ubuntu16.04-x64.json
@@ -142,7 +142,7 @@
       "value": "ENV_VAR_EMPTY_WORKAROUND"
     },
     "REPO_ID": {
-      "value": "ENV_VAR_EMPTY_WORKAROUND"
+      "value": "575f40f3797ef7280505232f"
     },
     "REPO_USER": {
       "value": "ENV_VAR_EMPTY_WORKAROUND"

--- a/buildpipeline/Core-Setup-Ubuntu16.04-x64.json
+++ b/buildpipeline/Core-Setup-Ubuntu16.04-x64.json
@@ -126,32 +126,32 @@
       "value": "--skip-prereqs --configuration $(BuildConfiguration)  --docker ubuntu.16.04 --targets Default"
     },
     "CONNECTION_STRING": {
-      "value": "PassedViaPipeBuild"
+      "value": "ENV_VAR_EMPTY_WORKAROUND"
     },
     "PUBLISH_TO_AZURE_BLOB": {
-      "value": "true",
+      "value": "false",
       "allowOverride": true
     },
     "NUGET_FEED_URL": {
-      "value": "https://dotnet.myget.org/F/dotnet-core"
+      "value": "ENV_VAR_EMPTY_WORKAROUND"
     },
     "NUGET_API_KEY": {
-      "value": "PassedViaPipeBuild"
+      "value": "ENV_VAR_EMPTY_WORKAROUND"
     },
     "GITHUB_PASSWORD": {
-      "value": "PassedViaPipeBuild"
+      "value": "ENV_VAR_EMPTY_WORKAROUND"
     },
     "REPO_ID": {
-      "value": "575f40f3797ef7280505232f"
+      "value": "ENV_VAR_EMPTY_WORKAROUND"
     },
     "REPO_USER": {
-      "value": "dotnet"
+      "value": "ENV_VAR_EMPTY_WORKAROUND"
     },
     "REPO_SERVER": {
-      "value": "azure-apt-cat.cloudapp.net"
+      "value": "ENV_VAR_EMPTY_WORKAROUND"
     },
     "REPO_PASS": {
-      "value": "PassedViaPipeBuild"
+      "value": "ENV_VAR_EMPTY_WORKAROUND"
     }
   },
   "demands": [

--- a/buildpipeline/Core-Setup-Ubuntu16.10-x64.json
+++ b/buildpipeline/Core-Setup-Ubuntu16.10-x64.json
@@ -126,32 +126,32 @@
       "value": "--skip-prereqs --configuration $(BuildConfiguration)  --docker ubuntu.16.10 --targets Default"
     },
     "CONNECTION_STRING": {
-      "value": "PassedViaPipeBuild"
+      "value": "ENV_VAR_EMPTY_WORKAROUND"
     },
     "PUBLISH_TO_AZURE_BLOB": {
-      "value": "true",
+      "value": "false",
       "allowOverride": true
     },
     "NUGET_FEED_URL": {
-      "value": "https://dotnet.myget.org/F/dotnet-core"
+      "value": "ENV_VAR_EMPTY_WORKAROUND"
     },
     "NUGET_API_KEY": {
-      "value": "PassedViaPipeBuild"
+      "value": "ENV_VAR_EMPTY_WORKAROUND"
     },
     "GITHUB_PASSWORD": {
-      "value": "PassedViaPipeBuild"
+      "value": "ENV_VAR_EMPTY_WORKAROUND"
     },
     "REPO_ID": {
-      "value": "575f40f3797ef7280505232f"
+      "value": "ENV_VAR_EMPTY_WORKAROUND"
     },
     "REPO_USER": {
-      "value": "dotnet"
+      "value": "ENV_VAR_EMPTY_WORKAROUND"
     },
     "REPO_SERVER": {
-      "value": "azure-apt-cat.cloudapp.net"
+      "value": "ENV_VAR_EMPTY_WORKAROUND"
     },
     "REPO_PASS": {
-      "value": "PassedViaPipeBuild"
+      "value": "ENV_VAR_EMPTY_WORKAROUND"
     }
   },
   "demands": [

--- a/buildpipeline/Core-Setup-Ubuntu16.10-x64.json
+++ b/buildpipeline/Core-Setup-Ubuntu16.10-x64.json
@@ -142,7 +142,7 @@
       "value": "ENV_VAR_EMPTY_WORKAROUND"
     },
     "REPO_ID": {
-      "value": "ENV_VAR_EMPTY_WORKAROUND"
+      "value": "575f40f3797ef7280505232f"
     },
     "REPO_USER": {
       "value": "ENV_VAR_EMPTY_WORKAROUND"

--- a/buildpipeline/Core-Setup-Windows-arm64.json
+++ b/buildpipeline/Core-Setup-Windows-arm64.json
@@ -83,13 +83,13 @@
   ],
   "variables": {
     "NUGET_FEED_URL": {
-      "value": "https://dotnet.myget.org/F/dotnet-core"
+      "value": "ENV_VAR_EMPTY_WORKAROUND"
     },
     "NUGET_API_KEY": {
-      "value": "PassedViaPipeBuild"
+      "value": "ENV_VAR_EMPTY_WORKAROUND"
     },
     "GITHUB_PASSWORD": {
-      "value": "PassedViaPipeBuild"
+      "value": "ENV_VAR_EMPTY_WORKAROUND"
     },
     "COREHOST_TRACE": {
       "value": "0"
@@ -101,10 +101,10 @@
       "value": "dotnet"
     },
     "CONNECTION_STRING": {
-      "value": "PassedViaPipeBuild"
+      "value": "ENV_VAR_EMPTY_WORKAROUND"
     },
     "PUBLISH_TO_AZURE_BLOB": {
-      "value": "true",
+      "value": "false",
       "allowOverride": true
     }
   },


### PR DESCRIPTION
This lets us configure which publish steps are performed. Before, there were only two modes: publish nothing or publish everything. "Publish everything" fails if some publish destinations are not configured. After this PR, unconfigured destinations are skipped. This will let us set up a new internal build that only publishes to blob storage. Official builds will continue unchanged.

---

This will require some PipeBuild definition changes to pass in the parameters that enable publishing.

Converted `PublishCoreHostPackagesToFeed` to targets so it can share the `EnvironmentAttribute` logic.

Workaround for https://github.com/dotnet/corefx/issues/17614: `EnvironmentAttribute` now evaluates "ENV_VAR_EMPTY_WORKAROUND" the same as null/empty.

I had this branch in `dotnet` so I could run test builds on it.