### PR TITLE
Update HostPolicy package

### DIFF
--- a/build_projects/shared-build-targets-utils/Utils/HostVersion.cs
+++ b/build_projects/shared-build-targets-utils/Utils/HostVersion.cs
@@ -74,7 +74,7 @@ namespace Microsoft.DotNet.Cli.Build
         // is being updated.
         public VerInfo LatestHostVersion => new VerInfo(1, 0, 1, "", "", "", CommitCountString);
         public VerInfo LatestHostFxrVersion => new VerInfo(1, 0, 1, "", "", "", CommitCountString);
-        public VerInfo LatestHostPolicyVersion => new VerInfo(1, 0, 3, "", "", "", CommitCountString);
+        public VerInfo LatestHostPolicyVersion => new VerInfo(1, 0, 5, LatestHostPrerelease, LatestHostBuildMajor, LatestHostBuildMinor, CommitCountString);
   
         public Dictionary<string, VerInfo> LatestHostPackages => new Dictionary<string, VerInfo>()
         {

--- a/pkg/projects/packages.builds
+++ b/pkg/projects/packages.builds
@@ -13,6 +13,7 @@
   <!-- Specify the packages to be rebuilt, for servicing, here -->
   <ItemGroup Condition="'$(BuildAllPackages)' == 'false'" >
     <Project Include="Microsoft.NETCore.App\Microsoft.NETCore.App.builds" />
+    <Project Include="Microsoft.NETCore.DotNetHost\Microsoft.NETCore.DotNetHostPolicy.builds" />
   </ItemGroup>
 
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />


### PR DESCRIPTION
Porting of the nuget lowering change (https://github.com/dotnet/core-setup/issues/1559) modified Hostpolicy.dll but the PR didnt incorporate the change to increment its version and produce a new package. 

This change fixes the issue. I have confirmed that the produced M.N.App has a dependency on HostPolicy package 1.0.5.

@eerhardt PTAL

CC @emgarten 