### PR TITLE
Remove CentOS from CI & Pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,6 @@ Daily Builds
 |   **Ubuntu 16.04 (arm32)**   |   [![][ubuntu-16.04-arm-badge-master]][ubuntu-16.04-arm-version-master]<br>[tar.gz][ubuntu-16.04-arm-targz-master]<br>[Symbols (tar.gz)][ubuntu-16.04-arm-symbols-targz-master]   |   N/A   |   N/A   |
 |   **Ubuntu 16.10 (x64)**   |   [![][ubuntu-16.10-badge-master]][ubuntu-16.10-version-master]<br>[Host][ubuntu-16.10-host-master]<br>[Host FX Resolver][ubuntu-16.10-hostfxr-master]<br>[Shared Framework][ubuntu-16.10-sharedfx-master]<br>[tar.gz][ubuntu-16.10-targz-master]<br>[Symbols (tar.gz)][ubuntu-16.10-symbols-targz-master]   |   [![][ubuntu-16.10-badge-1.1.X]][ubuntu-16.10-version-1.1.X]<br>[Host][ubuntu-16.10-host-1.1.X]<br>[Host FX Resolver][ubuntu-16.10-hostfxr-1.1.X]<br>[Shared Framework][ubuntu-16.10-sharedfx-1.1.X]<br>[tar.gz][ubuntu-16.10-targz-1.1.X]   |   N/A   |
 |   **Debian 8.2 (x64)**     |   [![][debian-8.2-badge-master]][debian-8.2-version-master]<br>[Host][debian-8.2-host-master]<br>[Host FX Resolver][debian-8.2-hostfxr-master]<br>[Shared Framework][debian-8.2-sharedfx-master]<br>[tar.gz][debian-8.2-targz-master]<br>[Symbols (tar.gz)][debian-8.2-symbols-targz-master]   |   [![][debian-8.2-badge-1.1.X]][debian-8.2-version-1.1.X]<br>[Host][debian-8.2-host-1.1.X]<br>[Host FX Resolver][debian-8.2-hostfxr-1.1.X]<br>[Shared Framework][debian-8.2-sharedfx-1.1.X]<br>[tar.gz][debian-8.2-targz-1.1.X]   |   [![][debian-8.2-badge-preview]][debian-8.2-version-preview]<br>[Host][debian-8.2-host-preview]<br>[Host FX Resolver][debian-8.2-hostfxr-preview]<br>[Shared Framework][debian-8.2-sharedfx-preview]<br>[tar.gz][debian-8.2-targz-preview]   |
-|   **CentOS 7.1 (x64)**     |   [![][centos-badge-master]][centos-version-master]<br>[tar.gz][centos-targz-master]<br>[Symbols (tar.gz)][centos-symbols-targz-master]   |   [![][centos-badge-1.1.X]][centos-version-1.1.X]<br>[tar.gz][centos-targz-1.1.X]   |   [![][centos-badge-preview]][centos-version-preview]<br>[tar.gz][centos-targz-preview]   |
 |   **RHEL 7.2 (x64)**       |   [![][rhel-badge-master]][rhel-version-master]<br>[tar.gz][rhel-targz-master]<br>[Symbols (tar.gz)][rhel-symbols-targz-master]   |   [![][rhel-badge-1.1.X]][rhel-version-1.1.X]<br>[tar.gz][rhel-targz-1.1.X]   |   [![][rhel-badge-preview]][rhel-version-preview]<br>[tar.gz][rhel-targz-preview]   |
 |   **Fedora 23 (x64)**      |   N/A   |   [![][fedora-23-badge-1.1.X]][fedora-23-version-1.1.X]<br>[tar.gz][fedora-23-targz-1.1.X]   |   [![][fedora-23-badge-preview]][fedora-23-version-preview]<br>[tar.gz][fedora-23-targz-preview]   |
 |   **Fedora 24 (x64)**      |   [![][fedora-24-badge-master]][fedora-24-version-master]<br>[tar.gz][fedora-24-targz-master]<br>[Symbols (tar.gz)][fedora-24-symbols-targz-master]   |   [![][fedora-24-badge-1.1.X]][fedora-24-version-1.1.X]<br>[tar.gz][fedora-24-targz-1.1.X]   |   N/A   |
@@ -282,20 +281,6 @@ Daily Builds
 [debian-8.2-hostfxr-preview]: https://dotnetcli.blob.core.windows.net/dotnet/preview/Installers/Latest/dotnet-hostfxr-debian-x64.latest.deb
 [debian-8.2-sharedfx-preview]: https://dotnetcli.blob.core.windows.net/dotnet/preview/Installers/Latest/dotnet-sharedframework-debian-x64.latest.deb
 [debian-8.2-targz-preview]: https://dotnetcli.blob.core.windows.net/dotnet/preview/Binaries/Latest/dotnet-debian-x64.latest.tar.gz
-
-
-[centos-badge-master]: https://dotnetcli.blob.core.windows.net/dotnet/master/Binaries/Latest/sharedfx_CentOS_x64_Release_version_badge.svg
-[centos-version-master]: https://dotnetcli.blob.core.windows.net/dotnet/master/dnvm/latest.sharedfx.centos.x64.version
-[centos-targz-master]: https://dotnetcli.blob.core.windows.net/dotnet/master/Binaries/Latest/dotnet-centos-x64.latest.tar.gz
-[centos-symbols-targz-master]: https://dotnetcli.blob.core.windows.net/dotnet/master/Binaries/Latest/dotnet-sharedframework-symbols-centos-x64.latest.tar.gz
-
-[centos-badge-1.1.X]: https://dotnetcli.blob.core.windows.net/dotnet/release/1.1.0/Binaries/Latest/sharedfx_CentOS_x64_Release_version_badge.svg
-[centos-version-1.1.X]: https://dotnetcli.blob.core.windows.net/dotnet/release/1.1.0/dnvm/latest.sharedfx.centos.x64.version
-[centos-targz-1.1.X]: https://dotnetcli.blob.core.windows.net/dotnet/release/1.1.0/Binaries/Latest/dotnet-centos-x64.latest.tar.gz
-
-[centos-badge-preview]: https://dotnetcli.blob.core.windows.net/dotnet/preview/Binaries/Latest/sharedfx_CentOS_x64_Release_version_badge.svg
-[centos-version-preview]: https://dotnetcli.blob.core.windows.net/dotnet/preview/dnvm/latest.sharedfx.centos.x64.version
-[centos-targz-preview]: https://dotnetcli.blob.core.windows.net/dotnet/preview/Binaries/Latest/dotnet-centos-x64.latest.tar.gz
 
 
 [rhel-badge-master]: https://dotnetcli.blob.core.windows.net/dotnet/master/Binaries/Latest/sharedfx_RHEL_x64_Release_version_badge.svg

--- a/buildpipeline/pipeline.json
+++ b/buildpipeline/pipeline.json
@@ -18,17 +18,6 @@
         {
           "Name": "Core-Setup-Linux",
           "Parameters": {
-            "PB_DockerOS": "centos.7"
-          },
-          "ReportingParameters": {
-            "OperatingSystem": "CentOS 7.1",
-            "Type": "build/product/",
-            "Platform": "x64"
-          }
-        },
-        {
-          "Name": "Core-Setup-Linux",
-          "Parameters": {
             "PB_DockerOS": "debian.8",
             "REPO_ID": "579f8fb0fedca9aeeb399132",
             "REPO_USER": "dotnet",


### PR DESCRIPTION
The CMake mirror specified at https://github.com/dotnet/core-setup/blob/master/scripts/docker/centos.7/Dockerfile#L26 is no longer active, which breaks CentOS builds. We're going to be moving away from Core-Setup's docker files & towards using the checked-in Docker Images anyways, so we should disable CentOS for now.

CC @gkhanna79 @Petermarcu @ellismg who might have a stake in CentOS staying alive