### PR TITLE
Fix checking of CMake define

### DIFF
--- a/src/corehost/cli/setup.cmake
+++ b/src/corehost/cli/setup.cmake
@@ -98,7 +98,7 @@ if (WIN32 AND CLI_CMAKE_PLATFORM_ARCH_ARM)
       endif()
 endif ()
 
-if (DEFINED CLI_CMAKE_PORTABLE_BUILD)
+if (CLI_CMAKE_PORTABLE_BUILD)
     add_definitions(-DFEATURE_PORTABLE_BUILD=1)
 endif ()
 


### PR DESCRIPTION
Fix a warning I saw in the official Windows build post Portable RID support.

@eerhardt PTAL