### PR TITLE
Change default clang version to clang3.9 in cross build

### DIFF
--- a/cross/build-rootfs.sh
+++ b/cross/build-rootfs.sh
@@ -5,7 +5,7 @@ usage()
     echo "Usage: $0 [BuildArch] [LinuxCodeName] [lldbx.y] [--skipunmount]"
     echo "BuildArch can be: arm(default), armel, arm64, x86"
     echo "LinuxCodeName - optional, Code name for Linux, can be: trusty(default), vivid, wily, xenial. If BuildArch is armel, LinuxCodeName is jessie(default) or tizen."
-    echo "lldbx.y - optional, LLDB version, can be: lldb3.6(default), lldb3.8, no-lldb"
+    echo "lldbx.y - optional, LLDB version, can be: lldb3.6(default), lldb3.8, lldb3.9, no-lldb"
     echo "--skipunmount - optional, will skip the unmount of rootfs folder."
     exit 1
 }
@@ -69,6 +69,9 @@ for i in "$@" ; do
             ;;
         lldb3.8)
             __LLDB_Package="lldb-3.8-dev"
+            ;;
+        lldb3.9)
+            __LLDB_Package="lldb-3.9-dev"
             ;;
         no-lldb)
             unset __LLDB_Package

--- a/scripts/arm32_ci_script.sh
+++ b/scripts/arm32_ci_script.sh
@@ -174,11 +174,11 @@ function cross_build_core_setup_with_docker {
         # TODO: For arm, we are going to embed RootFS inside Docker image.
         case $__linuxCodeName in
         trusty)
-            __dockerImage=" microsoft/dotnet-buildtools-prereqs:ubuntu1404_cross_prereqs_v2"
+            __dockerImage=" microsoft/dotnet-buildtools-prereqs:ubuntu-14.04-cross-0cd4667-20172211042239"
             __runtimeOS="ubuntu.14.04"
         ;;
         xenial)
-            __dockerImage=" microsoft/dotnet-buildtools-prereqs:ubuntu1604_cross_prereqs_v2"
+            __dockerImage=" microsoft/dotnet-buildtools-prereqs:ubuntu-16.04-cross-ef0ac75-20175511035548"
             __runtimeOS="ubuntu.16.04"
         ;;
         *)
@@ -189,7 +189,7 @@ function cross_build_core_setup_with_docker {
         # For armel Tizen, we are going to construct RootFS on the fly.
         case $__linuxCodeName in
         tizen)
-            __dockerImage=" t2wish/dotnetcore:ubuntu1404_cross_prereqs_v2"
+            __dockerImage=" t2wish/dotnetcore:ubuntu1404_cross_prereqs_v4"
             __runtimeOS="tizen.4.0.0"
         ;;
         *)

--- a/src/corehost/build.sh
+++ b/src/corehost/build.sh
@@ -178,25 +178,28 @@ if command -v "clang-3.5" > /dev/null 2>&1; then
 elif command -v "clang-3.6" > /dev/null 2>&1; then
     export CC="$(command -v clang-3.6)"
     export CXX="$(command -v clang++-3.6)"
+elif command -v "clang-3.9" > /dev/null 2>&1; then
+    export CC="$(command -v clang-3.9)"
+    export CXX="$(command -v clang++-3.9)"
 elif command -v clang > /dev/null 2>&1; then
     export CC="$(command -v clang)"
     export CXX="$(command -v clang++)"
 else
     echo "Unable to find Clang Compiler"
-    echo "Install clang-3.5 or clang3.6"
+    echo "Install clang-3.5 or clang3.6 or clang3.9"
     exit 1
 fi
 
 echo "Building Corehost from $DIR to $(pwd)"
 set -x # turn on trace
 if [ $__CrossBuild == 1 ]; then
-    # clang-3.6 is default compiler for cross compilation
-    if command -v "clang-3.6" > /dev/null 2>&1; then
-        export CC="$(command -v clang-3.6)"
-        export CXX="$(command -v clang++-3.6)"
+    # clang-3.9 is default compiler for cross compilation
+    if command -v "clang-3.9" > /dev/null 2>&1; then
+        export CC="$(command -v clang-3.9)"
+        export CXX="$(command -v clang++-3.9)"
     else
-        echo "Unable to find Clang 3.6 Compiler"
-        echo "Install clang-3.6 for cross compilation"
+        echo "Unable to find Clang 3.9 Compiler"
+        echo "Install clang-3.9 for cross compilation"
         exit 1
     fi
     cmake "$DIR" -G "Unix Makefiles" $__cmake_defines -DCLI_CMAKE_HOST_VER:STRING=$__host_ver -DCLI_CMAKE_APPHOST_VER:STRING=$__apphost_ver -DCLI_CMAKE_HOST_FXR_VER:STRING=$__fxr_ver -DCLI_CMAKE_HOST_POLICY_VER:STRING=$__policy_ver -DCLI_CMAKE_PKG_RID:STRING=$__base_rid -DCLI_CMAKE_COMMIT_HASH:STRING=$__commit_hash -DCMAKE_TOOLCHAIN_FILE=$DIR/../../cross/$__build_arch_lowcase/toolchain.cmake


### PR DESCRIPTION
Cross-build will set clang3.9 version by default, as it will use the latest docker image which contains clang3.9.

Related issue: https://github.com/dotnet/core-setup/issues/1411