### PR TITLE
Update Microsoft.NETCore.UniversalWindowsPlatform 5.3.2 to 5.3.3

### DIFF
--- a/pkg/projects/Microsoft.NETCore.UniversalWindowsPlatform/Microsoft.NETCore.UniversalWindowsPlatform.pkgproj
+++ b/pkg/projects/Microsoft.NETCore.UniversalWindowsPlatform/Microsoft.NETCore.UniversalWindowsPlatform.pkgproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
 
   <PropertyGroup>
-    <Version>5.3.2</Version>
+    <Version>5.3.3</Version>
     <PackagePlatform>AnyCPU</PackagePlatform>
   </PropertyGroup>
 

--- a/pkg/projects/Microsoft.NETCore.UniversalWindowsPlatform/project.json
+++ b/pkg/projects/Microsoft.NETCore.UniversalWindowsPlatform/project.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "Microsoft.Net.Native.Compiler": "1.6.1",
+    "Microsoft.Net.Native.Compiler": "1.6.2",
     "Microsoft.NETCore.Portable.Compatibility": "1.0.2",
     "Microsoft.NETCore.Runtime.CoreCLR": "1.0.3",
     "Microsoft.NETCore.Targets": "1.0.2",


### PR DESCRIPTION
We are updating the Microsoft.Net.Native.Compiler NuGet package to 1.6.2, and we must update the meta-package version to ship the new .NET Native bits.
