### PR TITLE
Remove OpenSSL from the macOS installer

### DIFF
--- a/packaging/osx/hostfxr/resources/cs.lproj/conclusion.html
+++ b/packaging/osx/hostfxr/resources/cs.lproj/conclusion.html
@@ -1,22 +1,14 @@
-
+﻿
 <!DOCTYPE html>
 <html lang="en">
 <head>
     <meta charset="utf-8" />
-    <title styles="color:white">Congratulations! You've successfully installed .NET Core CLI!</title>
+    <title styles="color:white">Congratulations! You've successfully installed .NET Core HostFxr!</title>
 </head>
 <body>
         <div align="center" style="font-family: Helvetica;">  
             <h1>The installation was successful.</h1>
-            <p>.NET Core CLI was successfully installed.</p>
-        <h2>
-            Install dependencies
-        </h2>
-        <p>
-        In order to be able to use .NET Core on OS X, you need to install <b>OpenSSL</b> version <b>1.0.1/1.0.2</b>. 
-        There are many ways to install/update your libssl. Using <a href="http://www.brew.sh">Homebrew</a> is the easiest. 
-        You can view the instructions <a href="http://brewformulas.org/Openssl">here</a> or if you're updating, <a href="https://github.com/dotnet/coreclr/blob/63766f74c4a641a274cd2933b9b7fd7bbddef2dd/Documentation/building/osx-instructions.md#openssl">on this page</a>.
-        </p>
+            <p>.NET Core Runtime was successfully installed.</p>
         </div>
 </body>
 </html>

--- a/packaging/osx/hostfxr/resources/cs.lproj/conclusion.html
+++ b/packaging/osx/hostfxr/resources/cs.lproj/conclusion.html
@@ -8,7 +8,7 @@
 <body>
         <div align="center" style="font-family: Helvetica;">  
             <h1>The installation was successful.</h1>
-            <p>.NET Core Runtime was successfully installed.</p>
+            <p>.NET Core HostFxr was successfully installed.</p>
         </div>
 </body>
 </html>

--- a/packaging/osx/hostfxr/resources/de.lproj/conclusion.html
+++ b/packaging/osx/hostfxr/resources/de.lproj/conclusion.html
@@ -1,22 +1,14 @@
-
+﻿
 <!DOCTYPE html>
 <html lang="en">
 <head>
     <meta charset="utf-8" />
-    <title styles="color:white">Congratulations! You've successfully installed .NET Core CLI!</title>
+    <title styles="color:white">Congratulations! You've successfully installed .NET Core HostFxr!</title>
 </head>
 <body>
         <div align="center" style="font-family: Helvetica;">  
             <h1>The installation was successful.</h1>
-            <p>.NET Core CLI was successfully installed.</p>
-        <h2>
-            Install dependencies
-        </h2>
-        <p>
-        In order to be able to use .NET Core on OS X, you need to install <b>OpenSSL</b> version <b>1.0.1/1.0.2</b>. 
-        There are many ways to install/update your libssl. Using <a href="http://www.brew.sh">Homebrew</a> is the easiest. 
-        You can view the instructions <a href="http://brewformulas.org/Openssl">here</a> or if you're updating, <a href="https://github.com/dotnet/coreclr/blob/63766f74c4a641a274cd2933b9b7fd7bbddef2dd/Documentation/building/osx-instructions.md#openssl">on this page</a>.
-        </p>
+            <p>.NET Core Runtime was successfully installed.</p>
         </div>
 </body>
 </html>

--- a/packaging/osx/hostfxr/resources/de.lproj/conclusion.html
+++ b/packaging/osx/hostfxr/resources/de.lproj/conclusion.html
@@ -8,7 +8,7 @@
 <body>
         <div align="center" style="font-family: Helvetica;">  
             <h1>The installation was successful.</h1>
-            <p>.NET Core Runtime was successfully installed.</p>
+            <p>.NET Core HostFxr was successfully installed.</p>
         </div>
 </body>
 </html>

--- a/packaging/osx/hostfxr/resources/en.lproj/conclusion.html
+++ b/packaging/osx/hostfxr/resources/en.lproj/conclusion.html
@@ -1,22 +1,14 @@
-
+﻿
 <!DOCTYPE html>
 <html lang="en">
 <head>
     <meta charset="utf-8" />
-    <title styles="color:white">Congratulations! You've successfully installed .NET Core CLI!</title>
+    <title styles="color:white">Congratulations! You've successfully installed .NET Core HostFxr!</title>
 </head>
 <body>
         <div align="center" style="font-family: Helvetica;">  
             <h1>The installation was successful.</h1>
-            <p>.NET Core CLI was successfully installed.</p>
-        <h2>
-            Install dependencies
-        </h2>
-        <p>
-        In order to be able to use .NET Core on OS X, you need to install <b>OpenSSL</b> version <b>1.0.1/1.0.2</b>. 
-        There are many ways to install/update your libssl. Using <a href="http://www.brew.sh">Homebrew</a> is the easiest. 
-        You can view the instructions <a href="http://brewformulas.org/Openssl">here</a> or if you're updating, <a href="https://github.com/dotnet/coreclr/blob/63766f74c4a641a274cd2933b9b7fd7bbddef2dd/Documentation/building/osx-instructions.md#openssl">on this page</a>.
-        </p>
+            <p>.NET Core Runtime was successfully installed.</p>
         </div>
 </body>
 </html>

--- a/packaging/osx/hostfxr/resources/en.lproj/conclusion.html
+++ b/packaging/osx/hostfxr/resources/en.lproj/conclusion.html
@@ -8,7 +8,7 @@
 <body>
         <div align="center" style="font-family: Helvetica;">  
             <h1>The installation was successful.</h1>
-            <p>.NET Core Runtime was successfully installed.</p>
+            <p>.NET Core HostFxr was successfully installed.</p>
         </div>
 </body>
 </html>

--- a/packaging/osx/hostfxr/resources/es.lproj/conclusion.html
+++ b/packaging/osx/hostfxr/resources/es.lproj/conclusion.html
@@ -1,22 +1,14 @@
-
+﻿
 <!DOCTYPE html>
 <html lang="en">
 <head>
     <meta charset="utf-8" />
-    <title styles="color:white">Congratulations! You've successfully installed .NET Core CLI!</title>
+    <title styles="color:white">Congratulations! You've successfully installed .NET Core HostFxr!</title>
 </head>
 <body>
         <div align="center" style="font-family: Helvetica;">  
             <h1>The installation was successful.</h1>
-            <p>.NET Core CLI was successfully installed.</p>
-        <h2>
-            Install dependencies
-        </h2>
-        <p>
-        In order to be able to use .NET Core on OS X, you need to install <b>OpenSSL</b> version <b>1.0.1/1.0.2</b>. 
-        There are many ways to install/update your libssl. Using <a href="http://www.brew.sh">Homebrew</a> is the easiest. 
-        You can view the instructions <a href="http://brewformulas.org/Openssl">here</a> or if you're updating, <a href="https://github.com/dotnet/coreclr/blob/63766f74c4a641a274cd2933b9b7fd7bbddef2dd/Documentation/building/osx-instructions.md#openssl">on this page</a>.
-        </p>
+            <p>.NET Core Runtime was successfully installed.</p>
         </div>
 </body>
 </html>

--- a/packaging/osx/hostfxr/resources/es.lproj/conclusion.html
+++ b/packaging/osx/hostfxr/resources/es.lproj/conclusion.html
@@ -8,7 +8,7 @@
 <body>
         <div align="center" style="font-family: Helvetica;">  
             <h1>The installation was successful.</h1>
-            <p>.NET Core Runtime was successfully installed.</p>
+            <p>.NET Core HostFxr was successfully installed.</p>
         </div>
 </body>
 </html>

--- a/packaging/osx/hostfxr/resources/fr.lproj/conclusion.html
+++ b/packaging/osx/hostfxr/resources/fr.lproj/conclusion.html
@@ -1,22 +1,14 @@
-
+﻿
 <!DOCTYPE html>
 <html lang="en">
 <head>
     <meta charset="utf-8" />
-    <title styles="color:white">Congratulations! You've successfully installed .NET Core CLI!</title>
+    <title styles="color:white">Congratulations! You've successfully installed .NET Core HostFxr!</title>
 </head>
 <body>
         <div align="center" style="font-family: Helvetica;">  
             <h1>The installation was successful.</h1>
-            <p>.NET Core CLI was successfully installed.</p>
-        <h2>
-            Install dependencies
-        </h2>
-        <p>
-        In order to be able to use .NET Core on OS X, you need to install <b>OpenSSL</b> version <b>1.0.1/1.0.2</b>. 
-        There are many ways to install/update your libssl. Using <a href="http://www.brew.sh">Homebrew</a> is the easiest. 
-        You can view the instructions <a href="http://brewformulas.org/Openssl">here</a> or if you're updating, <a href="https://github.com/dotnet/coreclr/blob/63766f74c4a641a274cd2933b9b7fd7bbddef2dd/Documentation/building/osx-instructions.md#openssl">on this page</a>.
-        </p>
+            <p>.NET Core Runtime was successfully installed.</p>
         </div>
 </body>
 </html>

--- a/packaging/osx/hostfxr/resources/fr.lproj/conclusion.html
+++ b/packaging/osx/hostfxr/resources/fr.lproj/conclusion.html
@@ -8,7 +8,7 @@
 <body>
         <div align="center" style="font-family: Helvetica;">  
             <h1>The installation was successful.</h1>
-            <p>.NET Core Runtime was successfully installed.</p>
+            <p>.NET Core HostFxr was successfully installed.</p>
         </div>
 </body>
 </html>

--- a/packaging/osx/hostfxr/resources/it.lproj/conclusion.html
+++ b/packaging/osx/hostfxr/resources/it.lproj/conclusion.html
@@ -1,22 +1,14 @@
-
+﻿
 <!DOCTYPE html>
 <html lang="en">
 <head>
     <meta charset="utf-8" />
-    <title styles="color:white">Congratulations! You've successfully installed .NET Core CLI!</title>
+    <title styles="color:white">Congratulations! You've successfully installed .NET Core HostFxr!</title>
 </head>
 <body>
         <div align="center" style="font-family: Helvetica;">  
             <h1>The installation was successful.</h1>
-            <p>.NET Core CLI was successfully installed.</p>
-        <h2>
-            Install dependencies
-        </h2>
-        <p>
-        In order to be able to use .NET Core on OS X, you need to install <b>OpenSSL</b> version <b>1.0.1/1.0.2</b>. 
-        There are many ways to install/update your libssl. Using <a href="http://www.brew.sh">Homebrew</a> is the easiest. 
-        You can view the instructions <a href="http://brewformulas.org/Openssl">here</a> or if you're updating, <a href="https://github.com/dotnet/coreclr/blob/63766f74c4a641a274cd2933b9b7fd7bbddef2dd/Documentation/building/osx-instructions.md#openssl">on this page</a>.
-        </p>
+            <p>.NET Core Runtime was successfully installed.</p>
         </div>
 </body>
 </html>

--- a/packaging/osx/hostfxr/resources/it.lproj/conclusion.html
+++ b/packaging/osx/hostfxr/resources/it.lproj/conclusion.html
@@ -8,7 +8,7 @@
 <body>
         <div align="center" style="font-family: Helvetica;">  
             <h1>The installation was successful.</h1>
-            <p>.NET Core Runtime was successfully installed.</p>
+            <p>.NET Core HostFxr was successfully installed.</p>
         </div>
 </body>
 </html>

--- a/packaging/osx/hostfxr/resources/ja.lproj/conclusion.html
+++ b/packaging/osx/hostfxr/resources/ja.lproj/conclusion.html
@@ -1,22 +1,14 @@
-
+﻿
 <!DOCTYPE html>
 <html lang="en">
 <head>
     <meta charset="utf-8" />
-    <title styles="color:white">Congratulations! You've successfully installed .NET Core CLI!</title>
+    <title styles="color:white">Congratulations! You've successfully installed .NET Core HostFxr!</title>
 </head>
 <body>
         <div align="center" style="font-family: Helvetica;">  
             <h1>The installation was successful.</h1>
-            <p>.NET Core CLI was successfully installed.</p>
-        <h2>
-            Install dependencies
-        </h2>
-        <p>
-        In order to be able to use .NET Core on OS X, you need to install <b>OpenSSL</b> version <b>1.0.1/1.0.2</b>. 
-        There are many ways to install/update your libssl. Using <a href="http://www.brew.sh">Homebrew</a> is the easiest. 
-        You can view the instructions <a href="http://brewformulas.org/Openssl">here</a> or if you're updating, <a href="https://github.com/dotnet/coreclr/blob/63766f74c4a641a274cd2933b9b7fd7bbddef2dd/Documentation/building/osx-instructions.md#openssl">on this page</a>.
-        </p>
+            <p>.NET Core Runtime was successfully installed.</p>
         </div>
 </body>
 </html>

--- a/packaging/osx/hostfxr/resources/ja.lproj/conclusion.html
+++ b/packaging/osx/hostfxr/resources/ja.lproj/conclusion.html
@@ -8,7 +8,7 @@
 <body>
         <div align="center" style="font-family: Helvetica;">  
             <h1>The installation was successful.</h1>
-            <p>.NET Core Runtime was successfully installed.</p>
+            <p>.NET Core HostFxr was successfully installed.</p>
         </div>
 </body>
 </html>

--- a/packaging/osx/hostfxr/resources/ko.lproj/conclusion.html
+++ b/packaging/osx/hostfxr/resources/ko.lproj/conclusion.html
@@ -1,22 +1,14 @@
-
+﻿
 <!DOCTYPE html>
 <html lang="en">
 <head>
     <meta charset="utf-8" />
-    <title styles="color:white">Congratulations! You've successfully installed .NET Core CLI!</title>
+    <title styles="color:white">Congratulations! You've successfully installed .NET Core HostFxr!</title>
 </head>
 <body>
         <div align="center" style="font-family: Helvetica;">  
             <h1>The installation was successful.</h1>
-            <p>.NET Core CLI was successfully installed.</p>
-        <h2>
-            Install dependencies
-        </h2>
-        <p>
-        In order to be able to use .NET Core on OS X, you need to install <b>OpenSSL</b> version <b>1.0.1/1.0.2</b>. 
-        There are many ways to install/update your libssl. Using <a href="http://www.brew.sh">Homebrew</a> is the easiest. 
-        You can view the instructions <a href="http://brewformulas.org/Openssl">here</a> or if you're updating, <a href="https://github.com/dotnet/coreclr/blob/63766f74c4a641a274cd2933b9b7fd7bbddef2dd/Documentation/building/osx-instructions.md#openssl">on this page</a>.
-        </p>
+            <p>.NET Core Runtime was successfully installed.</p>
         </div>
 </body>
 </html>

--- a/packaging/osx/hostfxr/resources/ko.lproj/conclusion.html
+++ b/packaging/osx/hostfxr/resources/ko.lproj/conclusion.html
@@ -8,7 +8,7 @@
 <body>
         <div align="center" style="font-family: Helvetica;">  
             <h1>The installation was successful.</h1>
-            <p>.NET Core Runtime was successfully installed.</p>
+            <p>.NET Core HostFxr was successfully installed.</p>
         </div>
 </body>
 </html>

--- a/packaging/osx/hostfxr/resources/pl.lproj/conclusion.html
+++ b/packaging/osx/hostfxr/resources/pl.lproj/conclusion.html
@@ -1,22 +1,14 @@
-
+﻿
 <!DOCTYPE html>
 <html lang="en">
 <head>
     <meta charset="utf-8" />
-    <title styles="color:white">Congratulations! You've successfully installed .NET Core CLI!</title>
+    <title styles="color:white">Congratulations! You've successfully installed .NET Core HostFxr!</title>
 </head>
 <body>
         <div align="center" style="font-family: Helvetica;">  
             <h1>The installation was successful.</h1>
-            <p>.NET Core CLI was successfully installed.</p>
-        <h2>
-            Install dependencies
-        </h2>
-        <p>
-        In order to be able to use .NET Core on OS X, you need to install <b>OpenSSL</b> version <b>1.0.1/1.0.2</b>. 
-        There are many ways to install/update your libssl. Using <a href="http://www.brew.sh">Homebrew</a> is the easiest. 
-        You can view the instructions <a href="http://brewformulas.org/Openssl">here</a> or if you're updating, <a href="https://github.com/dotnet/coreclr/blob/63766f74c4a641a274cd2933b9b7fd7bbddef2dd/Documentation/building/osx-instructions.md#openssl">on this page</a>.
-        </p>
+            <p>.NET Core Runtime was successfully installed.</p>
         </div>
 </body>
 </html>

--- a/packaging/osx/hostfxr/resources/pl.lproj/conclusion.html
+++ b/packaging/osx/hostfxr/resources/pl.lproj/conclusion.html
@@ -8,7 +8,7 @@
 <body>
         <div align="center" style="font-family: Helvetica;">  
             <h1>The installation was successful.</h1>
-            <p>.NET Core Runtime was successfully installed.</p>
+            <p>.NET Core HostFxr was successfully installed.</p>
         </div>
 </body>
 </html>

--- a/packaging/osx/hostfxr/resources/pt-br.lproj/conclusion.html
+++ b/packaging/osx/hostfxr/resources/pt-br.lproj/conclusion.html
@@ -1,22 +1,14 @@
-
+﻿
 <!DOCTYPE html>
 <html lang="en">
 <head>
     <meta charset="utf-8" />
-    <title styles="color:white">Congratulations! You've successfully installed .NET Core CLI!</title>
+    <title styles="color:white">Congratulations! You've successfully installed .NET Core HostFxr!</title>
 </head>
 <body>
         <div align="center" style="font-family: Helvetica;">  
             <h1>The installation was successful.</h1>
-            <p>.NET Core CLI was successfully installed.</p>
-        <h2>
-            Install dependencies
-        </h2>
-        <p>
-        In order to be able to use .NET Core on OS X, you need to install <b>OpenSSL</b> version <b>1.0.1/1.0.2</b>. 
-        There are many ways to install/update your libssl. Using <a href="http://www.brew.sh">Homebrew</a> is the easiest. 
-        You can view the instructions <a href="http://brewformulas.org/Openssl">here</a> or if you're updating, <a href="https://github.com/dotnet/coreclr/blob/63766f74c4a641a274cd2933b9b7fd7bbddef2dd/Documentation/building/osx-instructions.md#openssl">on this page</a>.
-        </p>
+            <p>.NET Core Runtime was successfully installed.</p>
         </div>
 </body>
 </html>

--- a/packaging/osx/hostfxr/resources/pt-br.lproj/conclusion.html
+++ b/packaging/osx/hostfxr/resources/pt-br.lproj/conclusion.html
@@ -8,7 +8,7 @@
 <body>
         <div align="center" style="font-family: Helvetica;">  
             <h1>The installation was successful.</h1>
-            <p>.NET Core Runtime was successfully installed.</p>
+            <p>.NET Core HostFxr was successfully installed.</p>
         </div>
 </body>
 </html>

--- a/packaging/osx/hostfxr/resources/ru.lproj/conclusion.html
+++ b/packaging/osx/hostfxr/resources/ru.lproj/conclusion.html
@@ -1,22 +1,14 @@
-
+﻿
 <!DOCTYPE html>
 <html lang="en">
 <head>
     <meta charset="utf-8" />
-    <title styles="color:white">Congratulations! You've successfully installed .NET Core CLI!</title>
+    <title styles="color:white">Congratulations! You've successfully installed .NET Core HostFxr!</title>
 </head>
 <body>
         <div align="center" style="font-family: Helvetica;">  
             <h1>The installation was successful.</h1>
-            <p>.NET Core CLI was successfully installed.</p>
-        <h2>
-            Install dependencies
-        </h2>
-        <p>
-        In order to be able to use .NET Core on OS X, you need to install <b>OpenSSL</b> version <b>1.0.1/1.0.2</b>. 
-        There are many ways to install/update your libssl. Using <a href="http://www.brew.sh">Homebrew</a> is the easiest. 
-        You can view the instructions <a href="http://brewformulas.org/Openssl">here</a> or if you're updating, <a href="https://github.com/dotnet/coreclr/blob/63766f74c4a641a274cd2933b9b7fd7bbddef2dd/Documentation/building/osx-instructions.md#openssl">on this page</a>.
-        </p>
+            <p>.NET Core Runtime was successfully installed.</p>
         </div>
 </body>
 </html>

--- a/packaging/osx/hostfxr/resources/ru.lproj/conclusion.html
+++ b/packaging/osx/hostfxr/resources/ru.lproj/conclusion.html
@@ -8,7 +8,7 @@
 <body>
         <div align="center" style="font-family: Helvetica;">  
             <h1>The installation was successful.</h1>
-            <p>.NET Core Runtime was successfully installed.</p>
+            <p>.NET Core HostFxr was successfully installed.</p>
         </div>
 </body>
 </html>

--- a/packaging/osx/hostfxr/resources/tr.lproj/conclusion.html
+++ b/packaging/osx/hostfxr/resources/tr.lproj/conclusion.html
@@ -1,22 +1,14 @@
-
+﻿
 <!DOCTYPE html>
 <html lang="en">
 <head>
     <meta charset="utf-8" />
-    <title styles="color:white">Congratulations! You've successfully installed .NET Core CLI!</title>
+    <title styles="color:white">Congratulations! You've successfully installed .NET Core HostFxr!</title>
 </head>
 <body>
         <div align="center" style="font-family: Helvetica;">  
             <h1>The installation was successful.</h1>
-            <p>.NET Core CLI was successfully installed.</p>
-        <h2>
-            Install dependencies
-        </h2>
-        <p>
-        In order to be able to use .NET Core on OS X, you need to install <b>OpenSSL</b> version <b>1.0.1/1.0.2</b>. 
-        There are many ways to install/update your libssl. Using <a href="http://www.brew.sh">Homebrew</a> is the easiest. 
-        You can view the instructions <a href="http://brewformulas.org/Openssl">here</a> or if you're updating, <a href="https://github.com/dotnet/coreclr/blob/63766f74c4a641a274cd2933b9b7fd7bbddef2dd/Documentation/building/osx-instructions.md#openssl">on this page</a>.
-        </p>
+            <p>.NET Core Runtime was successfully installed.</p>
         </div>
 </body>
 </html>

--- a/packaging/osx/hostfxr/resources/tr.lproj/conclusion.html
+++ b/packaging/osx/hostfxr/resources/tr.lproj/conclusion.html
@@ -8,7 +8,7 @@
 <body>
         <div align="center" style="font-family: Helvetica;">  
             <h1>The installation was successful.</h1>
-            <p>.NET Core Runtime was successfully installed.</p>
+            <p>.NET Core HostFxr was successfully installed.</p>
         </div>
 </body>
 </html>

--- a/packaging/osx/hostfxr/resources/zh-hans.lproj/conclusion.html
+++ b/packaging/osx/hostfxr/resources/zh-hans.lproj/conclusion.html
@@ -1,22 +1,14 @@
-
+﻿
 <!DOCTYPE html>
 <html lang="en">
 <head>
     <meta charset="utf-8" />
-    <title styles="color:white">Congratulations! You've successfully installed .NET Core CLI!</title>
+    <title styles="color:white">Congratulations! You've successfully installed .NET Core HostFxr!</title>
 </head>
 <body>
         <div align="center" style="font-family: Helvetica;">  
             <h1>The installation was successful.</h1>
-            <p>.NET Core CLI was successfully installed.</p>
-        <h2>
-            Install dependencies
-        </h2>
-        <p>
-        In order to be able to use .NET Core on OS X, you need to install <b>OpenSSL</b> version <b>1.0.1/1.0.2</b>. 
-        There are many ways to install/update your libssl. Using <a href="http://www.brew.sh">Homebrew</a> is the easiest. 
-        You can view the instructions <a href="http://brewformulas.org/Openssl">here</a> or if you're updating, <a href="https://github.com/dotnet/coreclr/blob/63766f74c4a641a274cd2933b9b7fd7bbddef2dd/Documentation/building/osx-instructions.md#openssl">on this page</a>.
-        </p>
+            <p>.NET Core Runtime was successfully installed.</p>
         </div>
 </body>
 </html>

--- a/packaging/osx/hostfxr/resources/zh-hans.lproj/conclusion.html
+++ b/packaging/osx/hostfxr/resources/zh-hans.lproj/conclusion.html
@@ -8,7 +8,7 @@
 <body>
         <div align="center" style="font-family: Helvetica;">  
             <h1>The installation was successful.</h1>
-            <p>.NET Core Runtime was successfully installed.</p>
+            <p>.NET Core HostFxr was successfully installed.</p>
         </div>
 </body>
 </html>

--- a/packaging/osx/hostfxr/resources/zh-hant.lproj/conclusion.html
+++ b/packaging/osx/hostfxr/resources/zh-hant.lproj/conclusion.html
@@ -1,22 +1,14 @@
-
+﻿
 <!DOCTYPE html>
 <html lang="en">
 <head>
     <meta charset="utf-8" />
-    <title styles="color:white">Congratulations! You've successfully installed .NET Core CLI!</title>
+    <title styles="color:white">Congratulations! You've successfully installed .NET Core HostFxr!</title>
 </head>
 <body>
         <div align="center" style="font-family: Helvetica;">  
             <h1>The installation was successful.</h1>
-            <p>.NET Core CLI was successfully installed.</p>
-        <h2>
-            Install dependencies
-        </h2>
-        <p>
-        In order to be able to use .NET Core on OS X, you need to install <b>OpenSSL</b> version <b>1.0.1/1.0.2</b>. 
-        There are many ways to install/update your libssl. Using <a href="http://www.brew.sh">Homebrew</a> is the easiest. 
-        You can view the instructions <a href="http://brewformulas.org/Openssl">here</a> or if you're updating, <a href="https://github.com/dotnet/coreclr/blob/63766f74c4a641a274cd2933b9b7fd7bbddef2dd/Documentation/building/osx-instructions.md#openssl">on this page</a>.
-        </p>
+            <p>.NET Core Runtime was successfully installed.</p>
         </div>
 </body>
 </html>

--- a/packaging/osx/hostfxr/resources/zh-hant.lproj/conclusion.html
+++ b/packaging/osx/hostfxr/resources/zh-hant.lproj/conclusion.html
@@ -8,7 +8,7 @@
 <body>
         <div align="center" style="font-family: Helvetica;">  
             <h1>The installation was successful.</h1>
-            <p>.NET Core Runtime was successfully installed.</p>
+            <p>.NET Core HostFxr was successfully installed.</p>
         </div>
 </body>
 </html>

--- a/packaging/osx/sharedframework/resources/cs.lproj/conclusion.html
+++ b/packaging/osx/sharedframework/resources/cs.lproj/conclusion.html
@@ -1,4 +1,4 @@
-
+﻿
 <!DOCTYPE html>
 <html lang="en">
 <head>
@@ -9,14 +9,6 @@
         <div align="center" style="font-family: Helvetica;">  
             <h1>The installation was successful.</h1>
             <p>.NET Core was successfully installed.</p>
-        <h2>
-            Install dependencies
-        </h2>
-        <p>
-        In order to be able to use .NET Core on OS X, you need to install <b>OpenSSL</b> version <b>1.0.1/1.0.2</b>. 
-        There are many ways to install/update your libssl. Using <a href="http://www.brew.sh">Homebrew</a> is the easiest. 
-        You can view the instructions <a href="http://brewformulas.org/Openssl">here</a> or if you're updating, <a href="https://github.com/dotnet/coreclr/blob/63766f74c4a641a274cd2933b9b7fd7bbddef2dd/Documentation/building/osx-instructions.md#openssl">on this page</a>.
-        </p>
         </div>
 </body>
 </html>

--- a/packaging/osx/sharedframework/resources/de.lproj/conclusion.html
+++ b/packaging/osx/sharedframework/resources/de.lproj/conclusion.html
@@ -1,4 +1,4 @@
-
+﻿
 <!DOCTYPE html>
 <html lang="en">
 <head>
@@ -9,14 +9,6 @@
         <div align="center" style="font-family: Helvetica;">  
             <h1>The installation was successful.</h1>
             <p>.NET Core was successfully installed.</p>
-        <h2>
-            Install dependencies
-        </h2>
-        <p>
-        In order to be able to use .NET Core on OS X, you need to install <b>OpenSSL</b> version <b>1.0.1/1.0.2</b>. 
-        There are many ways to install/update your libssl. Using <a href="http://www.brew.sh">Homebrew</a> is the easiest. 
-        You can view the instructions <a href="http://brewformulas.org/Openssl">here</a> or if you're updating, <a href="https://github.com/dotnet/coreclr/blob/63766f74c4a641a274cd2933b9b7fd7bbddef2dd/Documentation/building/osx-instructions.md#openssl">on this page</a>.
-        </p>
         </div>
 </body>
 </html>

--- a/packaging/osx/sharedframework/resources/en.lproj/conclusion.html
+++ b/packaging/osx/sharedframework/resources/en.lproj/conclusion.html
@@ -1,4 +1,4 @@
-
+﻿
 <!DOCTYPE html>
 <html lang="en">
 <head>
@@ -9,14 +9,6 @@
         <div align="center" style="font-family: Helvetica;">  
             <h1>The installation was successful.</h1>
             <p>.NET Core was successfully installed.</p>
-        <h2>
-            Install dependencies
-        </h2>
-        <p>
-        In order to be able to use .NET Core on OS X, you need to install <b>OpenSSL</b> version <b>1.0.1/1.0.2</b>. 
-        There are many ways to install/update your libssl. Using <a href="http://www.brew.sh">Homebrew</a> is the easiest. 
-        You can view the instructions <a href="http://brewformulas.org/Openssl">here</a> or if you're updating, <a href="https://github.com/dotnet/coreclr/blob/63766f74c4a641a274cd2933b9b7fd7bbddef2dd/Documentation/building/osx-instructions.md#openssl">on this page</a>.
-        </p>
         </div>
 </body>
 </html>

--- a/packaging/osx/sharedframework/resources/es.lproj/conclusion.html
+++ b/packaging/osx/sharedframework/resources/es.lproj/conclusion.html
@@ -1,4 +1,4 @@
-
+﻿
 <!DOCTYPE html>
 <html lang="en">
 <head>
@@ -9,14 +9,6 @@
         <div align="center" style="font-family: Helvetica;">  
             <h1>The installation was successful.</h1>
             <p>.NET Core was successfully installed.</p>
-        <h2>
-            Install dependencies
-        </h2>
-        <p>
-        In order to be able to use .NET Core on OS X, you need to install <b>OpenSSL</b> version <b>1.0.1/1.0.2</b>. 
-        There are many ways to install/update your libssl. Using <a href="http://www.brew.sh">Homebrew</a> is the easiest. 
-        You can view the instructions <a href="http://brewformulas.org/Openssl">here</a> or if you're updating, <a href="https://github.com/dotnet/coreclr/blob/63766f74c4a641a274cd2933b9b7fd7bbddef2dd/Documentation/building/osx-instructions.md#openssl">on this page</a>.
-        </p>
         </div>
 </body>
 </html>

--- a/packaging/osx/sharedframework/resources/fr.lproj/conclusion.html
+++ b/packaging/osx/sharedframework/resources/fr.lproj/conclusion.html
@@ -1,4 +1,4 @@
-
+﻿
 <!DOCTYPE html>
 <html lang="en">
 <head>
@@ -9,14 +9,6 @@
         <div align="center" style="font-family: Helvetica;">  
             <h1>The installation was successful.</h1>
             <p>.NET Core was successfully installed.</p>
-        <h2>
-            Install dependencies
-        </h2>
-        <p>
-        In order to be able to use .NET Core on OS X, you need to install <b>OpenSSL</b> version <b>1.0.1/1.0.2</b>. 
-        There are many ways to install/update your libssl. Using <a href="http://www.brew.sh">Homebrew</a> is the easiest. 
-        You can view the instructions <a href="http://brewformulas.org/Openssl">here</a> or if you're updating, <a href="https://github.com/dotnet/coreclr/blob/63766f74c4a641a274cd2933b9b7fd7bbddef2dd/Documentation/building/osx-instructions.md#openssl">on this page</a>.
-        </p>
         </div>
 </body>
 </html>

--- a/packaging/osx/sharedframework/resources/it.lproj/conclusion.html
+++ b/packaging/osx/sharedframework/resources/it.lproj/conclusion.html
@@ -1,4 +1,4 @@
-
+﻿
 <!DOCTYPE html>
 <html lang="en">
 <head>
@@ -9,14 +9,6 @@
         <div align="center" style="font-family: Helvetica;">  
             <h1>The installation was successful.</h1>
             <p>.NET Core was successfully installed.</p>
-        <h2>
-            Install dependencies
-        </h2>
-        <p>
-        In order to be able to use .NET Core on OS X, you need to install <b>OpenSSL</b> version <b>1.0.1/1.0.2</b>. 
-        There are many ways to install/update your libssl. Using <a href="http://www.brew.sh">Homebrew</a> is the easiest. 
-        You can view the instructions <a href="http://brewformulas.org/Openssl">here</a> or if you're updating, <a href="https://github.com/dotnet/coreclr/blob/63766f74c4a641a274cd2933b9b7fd7bbddef2dd/Documentation/building/osx-instructions.md#openssl">on this page</a>.
-        </p>
         </div>
 </body>
 </html>

--- a/packaging/osx/sharedframework/resources/ja.lproj/conclusion.html
+++ b/packaging/osx/sharedframework/resources/ja.lproj/conclusion.html
@@ -1,4 +1,4 @@
-
+﻿
 <!DOCTYPE html>
 <html lang="en">
 <head>
@@ -9,14 +9,6 @@
         <div align="center" style="font-family: Helvetica;">  
             <h1>The installation was successful.</h1>
             <p>.NET Core was successfully installed.</p>
-        <h2>
-            Install dependencies
-        </h2>
-        <p>
-        In order to be able to use .NET Core on OS X, you need to install <b>OpenSSL</b> version <b>1.0.1/1.0.2</b>. 
-        There are many ways to install/update your libssl. Using <a href="http://www.brew.sh">Homebrew</a> is the easiest. 
-        You can view the instructions <a href="http://brewformulas.org/Openssl">here</a> or if you're updating, <a href="https://github.com/dotnet/coreclr/blob/63766f74c4a641a274cd2933b9b7fd7bbddef2dd/Documentation/building/osx-instructions.md#openssl">on this page</a>.
-        </p>
         </div>
 </body>
 </html>

--- a/packaging/osx/sharedframework/resources/ko.lproj/conclusion.html
+++ b/packaging/osx/sharedframework/resources/ko.lproj/conclusion.html
@@ -1,4 +1,4 @@
-
+﻿
 <!DOCTYPE html>
 <html lang="en">
 <head>
@@ -9,14 +9,6 @@
         <div align="center" style="font-family: Helvetica;">  
             <h1>The installation was successful.</h1>
             <p>.NET Core was successfully installed.</p>
-        <h2>
-            Install dependencies
-        </h2>
-        <p>
-        In order to be able to use .NET Core on OS X, you need to install <b>OpenSSL</b> version <b>1.0.1/1.0.2</b>. 
-        There are many ways to install/update your libssl. Using <a href="http://www.brew.sh">Homebrew</a> is the easiest. 
-        You can view the instructions <a href="http://brewformulas.org/Openssl">here</a> or if you're updating, <a href="https://github.com/dotnet/coreclr/blob/63766f74c4a641a274cd2933b9b7fd7bbddef2dd/Documentation/building/osx-instructions.md#openssl">on this page</a>.
-        </p>
         </div>
 </body>
 </html>

--- a/packaging/osx/sharedframework/resources/pl.lproj/conclusion.html
+++ b/packaging/osx/sharedframework/resources/pl.lproj/conclusion.html
@@ -1,4 +1,4 @@
-
+﻿
 <!DOCTYPE html>
 <html lang="en">
 <head>
@@ -9,14 +9,6 @@
         <div align="center" style="font-family: Helvetica;">  
             <h1>The installation was successful.</h1>
             <p>.NET Core was successfully installed.</p>
-        <h2>
-            Install dependencies
-        </h2>
-        <p>
-        In order to be able to use .NET Core on OS X, you need to install <b>OpenSSL</b> version <b>1.0.1/1.0.2</b>. 
-        There are many ways to install/update your libssl. Using <a href="http://www.brew.sh">Homebrew</a> is the easiest. 
-        You can view the instructions <a href="http://brewformulas.org/Openssl">here</a> or if you're updating, <a href="https://github.com/dotnet/coreclr/blob/63766f74c4a641a274cd2933b9b7fd7bbddef2dd/Documentation/building/osx-instructions.md#openssl">on this page</a>.
-        </p>
         </div>
 </body>
 </html>

--- a/packaging/osx/sharedframework/resources/pt-br.lproj/conclusion.html
+++ b/packaging/osx/sharedframework/resources/pt-br.lproj/conclusion.html
@@ -1,4 +1,4 @@
-
+﻿
 <!DOCTYPE html>
 <html lang="en">
 <head>
@@ -9,14 +9,6 @@
         <div align="center" style="font-family: Helvetica;">  
             <h1>The installation was successful.</h1>
             <p>.NET Core was successfully installed.</p>
-        <h2>
-            Install dependencies
-        </h2>
-        <p>
-        In order to be able to use .NET Core on OS X, you need to install <b>OpenSSL</b> version <b>1.0.1/1.0.2</b>. 
-        There are many ways to install/update your libssl. Using <a href="http://www.brew.sh">Homebrew</a> is the easiest. 
-        You can view the instructions <a href="http://brewformulas.org/Openssl">here</a> or if you're updating, <a href="https://github.com/dotnet/coreclr/blob/63766f74c4a641a274cd2933b9b7fd7bbddef2dd/Documentation/building/osx-instructions.md#openssl">on this page</a>.
-        </p>
         </div>
 </body>
 </html>

--- a/packaging/osx/sharedframework/resources/ru.lproj/conclusion.html
+++ b/packaging/osx/sharedframework/resources/ru.lproj/conclusion.html
@@ -1,4 +1,4 @@
-
+﻿
 <!DOCTYPE html>
 <html lang="en">
 <head>
@@ -9,14 +9,6 @@
         <div align="center" style="font-family: Helvetica;">  
             <h1>The installation was successful.</h1>
             <p>.NET Core was successfully installed.</p>
-        <h2>
-            Install dependencies
-        </h2>
-        <p>
-        In order to be able to use .NET Core on OS X, you need to install <b>OpenSSL</b> version <b>1.0.1/1.0.2</b>. 
-        There are many ways to install/update your libssl. Using <a href="http://www.brew.sh">Homebrew</a> is the easiest. 
-        You can view the instructions <a href="http://brewformulas.org/Openssl">here</a> or if you're updating, <a href="https://github.com/dotnet/coreclr/blob/63766f74c4a641a274cd2933b9b7fd7bbddef2dd/Documentation/building/osx-instructions.md#openssl">on this page</a>.
-        </p>
         </div>
 </body>
 </html>

--- a/packaging/osx/sharedframework/resources/tr.lproj/conclusion.html
+++ b/packaging/osx/sharedframework/resources/tr.lproj/conclusion.html
@@ -1,4 +1,4 @@
-
+﻿
 <!DOCTYPE html>
 <html lang="en">
 <head>
@@ -9,14 +9,6 @@
         <div align="center" style="font-family: Helvetica;">  
             <h1>The installation was successful.</h1>
             <p>.NET Core was successfully installed.</p>
-        <h2>
-            Install dependencies
-        </h2>
-        <p>
-        In order to be able to use .NET Core on OS X, you need to install <b>OpenSSL</b> version <b>1.0.1/1.0.2</b>. 
-        There are many ways to install/update your libssl. Using <a href="http://www.brew.sh">Homebrew</a> is the easiest. 
-        You can view the instructions <a href="http://brewformulas.org/Openssl">here</a> or if you're updating, <a href="https://github.com/dotnet/coreclr/blob/63766f74c4a641a274cd2933b9b7fd7bbddef2dd/Documentation/building/osx-instructions.md#openssl">on this page</a>.
-        </p>
         </div>
 </body>
 </html>

--- a/packaging/osx/sharedframework/resources/zh-hans.lproj/conclusion.html
+++ b/packaging/osx/sharedframework/resources/zh-hans.lproj/conclusion.html
@@ -1,4 +1,4 @@
-
+﻿
 <!DOCTYPE html>
 <html lang="en">
 <head>
@@ -9,14 +9,6 @@
         <div align="center" style="font-family: Helvetica;">  
             <h1>The installation was successful.</h1>
             <p>.NET Core was successfully installed.</p>
-        <h2>
-            Install dependencies
-        </h2>
-        <p>
-        In order to be able to use .NET Core on OS X, you need to install <b>OpenSSL</b> version <b>1.0.1/1.0.2</b>. 
-        There are many ways to install/update your libssl. Using <a href="http://www.brew.sh">Homebrew</a> is the easiest. 
-        You can view the instructions <a href="http://brewformulas.org/Openssl">here</a> or if you're updating, <a href="https://github.com/dotnet/coreclr/blob/63766f74c4a641a274cd2933b9b7fd7bbddef2dd/Documentation/building/osx-instructions.md#openssl">on this page</a>.
-        </p>
         </div>
 </body>
 </html>

--- a/packaging/osx/sharedframework/resources/zh-hant.lproj/conclusion.html
+++ b/packaging/osx/sharedframework/resources/zh-hant.lproj/conclusion.html
@@ -1,4 +1,4 @@
-
+﻿
 <!DOCTYPE html>
 <html lang="en">
 <head>
@@ -9,14 +9,6 @@
         <div align="center" style="font-family: Helvetica;">  
             <h1>The installation was successful.</h1>
             <p>.NET Core was successfully installed.</p>
-        <h2>
-            Install dependencies
-        </h2>
-        <p>
-        In order to be able to use .NET Core on OS X, you need to install <b>OpenSSL</b> version <b>1.0.1/1.0.2</b>. 
-        There are many ways to install/update your libssl. Using <a href="http://www.brew.sh">Homebrew</a> is the easiest. 
-        You can view the instructions <a href="http://brewformulas.org/Openssl">here</a> or if you're updating, <a href="https://github.com/dotnet/coreclr/blob/63766f74c4a641a274cd2933b9b7fd7bbddef2dd/Documentation/building/osx-instructions.md#openssl">on this page</a>.
-        </p>
         </div>
 </body>
 </html>

--- a/packaging/osx/sharedframework/scripts/postinstall
+++ b/packaging/osx/sharedframework/scripts/postinstall
@@ -6,25 +6,8 @@
 
 PACKAGE=$1
 INSTALL_DESTINATION=$2
-LIBCRYPTO_NAME=libcrypto.1.0.0.dylib
-LIBSSL_NAME=libssl.1.0.0.dylib
-
-# Using this form to allow power users to export both of these
-if [ -z $OPENSSL_PATH ]; then OPENSSL_PATH=/usr/local/opt/openssl/lib; fi
-if [ -z $LINK_DEST ]; then LINK_DEST=/usr/local/lib; fi
 
 # A temporary fix for the permissions issue(s)
 chmod -R 755 $INSTALL_DESTINATION/shared
-
-if [ -e "$OPENSSL_PATH/$LIBSSL_NAME" ] && [ -e "$OPENSSL_PATH/$LIBCRYPTO_NAME" ]
-then
-   if [ ! -e "$LINK_DEST/$LIBSSL_NAME" ] && [ ! -e "$LINK_DEST/$LIBCRYPTO_NAME" ]
-   then
-       mkdir -p "$LINK_DEST"
-       ln -s "$OPENSSL_PATH/$LIBSSL_NAME" "$LINK_DEST"
-       ln -s "$OPENSSL_PATH/$LIBCRYPTO_NAME" "$LINK_DEST"
-   fi
-fi
-  
 
 exit 0

--- a/packaging/osx/sharedhost/resources/cs.lproj/conclusion.html
+++ b/packaging/osx/sharedhost/resources/cs.lproj/conclusion.html
@@ -8,7 +8,7 @@
 <body>
         <div align="center" style="font-family: Helvetica;">  
             <h1>The installation was successful.</h1>
-            <p>.NET Core CLI was successfully installed.</p>
+            <p>.NET Core Shared Host was successfully installed.</p>
         </div>
 </body>
 </html>

--- a/packaging/osx/sharedhost/resources/cs.lproj/conclusion.html
+++ b/packaging/osx/sharedhost/resources/cs.lproj/conclusion.html
@@ -1,22 +1,14 @@
-
+﻿
 <!DOCTYPE html>
 <html lang="en">
 <head>
     <meta charset="utf-8" />
-    <title styles="color:white">Congratulations! You've successfully installed .NET Core CLI!</title>
+    <title styles="color:white">Congratulations! You've successfully installed .NET Core Shared Host!</title>
 </head>
 <body>
         <div align="center" style="font-family: Helvetica;">  
             <h1>The installation was successful.</h1>
             <p>.NET Core CLI was successfully installed.</p>
-        <h2>
-            Install dependencies
-        </h2>
-        <p>
-        In order to be able to use .NET Core on OS X, you need to install <b>OpenSSL</b> version <b>1.0.1/1.0.2</b>. 
-        There are many ways to install/update your libssl. Using <a href="http://www.brew.sh">Homebrew</a> is the easiest. 
-        You can view the instructions <a href="http://brewformulas.org/Openssl">here</a> or if you're updating, <a href="https://github.com/dotnet/coreclr/blob/63766f74c4a641a274cd2933b9b7fd7bbddef2dd/Documentation/building/osx-instructions.md#openssl">on this page</a>.
-        </p>
         </div>
 </body>
 </html>

--- a/packaging/osx/sharedhost/resources/de.lproj/conclusion.html
+++ b/packaging/osx/sharedhost/resources/de.lproj/conclusion.html
@@ -8,7 +8,7 @@
 <body>
         <div align="center" style="font-family: Helvetica;">  
             <h1>The installation was successful.</h1>
-            <p>.NET Core CLI was successfully installed.</p>
+            <p>.NET Core Shared Host was successfully installed.</p>
         </div>
 </body>
 </html>

--- a/packaging/osx/sharedhost/resources/de.lproj/conclusion.html
+++ b/packaging/osx/sharedhost/resources/de.lproj/conclusion.html
@@ -1,22 +1,14 @@
-
+﻿
 <!DOCTYPE html>
 <html lang="en">
 <head>
     <meta charset="utf-8" />
-    <title styles="color:white">Congratulations! You've successfully installed .NET Core CLI!</title>
+    <title styles="color:white">Congratulations! You've successfully installed .NET Core Shared Host!</title>
 </head>
 <body>
         <div align="center" style="font-family: Helvetica;">  
             <h1>The installation was successful.</h1>
             <p>.NET Core CLI was successfully installed.</p>
-        <h2>
-            Install dependencies
-        </h2>
-        <p>
-        In order to be able to use .NET Core on OS X, you need to install <b>OpenSSL</b> version <b>1.0.1/1.0.2</b>. 
-        There are many ways to install/update your libssl. Using <a href="http://www.brew.sh">Homebrew</a> is the easiest. 
-        You can view the instructions <a href="http://brewformulas.org/Openssl">here</a> or if you're updating, <a href="https://github.com/dotnet/coreclr/blob/63766f74c4a641a274cd2933b9b7fd7bbddef2dd/Documentation/building/osx-instructions.md#openssl">on this page</a>.
-        </p>
         </div>
 </body>
 </html>

--- a/packaging/osx/sharedhost/resources/en.lproj/conclusion.html
+++ b/packaging/osx/sharedhost/resources/en.lproj/conclusion.html
@@ -8,7 +8,7 @@
 <body>
         <div align="center" style="font-family: Helvetica;">  
             <h1>The installation was successful.</h1>
-            <p>.NET Core CLI was successfully installed.</p>
+            <p>.NET Core Shared Host was successfully installed.</p>
         </div>
 </body>
 </html>

--- a/packaging/osx/sharedhost/resources/en.lproj/conclusion.html
+++ b/packaging/osx/sharedhost/resources/en.lproj/conclusion.html
@@ -1,22 +1,14 @@
-
+﻿
 <!DOCTYPE html>
 <html lang="en">
 <head>
     <meta charset="utf-8" />
-    <title styles="color:white">Congratulations! You've successfully installed .NET Core CLI!</title>
+    <title styles="color:white">Congratulations! You've successfully installed .NET Core Shared Host!</title>
 </head>
 <body>
         <div align="center" style="font-family: Helvetica;">  
             <h1>The installation was successful.</h1>
             <p>.NET Core CLI was successfully installed.</p>
-        <h2>
-            Install dependencies
-        </h2>
-        <p>
-        In order to be able to use .NET Core on OS X, you need to install <b>OpenSSL</b> version <b>1.0.1/1.0.2</b>. 
-        There are many ways to install/update your libssl. Using <a href="http://www.brew.sh">Homebrew</a> is the easiest. 
-        You can view the instructions <a href="http://brewformulas.org/Openssl">here</a> or if you're updating, <a href="https://github.com/dotnet/coreclr/blob/63766f74c4a641a274cd2933b9b7fd7bbddef2dd/Documentation/building/osx-instructions.md#openssl">on this page</a>.
-        </p>
         </div>
 </body>
 </html>

--- a/packaging/osx/sharedhost/resources/es.lproj/conclusion.html
+++ b/packaging/osx/sharedhost/resources/es.lproj/conclusion.html
@@ -8,7 +8,7 @@
 <body>
         <div align="center" style="font-family: Helvetica;">  
             <h1>The installation was successful.</h1>
-            <p>.NET Core CLI was successfully installed.</p>
+            <p>.NET Core Shared Host was successfully installed.</p>
         </div>
 </body>
 </html>

--- a/packaging/osx/sharedhost/resources/es.lproj/conclusion.html
+++ b/packaging/osx/sharedhost/resources/es.lproj/conclusion.html
@@ -1,22 +1,14 @@
-
+﻿
 <!DOCTYPE html>
 <html lang="en">
 <head>
     <meta charset="utf-8" />
-    <title styles="color:white">Congratulations! You've successfully installed .NET Core CLI!</title>
+    <title styles="color:white">Congratulations! You've successfully installed .NET Core Shared Host!</title>
 </head>
 <body>
         <div align="center" style="font-family: Helvetica;">  
             <h1>The installation was successful.</h1>
             <p>.NET Core CLI was successfully installed.</p>
-        <h2>
-            Install dependencies
-        </h2>
-        <p>
-        In order to be able to use .NET Core on OS X, you need to install <b>OpenSSL</b> version <b>1.0.1/1.0.2</b>. 
-        There are many ways to install/update your libssl. Using <a href="http://www.brew.sh">Homebrew</a> is the easiest. 
-        You can view the instructions <a href="http://brewformulas.org/Openssl">here</a> or if you're updating, <a href="https://github.com/dotnet/coreclr/blob/63766f74c4a641a274cd2933b9b7fd7bbddef2dd/Documentation/building/osx-instructions.md#openssl">on this page</a>.
-        </p>
         </div>
 </body>
 </html>

--- a/packaging/osx/sharedhost/resources/fr.lproj/conclusion.html
+++ b/packaging/osx/sharedhost/resources/fr.lproj/conclusion.html
@@ -8,7 +8,7 @@
 <body>
         <div align="center" style="font-family: Helvetica;">  
             <h1>The installation was successful.</h1>
-            <p>.NET Core CLI was successfully installed.</p>
+            <p>.NET Core Shared Host was successfully installed.</p>
         </div>
 </body>
 </html>

--- a/packaging/osx/sharedhost/resources/fr.lproj/conclusion.html
+++ b/packaging/osx/sharedhost/resources/fr.lproj/conclusion.html
@@ -1,22 +1,14 @@
-
+﻿
 <!DOCTYPE html>
 <html lang="en">
 <head>
     <meta charset="utf-8" />
-    <title styles="color:white">Congratulations! You've successfully installed .NET Core CLI!</title>
+    <title styles="color:white">Congratulations! You've successfully installed .NET Core Shared Host!</title>
 </head>
 <body>
         <div align="center" style="font-family: Helvetica;">  
             <h1>The installation was successful.</h1>
             <p>.NET Core CLI was successfully installed.</p>
-        <h2>
-            Install dependencies
-        </h2>
-        <p>
-        In order to be able to use .NET Core on OS X, you need to install <b>OpenSSL</b> version <b>1.0.1/1.0.2</b>. 
-        There are many ways to install/update your libssl. Using <a href="http://www.brew.sh">Homebrew</a> is the easiest. 
-        You can view the instructions <a href="http://brewformulas.org/Openssl">here</a> or if you're updating, <a href="https://github.com/dotnet/coreclr/blob/63766f74c4a641a274cd2933b9b7fd7bbddef2dd/Documentation/building/osx-instructions.md#openssl">on this page</a>.
-        </p>
         </div>
 </body>
 </html>

--- a/packaging/osx/sharedhost/resources/it.lproj/conclusion.html
+++ b/packaging/osx/sharedhost/resources/it.lproj/conclusion.html
@@ -8,7 +8,7 @@
 <body>
         <div align="center" style="font-family: Helvetica;">  
             <h1>The installation was successful.</h1>
-            <p>.NET Core CLI was successfully installed.</p>
+            <p>.NET Core Shared Host was successfully installed.</p>
         </div>
 </body>
 </html>

--- a/packaging/osx/sharedhost/resources/it.lproj/conclusion.html
+++ b/packaging/osx/sharedhost/resources/it.lproj/conclusion.html
@@ -1,22 +1,14 @@
-
+﻿
 <!DOCTYPE html>
 <html lang="en">
 <head>
     <meta charset="utf-8" />
-    <title styles="color:white">Congratulations! You've successfully installed .NET Core CLI!</title>
+    <title styles="color:white">Congratulations! You've successfully installed .NET Core Shared Host!</title>
 </head>
 <body>
         <div align="center" style="font-family: Helvetica;">  
             <h1>The installation was successful.</h1>
             <p>.NET Core CLI was successfully installed.</p>
-        <h2>
-            Install dependencies
-        </h2>
-        <p>
-        In order to be able to use .NET Core on OS X, you need to install <b>OpenSSL</b> version <b>1.0.1/1.0.2</b>. 
-        There are many ways to install/update your libssl. Using <a href="http://www.brew.sh">Homebrew</a> is the easiest. 
-        You can view the instructions <a href="http://brewformulas.org/Openssl">here</a> or if you're updating, <a href="https://github.com/dotnet/coreclr/blob/63766f74c4a641a274cd2933b9b7fd7bbddef2dd/Documentation/building/osx-instructions.md#openssl">on this page</a>.
-        </p>
         </div>
 </body>
 </html>

--- a/packaging/osx/sharedhost/resources/ja.lproj/conclusion.html
+++ b/packaging/osx/sharedhost/resources/ja.lproj/conclusion.html
@@ -8,7 +8,7 @@
 <body>
         <div align="center" style="font-family: Helvetica;">  
             <h1>The installation was successful.</h1>
-            <p>.NET Core CLI was successfully installed.</p>
+            <p>.NET Core Shared Host was successfully installed.</p>
         </div>
 </body>
 </html>

--- a/packaging/osx/sharedhost/resources/ja.lproj/conclusion.html
+++ b/packaging/osx/sharedhost/resources/ja.lproj/conclusion.html
@@ -1,22 +1,14 @@
-
+﻿
 <!DOCTYPE html>
 <html lang="en">
 <head>
     <meta charset="utf-8" />
-    <title styles="color:white">Congratulations! You've successfully installed .NET Core CLI!</title>
+    <title styles="color:white">Congratulations! You've successfully installed .NET Core Shared Host!</title>
 </head>
 <body>
         <div align="center" style="font-family: Helvetica;">  
             <h1>The installation was successful.</h1>
             <p>.NET Core CLI was successfully installed.</p>
-        <h2>
-            Install dependencies
-        </h2>
-        <p>
-        In order to be able to use .NET Core on OS X, you need to install <b>OpenSSL</b> version <b>1.0.1/1.0.2</b>. 
-        There are many ways to install/update your libssl. Using <a href="http://www.brew.sh">Homebrew</a> is the easiest. 
-        You can view the instructions <a href="http://brewformulas.org/Openssl">here</a> or if you're updating, <a href="https://github.com/dotnet/coreclr/blob/63766f74c4a641a274cd2933b9b7fd7bbddef2dd/Documentation/building/osx-instructions.md#openssl">on this page</a>.
-        </p>
         </div>
 </body>
 </html>

--- a/packaging/osx/sharedhost/resources/ko.lproj/conclusion.html
+++ b/packaging/osx/sharedhost/resources/ko.lproj/conclusion.html
@@ -8,7 +8,7 @@
 <body>
         <div align="center" style="font-family: Helvetica;">  
             <h1>The installation was successful.</h1>
-            <p>.NET Core CLI was successfully installed.</p>
+            <p>.NET Core Shared Host was successfully installed.</p>
         </div>
 </body>
 </html>

--- a/packaging/osx/sharedhost/resources/ko.lproj/conclusion.html
+++ b/packaging/osx/sharedhost/resources/ko.lproj/conclusion.html
@@ -1,22 +1,14 @@
-
+﻿
 <!DOCTYPE html>
 <html lang="en">
 <head>
     <meta charset="utf-8" />
-    <title styles="color:white">Congratulations! You've successfully installed .NET Core CLI!</title>
+    <title styles="color:white">Congratulations! You've successfully installed .NET Core Shared Host!</title>
 </head>
 <body>
         <div align="center" style="font-family: Helvetica;">  
             <h1>The installation was successful.</h1>
             <p>.NET Core CLI was successfully installed.</p>
-        <h2>
-            Install dependencies
-        </h2>
-        <p>
-        In order to be able to use .NET Core on OS X, you need to install <b>OpenSSL</b> version <b>1.0.1/1.0.2</b>. 
-        There are many ways to install/update your libssl. Using <a href="http://www.brew.sh">Homebrew</a> is the easiest. 
-        You can view the instructions <a href="http://brewformulas.org/Openssl">here</a> or if you're updating, <a href="https://github.com/dotnet/coreclr/blob/63766f74c4a641a274cd2933b9b7fd7bbddef2dd/Documentation/building/osx-instructions.md#openssl">on this page</a>.
-        </p>
         </div>
 </body>
 </html>

--- a/packaging/osx/sharedhost/resources/pl.lproj/conclusion.html
+++ b/packaging/osx/sharedhost/resources/pl.lproj/conclusion.html
@@ -8,7 +8,7 @@
 <body>
         <div align="center" style="font-family: Helvetica;">  
             <h1>The installation was successful.</h1>
-            <p>.NET Core CLI was successfully installed.</p>
+            <p>.NET Core Shared Host was successfully installed.</p>
         </div>
 </body>
 </html>

--- a/packaging/osx/sharedhost/resources/pl.lproj/conclusion.html
+++ b/packaging/osx/sharedhost/resources/pl.lproj/conclusion.html
@@ -1,22 +1,14 @@
-
+﻿
 <!DOCTYPE html>
 <html lang="en">
 <head>
     <meta charset="utf-8" />
-    <title styles="color:white">Congratulations! You've successfully installed .NET Core CLI!</title>
+    <title styles="color:white">Congratulations! You've successfully installed .NET Core Shared Host!</title>
 </head>
 <body>
         <div align="center" style="font-family: Helvetica;">  
             <h1>The installation was successful.</h1>
             <p>.NET Core CLI was successfully installed.</p>
-        <h2>
-            Install dependencies
-        </h2>
-        <p>
-        In order to be able to use .NET Core on OS X, you need to install <b>OpenSSL</b> version <b>1.0.1/1.0.2</b>. 
-        There are many ways to install/update your libssl. Using <a href="http://www.brew.sh">Homebrew</a> is the easiest. 
-        You can view the instructions <a href="http://brewformulas.org/Openssl">here</a> or if you're updating, <a href="https://github.com/dotnet/coreclr/blob/63766f74c4a641a274cd2933b9b7fd7bbddef2dd/Documentation/building/osx-instructions.md#openssl">on this page</a>.
-        </p>
         </div>
 </body>
 </html>

--- a/packaging/osx/sharedhost/resources/pt-br.lproj/conclusion.html
+++ b/packaging/osx/sharedhost/resources/pt-br.lproj/conclusion.html
@@ -8,7 +8,7 @@
 <body>
         <div align="center" style="font-family: Helvetica;">  
             <h1>The installation was successful.</h1>
-            <p>.NET Core CLI was successfully installed.</p>
+            <p>.NET Core Shared Host was successfully installed.</p>
         </div>
 </body>
 </html>

--- a/packaging/osx/sharedhost/resources/pt-br.lproj/conclusion.html
+++ b/packaging/osx/sharedhost/resources/pt-br.lproj/conclusion.html
@@ -1,22 +1,14 @@
-
+﻿
 <!DOCTYPE html>
 <html lang="en">
 <head>
     <meta charset="utf-8" />
-    <title styles="color:white">Congratulations! You've successfully installed .NET Core CLI!</title>
+    <title styles="color:white">Congratulations! You've successfully installed .NET Core Shared Host!</title>
 </head>
 <body>
         <div align="center" style="font-family: Helvetica;">  
             <h1>The installation was successful.</h1>
             <p>.NET Core CLI was successfully installed.</p>
-        <h2>
-            Install dependencies
-        </h2>
-        <p>
-        In order to be able to use .NET Core on OS X, you need to install <b>OpenSSL</b> version <b>1.0.1/1.0.2</b>. 
-        There are many ways to install/update your libssl. Using <a href="http://www.brew.sh">Homebrew</a> is the easiest. 
-        You can view the instructions <a href="http://brewformulas.org/Openssl">here</a> or if you're updating, <a href="https://github.com/dotnet/coreclr/blob/63766f74c4a641a274cd2933b9b7fd7bbddef2dd/Documentation/building/osx-instructions.md#openssl">on this page</a>.
-        </p>
         </div>
 </body>
 </html>

--- a/packaging/osx/sharedhost/resources/ru.lproj/conclusion.html
+++ b/packaging/osx/sharedhost/resources/ru.lproj/conclusion.html
@@ -8,7 +8,7 @@
 <body>
         <div align="center" style="font-family: Helvetica;">  
             <h1>The installation was successful.</h1>
-            <p>.NET Core CLI was successfully installed.</p>
+            <p>.NET Core Shared Host was successfully installed.</p>
         </div>
 </body>
 </html>

--- a/packaging/osx/sharedhost/resources/ru.lproj/conclusion.html
+++ b/packaging/osx/sharedhost/resources/ru.lproj/conclusion.html
@@ -1,22 +1,14 @@
-
+﻿
 <!DOCTYPE html>
 <html lang="en">
 <head>
     <meta charset="utf-8" />
-    <title styles="color:white">Congratulations! You've successfully installed .NET Core CLI!</title>
+    <title styles="color:white">Congratulations! You've successfully installed .NET Core Shared Host!</title>
 </head>
 <body>
         <div align="center" style="font-family: Helvetica;">  
             <h1>The installation was successful.</h1>
             <p>.NET Core CLI was successfully installed.</p>
-        <h2>
-            Install dependencies
-        </h2>
-        <p>
-        In order to be able to use .NET Core on OS X, you need to install <b>OpenSSL</b> version <b>1.0.1/1.0.2</b>. 
-        There are many ways to install/update your libssl. Using <a href="http://www.brew.sh">Homebrew</a> is the easiest. 
-        You can view the instructions <a href="http://brewformulas.org/Openssl">here</a> or if you're updating, <a href="https://github.com/dotnet/coreclr/blob/63766f74c4a641a274cd2933b9b7fd7bbddef2dd/Documentation/building/osx-instructions.md#openssl">on this page</a>.
-        </p>
         </div>
 </body>
 </html>

--- a/packaging/osx/sharedhost/resources/tr.lproj/conclusion.html
+++ b/packaging/osx/sharedhost/resources/tr.lproj/conclusion.html
@@ -8,7 +8,7 @@
 <body>
         <div align="center" style="font-family: Helvetica;">  
             <h1>The installation was successful.</h1>
-            <p>.NET Core CLI was successfully installed.</p>
+            <p>.NET Core Shared Host was successfully installed.</p>
         </div>
 </body>
 </html>

--- a/packaging/osx/sharedhost/resources/tr.lproj/conclusion.html
+++ b/packaging/osx/sharedhost/resources/tr.lproj/conclusion.html
@@ -1,22 +1,14 @@
-
+﻿
 <!DOCTYPE html>
 <html lang="en">
 <head>
     <meta charset="utf-8" />
-    <title styles="color:white">Congratulations! You've successfully installed .NET Core CLI!</title>
+    <title styles="color:white">Congratulations! You've successfully installed .NET Core Shared Host!</title>
 </head>
 <body>
         <div align="center" style="font-family: Helvetica;">  
             <h1>The installation was successful.</h1>
             <p>.NET Core CLI was successfully installed.</p>
-        <h2>
-            Install dependencies
-        </h2>
-        <p>
-        In order to be able to use .NET Core on OS X, you need to install <b>OpenSSL</b> version <b>1.0.1/1.0.2</b>. 
-        There are many ways to install/update your libssl. Using <a href="http://www.brew.sh">Homebrew</a> is the easiest. 
-        You can view the instructions <a href="http://brewformulas.org/Openssl">here</a> or if you're updating, <a href="https://github.com/dotnet/coreclr/blob/63766f74c4a641a274cd2933b9b7fd7bbddef2dd/Documentation/building/osx-instructions.md#openssl">on this page</a>.
-        </p>
         </div>
 </body>
 </html>

--- a/packaging/osx/sharedhost/resources/zh-hans.lproj/conclusion.html
+++ b/packaging/osx/sharedhost/resources/zh-hans.lproj/conclusion.html
@@ -8,7 +8,7 @@
 <body>
         <div align="center" style="font-family: Helvetica;">  
             <h1>The installation was successful.</h1>
-            <p>.NET Core CLI was successfully installed.</p>
+            <p>.NET Core Shared Host was successfully installed.</p>
         </div>
 </body>
 </html>

--- a/packaging/osx/sharedhost/resources/zh-hans.lproj/conclusion.html
+++ b/packaging/osx/sharedhost/resources/zh-hans.lproj/conclusion.html
@@ -1,22 +1,14 @@
-
+﻿
 <!DOCTYPE html>
 <html lang="en">
 <head>
     <meta charset="utf-8" />
-    <title styles="color:white">Congratulations! You've successfully installed .NET Core CLI!</title>
+    <title styles="color:white">Congratulations! You've successfully installed .NET Core Shared Host!</title>
 </head>
 <body>
         <div align="center" style="font-family: Helvetica;">  
             <h1>The installation was successful.</h1>
             <p>.NET Core CLI was successfully installed.</p>
-        <h2>
-            Install dependencies
-        </h2>
-        <p>
-        In order to be able to use .NET Core on OS X, you need to install <b>OpenSSL</b> version <b>1.0.1/1.0.2</b>. 
-        There are many ways to install/update your libssl. Using <a href="http://www.brew.sh">Homebrew</a> is the easiest. 
-        You can view the instructions <a href="http://brewformulas.org/Openssl">here</a> or if you're updating, <a href="https://github.com/dotnet/coreclr/blob/63766f74c4a641a274cd2933b9b7fd7bbddef2dd/Documentation/building/osx-instructions.md#openssl">on this page</a>.
-        </p>
         </div>
 </body>
 </html>

--- a/packaging/osx/sharedhost/resources/zh-hant.lproj/conclusion.html
+++ b/packaging/osx/sharedhost/resources/zh-hant.lproj/conclusion.html
@@ -8,7 +8,7 @@
 <body>
         <div align="center" style="font-family: Helvetica;">  
             <h1>The installation was successful.</h1>
-            <p>.NET Core CLI was successfully installed.</p>
+            <p>.NET Core Shared Host was successfully installed.</p>
         </div>
 </body>
 </html>

--- a/packaging/osx/sharedhost/resources/zh-hant.lproj/conclusion.html
+++ b/packaging/osx/sharedhost/resources/zh-hant.lproj/conclusion.html
@@ -1,22 +1,14 @@
-
+﻿
 <!DOCTYPE html>
 <html lang="en">
 <head>
     <meta charset="utf-8" />
-    <title styles="color:white">Congratulations! You've successfully installed .NET Core CLI!</title>
+    <title styles="color:white">Congratulations! You've successfully installed .NET Core Shared Host!</title>
 </head>
 <body>
         <div align="center" style="font-family: Helvetica;">  
             <h1>The installation was successful.</h1>
             <p>.NET Core CLI was successfully installed.</p>
-        <h2>
-            Install dependencies
-        </h2>
-        <p>
-        In order to be able to use .NET Core on OS X, you need to install <b>OpenSSL</b> version <b>1.0.1/1.0.2</b>. 
-        There are many ways to install/update your libssl. Using <a href="http://www.brew.sh">Homebrew</a> is the easiest. 
-        You can view the instructions <a href="http://brewformulas.org/Openssl">here</a> or if you're updating, <a href="https://github.com/dotnet/coreclr/blob/63766f74c4a641a274cd2933b9b7fd7bbddef2dd/Documentation/building/osx-instructions.md#openssl">on this page</a>.
-        </p>
         </div>
 </body>
 </html>


### PR DESCRIPTION
This can be removed now that the runtime no longer requires OpenSSL on macOS.

Fix #200 

Note: there is one code change to a postinstall script: https://github.com/dotnet/core-setup/compare/master...eerhardt:RemoveOpenSSLOsx?expand=1#diff-1a7a3b7494835bd54553b92434c18b43