### PR TITLE
Add logging to publish to diagnose publish-related issues

### DIFF
--- a/build_projects/dotnet-host-build/PublishTargets.cs
+++ b/build_projects/dotnet-host-build/PublishTargets.cs
@@ -169,6 +169,7 @@ namespace Microsoft.DotNet.Host.Build
 
         private static void CopyBlobs(string sourceFolder, string destinationFolder)
         {
+            Console.WriteLine($"--Copying blobs from '{sourceFolder}' to '{destinationFolder}'");
             foreach (string blob in AzurePublisherTool.ListBlobs(sourceFolder))
             {
                 string source = blob.Replace("/dotnet/", "");

--- a/build_projects/shared-build-targets-utils/Publishing/AzurePublisher.cs
+++ b/build_projects/shared-build-targets-utils/Publishing/AzurePublisher.cs
@@ -54,6 +54,8 @@ namespace Microsoft.DotNet.Cli.Build
 
         public void PublishFile(string blob, string file)
         {
+            Console.WriteLine($"Publishing file '{file}' to '{blob}'");
+
             CloudBlockBlob blockBlob = _blobContainer.GetBlockBlobReference(blob);
             blockBlob.UploadFromFileAsync(file).Wait();
 
@@ -71,6 +73,8 @@ namespace Microsoft.DotNet.Cli.Build
 
         public void CopyBlob(string sourceBlob, string targetBlob)
         {
+            Console.WriteLine($"Copying blob '{sourceBlob}' to '{targetBlob}'");
+
             CloudBlockBlob source = _blobContainer.GetBlockBlobReference(sourceBlob);
             CloudBlockBlob target = _blobContainer.GetBlockBlobReference(targetBlob);
 


### PR DESCRIPTION
(cherry picked from commit 7d020e76689fa0e312a27294c7c6bc035e5511a7)
See https://github.com/dotnet/core-setup/pull/1951.

Adding publish logging to diagnose https://github.com/dotnet/core-setup/issues/1994.