### PR TITLE
Revert "Remove signing for host binary"

### DIFF
--- a/build_projects/signing/sign.proj
+++ b/build_projects/signing/sign.proj
@@ -35,6 +35,9 @@
       <FilesToSign Include="$(OutDir)corehost/**/hostpolicy.dll">
         <Authenticode>$(CertificateId)</Authenticode>
       </FilesToSign>
+      <FilesToSign Include="$(OutDir)corehost/**/dotnet.exe">
+        <Authenticode>$(CertificateId)</Authenticode>
+      </FilesToSign>
     </ItemGroup>
   </Target>
 


### PR DESCRIPTION
This reverts commit 6e2d59e2fc3227fe355cf97a4a670d3ccf5b79bf.

@gkhanna79 @eerhardt PTAL

fixes https://github.com/dotnet/core-setup/issues/174