### PR TITLE
Updating/repairing the SDK lookup tests

### DIFF
--- a/test/HostActivationTests/GivenThatICareAboutMultilevelSDKLookup.cs
+++ b/test/HostActivationTests/GivenThatICareAboutMultilevelSDKLookup.cs
@@ -22,6 +22,8 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.MultilevelSDKLookup
         private string _exeSelectedMessage;
         private string _sdkDir;
 
+        private const string _dotnetSdkDllMessageTerminator = "dotnet.dll]";
+
         public GivenThatICareAboutMultilevelSDKLookup()
         {
             // From the artifacts dir, it's possible to find where the sharedFrameworkPublish folder is. We need
@@ -191,7 +193,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.MultilevelSDKLookup
                 .Should()
                 .Pass()
                 .And
-                .HaveStdErrContaining(Path.Combine(_userSelectedMessage, "9999.0.0"));
+                .HaveStdErrContaining(Path.Combine(_userSelectedMessage, "9999.0.0", _dotnetSdkDllMessageTerminator));
 
             // Add some dummy versions
             AddAvailableSdkVersions(_cwdSdkBaseDir, "9999.0.0");
@@ -211,7 +213,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.MultilevelSDKLookup
                 .Should()
                 .Pass()
                 .And
-                .HaveStdErrContaining(Path.Combine(_cwdSelectedMessage, "9999.0.0"));
+                .HaveStdErrContaining(Path.Combine(_cwdSelectedMessage, "9999.0.0", _dotnetSdkDllMessageTerminator));
             
             // Add a prerelease dummy version in the cwd
             AddAvailableSdkVersions(_cwdSdkBaseDir, "9999.0.0-global-dummy");
@@ -230,10 +232,115 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.MultilevelSDKLookup
                 .Should()
                 .Pass()
                 .And
-                .HaveStdErrContaining(Path.Combine(_cwdSelectedMessage, "9999.0.0-global-dummy"));
+                .HaveStdErrContaining(Path.Combine(_cwdSelectedMessage, "9999.0.0-global-dummy", _dotnetSdkDllMessageTerminator));
 
             // Remove dummy folders from user dir
             DeleteAvailableSdkVersions(_userSdkBaseDir, "9999.0.0", "9999.0.0-dummy");
+        }
+
+        [Fact]
+        public void SdkLookup_Must_Pick_The_Latest_Semantical_Version()
+        {
+            var fixture = PreviouslyBuiltAndRestoredPortableTestProjectFixture
+                .Copy();
+
+            var dotnet = fixture.BuiltDotnet;
+
+            // Add a dummy version in the exe dir
+            AddAvailableSdkVersions(_exeSdkBaseDir, "9999.0.0");
+
+            // Specified CLI version: none
+            // CWD: empty
+            // User: empty
+            // Exe: 9999.0.0
+            // Expected: 9999.0.0 from exe dir
+            dotnet.Exec("help")
+                .WorkingDirectory(_currentWorkingDir)
+                .EnvironmentVariable("COREHOST_TRACE", "1")
+                .CaptureStdOut()
+                .CaptureStdErr()
+                .Execute()
+                .Should()
+                .Pass()
+                .And
+                .HaveStdErrContaining(Path.Combine(_cwdSelectedMessage, "9999.0.0", _dotnetSdkDllMessageTerminator));
+
+            // Add a dummy version in the exe dir
+            AddAvailableSdkVersions(_exeSdkBaseDir, "9999.0.1");
+
+            // Specified CLI version: none
+            // CWD: empty
+            // User: empty
+            // Exe: 9999.0.0, 9999.0.1
+            // Expected: 9999.0.1 from exe dir
+            dotnet.Exec("help")
+                .WorkingDirectory(_currentWorkingDir)
+                .EnvironmentVariable("COREHOST_TRACE", "1")
+                .CaptureStdOut()
+                .CaptureStdErr()
+                .Execute()
+                .Should()
+                .Pass()
+                .And
+                .HaveStdErrContaining(Path.Combine(_cwdSelectedMessage, "9999.0.1", _dotnetSdkDllMessageTerminator));
+
+            // Add a dummy version in the exe dir
+            AddAvailableSdkVersions(_exeSdkBaseDir, "9999.0.0-dummy");
+
+            // Specified CLI version: none
+            // CWD: empty
+            // User: empty
+            // Exe: 9999.0.0, 9999.0.1, 9999.0.0-dummy
+            // Expected: 9999.0.1 from exe dir
+            dotnet.Exec("help")
+                .WorkingDirectory(_currentWorkingDir)
+                .EnvironmentVariable("COREHOST_TRACE", "1")
+                .CaptureStdOut()
+                .CaptureStdErr()
+                .Execute()
+                .Should()
+                .Pass()
+                .And
+                .HaveStdErrContaining(Path.Combine(_cwdSelectedMessage, "9999.0.1", _dotnetSdkDllMessageTerminator));
+
+            // Add a dummy version in the exe dir
+            AddAvailableSdkVersions(_exeSdkBaseDir, "10000.0.0-dummy");
+
+            // Specified CLI version: none
+            // CWD: empty
+            // User: empty
+            // Exe: 9999.0.0, 9999.0.1, 9999.0.0-dummy, 10000.0.0-dummy
+            // Expected: 10000.0.0-dummy from exe dir
+            dotnet.Exec("help")
+                .WorkingDirectory(_currentWorkingDir)
+                .EnvironmentVariable("COREHOST_TRACE", "1")
+                .CaptureStdOut()
+                .CaptureStdErr()
+                .Execute()
+                .Should()
+                .Pass()
+                .And
+                .HaveStdErrContaining(Path.Combine(_cwdSelectedMessage, "10000.0.0-dummy", _dotnetSdkDllMessageTerminator));
+
+            // Add a dummy version in the exe dir
+            AddAvailableSdkVersions(_exeSdkBaseDir, "10000.0.0");
+
+            // Specified CLI version: none
+            // CWD: empty
+            // User: empty
+            // Exe: 9999.0.0, 9999.0.1, 9999.0.0-dummy, 10000.0.0-dummy, 10000.0.0
+            // Expected: 10000.0.0 from exe dir
+            dotnet.Exec("help")
+                .WorkingDirectory(_currentWorkingDir)
+                .EnvironmentVariable("COREHOST_TRACE", "1")
+                .CaptureStdOut()
+                .CaptureStdErr()
+                .Execute()
+                .Should()
+                .Pass()
+                .And
+                .HaveStdErrContaining(Path.Combine(_cwdSelectedMessage, "10000.0.0", _dotnetSdkDllMessageTerminator));
+
         }
 
         // This method adds a list of new sdk version folders in the specified

--- a/test/HostActivationTests/GivenThatICareAboutMultilevelSDKLookup.cs
+++ b/test/HostActivationTests/GivenThatICareAboutMultilevelSDKLookup.cs
@@ -239,7 +239,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.MultilevelSDKLookup
         }
 
         [Fact]
-        public void SdkLookup_Must_Pick_The_Latest_Semantical_Version()
+        public void SdkLookup_Must_Pick_The_Highest_Semantical_Version()
         {
             var fixture = PreviouslyBuiltAndRestoredPortableTestProjectFixture
                 .Copy();
@@ -263,7 +263,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.MultilevelSDKLookup
                 .Should()
                 .Pass()
                 .And
-                .HaveStdErrContaining(Path.Combine(_cwdSelectedMessage, "9999.0.0", _dotnetSdkDllMessageTerminator));
+                .HaveStdErrContaining(Path.Combine(_exeSelectedMessage, "9999.0.0", _dotnetSdkDllMessageTerminator));
 
             // Add a dummy version in the exe dir
             AddAvailableSdkVersions(_exeSdkBaseDir, "9999.0.1");
@@ -282,7 +282,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.MultilevelSDKLookup
                 .Should()
                 .Pass()
                 .And
-                .HaveStdErrContaining(Path.Combine(_cwdSelectedMessage, "9999.0.1", _dotnetSdkDllMessageTerminator));
+                .HaveStdErrContaining(Path.Combine(_exeSelectedMessage, "9999.0.1", _dotnetSdkDllMessageTerminator));
 
             // Add a dummy version in the exe dir
             AddAvailableSdkVersions(_exeSdkBaseDir, "9999.0.0-dummy");
@@ -301,7 +301,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.MultilevelSDKLookup
                 .Should()
                 .Pass()
                 .And
-                .HaveStdErrContaining(Path.Combine(_cwdSelectedMessage, "9999.0.1", _dotnetSdkDllMessageTerminator));
+                .HaveStdErrContaining(Path.Combine(_exeSelectedMessage, "9999.0.1", _dotnetSdkDllMessageTerminator));
 
             // Add a dummy version in the exe dir
             AddAvailableSdkVersions(_exeSdkBaseDir, "10000.0.0-dummy");
@@ -320,7 +320,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.MultilevelSDKLookup
                 .Should()
                 .Pass()
                 .And
-                .HaveStdErrContaining(Path.Combine(_cwdSelectedMessage, "10000.0.0-dummy", _dotnetSdkDllMessageTerminator));
+                .HaveStdErrContaining(Path.Combine(_exeSelectedMessage, "10000.0.0-dummy", _dotnetSdkDllMessageTerminator));
 
             // Add a dummy version in the exe dir
             AddAvailableSdkVersions(_exeSdkBaseDir, "10000.0.0");
@@ -339,7 +339,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.MultilevelSDKLookup
                 .Should()
                 .Pass()
                 .And
-                .HaveStdErrContaining(Path.Combine(_cwdSelectedMessage, "10000.0.0", _dotnetSdkDllMessageTerminator));
+                .HaveStdErrContaining(Path.Combine(_exeSelectedMessage, "10000.0.0", _dotnetSdkDllMessageTerminator));
 
         }
 

--- a/test/HostActivationTests/GivenThatICareAboutMultilevelSDKLookup.cs
+++ b/test/HostActivationTests/GivenThatICareAboutMultilevelSDKLookup.cs
@@ -239,7 +239,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.MultilevelSDKLookup
         }
 
         [Fact]
-        public void SdkLookup_Must_Pick_The_Highest_Semantical_Version()
+        public void SdkLookup_Must_Pick_The_Highest_Semantic_Version()
         {
             var fixture = PreviouslyBuiltAndRestoredPortableTestProjectFixture
                 .Copy();


### PR DESCRIPTION
1. Fixing the: 'SdkLookup_Must_Look_For_Available_Versions_Before_Looking_Into_Another_Folder' test to be deterministic.
2. Adding semantical version tests.

A follow-up PR to: https://github.com/dotnet/core-setup/pull/2055
https://github.com/dotnet/cli/issues/6339

@dotnet/dotnet-cli