### PR TITLE
Push symbols packages to a separate symbols feed 

### DIFF
--- a/build_projects/dotnet-host-build/NugetUtil.cs
+++ b/build_projects/dotnet-host-build/NugetUtil.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;

--- a/build_projects/dotnet-host-build/NugetUtil.cs
+++ b/build_projects/dotnet-host-build/NugetUtil.cs
@@ -9,10 +9,11 @@ namespace Microsoft.DotNet.Cli.Build
 {
     public static class NuGetUtil
     {
+        [Flags]
         public enum NuGetIncludePackageType
         {
             Standard = 1,
-            Symbols
+            Symbols = 2
         }
         public static void PushPackages(
             string packageDirPath,
@@ -21,11 +22,11 @@ namespace Microsoft.DotNet.Cli.Build
             NuGetIncludePackageType includePackageTypes)
         {
             List<string> paths = new List<string>();
-            if ((includePackageTypes & NuGetIncludePackageType.Standard) != 0)
+            if ((includePackageTypes.HasFlag(NuGetIncludePackageType.Standard)))
             {
                 paths.AddRange(Directory.GetFiles(packageDirPath, "*.nupkg").Where(p => !p.EndsWith(".symbols.nupkg")));
             }
-            if ((includePackageTypes & NuGetIncludePackageType.Symbols) != 0)
+            if ((includePackageTypes.HasFlag(NuGetIncludePackageType.Symbols)))
             {
                 paths.AddRange(Directory.GetFiles(packageDirPath, "*.symbols.nupkg"));
             }

--- a/build_projects/dotnet-host-build/NugetUtil.cs
+++ b/build_projects/dotnet-host-build/NugetUtil.cs
@@ -22,11 +22,11 @@ namespace Microsoft.DotNet.Cli.Build
             NuGetIncludePackageType includePackageTypes)
         {
             List<string> paths = new List<string>();
-            if ((includePackageTypes.HasFlag(NuGetIncludePackageType.Standard)))
+            if (includePackageTypes.HasFlag(NuGetIncludePackageType.Standard))
             {
                 paths.AddRange(Directory.GetFiles(packageDirPath, "*.nupkg").Where(p => !p.EndsWith(".symbols.nupkg")));
             }
-            if ((includePackageTypes.HasFlag(NuGetIncludePackageType.Symbols)))
+            if (includePackageTypes.HasFlag(NuGetIncludePackageType.Symbols))
             {
                 paths.AddRange(Directory.GetFiles(packageDirPath, "*.symbols.nupkg"));
             }

--- a/build_projects/dotnet-host-build/NugetUtil.cs
+++ b/build_projects/dotnet-host-build/NugetUtil.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection;
@@ -8,25 +9,25 @@ namespace Microsoft.DotNet.Cli.Build
 {
     public static class NuGetUtil
     {
+        public enum NuGetIncludePackageType
+        {
+            Standard = 1,
+            Symbols
+        }
         public static void PushPackages(
             string packageDirPath,
             string destinationUrl,
             string apiKey,
-            bool includeSymbolPackages)
+            NuGetIncludePackageType includePackageTypes)
         {
-            string[] paths;
-            if (includeSymbolPackages)
+            List<string> paths = new List<string>();
+            if ((includePackageTypes & NuGetIncludePackageType.Standard) != 0)
             {
-                paths = new[]
-                {
-                    Path.Combine(packageDirPath, "*.nupkg")
-                };
+                paths.AddRange(Directory.GetFiles(packageDirPath, "*.nupkg").Where(p => !p.EndsWith(".symbols.nupkg")));
             }
-            else
+            if ((includePackageTypes & NuGetIncludePackageType.Symbols) != 0)
             {
-                paths = Directory.GetFiles(packageDirPath, "*.nupkg")
-                    .Where(path => !path.EndsWith(".symbols.nupkg"))
-                    .ToArray();
+                paths.AddRange(Directory.GetFiles(packageDirPath, "*.symbols.nupkg"));
             }
 
             foreach (var path in paths)

--- a/build_projects/dotnet-host-build/PublishTargets.cs
+++ b/build_projects/dotnet-host-build/PublishTargets.cs
@@ -63,9 +63,15 @@ namespace Microsoft.DotNet.Host.Build
         [BuildArchitectures(BuildArchitecture.x64)]
         public static BuildTargetResult PublishDotnetDebToolPackage(BuildTargetContext c)
         {
-            string nugetFeedUrl = EnvVars.EnsureVariable("CLI_NUGET_FEED_URL");
             string apiKey = EnvVars.EnsureVariable("CLI_NUGET_API_KEY");
-            NuGetUtil.PushPackages(Dirs.Packages, nugetFeedUrl, apiKey, IncludeSymbolPackages);
+
+            string nugetFeedUrl = EnvVars.EnsureVariable("CLI_NUGET_FEED_URL");
+            NuGetUtil.PushPackages(Dirs.Packages, nugetFeedUrl, apiKey, NuGetUtil.NuGetIncludePackageType.Standard);
+            if(IncludeSymbolPackages)
+            {
+                string symbolsNugetFeedUrl = EnvVars.EnsureVariable("CLI_NUGET_SYMBOLS_FEED_URL");
+                NuGetUtil.PushPackages(Dirs.PackagesNoRID, symbolsNugetFeedUrl, apiKey, NuGetUtil.NuGetIncludePackageType.Symbols);
+            }
 
             return c.Success();
         }
@@ -177,8 +183,15 @@ namespace Microsoft.DotNet.Host.Build
             AzurePublisherTool.DownloadFilesWithExtension(hostBlob, ".nupkg", Dirs.PackagesNoRID);
 
             string nugetFeedUrl = EnvVars.EnsureVariable("NUGET_FEED_URL");
+
             string apiKey = EnvVars.EnsureVariable("NUGET_API_KEY");
-            NuGetUtil.PushPackages(Dirs.PackagesNoRID, nugetFeedUrl, apiKey, IncludeSymbolPackages);
+            NuGetUtil.PushPackages(Dirs.PackagesNoRID, nugetFeedUrl, apiKey, NuGetUtil.NuGetIncludePackageType.Standard);
+            
+            if(IncludeSymbolPackages)
+            {
+                string symbolsNugetFeedUrl = EnvVars.EnsureVariable("NUGET_SYMBOLS_FEED_URL");
+                NuGetUtil.PushPackages(Dirs.PackagesNoRID, symbolsNugetFeedUrl, apiKey, NuGetUtil.NuGetIncludePackageType.Symbols);
+            }
 
             string githubAuthToken = EnvVars.EnsureVariable("GITHUB_PASSWORD");
             VersionRepoUpdater repoUpdater = new VersionRepoUpdater(githubAuthToken);

--- a/build_projects/dotnet-host-build/PublishTargets.cs
+++ b/build_projects/dotnet-host-build/PublishTargets.cs
@@ -182,9 +182,9 @@ namespace Microsoft.DotNet.Host.Build
             Directory.CreateDirectory(Dirs.PackagesNoRID);
             AzurePublisherTool.DownloadFilesWithExtension(hostBlob, ".nupkg", Dirs.PackagesNoRID);
 
-            string nugetFeedUrl = EnvVars.EnsureVariable("NUGET_FEED_URL");
-
             string apiKey = EnvVars.EnsureVariable("NUGET_API_KEY");
+
+            string nugetFeedUrl = EnvVars.EnsureVariable("NUGET_FEED_URL");
             NuGetUtil.PushPackages(Dirs.PackagesNoRID, nugetFeedUrl, apiKey, NuGetUtil.NuGetIncludePackageType.Standard);
             
             if(IncludeSymbolPackages)

--- a/build_projects/dotnet-host-build/PublishTargets.cs
+++ b/build_projects/dotnet-host-build/PublishTargets.cs
@@ -67,10 +67,10 @@ namespace Microsoft.DotNet.Host.Build
 
             string nugetFeedUrl = EnvVars.EnsureVariable("CLI_NUGET_FEED_URL");
             NuGetUtil.PushPackages(Dirs.Packages, nugetFeedUrl, apiKey, NuGetUtil.NuGetIncludePackageType.Standard);
-            if(IncludeSymbolPackages)
+            if (IncludeSymbolPackages)
             {
                 string symbolsNugetFeedUrl = EnvVars.EnsureVariable("CLI_NUGET_SYMBOLS_FEED_URL");
-                NuGetUtil.PushPackages(Dirs.PackagesNoRID, symbolsNugetFeedUrl, apiKey, NuGetUtil.NuGetIncludePackageType.Symbols);
+                NuGetUtil.PushPackages(Dirs.Packages, symbolsNugetFeedUrl, apiKey, NuGetUtil.NuGetIncludePackageType.Symbols);
             }
 
             return c.Success();
@@ -187,7 +187,7 @@ namespace Microsoft.DotNet.Host.Build
             string nugetFeedUrl = EnvVars.EnsureVariable("NUGET_FEED_URL");
             NuGetUtil.PushPackages(Dirs.PackagesNoRID, nugetFeedUrl, apiKey, NuGetUtil.NuGetIncludePackageType.Standard);
             
-            if(IncludeSymbolPackages)
+            if (IncludeSymbolPackages)
             {
                 string symbolsNugetFeedUrl = EnvVars.EnsureVariable("NUGET_SYMBOLS_FEED_URL");
                 NuGetUtil.PushPackages(Dirs.PackagesNoRID, symbolsNugetFeedUrl, apiKey, NuGetUtil.NuGetIncludePackageType.Symbols);

--- a/buildpipeline/Core-Setup-CrossBuild.json
+++ b/buildpipeline/Core-Setup-CrossBuild.json
@@ -125,7 +125,7 @@
       },
       "inputs": {
         "scriptPath": "$(PB_RepoName)/scripts/docker-as-current-user.sh",
-        "args": "run --name $(PB_DockerContainerName) --rm --privileged -v $(System.DefaultWorkingDirectory)/$(PB_RepoName):$(PB_GitDirectory) -w $(PB_GitDirectory) -e HOME -e ROOTFS_DIR -e PUBLISH_TO_AZURE_BLOB -e CONNECTION_STRING -e CLI_NUGET_FEED_URL -e CLI_NUGET_API_KEY -e NUGET_FEED_URL -e NUGET_API_KEY -e GITHUB_PASSWORD $(PB_DockerImageName) ./build.sh $(CommonArguments) $(BuildArguments) $(portableLinux) --env-vars \"DISABLE_CROSSGEN=1,TARGETPLATFORM=$(PB_Architecture),TARGETRID=$(TargetRid),CROSS=1\"",
+        "args": "run --name $(PB_DockerContainerName) --rm --privileged -v $(System.DefaultWorkingDirectory)/$(PB_RepoName):$(PB_GitDirectory) -w $(PB_GitDirectory) -e HOME -e ROOTFS_DIR -e PUBLISH_TO_AZURE_BLOB -e CONNECTION_STRING -e CLI_NUGET_FEED_URL -e CLI_NUGET_SYMBOLS_FEED_URL -e CLI_NUGET_API_KEY -e NUGET_FEED_URL -e NUGET_SYMBOLS_FEED_URL -e NUGET_API_KEY -e GITHUB_PASSWORD $(PB_DockerImageName) ./build.sh $(CommonArguments) $(BuildArguments) $(portableLinux) --env-vars \"DISABLE_CROSSGEN=1,TARGETPLATFORM=$(PB_Architecture),TARGETRID=$(TargetRid),CROSS=1\"",
         "disableAutoCwd": "false",
         "cwd": "",
         "failOnStandardError": "false"
@@ -169,6 +169,15 @@
     }
   ],
   "options": [
+    {
+      "enabled": false,
+      "definition": {
+        "id": "5bc3cfb7-6b54-4a4b-b5d2-a3905949f8a6"
+      },
+      "inputs": {
+        "additionalFields": "{}"
+      }
+    },
     {
       "enabled": false,
       "definition": {
@@ -297,6 +306,9 @@
     },
     "PB_CleanAgent": {
       "value": "true"
+    },
+    "NUGET_SYMBOLS_FEED_URL": {
+      "value": "https://dotnet.myget.org/F/dotnet-core/symbols/api/v2"
     }
   },
   "demands": [
@@ -361,6 +373,6 @@
     "description": "Visual Studio and DevDiv team project for git source code repositories.  Work items will be added for Adams, Dev14 work items are tracked in vstfdevdiv.  ",
     "url": "https://devdiv.visualstudio.com/DefaultCollection/_apis/projects/0bdbc590-a062-4c3f-b0f6-9383f67865ee",
     "state": "wellFormed",
-    "revision": 418097529
+    "revision": 418097620
   }
 }

--- a/buildpipeline/Core-Setup-Linux.json
+++ b/buildpipeline/Core-Setup-Linux.json
@@ -234,6 +234,9 @@
     },
     "DockerHost_ToolsDirectory": {
       "value": "$(DockerHost_Sandbox)/Tools"
+    },
+    "NUGET_SYMBOLS_FEED_URL": {
+      "value": " https://dotnet.myget.org/F/dotnet-core/api/v2/package"
     }
   },
   "demands": [
@@ -267,7 +270,9 @@
       "cloneUrl": "https://github.com/dotnet/core-setup.git",
       "refsUrl": "https://api.github.com/repos/dotnet/core-setup/git/refs",
       "gitLfsSupport": "false",
-      "fetchDepth": "0"
+      "skipSyncSource": "false",
+      "fetchDepth": "0",
+      "cleanOptions": "0"
     },
     "id": "https://github.com/dotnet/core-setup.git",
     "type": "GitHub",
@@ -296,6 +301,6 @@
     "description": "Visual Studio and DevDiv team project for git source code repositories.  Work items will be added for Adams, Dev14 work items are tracked in vstfdevdiv.  ",
     "url": "https://devdiv.visualstudio.com/DefaultCollection/_apis/projects/0bdbc590-a062-4c3f-b0f6-9383f67865ee",
     "state": "wellFormed",
-    "revision": 418097459
+    "revision": 418097620
   }
 }

--- a/buildpipeline/Core-Setup-OSX-x64.json
+++ b/buildpipeline/Core-Setup-OSX-x64.json
@@ -142,6 +142,9 @@
     },
     "GITHUB_PASSWORD": {
       "value": "PassedViaPipeBuild"
+    },
+    "NUGET_SYMBOLS_FEED_URL": {
+      "value": " https://dotnet.myget.org/F/dotnet-core/symbols/api/v2"
     }
   },
   "demands": [
@@ -175,7 +178,9 @@
       "cloneUrl": "https://github.com/dotnet/core-setup.git",
       "refsUrl": "https://api.github.com/repos/dotnet/core-setup/git/refs",
       "gitLfsSupport": "false",
-      "fetchDepth": "0"
+      "skipSyncSource": "false",
+      "fetchDepth": "0",
+      "cleanOptions": "0"
     },
     "id": "https://github.com/dotnet/core-setup.git",
     "type": "GitHub",
@@ -204,6 +209,6 @@
     "description": "Visual Studio and DevDiv team project for git source code repositories.  Work items will be added for Adams, Dev14 work items are tracked in vstfdevdiv.  ",
     "url": "https://devdiv.visualstudio.com/DefaultCollection/_apis/projects/0bdbc590-a062-4c3f-b0f6-9383f67865ee",
     "state": "wellFormed",
-    "revision": 418097459
+    "revision": 418097620
   }
 }

--- a/buildpipeline/Core-Setup-PortableLinux-x64.json
+++ b/buildpipeline/Core-Setup-PortableLinux-x64.json
@@ -215,6 +215,9 @@
     },
     "DockerHost_ToolsDirectory": {
       "value": "$(DockerHost_Sandbox)/Tools"
+    },
+    "NUGET_SYMBOLS_FEED_URL": {
+      "value": " https://dotnet.myget.org/F/dotnet-core/symbols/api/v2"
     }
   },
   "demands": [
@@ -225,7 +228,7 @@
       "branches": [
         "+refs/heads/*"
       ],
-      "artifacts": [ ],
+      "artifacts": [],
       "artifactTypesToDelete": [
         "FilePath",
         "SymbolStore"
@@ -248,7 +251,9 @@
       "cloneUrl": "https://github.com/dotnet/core-setup.git",
       "refsUrl": "https://api.github.com/repos/dotnet/core-setup/git/refs",
       "gitLfsSupport": "false",
-      "fetchDepth": "0"
+      "skipSyncSource": "false",
+      "fetchDepth": "0",
+      "cleanOptions": "0"
     },
     "id": "https://github.com/dotnet/core-setup.git",
     "type": "GitHub",
@@ -277,6 +282,6 @@
     "description": "Visual Studio and DevDiv team project for git source code repositories.  Work items will be added for Adams, Dev14 work items are tracked in vstfdevdiv.  ",
     "url": "https://devdiv.visualstudio.com/DefaultCollection/_apis/projects/0bdbc590-a062-4c3f-b0f6-9383f67865ee",
     "state": "wellFormed",
-    "revision": 418097459
+    "revision": 418097620
   }
 }

--- a/buildpipeline/Core-Setup-RHEL7-x64.json
+++ b/buildpipeline/Core-Setup-RHEL7-x64.json
@@ -215,6 +215,9 @@
     },
     "DockerHost_ToolsDirectory": {
       "value": "$(DockerHost_Sandbox)/Tools"
+    },
+    "NUGET_SYMBOLS_FEED_URL": {
+      "value": " https://dotnet.myget.org/F/dotnet-core/symbols/api/v2"
     }
   },
   "demands": [
@@ -225,7 +228,7 @@
       "branches": [
         "+refs/heads/*"
       ],
-      "artifacts": [ ],
+      "artifacts": [],
       "artifactTypesToDelete": [
         "FilePath",
         "SymbolStore"
@@ -279,6 +282,6 @@
     "description": "Visual Studio and DevDiv team project for git source code repositories.  Work items will be added for Adams, Dev14 work items are tracked in vstfdevdiv.  ",
     "url": "https://devdiv.visualstudio.com/DefaultCollection/_apis/projects/0bdbc590-a062-4c3f-b0f6-9383f67865ee",
     "state": "wellFormed",
-    "revision": 418097568
+    "revision": 418097620
   }
 }

--- a/buildpipeline/Core-Setup-Signing-Windows-x64.json
+++ b/buildpipeline/Core-Setup-Signing-Windows-x64.json
@@ -104,6 +104,26 @@
     },
     {
       "enabled": true,
+      "continueOnError": true,
+      "alwaysRun": false,
+      "displayName": "PackagePkgProjects",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "e213ff0f-5d5c-4791-802d-52ea3e7be1f1",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "scriptType": "filePath",
+        "scriptName": "build_projects/dotnet-host-build/build.ps1",
+        "arguments": "-Configuration $(BuildConfiguration) -Targets Prepare,PackagePkgProjects,BuildProjectsForNuGetPackages",
+        "inlineScript": "# You can write your powershell scripts inline here. \n# You can also pass predefined and custom variables to this scripts using arguments\n\n Write-Host \"Hello World\"",
+        "workingFolder": "",
+        "failOnStandardError": "true"
+      }
+    },
+    {
+      "enabled": true,
       "continueOnError": false,
       "alwaysRun": false,
       "displayName": "PublishSharedFramework",
@@ -173,26 +193,6 @@
         "msbuildVersion": "15.0",
         "msbuildArchitecture": "x64",
         "msbuildLocation": ""
-      }
-    },
-    {
-      "enabled": true,
-      "continueOnError": true,
-      "alwaysRun": false,
-      "displayName": "PackagePkgProjects",
-      "timeoutInMinutes": 0,
-      "task": {
-        "id": "e213ff0f-5d5c-4791-802d-52ea3e7be1f1",
-        "versionSpec": "1.*",
-        "definitionType": "task"
-      },
-      "inputs": {
-        "scriptType": "filePath",
-        "scriptName": "build_projects/dotnet-host-build/build.ps1",
-        "arguments": "-Configuration $(BuildConfiguration) -Targets Prepare,PackagePkgProjects,BuildProjectsForNuGetPackages",
-        "inlineScript": "# You can write your powershell scripts inline here. \n# You can also pass predefined and custom variables to this scripts using arguments\n\n Write-Host \"Hello World\"",
-        "workingFolder": "",
-        "failOnStandardError": "true"
       }
     },
     {

--- a/buildpipeline/Core-Setup-Signing-Windows-x64.json
+++ b/buildpipeline/Core-Setup-Signing-Windows-x64.json
@@ -104,26 +104,6 @@
     },
     {
       "enabled": true,
-      "continueOnError": true,
-      "alwaysRun": false,
-      "displayName": "PackagePkgProjects",
-      "timeoutInMinutes": 0,
-      "task": {
-        "id": "e213ff0f-5d5c-4791-802d-52ea3e7be1f1",
-        "versionSpec": "1.*",
-        "definitionType": "task"
-      },
-      "inputs": {
-        "scriptType": "filePath",
-        "scriptName": "build_projects/dotnet-host-build/build.ps1",
-        "arguments": "-Configuration $(BuildConfiguration) -Targets Prepare,PackagePkgProjects,BuildProjectsForNuGetPackages",
-        "inlineScript": "# You can write your powershell scripts inline here. \n# You can also pass predefined and custom variables to this scripts using arguments\n\n Write-Host \"Hello World\"",
-        "workingFolder": "",
-        "failOnStandardError": "true"
-      }
-    },
-    {
-      "enabled": true,
       "continueOnError": false,
       "alwaysRun": false,
       "displayName": "PublishSharedFramework",
@@ -193,6 +173,26 @@
         "msbuildVersion": "15.0",
         "msbuildArchitecture": "x64",
         "msbuildLocation": ""
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": true,
+      "alwaysRun": false,
+      "displayName": "PackagePkgProjects",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "e213ff0f-5d5c-4791-802d-52ea3e7be1f1",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "scriptType": "filePath",
+        "scriptName": "build_projects/dotnet-host-build/build.ps1",
+        "arguments": "-Configuration $(BuildConfiguration) -Targets Prepare,PackagePkgProjects,BuildProjectsForNuGetPackages",
+        "inlineScript": "# You can write your powershell scripts inline here. \n# You can also pass predefined and custom variables to this scripts using arguments\n\n Write-Host \"Hello World\"",
+        "workingFolder": "",
+        "failOnStandardError": "true"
       }
     },
     {
@@ -389,6 +389,15 @@
     {
       "enabled": false,
       "definition": {
+        "id": "5bc3cfb7-6b54-4a4b-b5d2-a3905949f8a6"
+      },
+      "inputs": {
+        "additionalFields": "{}"
+      }
+    },
+    {
+      "enabled": false,
+      "definition": {
         "id": "7c555368-ca64-4199-add6-9ebaf0b0137d"
       },
       "inputs": {
@@ -466,6 +475,9 @@
     },
     "system.debug": {
       "value": "false"
+    },
+    "NUGET_SYMBOLS_FEED_URL": {
+      "value": " https://dotnet.myget.org/F/dotnet-core/symbols/api/v2"
     }
   },
   "demands": [
@@ -476,7 +488,7 @@
       "branches": [
         "+refs/heads/*"
       ],
-      "artifacts": [ ],
+      "artifacts": [],
       "artifactTypesToDelete": [
         "FilePath",
         "SymbolStore"
@@ -530,6 +542,6 @@
     "description": "Visual Studio and DevDiv team project for git source code repositories.  Work items will be added for Adams, Dev14 work items are tracked in vstfdevdiv.  ",
     "url": "https://devdiv.visualstudio.com/DefaultCollection/_apis/projects/0bdbc590-a062-4c3f-b0f6-9383f67865ee",
     "state": "wellFormed",
-    "revision": 418097471
+    "revision": 418097620
   }
 }

--- a/buildpipeline/Core-Setup-Signing-Windows-x86.json
+++ b/buildpipeline/Core-Setup-Signing-Windows-x86.json
@@ -362,6 +362,15 @@
     {
       "enabled": false,
       "definition": {
+        "id": "5bc3cfb7-6b54-4a4b-b5d2-a3905949f8a6"
+      },
+      "inputs": {
+        "additionalFields": "{}"
+      }
+    },
+    {
+      "enabled": false,
+      "definition": {
         "id": "7c555368-ca64-4199-add6-9ebaf0b0137d"
       },
       "inputs": {
@@ -439,6 +448,9 @@
     },
     "system.debug": {
       "value": "false"
+    },
+    "NUGET_SYMBOLS_FEED_URL": {
+      "value": " https://dotnet.myget.org/F/dotnet-core/symbols/api/v2"
     }
   },
   "demands": [
@@ -449,7 +461,7 @@
       "branches": [
         "+refs/heads/*"
       ],
-      "artifacts": [ ],
+      "artifacts": [],
       "artifactTypesToDelete": [
         "FilePath",
         "SymbolStore"
@@ -503,6 +515,6 @@
     "description": "Visual Studio and DevDiv team project for git source code repositories.  Work items will be added for Adams, Dev14 work items are tracked in vstfdevdiv.  ",
     "url": "https://devdiv.visualstudio.com/DefaultCollection/_apis/projects/0bdbc590-a062-4c3f-b0f6-9383f67865ee",
     "state": "wellFormed",
-    "revision": 418097471
+    "revision": 418097620
   }
 }

--- a/buildpipeline/Core-Setup-Windows-arm32.json
+++ b/buildpipeline/Core-Setup-Windows-arm32.json
@@ -106,6 +106,9 @@
     "PUBLISH_TO_AZURE_BLOB": {
       "value": "true",
       "allowOverride": true
+    },
+    "NUGET_SYMBOLS_FEED_URL": {
+      "value": " https://dotnet.myget.org/F/dotnet-core/symbols/api/v2"
     }
   },
   "demands": [
@@ -141,7 +144,9 @@
       "cloneUrl": "https://github.com/dotnet/core-setup.git",
       "refsUrl": "https://api.github.com/repos/dotnet/core-setup/git/refs",
       "gitLfsSupport": "false",
-      "fetchDepth": "0"
+      "skipSyncSource": "false",
+      "fetchDepth": "0",
+      "cleanOptions": "0"
     },
     "id": "https://github.com/dotnet/core-setup.git",
     "type": "GitHub",
@@ -170,6 +175,6 @@
     "description": "Visual Studio and DevDiv team project for git source code repositories.  Work items will be added for Adams, Dev14 work items are tracked in vstfdevdiv.  ",
     "url": "https://devdiv.visualstudio.com/DefaultCollection/_apis/projects/0bdbc590-a062-4c3f-b0f6-9383f67865ee",
     "state": "wellFormed",
-    "revision": 418097459
+    "revision": 418097620
   }
 }

--- a/buildpipeline/Core-Setup-Windows-arm64.json
+++ b/buildpipeline/Core-Setup-Windows-arm64.json
@@ -106,6 +106,9 @@
     "PUBLISH_TO_AZURE_BLOB": {
       "value": "true",
       "allowOverride": true
+    },
+    "NUGET_SYMBOLS_FEED_URL": {
+      "value": " https://dotnet.myget.org/F/dotnet-core/symbols/api/v2"
     }
   },
   "demands": [
@@ -141,7 +144,9 @@
       "cloneUrl": "https://github.com/dotnet/core-setup.git",
       "refsUrl": "https://api.github.com/repos/dotnet/core-setup/git/refs",
       "gitLfsSupport": "false",
-      "fetchDepth": "0"
+      "skipSyncSource": "false",
+      "fetchDepth": "0",
+      "cleanOptions": "0"
     },
     "id": "https://github.com/dotnet/core-setup.git",
     "type": "GitHub",
@@ -170,6 +175,6 @@
     "description": "Visual Studio and DevDiv team project for git source code repositories.  Work items will be added for Adams, Dev14 work items are tracked in vstfdevdiv.  ",
     "url": "https://devdiv.visualstudio.com/DefaultCollection/_apis/projects/0bdbc590-a062-4c3f-b0f6-9383f67865ee",
     "state": "wellFormed",
-    "revision": 418097459
+    "revision": 418097620
   }
 }

--- a/buildpipeline/pipeline.json
+++ b/buildpipeline/pipeline.json
@@ -81,6 +81,7 @@
             "REPO_USER": "dotnet",
             "REPO_SERVER": "azure-apt-cat.cloudapp.net",
             "CLI_NUGET_FEED_URL": "https://dotnet.myget.org/F/cli-deps",
+            "CLI_NUGET_SYMBOLS_FEED_URL": "https://dotnet.myget.org/F/cli-deps/symbols"
           },
           "ReportingParameters": {
             "OperatingSystem": "Ubuntu 14.04",

--- a/scripts/dockerrun.sh
+++ b/scripts/dockerrun.sh
@@ -146,9 +146,11 @@ docker run $INTERACTIVE -t --rm --sig-proxy=true \
     -e DOCKER_HUB_REPO \
     -e DOCKER_HUB_TRIGGER_TOKEN \
     -e NUGET_FEED_URL \
+    -e NUGET_SYMBOLS_FEED_URL \
     -e NUGET_API_KEY \
     -e GITHUB_PASSWORD \
     -e CLI_NUGET_FEED_URL \
+    -e CLI_NUGET_SYMBOLS_FEED_URL \
     -e CLI_NUGET_API_KEY \
     $DOTNET_BUILD_CONTAINER_TAG \
     $BUILD_COMMAND "$@"


### PR DESCRIPTION
Fixes #1884 

Core-Setup is now producing symbols packages.  When the standard / symbols packages are uploaded to myget, it's the symbols packages that are getting listed on the main feed.  Prevent this by pushing standard and symbols packages to separate feeds.  

I don't have a good way to test the publishing piece of this outside of official builds. :/
