### PR TITLE
Resolve NuGet conflict: update Newtonsoft.Json for WindowsAzure.Storage

### DIFF
--- a/build_projects/update-dependencies/project.json
+++ b/build_projects/update-dependencies/project.json
@@ -16,7 +16,7 @@
       "target": "project"
     },
     "NuGet.Versioning": "3.5.0-rc-1285",
-    "Newtonsoft.Json": "7.0.1",
+    "Newtonsoft.Json": "9.0.1",
     "Octokit": "0.18.0",
     "Microsoft.Net.Http": "2.2.29"
   },


### PR DESCRIPTION
Resolve a conflict that started when [upgrading WindowsAzure.Storage to 8.1.1](https://github.com/dotnet/core-setup/pull/1935).

It only caused a warning, but that marked the auto-upgrade build as failed.