### PR TITLE
Skipping UWP package build on non-Windows

### DIFF
--- a/pkg/packages.builds
+++ b/pkg/packages.builds
@@ -3,7 +3,8 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
 
   <ItemGroup>
-    <Project Include="$(MSBuildThisFileDirectory)\projects\*\*.builds" />
+  	<ProjectExclusions Include="$(MSBuildThisFileDirectory)\projects\*\Microsoft.NETCore.UniversalWindowsPlatform.builds" Condition="'$(OSEnvironment)' != 'Windows_NT'" />
+    <Project Include="$(MSBuildThisFileDirectory)\projects\*\*.builds" Exclude="@(ProjectExclusions)" />
   </ItemGroup>
 
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />


### PR DESCRIPTION
fixes #2014 

cc: @ericstj @dagood @eerhardt 

Skipping UAP package build when building for non-Windows.