### PR TITLE
Use cannot instead of can not in error text

### DIFF
--- a/src/Microsoft.Extensions.DependencyModel/CompilationLibrary.cs
+++ b/src/Microsoft.Extensions.DependencyModel/CompilationLibrary.cs
@@ -54,7 +54,7 @@ namespace Microsoft.Extensions.DependencyModel
             var assemblies = new List<string>();
             if (!DefaultResolver.TryResolveAssemblyPaths(this, assemblies))
             {
-                throw new InvalidOperationException($"Can not find compilation library location for package '{Name}'");
+                throw new InvalidOperationException($"Cannot find compilation library location for package '{Name}'");
             }
             return assemblies;
         }

--- a/src/Microsoft.Extensions.DependencyModel/Resolution/AppBaseCompilationAssemblyResolver.cs
+++ b/src/Microsoft.Extensions.DependencyModel/Resolution/AppBaseCompilationAssemblyResolver.cs
@@ -106,7 +106,7 @@ namespace Microsoft.Extensions.DependencyModel.Resolution
                     if (isPublished)
                     {
                     throw new InvalidOperationException(
-                        $"Can not find assembly file {assemblyFile} at '{string.Join(",", directories)}'");
+                        $"Cannot find assembly file {assemblyFile} at '{string.Join(",", directories)}'");
                 }
                     return false;
             }

--- a/src/Microsoft.Extensions.DependencyModel/Resolution/ReferenceAssemblyPathResolver.cs
+++ b/src/Microsoft.Extensions.DependencyModel/Resolution/ReferenceAssemblyPathResolver.cs
@@ -49,7 +49,7 @@ namespace Microsoft.Extensions.DependencyModel.Resolution
                 string fullName;
                 if (!TryResolveReferenceAssembly(assembly, out fullName))
                 {
-                    throw new InvalidOperationException($"Can not find reference assembly '{assembly}' file for package {library.Name}");
+                    throw new InvalidOperationException($"Cannot find reference assembly '{assembly}' file for package {library.Name}");
                 }
                 assemblies.Add(fullName);
             }

--- a/src/Microsoft.Extensions.DependencyModel/Resolution/ResolverUtils.cs
+++ b/src/Microsoft.Extensions.DependencyModel/Resolution/ResolverUtils.cs
@@ -33,7 +33,7 @@ namespace Microsoft.Extensions.DependencyModel.Resolution
                 string fullName;
                 if (!TryResolveAssemblyFile(fileSystem, basePath, assembly, out fullName))
                 {
-                    throw new InvalidOperationException($"Can not find assembly file for package {library.Name} at '{fullName}'");
+                    throw new InvalidOperationException($"Cannot find assembly file for package {library.Name} at '{fullName}'");
                 }
                 yield return fullName;
             }


### PR DESCRIPTION
While "can not" is technically OK, "cannot" is the more common form and looks more professional.