### PR TITLE
[release/1.0.0] Only publish when destination deliberately specified

### DIFF
--- a/build_projects/Microsoft.DotNet.Cli.Build.Framework/TargetConditions/EnvironmentAttribute.cs
+++ b/build_projects/Microsoft.DotNet.Cli.Build.Framework/TargetConditions/EnvironmentAttribute.cs
@@ -6,6 +6,7 @@ namespace Microsoft.DotNet.Cli.Build.Framework
     [AttributeUsage(AttributeTargets.Method, AllowMultiple = true, Inherited = false)]
     public class EnvironmentAttribute : TargetConditionAttribute
     {
+        private const string EnvVarEmptyWorkaround = "ENV_VAR_EMPTY_WORKAROUND";
         private string _envVar;
         private string[] _expectedVals;
 
@@ -34,7 +35,7 @@ namespace Microsoft.DotNet.Cli.Build.Framework
             }
             else
             {
-                return !string.IsNullOrEmpty(actualVal);
+                return actualVal != EnvVarEmptyWorkaround && !string.IsNullOrEmpty(actualVal);
             }
         }
     }

--- a/buildpipeline/Core-Setup-CentOS-x64.json
+++ b/buildpipeline/Core-Setup-CentOS-x64.json
@@ -128,20 +128,20 @@
       "allowOverride": true
     },
     "CONNECTION_STRING": {
-      "value": "PassedViaPipeBuild"
+      "value": "ENV_VAR_EMPTY_WORKAROUND"
     },
     "PUBLISH_TO_AZURE_BLOB": {
-      "value": "true",
+      "value": "false",
       "allowOverride": true
     },
     "NUGET_FEED_URL": {
-      "value": "https://dotnet.myget.org/F/dotnet-core"
+      "value": "ENV_VAR_EMPTY_WORKAROUND"
     },
     "NUGET_API_KEY": {
-      "value": "PassedViaPipeBuild"
+      "value": "ENV_VAR_EMPTY_WORKAROUND"
     },
     "GITHUB_PASSWORD": {
-      "value": "PassedViaPipeBuild"
+      "value": "ENV_VAR_EMPTY_WORKAROUND"
     }
   },
   "demands": [

--- a/buildpipeline/Core-Setup-Debian8-x64.json
+++ b/buildpipeline/Core-Setup-Debian8-x64.json
@@ -128,20 +128,20 @@
       "allowOverride": true
     },
     "CONNECTION_STRING": {
-      "value": "PassedViaPipeBuild"
+      "value": "ENV_VAR_EMPTY_WORKAROUND"
     },
     "PUBLISH_TO_AZURE_BLOB": {
-      "value": "true",
+      "value": "false",
       "allowOverride": true
     },
     "NUGET_FEED_URL": {
-      "value": "https://dotnet.myget.org/F/dotnet-core"
+      "value": "ENV_VAR_EMPTY_WORKAROUND"
     },
     "NUGET_API_KEY": {
-      "value": "PassedViaPipeBuild"
+      "value": "ENV_VAR_EMPTY_WORKAROUND"
     },
     "GITHUB_PASSWORD": {
-      "value": "PassedViaPipeBuild"
+      "value": "ENV_VAR_EMPTY_WORKAROUND"
     }
   },
   "demands": [

--- a/buildpipeline/Core-Setup-Fedora23-x64.json
+++ b/buildpipeline/Core-Setup-Fedora23-x64.json
@@ -145,20 +145,20 @@
       "value": "--skip-prereqs --configuration $(BuildConfiguration)  --docker fedora.23 --targets Default"
     },
     "CONNECTION_STRING": {
-      "value": "PassedViaPipeBuild"
+      "value": "ENV_VAR_EMPTY_WORKAROUND"
     },
     "PUBLISH_TO_AZURE_BLOB": {
-      "value": "true",
+      "value": "false",
       "allowOverride": true
     },
     "NUGET_FEED_URL": {
-      "value": "https://dotnet.myget.org/F/dotnet-core"
+      "value": "ENV_VAR_EMPTY_WORKAROUND"
     },
     "NUGET_API_KEY": {
-      "value": "PassedViaPipeBuild"
+      "value": "ENV_VAR_EMPTY_WORKAROUND"
     },
     "GITHUB_PASSWORD": {
-      "value": "PassedViaPipeBuild"
+      "value": "ENV_VAR_EMPTY_WORKAROUND"
     }
   },
   "demands": [

--- a/buildpipeline/Core-Setup-OSX-x64.json
+++ b/buildpipeline/Core-Setup-OSX-x64.json
@@ -128,20 +128,20 @@
       "allowOverride": true
     },
     "CONNECTION_STRING": {
-      "value": "PassedViaPipeBuild"
+      "value": "ENV_VAR_EMPTY_WORKAROUND"
     },
     "PUBLISH_TO_AZURE_BLOB": {
-      "value": "true",
+      "value": "false",
       "allowOverride": true
     },
     "NUGET_FEED_URL": {
-      "value": "https://dotnet.myget.org/F/dotnet-core"
+      "value": "ENV_VAR_EMPTY_WORKAROUND"
     },
     "NUGET_API_KEY": {
-      "value": "PassedViaPipeBuild"
+      "value": "ENV_VAR_EMPTY_WORKAROUND"
     },
     "GITHUB_PASSWORD": {
-      "value": "PassedViaPipeBuild"
+      "value": "ENV_VAR_EMPTY_WORKAROUND"
     }
   },
   "demands": [

--- a/buildpipeline/Core-Setup-OpenSuse13.2-x64.json
+++ b/buildpipeline/Core-Setup-OpenSuse13.2-x64.json
@@ -126,20 +126,20 @@
       "value": "--skip-prereqs --configuration $(BuildConfiguration)  --docker opensuse.13.2 --targets Default"
     },
     "CONNECTION_STRING": {
-      "value": "PassedViaPipeBuild"
+      "value": "ENV_VAR_EMPTY_WORKAROUND"
     },
     "PUBLISH_TO_AZURE_BLOB": {
-      "value": "true",
+      "value": "false",
       "allowOverride": true
     },
     "NUGET_FEED_URL": {
-      "value": "https://dotnet.myget.org/F/dotnet-core"
+      "value": "ENV_VAR_EMPTY_WORKAROUND"
     },
     "NUGET_API_KEY": {
-      "value": "PassedViaPipeBuild"
+      "value": "ENV_VAR_EMPTY_WORKAROUND"
     },
     "GITHUB_PASSWORD": {
-      "value": "PassedViaPipeBuild"
+      "value": "ENV_VAR_EMPTY_WORKAROUND"
     }
   },
   "demands": [

--- a/buildpipeline/Core-Setup-RHEL7-x64.json
+++ b/buildpipeline/Core-Setup-RHEL7-x64.json
@@ -68,7 +68,7 @@
       },
       "inputs": {
         "scriptPath": "scripts/dockerrun-as-current-user.sh",
-        "args": "-t --rm --sig-proxy=true --name $(DockerContainerName) -v $(Build.SourcesDirectory):/opt/code -w /opt/code -e CONNECTION_STRING -e PUBLISH_TO_AZURE_BLOB -e NUGET_FEED_URL -e NUGET_API_KEY -e GITHUB_PASSWORD $(DockerImageName) /bin/bash -c \"HOME=/opt/code; git clean -X -d -f; ./build.sh $(BuildArguments)\"",
+        "args": "-t --rm --sig-proxy=true --name $(DockerContainerName) -v $(Build.SourcesDirectory):/opt/code -w /opt/code $(BuildEnvironmentVariables) $(DockerImageName) /bin/bash -c \"HOME=/opt/code; git clean -X -d -f; ./build.sh $(BuildArguments)\"",
         "disableAutoCwd": "false",
         "cwd": "",
         "failOnStandardError": "false"
@@ -164,25 +164,29 @@
       "value": "--skip-prereqs --configuration $(BuildConfiguration) --targets Default",
       "allowOverride": true
     },
+    "BuildEnvironmentVariables": {
+      "value": "-e CHANNEL -e CONNECTION_STRING -e REPO_ID -e REPO_USER -e REPO_PASS -e REPO_SERVER -e DOTNET_BUILD_SKIP_CROSSGEN -e PUBLISH_TO_AZURE_BLOB -e DOCKER_HUB_REPO -e DOCKER_HUB_TRIGGER_TOKEN -e NUGET_FEED_URL -e NUGET_API_KEY -e GITHUB_PASSWORD -e CLI_NUGET_FEED_URL -e CLI_NUGET_API_KEY",
+      "allowOverride": true
+    },
     "DockerContainerName": {
       "value": "dotnetcore-setup-build-container-rhel",
       "allowOverride": true
     },
     "CONNECTION_STRING": {
-      "value": "PassedViaPipeBuild"
+      "value": "ENV_VAR_EMPTY_WORKAROUND"
     },
     "PUBLISH_TO_AZURE_BLOB": {
-      "value": "true",
+      "value": "false",
       "allowOverride": true
     },
     "NUGET_FEED_URL": {
-      "value": "https://dotnet.myget.org/F/dotnet-core"
+      "value": "ENV_VAR_EMPTY_WORKAROUND"
     },
     "NUGET_API_KEY": {
-      "value": "PassedViaPipeBuild"
+      "value": "ENV_VAR_EMPTY_WORKAROUND"
     },
     "GITHUB_PASSWORD": {
-      "value": "PassedViaPipeBuild"
+      "value": "ENV_VAR_EMPTY_WORKAROUND"
     },
     "DockerImageName": {
       "value": "microsoft/dotnet-buildtools-prereqs:rhel7_prereqs_2"

--- a/buildpipeline/Core-Setup-Signing-Windows-x64.json
+++ b/buildpipeline/Core-Setup-Signing-Windows-x64.json
@@ -408,19 +408,20 @@
       "value": "dotnet"
     },
     "CONNECTION_STRING": {
-      "value": "PassedViaPipeBuild"
+      "value": "ENV_VAR_EMPTY_WORKAROUND"
     },
     "PUBLISH_TO_AZURE_BLOB": {
-      "value": "true"
+      "value": "false",
+      "allowOverride": true
     },
     "NUGET_FEED_URL": {
-      "value": "https://dotnet.myget.org/F/dotnet-core"
+      "value": "ENV_VAR_EMPTY_WORKAROUND"
     },
     "NUGET_API_KEY": {
-      "value": "PassedViaPipeBuild"
+      "value": "ENV_VAR_EMPTY_WORKAROUND"
     },
     "GITHUB_PASSWORD": {
-      "value": "PassedViaPipeBuild"
+      "value": "ENV_VAR_EMPTY_WORKAROUND"
     },
     "CertificateId": {
       "value": "400"

--- a/buildpipeline/Core-Setup-Signing-Windows-x86.json
+++ b/buildpipeline/Core-Setup-Signing-Windows-x86.json
@@ -408,19 +408,20 @@
       "value": "dotnet"
     },
     "CONNECTION_STRING": {
-      "value": "PassedViaPipeBuild"
+      "value": "ENV_VAR_EMPTY_WORKAROUND"
     },
     "PUBLISH_TO_AZURE_BLOB": {
-      "value": "true"
+      "value": "false",
+      "allowOverride": true
     },
     "NUGET_FEED_URL": {
-      "value": "https://dotnet.myget.org/F/dotnet-core"
+      "value": "ENV_VAR_EMPTY_WORKAROUND"
     },
     "NUGET_API_KEY": {
-      "value": "PassedViaPipeBuild"
+      "value": "ENV_VAR_EMPTY_WORKAROUND"
     },
     "GITHUB_PASSWORD": {
-      "value": "PassedViaPipeBuild"
+      "value": "ENV_VAR_EMPTY_WORKAROUND"
     },
     "BuildArchitecture": {
       "value": "x86"

--- a/buildpipeline/Core-Setup-Ubuntu14.04-x64.json
+++ b/buildpipeline/Core-Setup-Ubuntu14.04-x64.json
@@ -128,38 +128,38 @@
       "allowOverride": true
     },
     "CONNECTION_STRING": {
-      "value": "PassedViaPipeBuild"
+      "value": "ENV_VAR_EMPTY_WORKAROUND"
     },
     "PUBLISH_TO_AZURE_BLOB": {
-      "value": "true",
+      "value": "false",
       "allowOverride": true
     },
     "REPO_ID": {
       "value": "562fbfe0b2d7d0e0a43780c4"
     },
     "REPO_USER": {
-      "value": "dotnet"
+      "value": "ENV_VAR_EMPTY_WORKAROUND"
     },
     "REPO_PASS": {
-      "value": "PassedViaPipeBuild"
+      "value": "ENV_VAR_EMPTY_WORKAROUND"
     },
     "REPO_SERVER": {
-      "value": "azure-apt-cat.cloudapp.net"
+      "value": "ENV_VAR_EMPTY_WORKAROUND"
     },
     "NUGET_FEED_URL": {
-      "value": "https://dotnet.myget.org/F/dotnet-core"
+      "value": "ENV_VAR_EMPTY_WORKAROUND"
     },
     "NUGET_API_KEY": {
-      "value": "PassedViaPipeBuild"
+      "value": "ENV_VAR_EMPTY_WORKAROUND"
     },
     "GITHUB_PASSWORD": {
-      "value": "PassedViaPipeBuild"
+      "value": "ENV_VAR_EMPTY_WORKAROUND"
     },
     "CLI_NUGET_FEED_URL": {
-      "value": "https://dotnet.myget.org/F/cli-deps"
+      "value": "ENV_VAR_EMPTY_WORKAROUND"
     },
     "CLI_NUGET_API_KEY": {
-      "value": "PassedViaPipeBuild"
+      "value": "ENV_VAR_EMPTY_WORKAROUND"
     }
   },
   "demands": [

--- a/buildpipeline/Core-Setup-Ubuntu16.04-x64.json
+++ b/buildpipeline/Core-Setup-Ubuntu16.04-x64.json
@@ -126,32 +126,32 @@
       "value": "--skip-prereqs --configuration $(BuildConfiguration)  --docker ubuntu.16.04 --targets Default"
     },
     "CONNECTION_STRING": {
-      "value": "PassedViaPipeBuild"
+      "value": "ENV_VAR_EMPTY_WORKAROUND"
     },
     "PUBLISH_TO_AZURE_BLOB": {
-      "value": "true",
+      "value": "false",
       "allowOverride": true
     },
     "NUGET_FEED_URL": {
-      "value": "https://dotnet.myget.org/F/dotnet-core"
+      "value": "ENV_VAR_EMPTY_WORKAROUND"
     },
     "NUGET_API_KEY": {
-      "value": "PassedViaPipeBuild"
+      "value": "ENV_VAR_EMPTY_WORKAROUND"
     },
     "GITHUB_PASSWORD": {
-      "value": "PassedViaPipeBuild"
+      "value": "ENV_VAR_EMPTY_WORKAROUND"
     },
     "REPO_ID": {
       "value": "575f40f3797ef7280505232f"
     },
     "REPO_USER": {
-      "value": "dotnet"
+      "value": "ENV_VAR_EMPTY_WORKAROUND"
     },
     "REPO_SERVER": {
-      "value": "azure-apt-cat.cloudapp.net"
+      "value": "ENV_VAR_EMPTY_WORKAROUND"
     },
     "REPO_PASS": {
-      "value": "PassedViaPipeBuild"
+      "value": "ENV_VAR_EMPTY_WORKAROUND"
     }
   },
   "demands": [

--- a/buildpipeline/Core-Setup-Windows-arm32.json
+++ b/buildpipeline/Core-Setup-Windows-arm32.json
@@ -83,13 +83,13 @@
   ],
   "variables": {
     "NUGET_FEED_URL": {
-      "value": "https://dotnet.myget.org/F/dotnet-core/api/v2"
+      "value": "ENV_VAR_EMPTY_WORKAROUND"
     },
     "NUGET_API_KEY": {
-      "value": "PassedViaPipeBuild"
+      "value": "ENV_VAR_EMPTY_WORKAROUND"
     },
     "GITHUB_PASSWORD": {
-      "value": "PassedViaPipeBuild"
+      "value": "ENV_VAR_EMPTY_WORKAROUND"
     },
     "COREHOST_TRACE": {
       "value": "0"
@@ -101,10 +101,10 @@
       "value": "dotnet"
     },
     "CONNECTION_STRING": {
-      "value": "PassedViaPipeBuild"
+      "value": "ENV_VAR_EMPTY_WORKAROUND"
     },
     "PUBLISH_TO_AZURE_BLOB": {
-      "value": "true",
+      "value": "false",
       "allowOverride": true
     }
   },


### PR DESCRIPTION
This will require some PipeBuild definition changes to pass in the parameters that enable publishing.

See https://github.com/dotnet/core-setup/pull/1869