### PR TITLE
Reference the latest HostPolicy package

### DIFF
--- a/build_projects/shared-build-targets-utils/Utils/HostVersion.cs
+++ b/build_projects/shared-build-targets-utils/Utils/HostVersion.cs
@@ -79,7 +79,7 @@ namespace Microsoft.DotNet.Cli.Build
 
         public VerInfo LatestHostVersion => new VerInfo(1, 1, 0, "", "", "", CommitCountString);
         public VerInfo LatestHostFxrVersion => new VerInfo(1, 1, 0, "", "", "", CommitCountString);
-        public VerInfo LatestHostPolicyVersion => new VerInfo(1, 1, 0, "", "", "", CommitCountString);
+        public VerInfo LatestHostPolicyVersion => new VerInfo(1, 1, 2, ReleaseSuffix, LatestHostBuildMajor, LatestHostBuildMinor, CommitCountString);
 
 
         // If you are producing host packages use this to validate them.

--- a/pkg/projects/Microsoft.NETCore.DotNetHost/Microsoft.NETCore.DotNetHostPolicy.pkgproj
+++ b/pkg/projects/Microsoft.NETCore.DotNetHost/Microsoft.NETCore.DotNetHostPolicy.pkgproj
@@ -14,7 +14,7 @@
 
   <ItemGroup>
     <Dependency Include="Microsoft.NETCore.DotNetHostResolver">
-      <Version>$(HostResolverFullVersion)</Version>
+      <Version>$(HostResolverVersion)</Version>
     </Dependency>
     <ProjectReference Include="win\Microsoft.NETCore.DotNetHostPolicy.pkgproj">
       <Platform>amd64</Platform>

--- a/pkg/projects/Microsoft.NETCore.DotNetHost/win/Microsoft.NETCore.DotNetHostPolicy.pkgproj
+++ b/pkg/projects/Microsoft.NETCore.DotNetHost/win/Microsoft.NETCore.DotNetHostPolicy.pkgproj
@@ -14,7 +14,7 @@
   
   <ItemGroup>
     <Dependency Include="Microsoft.NETCore.DotNetHostResolver">
-      <Version>$(HostResolverFullVersion)</Version>
+      <Version>$(HostResolverVersion)</Version>
     </Dependency>
 
     <ArchitectureSpecificNativeFile Include="$(DotNetHostBinDir)/hostpolicy.dll"/>

--- a/pkg/projects/packages.builds
+++ b/pkg/projects/packages.builds
@@ -12,6 +12,7 @@
 
   <ItemGroup Condition="'$(BuildAllPackages)' == 'false'" >
     <Project Include="Microsoft.NETCore.App\Microsoft.NETCore.App.builds" />
+    <Project Include="Microsoft.NETCore.DotNetHost\Microsoft.NETCore.DotNetHostPolicy.builds" />
     <Project Include="Microsoft.NETCore.UniversalWindowsPlatform\Microsoft.NETCore.UniversalWindowsPlatform.builds" />
   </ItemGroup>
 


### PR DESCRIPTION
@ellismg had pointed out that the latest build of hostpolicy is copied over to the generated SharedFX, it implies that we need to reference the corresponding package from M.N.App as well (see https://github.com/dotnet/core-setup/blob/release/1.1.0/build_projects/shared-build-targets-utils/Utils/SharedFrameworkPublisher.cs#L188).

This change enables that. I also made some targeting fixes that were present in 1.0.0 branch, but not in 1.1.0, resulting in locked version of HostFXR to get pre-release suffix even when it should not have.

Confirmed that M.N.App 1.1.x references the built M.N.DotnetHostPolicy 1.1.x package that references the locked HostFXR package.

@eerhardt PTAL.
