### PR TITLE
Revert "Revert "Build Native Debian installers consuming Portable Linux binaries (#2027)

### DIFF
--- a/build_projects/dotnet-host-build/PrepareTargets.cs
+++ b/build_projects/dotnet-host-build/PrepareTargets.cs
@@ -127,6 +127,7 @@ namespace Microsoft.DotNet.Host.Build
                 Environment.SetEnvironmentVariable("TARGETRID", targetRID);
             }
 
+            string portableBuildStagingLocation = Environment.GetEnvironmentVariable("PORTABLE_BUILD_STAGING_LOCATION")?.Trim();
 
             c.BuildContext["TargetRID"] = targetRID;
 
@@ -135,6 +136,7 @@ namespace Microsoft.DotNet.Host.Build
             c.BuildContext["ArtifactsTargetRID"] = realTargetRID; 
             c.BuildContext["LinkPortable"] = linkPortable;
             c.BuildContext["Platform"] = platformEnv;
+            c.BuildContext["PortableBuildStagingLocation"] = portableBuildStagingLocation;
 
             return c.Success();
         }

--- a/build_projects/dotnet-host-build/PublishTargets.cs
+++ b/build_projects/dotnet-host-build/PublishTargets.cs
@@ -58,6 +58,16 @@ namespace Microsoft.DotNet.Host.Build
             return c.Success();
         }
 
+        [Target(nameof(PrepareTargets.Init),
+        nameof(PublishTargets.InitPublish),
+        nameof(PublishTargets.PublishInstallerArtifacts),
+        nameof(PublishTargets.FinalizeBuild))]
+        [Environment("PUBLISH_TO_AZURE_BLOB", "1", "true")] // This is set by CI systems
+        public static BuildTargetResult PublishInstallers(BuildTargetContext c)
+        {
+            return c.Success();
+        }
+
         [Target]
         [BuildPlatforms(BuildPlatform.Ubuntu, "14.04")]
         [BuildArchitectures(BuildArchitecture.x64)]
@@ -286,6 +296,13 @@ namespace Microsoft.DotNet.Host.Build
             nameof(PublishTargets.PublishManagedPackages),
             nameof(PublishTargets.PublishSharedFrameworkVersionBadge))]
         public static BuildTargetResult PublishArtifacts(BuildTargetContext c) => c.Success();
+
+        [Target(
+            nameof(PublishTargets.PublishInstallerFilesToAzure),
+            nameof(PublishTargets.PublishDotnetDebToolPackage),
+            nameof(PublishTargets.PublishDebFilesToDebianRepo),
+            nameof(PublishTargets.PublishSharedFrameworkVersionBadge))]
+        public static BuildTargetResult PublishInstallerArtifacts(BuildTargetContext c) => c.Success();
 
         [Target(
             nameof(PublishTargets.PublishSharedHostInstallerFileToAzure),

--- a/buildpipeline/Core-Setup-PortableLinux-x64.json
+++ b/buildpipeline/Core-Setup-PortableLinux-x64.json
@@ -97,6 +97,178 @@
     },
     {
       "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Copy built Portable binaries to staging directory",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "5bfb729a-a7c8-4a78-a7c3-8d717bb7c13c",
+        "versionSpec": "2.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "SourceFolder": "$(Build.SourcesDirectory)/artifacts/linux-x64/intermediate/sharedFrameworkPublish",
+        "Contents": "**",
+        "TargetFolder": "$(Build.StagingDirectory)/sharedFrameworkPublish",
+        "CleanTargetFolder": "false",
+        "OverWrite": "false",
+        "flattenFolders": "false"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Build Ubuntu.14.04 docker image",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "6c731c3c-3c68-459a-a5c9-bde6e6595b5b",
+        "versionSpec": "2.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "scriptPath": "scripts/dockerbuild.sh",
+        "args": "-d $(Build.SourcesDirectory)/scripts/docker/ubuntu.14.04 -t ubuntu.14.04-coresetup",
+        "disableAutoCwd": "false",
+        "cwd": "",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Build Debian Installer in Ubuntu.14.04 docker container",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "6c731c3c-3c68-459a-a5c9-bde6e6595b5b",
+        "versionSpec": "2.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "scriptPath": "scripts/dockerrun-as-current-user.sh",
+        "args": "--rm $(DockerBuildEnvironmentVariables) -e CLI_NUGET_API_KEY -e CLI_NUGET_FEED_URL -e CLI_NUGET_SYMBOLS_FEED_URL -v $(Build.SourcesDirectory):/opt/code/ -v $(Build.StagingDirectory)/sharedFrameworkPublish/:/opt/sharedFrameworkPublish/ -w /opt/code ubuntu.14.04-coresetup /bin/bash -c \"HOME=/opt/code; git clean -X -d -f; ./build.sh --skip-prereqs --configuration Release --targets $(InstallerOnlyBuildArguments)\"",
+        "disableAutoCwd": "false",
+        "cwd": "",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Build Ubuntu.16.04 docker image",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "6c731c3c-3c68-459a-a5c9-bde6e6595b5b",
+        "versionSpec": "2.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "scriptPath": "scripts/dockerbuild.sh",
+        "args": "-d $(Build.SourcesDirectory)/scripts/docker/ubuntu.16.04 -t ubuntu.16.04-coresetup",
+        "disableAutoCwd": "false",
+        "cwd": "",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Build Debian Installer in Ubuntu.16.04 docker container",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "6c731c3c-3c68-459a-a5c9-bde6e6595b5b",
+        "versionSpec": "2.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "scriptPath": "scripts/dockerrun-as-current-user.sh",
+        "args": "--rm $(DockerBuildEnvironmentVariables) -v $(Build.SourcesDirectory):/opt/code/ -v $(Build.StagingDirectory)/sharedFrameworkPublish/:/opt/sharedFrameworkPublish/ -w /opt/code ubuntu.16.04-coresetup /bin/bash -c \"HOME=/opt/code; git clean -X -d -f; ./build.sh --skip-prereqs --configuration Release --targets $(InstallerOnlyBuildArguments)\"",
+        "disableAutoCwd": "false",
+        "cwd": "",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Build Ubuntu.16.10 docker image",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "6c731c3c-3c68-459a-a5c9-bde6e6595b5b",
+        "versionSpec": "2.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "scriptPath": "scripts/dockerbuild.sh",
+        "args": "-d $(Build.SourcesDirectory)/scripts/docker/ubuntu.16.10 -t ubuntu.16.10-coresetup",
+        "disableAutoCwd": "false",
+        "cwd": "",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Build Debian Installer in Ubuntu 16.10 docker container",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "6c731c3c-3c68-459a-a5c9-bde6e6595b5b",
+        "versionSpec": "2.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "scriptPath": "scripts/dockerrun-as-current-user.sh",
+        "args": "--rm $(DockerBuildEnvironmentVariables) -v $(Build.SourcesDirectory):/opt/code/ -v $(Build.StagingDirectory)/sharedFrameworkPublish/:/opt/sharedFrameworkPublish/ -w /opt/code ubuntu.16.10-coresetup /bin/bash -c \"HOME=/opt/code; git clean -X -d -f; ./build.sh --skip-prereqs --configuration Release --targets $(InstallerOnlyBuildArguments)\"",
+        "disableAutoCwd": "false",
+        "cwd": "",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Build Debian.8 docker image ",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "6c731c3c-3c68-459a-a5c9-bde6e6595b5b",
+        "versionSpec": "2.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "scriptPath": "scripts/dockerbuild.sh",
+        "args": "-d $(Build.SourcesDirectory)/scripts/docker/debian.8 -t debian.8-coresetup",
+        "disableAutoCwd": "false",
+        "cwd": "",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Build Debian Installer in Debian.8 docker container",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "6c731c3c-3c68-459a-a5c9-bde6e6595b5b",
+        "versionSpec": "2.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "scriptPath": "scripts/dockerrun-as-current-user.sh",
+        "args": "--rm $(DockerBuildEnvironmentVariables) -v $(Build.SourcesDirectory):/opt/code/ -v $(Build.StagingDirectory)/sharedFrameworkPublish/:/opt/sharedFrameworkPublish/ -w /opt/code debian.8-coresetup /bin/bash -c \"HOME=/opt/code; git clean -X -d -f; ./build.sh --skip-prereqs --configuration Release --targets $(InstallerOnlyBuildArguments)\"",
+        "disableAutoCwd": "false",
+        "cwd": "",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "enabled": true,
       "continueOnError": true,
       "alwaysRun": true,
       "displayName": "Cleanup Docker",
@@ -241,6 +413,33 @@
     },
     "NUGET_SYMBOLS_FEED_URL": {
       "value": "https://dotnet.myget.org/F/dotnet-core/symbols/api/v2/package"
+    },
+    "REPO_ID": {
+      "value": "579f8fb0fedca9aeeb399132"
+    },
+    "REPO_USER": {
+      "value": "dotnet"
+    },
+    "REPO_PASS": {
+      "value": "PassedViaPipeBuild"
+    },
+    "REPO_SERVER": {
+      "value": "azure-apt-cat.cloudapp.net"
+    },
+    "DockerBuildEnvironmentVariables": {
+      "value": "-e PORTABLE_BUILD_STAGING_LOCATION=/opt/sharedFrameworkPublish -e CONNECTION_STRING -e PUBLISH_TO_AZURE_BLOB -e REPO_ID -e REPO_USER -e REPO_PASS -e REPO_SERVER -e NUGET_FEED_URL -e NUGET_API_KEY -e NUGET_SYMBOLS_FEED_URL -e GITHUB_PASSWORD"
+    },
+    "InstallerOnlyBuildArguments": {
+      "value": "Init,Prepare,InitPackage,GenerateVersionBadge,GenerateInstaller,TestInstaller,PublishInstallers"
+    },
+    "CLI_NUGET_API_KEY": {
+      "value": "PassedViaPipeBuild"
+    },
+    "CLI_NUGET_FEED_URL": {
+      "value": "https://dotnet.myget.org/F/cli-deps/api/v2/package"
+    },
+    "CLI_NUGET_SYMBOLS_FEED_URL": {
+      "value": "https://dotnet.myget.org/F/cli-deps/symbols/api/v2/package"
     }
   },
   "demands": [
@@ -265,6 +464,7 @@
   "buildNumberFormat": "$(Date:yyyMMdd)$(Rev:.r)",
   "jobAuthorizationScope": "projectCollection",
   "jobTimeoutInMinutes": 90,
+  "jobCancelTimeoutInMinutes": 5,
   "badgeEnabled": true,
   "repository": {
     "properties": {
@@ -288,23 +488,23 @@
   },
   "quality": "definition",
   "queue": {
+    "id": 36,
+    "name": "DotNet-Build",
     "pool": {
       "id": 39,
       "name": "DotNet-Build"
-    },
-    "id": 36,
-    "name": "DotNet-Build"
+    }
   },
-  "path": "\\",
-  "type": "build",
   "id": 4573,
   "name": "Core-Setup-PortableLinux-x64",
+  "path": "\\",
+  "type": "build",
   "project": {
     "id": "0bdbc590-a062-4c3f-b0f6-9383f67865ee",
     "name": "DevDiv",
     "description": "Visual Studio and DevDiv team project for git source code repositories.  Work items will be added for Adams, Dev14 work items are tracked in vstfdevdiv.  ",
     "url": "https://devdiv.visualstudio.com/DefaultCollection/_apis/projects/0bdbc590-a062-4c3f-b0f6-9383f67865ee",
     "state": "wellFormed",
-    "revision": 418097620
+    "revision": 418097642
   }
 }

--- a/buildpipeline/pipeline.json
+++ b/buildpipeline/pipeline.json
@@ -18,20 +18,6 @@
         {
           "Name": "Core-Setup-Linux",
           "Parameters": {
-            "PB_DockerOS": "debian.8",
-            "REPO_ID": "579f8fb0fedca9aeeb399132",
-            "REPO_USER": "dotnet",
-            "REPO_SERVER": "azure-apt-cat.cloudapp.net"
-          },
-          "ReportingParameters": {
-            "OperatingSystem": "Debian 8.2",
-            "Type": "build/product/",
-            "Platform": "x64"
-          }
-        },
-        {
-          "Name": "Core-Setup-Linux",
-          "Parameters": {
             "PB_DockerOS": "fedora.24"
           },
           "ReportingParameters": {
@@ -47,50 +33,6 @@
           },
           "ReportingParameters": {
             "OperatingSystem": "OpenSuse 42.1",
-            "Type": "build/product/",
-            "Platform": "x64"
-          }
-        },
-        {
-          "Name": "Core-Setup-Linux",
-          "Parameters": {
-            "PB_DockerOS": "ubuntu.14.04",
-            "REPO_ID": "562fbfe0b2d7d0e0a43780c4",
-            "REPO_USER": "dotnet",
-            "REPO_SERVER": "azure-apt-cat.cloudapp.net",
-            "CLI_NUGET_FEED_URL": "https://dotnet.myget.org/F/cli-deps/api/v2/package",
-            "CLI_NUGET_SYMBOLS_FEED_URL": "https://dotnet.myget.org/F/cli-deps/symbols/api/v2/package"
-          },
-          "ReportingParameters": {
-            "OperatingSystem": "Ubuntu 14.04",
-            "Type": "build/product/",
-            "Platform": "x64"
-          }
-        },
-        {
-          "Name": "Core-Setup-Linux",
-          "Parameters": {
-            "PB_DockerOS": "ubuntu.16.04",
-            "REPO_ID": "575f40f3797ef7280505232f",
-            "REPO_USER": "dotnet",
-            "REPO_SERVER": "azure-apt-cat.cloudapp.net"
-          },
-          "ReportingParameters": {
-            "OperatingSystem": "Ubuntu 16.04",
-            "Type": "build/product/",
-            "Platform": "x64"
-          }
-        },
-        {
-          "Name": "Core-Setup-Linux",
-          "Parameters": {
-            "PB_DockerOS": "ubuntu.16.10",
-            "REPO_ID": "575f40f3797ef7280505232f",
-            "REPO_USER": "dotnet",
-            "REPO_SERVER": "azure-apt-cat.cloudapp.net"
-          },
-          "ReportingParameters": {
-            "OperatingSystem": "Ubuntu 16.10",
             "Type": "build/product/",
             "Platform": "x64"
           }

--- a/scripts/dockerbuild.sh
+++ b/scripts/dockerbuild.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) .NET Foundation and contributors. All rights reserved.
+# Licensed under the MIT license. See LICENSE file in the project root for full license information.
+#
+
+set -e
+
+SOURCE="${BASH_SOURCE[0]}"
+while [ -h "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symlink
+  DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
+  SOURCE="$(readlink "$SOURCE")"
+  [[ "$SOURCE" != /* ]] && SOURCE="$DIR/$SOURCE" # if $SOURCE was a relative symlink, we need to resolve it relative to the path where the symlink file was located
+done
+DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
+
+cd "$DIR/.."
+
+while [[ $# > 0 ]]; do
+    key=$1
+
+    case $key in
+        -t|--tag)
+            DOCKER_TAG=$2
+            shift
+            ;;
+        -d|--dockerfile)
+            DOCKERFILE=$2
+            shift
+            ;;
+        -h|-?|--help)
+            echo "Usage: $0 [-d|--dockerfile <Dockerfile>] [-t|--tag <Tag>] <Command>"
+            echo ""
+            echo "Options:"
+            echo "  <Dockerfile>    The path to the folder that contains a Dockerfile to use to create the build container"
+            echo "  <Tag>           The name of docker image tag"
+            exit 0
+            ;;
+        *)
+            break # the first non-switch we get ends parsing
+            ;;
+    esac
+
+    shift
+done
+
+# Executes a command and retries if it fails.
+# NOTE: This function is the exact copy from init-docker.sh.
+# Reason for not invoking init.docker.sh directly is since that script 
+# also performs cleanup, which we do not want in this case.
+execute() {
+    local count=0
+    local retries=5
+    local waitFactor=6
+    until "$@"; do
+        local exit=$?
+        count=$(( $count + 1 ))
+        if [ $count -lt $retries ]; then
+            local wait=$(( waitFactor ** (( count - 1 )) ))
+            echo "Retry $count/$retries exited $exit, retrying in $wait seconds..."
+            sleep $wait
+        else    
+            say_err "Retry $count/$retries exited $exit, no more retries left."
+            return $exit
+        fi
+    done
+
+    return 0
+}
+
+# Build the docker container (will be fast if it is already built)
+echo "Building Docker Container using Dockerfile: $DOCKERFILE"
+
+# Get the name of Docker image.
+image=$(grep -i "^FROM " "$DOCKERFILE/Dockerfile" | awk '{ print $2 }')
+
+# Explicitly pull the base image with retry logic. 
+# This eliminates intermittent failures during docker build caused by failing to retrieve the base image.
+if [ ! -z "$image" ]; then
+    echo "Pulling Docker image $image"
+    execute docker pull $image
+fi
+
+docker build --build-arg USER_ID=$(id -u) -t $DOCKER_TAG $DOCKERFILE


### PR DESCRIPTION
Brining back the original commit as it is confirmed the flakiness in system was due to myget.org known issue and https://github.com/dotnet/core-setup/commit/fd51d23c54afcba9624d490ca926006d4d7c1cab 
This reverts commit e9456614cfe65b6dc7c5326a597337159142c84c.

