### PR TITLE
Probe paths

### DIFF
--- a/src/corehost/cli/deps_resolver.cpp
+++ b/src/corehost/cli/deps_resolver.cpp
@@ -164,6 +164,18 @@ void deps_resolver_t::setup_shared_store_probes(
     }
 }
 
+pal::string_t deps_resolver_t::get_probe_directories()
+{
+    pal::string_t directories;
+    for (const auto& pc : m_probes)
+    {
+        directories.append(pc.probe_dir);
+        directories.push_back(PATH_SEPARATOR);
+    }
+
+    return directories;
+}
+
 void deps_resolver_t::setup_probe_config(
     const hostpolicy_init_t& init,
     const arguments_t& args)

--- a/src/corehost/cli/deps_resolver.h
+++ b/src/corehost/cli/deps_resolver.h
@@ -80,6 +80,8 @@ public:
         const hostpolicy_init_t& init,
         const arguments_t& args);
 
+    pal::string_t get_probe_directories();
+
     void setup_probe_config(
         const hostpolicy_init_t& init,
         const arguments_t& args);

--- a/src/corehost/cli/hostpolicy.cpp
+++ b/src/corehost/cli/hostpolicy.cpp
@@ -73,11 +73,12 @@ int run(const arguments_t& args)
         // Workaround: mscorlib does not resolve symlinks for AppContext.BaseDirectory dotnet/coreclr/issues/2128
         "APP_CONTEXT_BASE_DIRECTORY",
         "APP_CONTEXT_DEPS_FILES",
-        "FX_DEPS_FILE"
+        "FX_DEPS_FILE",
+        "PROBING_DIRECTORIES"
     };
 
     // Note: these variables' lifetime should be longer than coreclr_initialize.
-    std::vector<char> tpa_paths_cstr, app_base_cstr, native_dirs_cstr, resources_dirs_cstr, fx_deps, deps, clrjit_path_cstr;
+    std::vector<char> tpa_paths_cstr, app_base_cstr, native_dirs_cstr, resources_dirs_cstr, fx_deps, deps, clrjit_path_cstr, probe_directories;
     pal::pal_clrstring(probe_paths.tpa, &tpa_paths_cstr);
     pal::pal_clrstring(args.app_dir, &app_base_cstr);
     pal::pal_clrstring(probe_paths.native, &native_dirs_cstr);
@@ -85,6 +86,8 @@ int run(const arguments_t& args)
 
     pal::pal_clrstring(resolver.get_fx_deps_file(), &fx_deps);
     pal::pal_clrstring(resolver.get_deps_file() + _X(";") + resolver.get_fx_deps_file(), &deps);
+
+    pal::pal_clrstring(resolver.get_probe_directories(), &probe_directories);
 
     std::vector<const char*> property_values = {
         // TRUSTED_PLATFORM_ASSEMBLIES
@@ -100,7 +103,9 @@ int run(const arguments_t& args)
         // APP_CONTEXT_DEPS_FILES,
         deps.data(),
         // FX_DEPS_FILE
-        fx_deps.data()
+        fx_deps.data(),
+        //PROBING_DIRECTORIES
+        probe_directories.data()
     };
 
     if (!clrjit_path.empty())

--- a/test/Microsoft.Extensions.DependencyModel.Tests/PackageResolverTest.cs
+++ b/test/Microsoft.Extensions.DependencyModel.Tests/PackageResolverTest.cs
@@ -24,8 +24,8 @@ namespace Microsoft.Extensions.DependencyModel.Tests
                 .AddVariable("NUGET_PACKAGES", PackagesPath)
                 .Build();
 
-            var result = PackageCompilationAssemblyResolver.GetDefaultPackageDirectory(Platform.Unknown, environment);
-            result.Should().Be(PackagesPath);
+            var result = PackageCompilationAssemblyResolver.GetDefaultProbeDirectories(Platform.Unknown, environment);
+            result.Should().Contain(PackagesPath);
         }
 
 
@@ -36,8 +36,8 @@ namespace Microsoft.Extensions.DependencyModel.Tests
                 .AddVariable("USERPROFILE", "User Profile")
                 .Build();
 
-            var result = PackageCompilationAssemblyResolver.GetDefaultPackageDirectory(Platform.Windows, environment);
-            result.Should().Be(Path.Combine("User Profile", ".nuget", "packages"));
+            var result = PackageCompilationAssemblyResolver.GetDefaultProbeDirectories(Platform.Windows, environment);
+            result.Should().Contain(Path.Combine("User Profile", ".nuget", "packages"));
         }
 
         [Fact]
@@ -47,8 +47,8 @@ namespace Microsoft.Extensions.DependencyModel.Tests
                 .AddVariable("HOME", "User Home")
                 .Build();
 
-            var result = PackageCompilationAssemblyResolver.GetDefaultPackageDirectory(Platform.Linux, environment);
-            result.Should().Be(Path.Combine("User Home", ".nuget", "packages"));
+            var result = PackageCompilationAssemblyResolver.GetDefaultProbeDirectories(Platform.Linux, environment);
+            result.Should().Contain(Path.Combine("User Home", ".nuget", "packages"));
         }
 
         [Fact]
@@ -60,7 +60,7 @@ namespace Microsoft.Extensions.DependencyModel.Tests
                 .Build();
             var library = F.Create(assemblies: F.TwoAssemblies);
 
-            var resolver = new PackageCompilationAssemblyResolver(fileSystem, PackagesPath);
+            var resolver = new PackageCompilationAssemblyResolver(fileSystem, new string[] { PackagesPath });
             var assemblies = new List<string>();
 
             var result = resolver.TryResolveAssemblyPaths(library, assemblies);
@@ -80,7 +80,7 @@ namespace Microsoft.Extensions.DependencyModel.Tests
                 .Build();
             var library = F.Create(assemblies: F.TwoAssemblies);
 
-            var resolver = new PackageCompilationAssemblyResolver(fileSystem, PackagesPath);
+            var resolver = new PackageCompilationAssemblyResolver(fileSystem,  new string[] { PackagesPath });
             var assemblies = new List<string>();
 
             var exception = Assert.Throws<InvalidOperationException>(() => resolver.TryResolveAssemblyPaths(library, assemblies));


### PR DESCRIPTION
The host passes  the provided probing paths to AppContext and these can be queried by the DependencyModel when it is resolving the assemblies