### PR TITLE
Export SDK resolution

### DIFF
--- a/src/corehost/cli/fxr/fx_muxer.cpp
+++ b/src/corehost/cli/fxr/fx_muxer.cpp
@@ -600,8 +600,20 @@ bool fx_muxer_t::resolve_sdk_dotnet_path(const pal::string_t& own_dir, pal::stri
 {
     trace::verbose(_X("--- Resolving dotnet from working dir"));
     pal::string_t cwd;
+    if (!pal::getcwd(&cwd))
+    {
+        trace::verbose(_X("Failed to obtain current working dir"));
+        assert(cwd.empty());
+    }
+
+    return resolve_sdk_dotnet_path(own_dir, cwd, cli_sdk);
+}
+
+bool fx_muxer_t::resolve_sdk_dotnet_path(const pal::string_t& own_dir, const pal::string_t& cwd, pal::string_t* cli_sdk)
+{
     pal::string_t global;
-    if (pal::getcwd(&cwd))
+
+    if (!cwd.empty())
     {
         for (pal::string_t parent_dir, cur_dir = cwd; true; cur_dir = parent_dir)
         {
@@ -623,10 +635,6 @@ bool fx_muxer_t::resolve_sdk_dotnet_path(const pal::string_t& own_dir, pal::stri
             }
         }
     }
-    else
-    {
-        trace::verbose(_X("Failed to obtain current working dir"));
-    }
 
     std::vector<pal::string_t> hive_dir;
     pal::string_t local_dir;
@@ -635,7 +643,7 @@ bool fx_muxer_t::resolve_sdk_dotnet_path(const pal::string_t& own_dir, pal::stri
 
     if (multilevel_lookup)
     {
-        if (pal::getcwd(&cwd))
+        if (!cwd.empty())
         {
             hive_dir.push_back(cwd);
         }
@@ -644,7 +652,12 @@ bool fx_muxer_t::resolve_sdk_dotnet_path(const pal::string_t& own_dir, pal::stri
             hive_dir.push_back(local_dir);
         }
     }
-    hive_dir.push_back(own_dir);
+
+    if (!own_dir.empty())
+    {
+        hive_dir.push_back(own_dir);
+    }
+
     if (multilevel_lookup && pal::get_global_dotnet_dir(&global_dir))
     {
         hive_dir.push_back(global_dir);

--- a/src/corehost/cli/fxr/fx_muxer.h
+++ b/src/corehost/cli/fxr/fx_muxer.h
@@ -18,6 +18,7 @@ class fx_muxer_t
 public:
     static int execute(const int argc, const pal::char_t* argv[]);
     static std::vector<host_option> get_known_opts(bool exec_mode, host_mode_t mode, bool get_all_options = false);
+    static bool resolve_sdk_dotnet_path(const pal::string_t& own_dir, const pal::string_t& cwd, pal::string_t* cli_sdk);
 private:
     static int read_config_and_execute(
         const pal::string_t& own_dir,

--- a/src/corehost/cli/fxr/hostfxr.cpp
+++ b/src/corehost/cli/fxr/hostfxr.cpp
@@ -99,3 +99,96 @@ SHARED_API int hostfxr_main(const int argc, const pal::char_t* argv[])
     return muxer.execute(argc, argv);
 }
 
+//
+// Determines the directory location of the SDK accounting for
+// global.json and multi-level lookup policy.
+//
+// Invoked via MSBuild SDK resolver to locate SDK props and targets
+// from an msbuild other than the one bundled by the CLI.
+//
+// Parameters:
+//    exe_dir
+//      The main directory where SDKs are located in sdk\[version]
+//      sub-folders. Pass the directory of a dotnet executable to
+//      mimic how that executable would search in its own directory.
+//      It is also valid to pass nullptr or empty, in which case
+//      multi-level lookup can still search other locations if 
+//      it has not been disabled by the user's environment.
+//
+//    working_dir
+//      The directory where the search for global.json (which can
+//      control the resolved SDK version) starts and proceeds
+//      upwards. This directory may also be searched for SDKs if
+//      multi-level lookup has not been disabled by the user's
+//      environment. This mimics the current working directory's
+//      interpretation when the dotnet exectuable resolves the SDK
+//      for CLI commands.
+//
+//    buffer
+//      The buffer where the resolved SDK path will be written.
+//
+//    buffer_size
+//      The size of the buffer argument in pal::char_t units.
+//
+// Return value:
+//   <0 - Invalid argument
+//   0  - SDK could not be found.
+//   >0 - The number of characters (including null terminator)
+//        required to store the located SDK.
+//
+//   If resolution succeeds and the positive return value is less than
+//   or equal to buffer_size (i.e. the the buffer is large enough),
+//   then the resolved SDK path is copied to the buffer and null
+//   terminated. Otherwise, no data is written to the buffer.
+//
+// String encoding:
+//   Windows     - UTF-16 (pal::char_t is 2 byte wchar_t)
+//   Unix        - UTF-8  (pal::char_t is 1 byte char)
+//
+SHARED_API int32_t hostfxr_resolve_sdk(
+    const pal::char_t* exe_dir,
+    const pal::char_t* working_dir,
+    pal::char_t buffer[],
+    int32_t buffer_size)
+{
+    trace::setup();
+
+    trace::info(_X("--- Invoked hostfxr [commit hash: %s] hostfxr_resolve_sdk"), _STRINGIFY(REPO_COMMIT_HASH));
+
+    if (buffer_size < 0 || (buffer_size > 0 && buffer == nullptr))
+    {
+        trace::error(_X("hostfxr_resolve_sdk received an invalid argument."));
+        return -1;
+    }
+
+    if (exe_dir == nullptr)
+    {
+        exe_dir = _X("");
+    }
+
+    if (working_dir == nullptr)
+    {
+        working_dir = _X("");
+    }
+
+    pal::string_t cli_sdk;
+    if (!fx_muxer_t::resolve_sdk_dotnet_path(exe_dir, working_dir, &cli_sdk))
+    {
+        // fx_muxer_t::resolve_sdk_dotnet_path handles tracing for this error case.
+        return 0; 
+    }
+
+    if (cli_sdk.size() < buffer_size)
+    {
+        size_t length = cli_sdk.copy(buffer, buffer_size - 1);
+        assert(length == cli_sdk.size());
+        assert(length < buffer_size); 
+        buffer[length] = 0;
+    }
+    else
+    {
+        trace::info(_X("hostfxr_resolve_sdk received a buffer that is too small to hold the located SDK path."));
+    }
+
+    return cli_sdk.size() + 1;
+}

--- a/src/corehost/common/pal.h
+++ b/src/corehost/common/pal.h
@@ -11,6 +11,7 @@
 #include <iostream>
 #include <cstring>
 #include <cstdarg>
+#include <cstdint>
 #include <tuple>
 #include <unordered_map>
 #include <unordered_set>


### PR DESCRIPTION
This exports a new entry point to hostfxr.dll that will be used via a CLI plug-in to desktop msbuild so that VS can pick up tasks and targets directly from the CLI SDK.

I considered packaging this in to a separate native library, but after discussion with @eerhardt, we felt that this would increase the infrastructure burden too much. It is something we might want to consider later if we choose to reduce the footprint of the MSBuild plug-in.

@livarcocc @eerhardt @gkhanna79 @ramarag 