### PR TITLE
Fix pack.cmd ERRORLEVEL early exits

### DIFF
--- a/pkg/pack.cmd
+++ b/pkg/pack.cmd
@@ -15,22 +15,24 @@ if /i "%1" == "-portable"             (set __PortableBuildArgs=true&shift&goto A
 
 :: Initialize the MSBuild Tools
 call "%__ProjectDir%\init-tools.cmd"
+if NOT [!ERRORLEVEL!]==[0] goto :Error
 
 :: Restore dependencies mainly to obtain runtime.json
 pushd "%__ProjectDir%\deps"
 "%__DotNet%" restore --configfile "%__ProjectDir%\..\NuGet.Config" --packages "%__ProjectDir%\packages"
+if NOT [!ERRORLEVEL!]==[0] goto :Error
 popd
 
 :: Clean up existing nupkgs
 if exist "%__ProjectDir%\bin" (rmdir /s /q "%__ProjectDir%\bin")
 
 "%__DotNet%" "%__MSBuild%" "%__ProjectDir%\tasks\core-setup.tasks.builds" /verbosity:minimal /flp:logfile=tools.log;v=diag
-if not ERRORLEVEL 0 goto :Error
+if NOT [!ERRORLEVEL!]==[0] goto :Error
 
 :: Package the assets using Tools
 "%__DotNet%" "%__MSBuild%" "%__ProjectDir%\packages.builds" /p:OSGroup=Windows_NT /verbosity:minimal /p:PortableBuild=%__PortableBuildArgs%
+if NOT [!ERRORLEVEL!]==[0] goto :Error
 
-if not ERRORLEVEL 0 goto :Error
 exit /b 0
 
 :Error


### PR DESCRIPTION
`if ERRORLEVEL x` runs if ERRORLEVEL >= x. `if not ERRORLEVEL 0` means ERRORLEVEL < 0, which doesn't detect the error we get. `if ERRORLEVEL 1` is idiomatic in cmd ~~Negative error levels aren't caught, but those aren't normal in cmd.~~ , but to catch negative ERRORLEVEL, use string matching on the ERRORLEVEL variable.

Also added early exits on steps that didn't have one.

This makes it so we can detect issues in pack.cmd rather than only seeing them when they break the build downstream. E.g. https://github.com/dotnet/core-setup/pull/2066