### PR TITLE
Revert "Fix pack.cmd ERRORLEVEL early exits"

### DIFF
--- a/pkg/pack.cmd
+++ b/pkg/pack.cmd
@@ -15,24 +15,22 @@ if /i "%1" == "-portable"             (set __PortableBuildArgs=true&shift&goto A
 
 :: Initialize the MSBuild Tools
 call "%__ProjectDir%\init-tools.cmd"
-if NOT [!ERRORLEVEL!]==[0] goto :Error
 
 :: Restore dependencies mainly to obtain runtime.json
 pushd "%__ProjectDir%\deps"
 "%__DotNet%" restore --configfile "%__ProjectDir%\..\NuGet.Config" --packages "%__ProjectDir%\packages"
-if NOT [!ERRORLEVEL!]==[0] goto :Error
 popd
 
 :: Clean up existing nupkgs
 if exist "%__ProjectDir%\bin" (rmdir /s /q "%__ProjectDir%\bin")
 
 "%__DotNet%" "%__MSBuild%" "%__ProjectDir%\tasks\core-setup.tasks.builds" /verbosity:minimal /flp:logfile=tools.log;v=diag
-if NOT [!ERRORLEVEL!]==[0] goto :Error
+if not ERRORLEVEL 0 goto :Error
 
 :: Package the assets using Tools
 "%__DotNet%" "%__MSBuild%" "%__ProjectDir%\packages.builds" /p:OSGroup=Windows_NT /verbosity:minimal /p:PortableBuild=%__PortableBuildArgs%
-if NOT [!ERRORLEVEL!]==[0] goto :Error
 
+if not ERRORLEVEL 0 goto :Error
 exit /b 0
 
 :Error


### PR DESCRIPTION
Unblocks the build: arm64 builds depend on pack.cmd errors being ignored

This reverts commit d6d8a172fccab36486fa23e17bbe920d2868c21d. (https://github.com/dotnet/core-setup/pull/2067)

We need to figure out what the right fix is to the arm64 builds before putting this back. Right now the ignored errors are causing the arm64 builds to "skip" creating UWP packages.