### PR TITLE
Have Windows x64 build depend on all other builds

### DIFF
--- a/buildpipeline/pipeline.json
+++ b/buildpipeline/pipeline.json
@@ -139,17 +139,6 @@
         {
           "Name": "Core-Setup-Signing-Windows-x64",
           "Parameters": {
-            "SIGNED_PACKAGES": "true"
-          },
-          "ReportingParameters": {
-            "OperatingSystem": "Windows",
-            "Type": "build/product/",
-            "Platform": "x64"
-          }
-        },
-        {
-          "Name": "Core-Setup-Signing-Windows-x64",
-          "Parameters": {
             "PB_PortableBuild": "-portable",
             "RID": "win-x64"
           },
@@ -259,6 +248,31 @@
             "Platform": "arm64"
           }
         }
+      ]
+    },
+    {
+      "Name": "Trusted-Publish-Release",
+      "Parameters": {
+        "TreatWarningsAsErrors": "false"
+      },
+      "BuildParameters": {
+        "BuildConfiguration": "Release"
+      },
+      "Definitions": [
+        {
+          "Name": "Core-Setup-Signing-Windows-x64",
+          "Parameters": {
+            "SIGNED_PACKAGES": "true"
+          },
+          "ReportingParameters": {
+            "OperatingSystem": "Windows",
+            "Type": "build/product/",
+            "Platform": "x64"
+          }
+        }
+      ],
+      "DependsOn": [
+        "Trusted-All-Release"
       ]
     }
   ]


### PR DESCRIPTION
The Windows x64 job should start executing after all other jobs complete.

@MattGal @chcosta @MichaelSimons PTAL at the formatting

CC @gkhanna79 @eerhardt @ericstj 