### PR TITLE
Revert "Merge pull request #2046 from ellismg/remove-infer-runtimes"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -297,8 +297,3 @@ test/PackagedCommands/Consumers/*/project.json
 
 # VS generated files
 launchSettings.json
-
-# Generated project.json files (the project.json.template file is the authoritative copy)
-setuptools/independent/DepsProcessor/project.json
-build_projects/dotnet-host-build/project.json
-build_projects/update-dependencies/project.json

--- a/build_projects/dotnet-host-build/PrepareTargets.cs
+++ b/build_projects/dotnet-host-build/PrepareTargets.cs
@@ -385,16 +385,7 @@ namespace Microsoft.DotNet.Host.Build
                 .WorkingDirectory(Path.Combine(c.BuildContext.BuildDirectory, "setuptools", "dotnet-deb-tool"))
                 .Execute()
                 .EnsureSuccessful();
-
-            var independentToolsRoot = Path.Combine(c.BuildContext.BuildDirectory, "setuptools", "independent");
-
-            foreach (string templateFile in Directory.GetFiles(independentToolsRoot, "project.json.template", SearchOption.AllDirectories))
-            {
-                string projectJsonFile = Path.Combine(Path.GetDirectoryName(templateFile), "project.json");
-                File.WriteAllText(projectJsonFile, File.ReadAllText(templateFile).Replace("{RID}", RuntimeEnvironment.GetRuntimeIdentifier()));
-            }
-
-            dotnet.Restore("--verbosity", "verbose", "--disable-parallel")
+            dotnet.Restore("--verbosity", "verbose", "--disable-parallel", "--infer-runtimes")
                 .WorkingDirectory(Path.Combine(c.BuildContext.BuildDirectory, "setuptools", "independent"))
                 .Execute()
                 .EnsureSuccessful();

--- a/build_projects/dotnet-host-build/build.ps1
+++ b/build_projects/dotnet-host-build/build.ps1
@@ -125,17 +125,10 @@ $env:PATH = "$env:DOTNET_INSTALL_DIR;$env:PATH"
 # Disable first run since we want to control all package sources
 $env:DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1
 
-# Figure out the RID of the current platform, based on what stage 0 thinks.
-$HOST_RID=(dotnet --info | Select-String -Pattern "\s*RID:\s*(?<rid>.*)").Matches[0].Groups['rid'].Value
-
 # Restore the build scripts
 Write-Host "Restoring Build Script projects..."
 pushd "$PSScriptRoot\.."
-
-(Get-Content "dotnet-host-build\project.json.template").Replace("{RID}", $HOST_RID) | Set-Content "dotnet-host-build\project.json"
-(Get-Content "update-dependencies\project.json.template").Replace("{RID}", $HOST_RID) | Set-Content "update-dependencies\project.json"
-
-dotnet restore
+dotnet restore --infer-runtimes
 if($LASTEXITCODE -ne 0) { throw "Failed to restore" }
 popd
 

--- a/build_projects/dotnet-host-build/build.sh
+++ b/build_projects/dotnet-host-build/build.sh
@@ -142,9 +142,6 @@ curl -sSL "$DOTNET_INSTALL_SCRIPT_URL" | bash /dev/stdin --version 1.0.0-preview
 # Put stage 0 on the PATH (for this shell only)
 PATH="$DOTNET_INSTALL_DIR:$PATH"
 
-# Figure out the RID of the current platform, based on what stage 0 thinks.
-RID=$(dotnet --info | grep 'RID:' | sed -e 's/[[:space:]]*RID:[[:space:]]*\(.*\)/\1/g')
-
 # Increases the file descriptors limit for this bash. It prevents an issue we were hitting during restore
 FILE_DESCRIPTOR_LIMIT=$( ulimit -n )
 if [ $FILE_DESCRIPTOR_LIMIT -lt 1024 ]
@@ -160,10 +157,7 @@ export DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1
 echo "Restoring Build Script projects..."
 (
     cd "$DIR/.."
-    sed -e "s/{RID}/$RID/g" "dotnet-host-build/project.json.template" > "dotnet-host-build/project.json"
-    sed -e "s/{RID}/$RID/g" "update-dependencies/project.json.template" > "update-dependencies/project.json"
-
-    dotnet restore --disable-parallel
+    dotnet restore --infer-runtimes --disable-parallel
 )
 
 # Build the builder

--- a/build_projects/dotnet-host-build/project.json
+++ b/build_projects/dotnet-host-build/project.json
@@ -29,8 +29,5 @@
         "portable-net45+win8"
       ]
     }
-  },
-  "runtimes": {
-    "{RID}": {}
   }
 }

--- a/build_projects/shared-build-targets-utils/Utils/SharedFrameworkPublisher.cs
+++ b/build_projects/shared-build-targets-utils/Utils/SharedFrameworkPublisher.cs
@@ -116,6 +116,7 @@ namespace Microsoft.DotNet.Cli.Build
             dotnetCli.Restore(
                 "--verbosity", "verbose",
                 "--disable-parallel",
+                "--infer-runtimes",
                 "--fallbacksource", _corehostPackageSource)
                 .WorkingDirectory(_sharedFrameworkSourceRoot)
                 .Execute()

--- a/build_projects/update-dependencies/project.json
+++ b/build_projects/update-dependencies/project.json
@@ -27,8 +27,5 @@
         "portable-net45+win"
       ]
     }
-  },
-  "runtimes": {
-    "{RID}": {}
   }
 }

--- a/build_projects/update-dependencies/update-dependencies.ps1
+++ b/build_projects/update-dependencies/update-dependencies.ps1
@@ -50,17 +50,10 @@ $env:PATH = "$env:DOTNET_INSTALL_DIR;$env:PATH"
 
 $appPath = "$PSScriptRoot"
 
-# Figure out the RID of the current platform, based on what stage 0 thinks.
-$HOST_RID=(dotnet --info | Select-String -Pattern "\s*RID:\s*(?<rid>.*)").Matches[0].Groups['rid'].Value
-
 # Restore the build scripts
 Write-Host "Restoring Build Script projects..."
 pushd "$PSScriptRoot\.."
-
-(Get-Content "dotnet-host-build\project.json.template").Replace("{RID}", $HOST_RID) | Set-Content "dotnet-host-build\project.json"
-(Get-Content "update-dependencies\project.json.template").Replace("{RID}", $HOST_RID) | Set-Content "update-dependencies\project.json"
-
-dotnet restore
+dotnet restore --infer-runtimes
 if($LASTEXITCODE -ne 0) { throw "Failed to restore" }
 popd
 

--- a/build_projects/update-dependencies/update-dependencies.sh
+++ b/build_projects/update-dependencies/update-dependencies.sh
@@ -59,9 +59,6 @@ curl -sSL "$DOTNET_INSTALL_SCRIPT_URL" | bash /dev/stdin --version 1.0.0-preview
 # Put stage 0 on the PATH (for this shell only)
 PATH="$DOTNET_INSTALL_DIR:$PATH"
 
-# Figure out the RID of the current platform, based on what stage 0 thinks.
-RID=$(dotnet --info | grep 'RID:' | sed -e 's/[[:space:]]*RID:[[:space:]]*\(.*\)/\1/g')
-
 # Increases the file descriptors limit for this bash. It prevents an issue we were hitting during restore
 FILE_DESCRIPTOR_LIMIT=$( ulimit -n )
 if [ $FILE_DESCRIPTOR_LIMIT -lt 1024 ]
@@ -77,10 +74,7 @@ export DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1
 echo "Restoring Build Script projects..."
 (
     pushd "$DIR/.."
-    sed -e "s/{RID}/$RID/g" "dotnet-host-build/project.json.template" > "dotnet-host-build/project.json"
-    sed -e "s/{RID}/$RID/g" "update-dependencies/project.json.template" > "update-dependencies/project.json"
-
-    dotnet restore --disable-parallel
+    dotnet restore --infer-runtimes --disable-parallel
     popd
 )
 

--- a/setuptools/independent/DepsProcessor/project.json
+++ b/setuptools/independent/DepsProcessor/project.json
@@ -21,8 +21,5 @@
         "portable-net45+wp80+win8+wpa81+dnxcore50"
       ]
     }
-  },
-  "runtimes": {
-    "{RID}" : {}
   }
 }


### PR DESCRIPTION
This reverts commit 3e354ac6f6a4efe241928ac03fc5ee740d7c7f61, reversing
changes made to 4e4d0a2046227332678d40c8e80f1b89a74e7956.

It appears that after this change we started to hit some flakyness in
our official builds and the thought is that this commit may have been
the issue.

Reverting for now to try to unblock the official builds and we'll
reapply this once we understand the issue.