### PR TITLE
[release/1.1.0] Swap host and framework installer copies to Latest

### DIFF
--- a/build_projects/dotnet-host-build/PublishTargets.cs
+++ b/build_projects/dotnet-host-build/PublishTargets.cs
@@ -110,11 +110,11 @@ namespace Microsoft.DotNet.Host.Build
                     // Copy the shared framework + host Archives
                     CopyBlobs($"{Channel}/Binaries/{SharedFrameworkNugetVersion}/", targetContainer);
 
-                    // Copy the shared framework installers
-                    CopyBlobs($"{Channel}/Installers/{SharedFrameworkNugetVersion}/", $"{Channel}/Installers/Latest/");
-
                     // Copy the shared host installers
                     CopyBlobs($"{Channel}/Installers/{SharedHostNugetVersion}/", $"{Channel}/Installers/Latest/");
+
+                    // Copy the shared framework installers
+                    CopyBlobs($"{Channel}/Installers/{SharedFrameworkNugetVersion}/", $"{Channel}/Installers/Latest/");
 
                     // Generate the Sharedfx Version text files
                     List<string> versionFiles = new List<string>() 


### PR DESCRIPTION
This tweaks the overwrite order to keep the just-built installers, if there is overlap.

(cherry picked from commit 5647411ba1687b50b9e2b522d1551c68daaba8f1)

See https://github.com/dotnet/core-setup/issues/1950