### PR TITLE
Remove Centos entry from expected list of published package badge

### DIFF
--- a/build_projects/dotnet-host-build/PublishTargets.cs
+++ b/build_projects/dotnet-host-build/PublishTargets.cs
@@ -155,7 +155,6 @@ namespace Microsoft.DotNet.Host.Build
                         "osx.x64.portable.version",
                         "debian.8.armel.version",
                         "debian.x64.version",
-                        "centos.x64.version",
                         "fedora.24.x64.version",
                         "opensuse.42.1.x64.version"
                     };
@@ -238,7 +237,6 @@ namespace Microsoft.DotNet.Host.Build
                  { "sharedfx_osx_portable_x64", false },
                  // { "sharedfx_Debian_8_armel", false },
                  { "sharedfx_Debian_x64", false },
-                 { "sharedfx_CentOS_x64", false },
                  { "sharedfx_Fedora_24_x64", false },
                  { "sharedfx_openSUSE_42_1_x64", false }
              };


### PR DESCRIPTION

FinalizeBuild step is skipped with below message :

FinalizeBuild                                              (Microsoft.DotNet.Host.Build.PublishTargets.FinalizeBuild)
2017-04-19T22:16:32.3717000Z Not all builds complete, badge not found: sharedfx_CentOS_x64

This change will complete the intended fix for :
https://github.com/dotnet/core-setup/pull/2087

Finalize step expects the listed badges and since centos are not being built anymore, it should not have entry in the list of expected badge list .Finalize step is marked as complete with below message :
