### PR TITLE
Issue #2016: Add Unsupported Blocker to Runtime Bundle (Windows Platform only) (1.1)

### DIFF
--- a/packaging/windows/sharedframework/bundle.wxs
+++ b/packaging/windows/sharedframework/bundle.wxs
@@ -10,6 +10,11 @@
           Version="$(var.DisplayVersion)" UpgradeCode="$(var.UpgradeCode)"
           AboutUrl="http://dotnet.github.io/"
           Compressed="yes">
+    
+    <bal:Condition
+     Message="The $(var.ProductName) is not supported on this operating system. For more information, see $(var.Link_PreReqPage).">
+    ((VersionNT &gt; v6.1) OR (VersionNT = v6.1 AND ServicePackLevel &gt;= 1))
+    </bal:Condition>
 
     <BootstrapperApplicationRef Id="WixStandardBootstrapperApplication.Foundation">
       <bal:WixStandardBootstrapperApplication

--- a/packaging/windows/sharedframework/variables.wxi
+++ b/packaging/windows/sharedframework/variables.wxi
@@ -9,7 +9,7 @@
   <?define ProductLanguage  =   "1033" ?>
   <?define ProductVersion   =   "$(var.BuildVersion)" ?>
   <?define LCID  = "$(var.ProductLanguage)"?>
-  <?define Link_PreReqPage  = "https://docs.microsoft.com/en-us/dotnet/articles/core/windows-prerequisites"?>
+  <?define Link_PreReqPage  = "https://go.microsoft.com/fwlink/?linkid=846817"?>
   <?define DowngradeErrorMessage  = "A newer version is already installed; please uninstall it and re-run setup."?>
 
   <?define Platform   =   "$(sys.BUILDARCH)" ?>

--- a/packaging/windows/sharedframework/variables.wxi
+++ b/packaging/windows/sharedframework/variables.wxi
@@ -9,6 +9,7 @@
   <?define ProductLanguage  =   "1033" ?>
   <?define ProductVersion   =   "$(var.BuildVersion)" ?>
   <?define LCID  = "$(var.ProductLanguage)"?>
+  <?define Link_PreReqPage  = "https://docs.microsoft.com/en-us/dotnet/articles/core/windows-prerequisites"?>
   <?define DowngradeErrorMessage  = "A newer version is already installed; please uninstall it and re-run setup."?>
 
   <?define Platform   =   "$(sys.BUILDARCH)" ?>


### PR DESCRIPTION
- Add a blocker for unsupported platforms (pre Win 7 SP1).

Issue: #2016 