### PR TITLE
[release/1.0.0] Swap host and framework installer copies to Latest

### DIFF
--- a/build_projects/dotnet-host-build/PublishTargets.cs
+++ b/build_projects/dotnet-host-build/PublishTargets.cs
@@ -113,11 +113,11 @@ namespace Microsoft.DotNet.Host.Build
                     // Copy the shared framework + host Archives
                     CopyBlobs($"{Channel}/Binaries/{SharedFrameworkNugetVersion}/", targetContainer);
 
-                    // Copy the shared framework installers
-                    CopyBlobs($"{Channel}/Installers/{SharedFrameworkNugetVersion}/", $"{Channel}/Installers/Latest/");
-
                     // Copy the shared host installers
                     CopyBlobs($"{Channel}/Installers/{SharedHostNugetVersion}/", $"{Channel}/Installers/Latest/");
+
+                    // Copy the shared framework installers
+                    CopyBlobs($"{Channel}/Installers/{SharedFrameworkNugetVersion}/", $"{Channel}/Installers/Latest/");
 
                     // Generate the Sharedfx Version text files
                     List<string> versionFiles = new List<string>() 


### PR DESCRIPTION
This tweaks the overwrite order to keep the just-built installers, if there is overlap.

See https://github.com/dotnet/core-setup/issues/1950