### PR TITLE
Remove the use of --infer-runtimes during restore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -297,3 +297,8 @@ test/PackagedCommands/Consumers/*/project.json
 
 # VS generated files
 launchSettings.json
+
+# Generated project.json files (the project.json.template file is the authoritative copy)
+setuptools/independent/DepsProcessor/project.json
+build_projects/dotnet-host-build/project.json
+build_projects/update-dependencies/project.json

--- a/build_projects/dotnet-host-build/PrepareTargets.cs
+++ b/build_projects/dotnet-host-build/PrepareTargets.cs
@@ -385,7 +385,16 @@ namespace Microsoft.DotNet.Host.Build
                 .WorkingDirectory(Path.Combine(c.BuildContext.BuildDirectory, "setuptools", "dotnet-deb-tool"))
                 .Execute()
                 .EnsureSuccessful();
-            dotnet.Restore("--verbosity", "verbose", "--disable-parallel", "--infer-runtimes")
+
+            var independentToolsRoot = Path.Combine(c.BuildContext.BuildDirectory, "setuptools", "independent");
+
+            foreach (string templateFile in Directory.GetFiles(independentToolsRoot, "project.json.template", SearchOption.AllDirectories))
+            {
+                string projectJsonFile = Path.Combine(Path.GetDirectoryName(templateFile), "project.json");
+                File.WriteAllText(projectJsonFile, File.ReadAllText(templateFile).Replace("{RID}", RuntimeEnvironment.GetRuntimeIdentifier()));
+            }
+
+            dotnet.Restore("--verbosity", "verbose", "--disable-parallel")
                 .WorkingDirectory(Path.Combine(c.BuildContext.BuildDirectory, "setuptools", "independent"))
                 .Execute()
                 .EnsureSuccessful();

--- a/build_projects/dotnet-host-build/project.json.template
+++ b/build_projects/dotnet-host-build/project.json.template
@@ -29,5 +29,8 @@
         "portable-net45+win8"
       ]
     }
+  },
+  "runtimes": {
+    "{RID}": {}
   }
 }

--- a/build_projects/shared-build-targets-utils/Utils/SharedFrameworkPublisher.cs
+++ b/build_projects/shared-build-targets-utils/Utils/SharedFrameworkPublisher.cs
@@ -116,7 +116,6 @@ namespace Microsoft.DotNet.Cli.Build
             dotnetCli.Restore(
                 "--verbosity", "verbose",
                 "--disable-parallel",
-                "--infer-runtimes",
                 "--fallbacksource", _corehostPackageSource)
                 .WorkingDirectory(_sharedFrameworkSourceRoot)
                 .Execute()

--- a/build_projects/update-dependencies/project.json.template
+++ b/build_projects/update-dependencies/project.json.template
@@ -27,5 +27,8 @@
         "portable-net45+win"
       ]
     }
+  },
+  "runtimes": {
+    "{RID}": {}
   }
 }

--- a/build_projects/update-dependencies/update-dependencies.ps1
+++ b/build_projects/update-dependencies/update-dependencies.ps1
@@ -50,10 +50,17 @@ $env:PATH = "$env:DOTNET_INSTALL_DIR;$env:PATH"
 
 $appPath = "$PSScriptRoot"
 
+# Figure out the RID of the current platform, based on what stage 0 thinks.
+$HOST_RID=(dotnet --info | Select-String -Pattern "\s*RID:\s*(?<rid>.*)").Matches[0].Groups['rid'].Value
+
 # Restore the build scripts
 Write-Host "Restoring Build Script projects..."
 pushd "$PSScriptRoot\.."
-dotnet restore --infer-runtimes
+
+(Get-Content "dotnet-host-build\project.json.template").Replace("{RID}", $HOST_RID) | Set-Content "dotnet-host-build\project.json"
+(Get-Content "update-dependencies\project.json.template").Replace("{RID}", $HOST_RID) | Set-Content "update-dependencies\project.json"
+
+dotnet restore
 if($LASTEXITCODE -ne 0) { throw "Failed to restore" }
 popd
 

--- a/build_projects/update-dependencies/update-dependencies.sh
+++ b/build_projects/update-dependencies/update-dependencies.sh
@@ -59,6 +59,9 @@ curl -sSL "$DOTNET_INSTALL_SCRIPT_URL" | bash /dev/stdin --version 1.0.0-preview
 # Put stage 0 on the PATH (for this shell only)
 PATH="$DOTNET_INSTALL_DIR:$PATH"
 
+# Figure out the RID of the current platform, based on what stage 0 thinks.
+RID=$(dotnet --info | grep 'RID:' | sed -e 's/[[:space:]]*RID:[[:space:]]*\(.*\)/\1/g')
+
 # Increases the file descriptors limit for this bash. It prevents an issue we were hitting during restore
 FILE_DESCRIPTOR_LIMIT=$( ulimit -n )
 if [ $FILE_DESCRIPTOR_LIMIT -lt 1024 ]
@@ -74,7 +77,10 @@ export DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1
 echo "Restoring Build Script projects..."
 (
     pushd "$DIR/.."
-    dotnet restore --infer-runtimes --disable-parallel
+    sed -e "s/{RID}/$RID/g" "dotnet-host-build/project.json.template" > "dotnet-host-build/project.json"
+    sed -e "s/{RID}/$RID/g" "update-dependencies/project.json.template" > "update-dependencies/project.json"
+
+    dotnet restore --disable-parallel
     popd
 )
 

--- a/setuptools/independent/DepsProcessor/project.json.template
+++ b/setuptools/independent/DepsProcessor/project.json.template
@@ -21,5 +21,8 @@
         "portable-net45+wp80+win8+wpa81+dnxcore50"
       ]
     }
+  },
+  "runtimes": {
+    "{RID}" : {}
   }
 }


### PR DESCRIPTION
--infer-runtimes has been deprecated for a long time, but we continued to
use it because there was no pressing reason to move away from it. I've
been trying to build core-setup on newer versions of RHEL, where the RID
has changed from rhel.7.2-x64 to rhel.7.3-x64. Since our long term plan
(which will happen for 2.0) is to unify all RHEL 7 rids to rhel.7-<arch>,
I had hoped I could use DOTNET_RUNTIME_ID to specifcy a RID of rhel.7-x64
and have everything work.

However, the use of infer-runtimes is not playing nicely with that, so now
is the time to stop using this feature. We only have a handful of projects
now where we care about restoring for a specific rid (the build system,
the update scripts and a tool run during build time to generate some deps
files for the shared framework) so it was easy enough to get everyone on a
project.json.template plan.

Long term, the build project and update-dependencies scripts will be
removed as we move over to MSBuild + BuildTools. I expect that we'll also
just use a custom MSBuild task in the future to replace the DepsProcessor
tool and then we can delete all of this stuff.