### PR TITLE
Exclude symbols from runtime packages

### DIFF
--- a/pkg/projects/dir.props
+++ b/pkg/projects/dir.props
@@ -49,6 +49,11 @@
     </Otherwise>
   </Choose>
 
+  <ItemGroup>
+    <AdditionalLibPackageExcludes Condition="'$(SymbolFileExtension)' != ''" Include="%2A%2A\%2A$(SymbolFileExtension)" />
+    <AdditionalSymbolPackageExcludes Condition="'$(LibraryFileExtension)' != ''" Include="%2A%2A\%2A.a;%2A%2A\%2A$(LibraryFileExtension)" />
+  </ItemGroup>
+
   <PropertyGroup Condition="'$(PackageRID)' == ''">
     <PackageRID>$(DistroRid)</PackageRID>
     <PackageRID Condition="'$(OSEnvironment)' == 'OSX'">osx.10.12-$(Platform)</PackageRID>


### PR DESCRIPTION
Fixes #1884 

Prevent symbols from being include in lib packages.

/cc @eerhardt @ericstj 