### PR TITLE
Only publish identity packages from a single build leg (windows x64).

### DIFF
--- a/build_projects/shared-build-targets-utils/Publishing/AzurePublisher.cs
+++ b/build_projects/shared-build-targets-utils/Publishing/AzurePublisher.cs
@@ -57,7 +57,11 @@ namespace Microsoft.DotNet.Cli.Build
             Console.WriteLine($"Publishing file '{file}' to '{blob}'");
 
             CloudBlockBlob blockBlob = _blobContainer.GetBlockBlobReference(blob);
-            blockBlob.UploadFromFileAsync(file).Wait();
+            blockBlob.UploadFromFileAsync(
+                file, 
+                AccessCondition.GenerateIfNotExistsCondition(),
+                options: null,
+                operationContext: null).Wait();
 
             SetBlobPropertiesBasedOnFileType(blockBlob);
         }

--- a/build_projects/shared-build-targets-utils/Utils/EnvVars.cs
+++ b/build_projects/shared-build-targets-utils/Utils/EnvVars.cs
@@ -7,7 +7,7 @@ namespace Microsoft.DotNet.Cli.Build
     {
         public static readonly bool Verbose = GetBool("DOTNET_BUILD_VERBOSE");
 
-        public static readonly bool Signed = GetBool("SIGNED_PACKAGES");
+        public static readonly bool PublishRidAgnosticPackages = GetBool("PUBLISH_RID_AGNOSTIC_PACKAGES");
 
         private static bool GetBool(string name, bool defaultValue = false)
         {

--- a/buildpipeline/Core-Setup-Signing-Windows-x64.json
+++ b/buildpipeline/Core-Setup-Signing-Windows-x64.json
@@ -477,7 +477,10 @@
     "GITHUB_PASSWORD": {
       "value": "PassedViaPipeBuild"
     },
-    "SIGNED_PACKAGES": {
+    "BUILD_FULL_PLATFORM_MANIFEST": {
+      "value": "true"
+    },
+    "PUBLISH_RID_AGNOSTIC_PACKAGES": {
       "value": "true"
     },
     "CertificateId": {

--- a/pkg/projects/Microsoft.NETCore.App/Microsoft.NETCore.App.pkgproj
+++ b/pkg/projects/Microsoft.NETCore.App/Microsoft.NETCore.App.pkgproj
@@ -15,7 +15,7 @@
          restore all of those dependencies and gather the prospective content of the RID-specific Core.App
          packages.  This is needed so that we have a complete platform manifest in the shipping version of
          the Microsoft.NETCore.App (RID-agnostic/identity package). -->
-    <IncludeAllRuntimePackagesInPlatformManifest Condition="'$(SIGNED_PACKAGES)' == 'true'">true</IncludeAllRuntimePackagesInPlatformManifest>
+    <IncludeAllRuntimePackagesInPlatformManifest Condition="'$(BUILD_FULL_PLATFORM_MANIFEST)' == 'true'">true</IncludeAllRuntimePackagesInPlatformManifest>
   </PropertyGroup>
   
   

--- a/pkg/projects/Microsoft.NETCore.UniversalWindowsPlatform/Microsoft.NETCore.UniversalWindowsPlatform.pkgproj
+++ b/pkg/projects/Microsoft.NETCore.UniversalWindowsPlatform/Microsoft.NETCore.UniversalWindowsPlatform.pkgproj
@@ -14,7 +14,7 @@
          restore all of those dependencies and gather the prospective content of the RID-specific Core.App
          packages.  This is needed so that we have a complete platform manifest in the shipping version of
          the Microsoft.NETCore.UniversalWindowsPlatform (RID-agnostic/identity package). -->
-    <IncludeAllRuntimePackagesInPlatformManifest Condition="'$(SIGNED_PACKAGES)' == 'true'">true</IncludeAllRuntimePackagesInPlatformManifest>
+    <IncludeAllRuntimePackagesInPlatformManifest Condition="'$(BUILD_FULL_PLATFORM_MANIFEST)' == 'true'">true</IncludeAllRuntimePackagesInPlatformManifest>
   </PropertyGroup>
   
   


### PR DESCRIPTION
Also, fail publishing if an existing blob exists - no more overwriting azure storage blobs.  We need to ensure each leg publishes distinct packages so we don't get into race conditions in publishing.

Fix #2136, #1994 and #1824
@ericstj @dagood @chcosta @gkhanna79 @wtgodbe 