### PR TITLE
Updating the SDK 'lookup' policy.

### DIFF
--- a/Documentation/design-docs/multilevel-sharedfx-lookup.md
+++ b/Documentation/design-docs/multilevel-sharedfx-lookup.md
@@ -1,4 +1,4 @@
-# Multi-level SharedFX Lookup
+﻿# Multi-level SharedFX Lookup
 
 ## Introduction
 
@@ -41,7 +41,7 @@ There are two possibilities for a muxer: it can be a portable app or a .NET Core
 
 In the first case the app file path should have been specified as an argument to the dotnet.exe.
 
-In the second case the dotnet.dll from SDK must be invoked as a portable app. At first the running program searches for the global.json file which may have specified a CLI version. It starts from the current working directory and looks for it inside all parent folder hierarchy. After that, it searches for the dotnet.dll file inside the sdk\CLI_version subfolder in the executable directory. If the version defined in the global.json file or the specified version folder cannot be found, then it must choose the most appropriate one. The most appropriate version is defined as the latest production version according to the Semantic Versioning system. If no production version is available, then the latest pre-release must be chosen.
+In the second case the dotnet.dll from SDK must be invoked as a portable app. At first the running program searches for the global.json file which may have specified a CLI version. It starts from the current working directory and looks for it inside all parent folder hierarchy. After that, it searches for the dotnet.dll file inside the sdk\CLI_version subfolder in the executable directory. If the version defined in the global.json file or the specified version folder cannot be found, then it must choose the most appropriate one. The most appropriate version is defined as the latest version according to the Semantic Versioning system.
 
 ### Framework search and rolling forward
 

--- a/src/corehost/cli/fxr/fx_muxer.cpp
+++ b/src/corehost/cli/fxr/fx_muxer.cpp
@@ -572,27 +572,15 @@ pal::string_t resolve_sdk_version(pal::string_t sdk_path)
 
     pal::readdir(sdk_path, &versions);
     fx_ver_t max_ver(-1, -1, -1);
-    fx_ver_t max_pre(-1, -1, -1);
     for (const auto& version : versions)
     {
         trace::verbose(_X("Considering version... [%s]"), version.c_str());
 
         fx_ver_t ver(-1, -1, -1);
-        if (fx_ver_t::parse(version, &ver, true))
+        if (fx_ver_t::parse(version, &ver, false))  // false -- implies both production and prerelease.
         {
             max_ver = std::max(ver, max_ver);
         }
-        if (fx_ver_t::parse(version, &ver, false))
-        {
-            max_pre = std::max(ver, max_pre);
-        }
-    }
-
-    // No production, use the max pre-release.
-    if (max_ver == fx_ver_t(-1, -1, -1))
-    {
-        trace::verbose(_X("No production version found, so using latest prerelease"));
-        max_ver = max_pre;
     }
 
     pal::string_t max_ver_str = max_ver.as_str();

--- a/test/HostActivationTests/GivenThatICareAboutMultilevelSDKLookup.cs
+++ b/test/HostActivationTests/GivenThatICareAboutMultilevelSDKLookup.cs
@@ -220,7 +220,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.MultilevelSDKLookup
             // CWD: 9999.0.0, 9999.0.0-global-dummy
             // User: 9999.0.0, 9999.0.0-dummy
             // Exe: 9999.0.0-dummy, 9999.0.0-global-dummy
-            // Expected: 9999.0.0-global-dummy from cwd
+            // Expected: 9999.0.0 from cwd
             dotnet.Exec("help")
                 .WorkingDirectory(_currentWorkingDir)
                 .EnvironmentVariable("COREHOST_TRACE", "1")
@@ -230,7 +230,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.MultilevelSDKLookup
                 .Should()
                 .Pass()
                 .And
-                .HaveStdErrContaining(Path.Combine(_cwdSelectedMessage, "9999.0.0-global-dummy"));
+                .HaveStdErrContaining(Path.Combine(_cwdSelectedMessage, "9999.0.0"));
 
             // Remove dummy folders from user dir
             DeleteAvailableSdkVersions(_userSdkBaseDir, "9999.0.0", "9999.0.0-dummy");

--- a/test/HostActivationTests/GivenThatICareAboutMultilevelSDKLookup.cs
+++ b/test/HostActivationTests/GivenThatICareAboutMultilevelSDKLookup.cs
@@ -220,7 +220,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.MultilevelSDKLookup
             // CWD: 9999.0.0, 9999.0.0-global-dummy
             // User: 9999.0.0, 9999.0.0-dummy
             // Exe: 9999.0.0-dummy, 9999.0.0-global-dummy
-            // Expected: 9999.0.0 from cwd
+            // Expected: 9999.0.0-global-dummy from cwd
             dotnet.Exec("help")
                 .WorkingDirectory(_currentWorkingDir)
                 .EnvironmentVariable("COREHOST_TRACE", "1")
@@ -230,7 +230,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.MultilevelSDKLookup
                 .Should()
                 .Pass()
                 .And
-                .HaveStdErrContaining(Path.Combine(_cwdSelectedMessage, "9999.0.0"));
+                .HaveStdErrContaining(Path.Combine(_cwdSelectedMessage, "9999.0.0-global-dummy"));
 
             // Remove dummy folders from user dir
             DeleteAvailableSdkVersions(_userSdkBaseDir, "9999.0.0", "9999.0.0-dummy");


### PR DESCRIPTION
Updating the SDK 'lookup' policy.
Note - no change to the FX 'look-up' policy.

Documentation/design-docs/multilevel-sharedfx-lookup.md:
Stating the change to SDK 'look-up' policy - latest version irrespective of production/pre-release

src/corehost/cli/fxr/fx_muxer.cpp:
line 580 -When considering a version, include pre-release in the search
removing capture of the 'max-pre'

test/HostActivationTests/GivenThatICareAboutMultilevelSDKLookup.cs:
Given pre-release; when the choices are 9999.0.0 or 9999.0.0-global-dummy - choose the latest semantical version -> 9999.0.0

built clean and all tests passed: 4/13/2017 1:07PM on local system

https://github.com/dotnet/cli/issues/6038
@dotnet/dotnet-cli