### PR TITLE
[release/2.0.0] Auto-update release/2.0.0 from 2.0.0 branches

### DIFF
--- a/build_projects/update-dependencies/Config.cs
+++ b/build_projects/update-dependencies/Config.cs
@@ -36,9 +36,9 @@ namespace Microsoft.DotNet.Scripts
         private Lazy<string> _userName = new Lazy<string>(() => GetEnvironmentVariable("GITHUB_USER"));
         private Lazy<string> _email = new Lazy<string>(() => GetEnvironmentVariable("GITHUB_EMAIL"));
         private Lazy<string> _password = new Lazy<string>(() => GetEnvironmentVariable("GITHUB_PASSWORD"));
-        private Lazy<string> _coreFxVersionUrl = new Lazy<string>(() => GetEnvironmentVariable("COREFX_VERSION_URL", "https://raw.githubusercontent.com/dotnet/versions/master/build-info/dotnet/corefx/master/"));
-        private Lazy<string> _coreClrVersionUrl = new Lazy<string>(() => GetEnvironmentVariable("CORECLR_VERSION_URL", "https://raw.githubusercontent.com/dotnet/versions/master/build-info/dotnet/coreclr/master/"));
-        private Lazy<string> _standardVersionUrl = new Lazy<string>(() => GetEnvironmentVariable("STANDARD_VERSION_URL", "https://raw.githubusercontent.com/dotnet/versions/master/build-info/dotnet/standard/master/"));
+        private Lazy<string> _coreFxVersionUrl = new Lazy<string>(() => GetEnvironmentVariable("COREFX_VERSION_URL", "https://raw.githubusercontent.com/dotnet/versions/master/build-info/dotnet/corefx/release/2.0.0/"));
+        private Lazy<string> _coreClrVersionUrl = new Lazy<string>(() => GetEnvironmentVariable("CORECLR_VERSION_URL", "https://raw.githubusercontent.com/dotnet/versions/master/build-info/dotnet/coreclr/release/2.0.0/"));
+        private Lazy<string> _standardVersionUrl = new Lazy<string>(() => GetEnvironmentVariable("STANDARD_VERSION_URL", "https://raw.githubusercontent.com/dotnet/versions/master/build-info/dotnet/standard/release/2.0.0/"));
         private Lazy<string> _gitHubOriginOwner;
         private Lazy<string> _gitHubUpstreamOwner = new Lazy<string>(() => GetEnvironmentVariable("GITHUB_UPSTREAM_OWNER", "dotnet"));
         private Lazy<string> _gitHubProject = new Lazy<string>(() => GetEnvironmentVariable("GITHUB_PROJECT", "core-setup"));


### PR DESCRIPTION
Consume release/2.0.0 branch builds from CoreFX, CoreCLR, and Standard.

Right now, CoreCLR and Standard are building preview2 packages for both master and release/2.0.0 branches. CoreFX is building preview1 for release/2.0.0 and preview2 for master. Once this PR gets merged and the 2.0.0 Standard and CoreCLR builds get fixed (?), the auto-upgrades will use preview1 for all. @gkhanna79 @weshaggard 

https://github.com/dotnet/versions/blob/master/build-info/dotnet/standard/release/2.0.0/Latest_Packages.txt
https://github.com/dotnet/versions/blob/master/build-info/dotnet/corefx/release/2.0.0/Latest_Packages.txt
https://github.com/dotnet/versions/blob/master/build-info/dotnet/coreclr/release/2.0.0/Latest_Packages.txt

See https://github.com/dotnet/core-setup/pull/2149#issuecomment-296510928