### PR TITLE
Remove alpine from official build rid list.

### DIFF
--- a/pkg/projects/netcoreappRIDs.props
+++ b/pkg/projects/netcoreappRIDs.props
@@ -16,7 +16,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <OfficialBuildRID Include="alpine.3.4.3-x64" />
     <OfficialBuildRid Include="debian.8-armel">
       <Platform>armel</Platform>
     </OfficialBuildRid>


### PR DESCRIPTION
alpine isn't supported by corefx, so we can't build core-setup supporting it.

@mellinoe @ericstj @weshaggard @gkhanna79 