### PR TITLE
Upgrade WindowsAzure.Storage to 8.1.1

### DIFF
--- a/build_projects/dotnet-host-build/project.json
+++ b/build_projects/dotnet-host-build/project.json
@@ -11,8 +11,9 @@
     "System.Dynamic.Runtime": "4.0.11",
     "System.Reflection.Metadata": "1.3.0",
     "System.Runtime.Serialization.Primitives": "4.1.1",
+    "System.Threading.Thread": "4.0.0",
     "System.Xml.XmlSerializer": "4.0.11",
-    "WindowsAzure.Storage": "6.2.2-preview",
+    "WindowsAzure.Storage": "8.1.1",
     "NuGet.CommandLine.XPlat": "4.0.0-rc3-2140",
     "Microsoft.DotNet.Cli.Build.Framework": {
       "target": "project"

--- a/build_projects/shared-build-targets-utils/Publishing/AzurePublisher.cs
+++ b/build_projects/shared-build-targets-utils/Publishing/AzurePublisher.cs
@@ -55,7 +55,7 @@ namespace Microsoft.DotNet.Cli.Build
         public void PublishFile(string blob, string file)
         {
             CloudBlockBlob blockBlob = _blobContainer.GetBlockBlobReference(blob);
-            blockBlob.UploadFromFileAsync(file, FileMode.Open).Wait();
+            blockBlob.UploadFromFileAsync(file).Wait();
 
             SetBlobPropertiesBasedOnFileType(blockBlob);
         }

--- a/build_projects/shared-build-targets-utils/project.json
+++ b/build_projects/shared-build-targets-utils/project.json
@@ -7,8 +7,9 @@
     "System.Dynamic.Runtime": "4.0.11",
     "System.Reflection.Metadata": "1.3.0",
     "System.Runtime.Serialization.Primitives": "4.1.1",
+    "System.Threading.Thread": "4.0.0",
     "System.Xml.XmlSerializer": "4.0.11",
-    "WindowsAzure.Storage": "6.2.2-preview",
+    "WindowsAzure.Storage": "8.1.1",
     "Microsoft.DotNet.Cli.Build.Framework": {
       "target": "project"
     }


### PR DESCRIPTION
Potentially a fix for https://github.com/dotnet/core-setup/issues/1824.

After the upgrade, I had to change the `UploadFromFileAsync` call to remove a parameter that no longer exists and add in a `System.Threading.Thread` reference to get the build projects to compile.