### PR TITLE
[release/1.0.0] Update CentOS cmake mirror: symnds.com is down

### DIFF
--- a/scripts/docker/centos.7/Dockerfile
+++ b/scripts/docker/centos.7/Dockerfile
@@ -23,7 +23,8 @@ RUN yum -q -y install unzip libunwind gettext libcurl-devel openssl-devel zlib l
 
 # Install Build Prereqs
 # CMake 3.3.2 from GhettoForge; LLVM 3.6.2 built from source ourselves;
-RUN yum install -y http://mirror.symnds.com/distributions/gf/el/7/plus/x86_64/cmake-3.3.2-1.gf.el7.x86_64.rpm \
+RUN yum install -y \
+        https://matell.blob.core.windows.net/rpms/cmake-3.3.2-1.gf.el7.x86_64.rpm \
         https://matell.blob.core.windows.net/rpms/clang-3.6.2-1.el7.centos.x86_64.rpm \
         https://matell.blob.core.windows.net/rpms/clang-libs-3.6.2-1.el7.centos.x86_64.rpm \
         https://matell.blob.core.windows.net/rpms/lldb-3.6.2-1.el7.centos.x86_64.rpm \


### PR DESCRIPTION
According to https://mirror-status.centos.org, http://mirror.symnds.com has been down for 20 hours. This is blocking servicing builds. ~~I found another mirror that seems to have the same package--see https://centos.pkgs.org/7/ghettoforge-plus-x86_64/cmake-3.3.2-1.gf.el7.x86_64.rpm.html.~~ This uses @ellismg's blob storage mirror of the package.

Related: https://github.com/dotnet/core-setup/pull/2087, which removed CentOS builds in `master`. We can't do that in the servicing branch without dropping support for CentOS.