### PR TITLE
Specify portable RID for Windows build for binaries to be signed.

### DIFF
--- a/buildpipeline/Core-Setup-Signing-Windows-x64.json
+++ b/buildpipeline/Core-Setup-Signing-Windows-x64.json
@@ -484,7 +484,8 @@
       "value": "400"
     },
     "RID": {
-      "value": "win81-x64"
+      "value": "win81-x64",
+      "allowOverride": true
     },
     "MsbuildSigningArguments": {
       "value": "/p:RID=$(RID) /p:CertificateId=$(CertificateId) /v:detailed"

--- a/buildpipeline/Core-Setup-Signing-Windows-x86.json
+++ b/buildpipeline/Core-Setup-Signing-Windows-x86.json
@@ -457,7 +457,8 @@
       "value": "400"
     },
     "RID": {
-      "value": "win81-x86"
+      "value": "win81-x86",
+      "allowOverride": true
     },
     "PB_PortableBuild": {
       "value": "",

--- a/buildpipeline/pipeline.json
+++ b/buildpipeline/pipeline.json
@@ -150,7 +150,8 @@
         {
           "Name": "Core-Setup-Signing-Windows-x64",
           "Parameters": {
-            "PB_PortableBuild": "-portable"
+            "PB_PortableBuild": "-portable",
+            "RID": "win-x64"
           },
           "ReportingParameters": {
             "OperatingSystem": "Windows",
@@ -170,7 +171,8 @@
         {
           "Name": "Core-Setup-Signing-Windows-x86",
           "Parameters": {
-            "PB_PortableBuild": "-portable"
+            "PB_PortableBuild": "-portable",
+            "RID": "win-x86"
           },
           "ReportingParameters": {
             "OperatingSystem": "Windows",


### PR DESCRIPTION
@eerhardt PTAL.

This should specify the correct RID to be used for signing purposes (specified at https://github.com/dotnet/core-setup/blob/master/buildpipeline/Core-Setup-Signing-Windows-x64.json#L490) for portable builds.