### PR TITLE
Add support for local copies of native dependencies on Linux

### DIFF
--- a/src/corehost/cli/exe/apphost/CMakeLists.txt
+++ b/src/corehost/cli/exe/apphost/CMakeLists.txt
@@ -3,6 +3,17 @@
 
 cmake_minimum_required (VERSION 2.6)
 set(DOTNET_HOST_EXE_NAME "apphost")
+
+# Add RPATH to the apphost binary that allows using local copies of shared libraries
+# dotnet core depends on for special scenarios when system wide installation of such 
+# dependencies is not possible for some reason.
+# This cannot be enabled for MacOS (Darwin) since its RPATH works in a different way,
+# doesn't apply to libraries loaded via dlopen and most importantly, it is not transitive.
+if (NOT CMAKE_SYSTEM_NAME STREQUAL Darwin)
+    set(CMAKE_BUILD_WITH_INSTALL_RPATH TRUE)
+    set(CMAKE_INSTALL_RPATH "\$ORIGIN/netcoredeps")
+endif()
+
 include(../exe.cmake)
 set(SOURCES)
 add_definitions(-DFEATURE_APPHOST=1)


### PR DESCRIPTION
This change adds support for local copies of native dependencies for
standalone apps on Linux. If there is a folder called `netcoredeps` next
to the main app executable, the system dynamic loader looks into that
folder first when resolving shared library dependencies of the main app
and all of the shared libraries it transitively loads.