### PR TITLE
Fix Build break in UWP Arm64

### DIFF
--- a/pkg/packages.builds
+++ b/pkg/packages.builds
@@ -4,6 +4,7 @@
 
   <ItemGroup>
   	<ProjectExclusions Include="$(MSBuildThisFileDirectory)\projects\*\Microsoft.NETCore.UniversalWindowsPlatform.builds" Condition="'$(OSEnvironment)' != 'Windows_NT'" />
+    <ProjectExclusions Include="$(MSBuildThisFileDirectory)\projects\*\Microsoft.NETCore.UniversalWindowsPlatform.builds" Condition="'$(Platform)' == 'arm64'" />
     <Project Include="$(MSBuildThisFileDirectory)\projects\*\*.builds" Exclude="@(ProjectExclusions)" />
   </ItemGroup>
 


### PR DESCRIPTION
Fixes build break in https://devdiv.visualstudio.com/DefaultCollection/DevDiv/_build?_a=summary&buildId=679688 and alleviating the need for https://github.com/dotnet/core-setup/pull/2072

@dagood @joperezr @weshaggard PTAL