### PR TITLE
Allow additional ICompilationAssemblyResolvers

### DIFF
--- a/src/Microsoft.DotNet.PlatformAbstractions/project.json
+++ b/src/Microsoft.DotNet.PlatformAbstractions/project.json
@@ -21,11 +21,10 @@
       }
     }
   },
-  "scripts": {},
   "packOptions": {
     "repository": {
       "type": "git",
-      "url": "git://github.com/dotnet/cli"
+      "url": "git://github.com/dotnet/core-setup"
     }
   }
 }

--- a/src/Microsoft.Extensions.DependencyModel/CompilationLibrary.cs
+++ b/src/Microsoft.Extensions.DependencyModel/CompilationLibrary.cs
@@ -51,8 +51,32 @@ namespace Microsoft.Extensions.DependencyModel
 
         public IEnumerable<string> ResolveReferencePaths()
         {
+            return ResolveReferencePaths(DefaultResolver);
+        }
+
+        public IEnumerable<string> ResolveReferencePaths(params ICompilationAssemblyResolver[] additionalResolvers)
+        {
+            ICompilationAssemblyResolver resolver;
+            if (additionalResolvers?.Length > 0)
+            {
+                var allResolvers = new ICompilationAssemblyResolver[additionalResolvers.Length + 1];
+                additionalResolvers.CopyTo(allResolvers, 0);
+                allResolvers[additionalResolvers.Length] = DefaultResolver;
+
+                resolver = new CompositeCompilationAssemblyResolver(allResolvers);
+            }
+            else
+            {
+                resolver = DefaultResolver;
+            }
+
+            return ResolveReferencePaths(resolver);
+        }
+
+        private IEnumerable<string> ResolveReferencePaths(ICompilationAssemblyResolver resolver)
+        {
             var assemblies = new List<string>();
-            if (!DefaultResolver.TryResolveAssemblyPaths(this, assemblies))
+            if (!resolver.TryResolveAssemblyPaths(this, assemblies))
             {
                 throw new InvalidOperationException($"Cannot find compilation library location for package '{Name}'");
             }

--- a/src/Microsoft.Extensions.DependencyModel/CompilationLibrary.cs
+++ b/src/Microsoft.Extensions.DependencyModel/CompilationLibrary.cs
@@ -51,31 +51,31 @@ namespace Microsoft.Extensions.DependencyModel
 
         public IEnumerable<string> ResolveReferencePaths()
         {
-            return ResolveReferencePaths(DefaultResolver);
+            var assemblies = new List<string>();
+
+            return ResolveReferencePaths(DefaultResolver, assemblies);
         }
 
-        public IEnumerable<string> ResolveReferencePaths(params ICompilationAssemblyResolver[] additionalResolvers)
-        {
-            ICompilationAssemblyResolver resolver;
-            if (additionalResolvers?.Length > 0)
-            {
-                var allResolvers = new ICompilationAssemblyResolver[additionalResolvers.Length + 1];
-                additionalResolvers.CopyTo(allResolvers, 0);
-                allResolvers[additionalResolvers.Length] = DefaultResolver;
-
-                resolver = new CompositeCompilationAssemblyResolver(allResolvers);
-            }
-            else
-            {
-                resolver = DefaultResolver;
-            }
-
-            return ResolveReferencePaths(resolver);
-        }
-
-        private IEnumerable<string> ResolveReferencePaths(ICompilationAssemblyResolver resolver)
+        public IEnumerable<string> ResolveReferencePaths(params ICompilationAssemblyResolver[] customResolvers)
         {
             var assemblies = new List<string>();
+
+            if (customResolvers?.Length > 0)
+            {
+                foreach (var resolver in customResolvers)
+                {
+                    if (resolver.TryResolveAssemblyPaths(this, assemblies))
+                    {
+                        return assemblies;
+                    }
+                }
+            }
+
+            return ResolveReferencePaths(DefaultResolver, assemblies);
+        }
+
+        private IEnumerable<string> ResolveReferencePaths(ICompilationAssemblyResolver resolver, List<string> assemblies)
+        {
             if (!resolver.TryResolveAssemblyPaths(this, assemblies))
             {
                 throw new InvalidOperationException($"Cannot find compilation library location for package '{Name}'");

--- a/src/Microsoft.Extensions.DependencyModel/Resolution/CompositeCompilationAssemblyResolver.cs
+++ b/src/Microsoft.Extensions.DependencyModel/Resolution/CompositeCompilationAssemblyResolver.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;
-using Microsoft.Extensions.DependencyModel.Resolution;
 
 namespace Microsoft.Extensions.DependencyModel.Resolution
 {
@@ -24,7 +23,7 @@ namespace Microsoft.Extensions.DependencyModel.Resolution
                     return true;
                 }
             }
-            return false;;
+            return false;
         }
     }
 }

--- a/src/Microsoft.Extensions.DependencyModel/project.json
+++ b/src/Microsoft.Extensions.DependencyModel/project.json
@@ -30,11 +30,10 @@
       }
     }
   },
-  "scripts": {},
   "packOptions": {
     "repository": {
       "type": "git",
-      "url": "git://github.com/dotnet/cli"
+      "url": "git://github.com/dotnet/core-setup"
     }
   }
 }

--- a/test/Microsoft.Extensions.DependencyModel.Tests/CompilationLibraryTests.cs
+++ b/test/Microsoft.Extensions.DependencyModel.Tests/CompilationLibraryTests.cs
@@ -1,0 +1,49 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using FluentAssertions;
+using Microsoft.Extensions.DependencyModel.Resolution;
+using Moq;
+using System.Collections.Generic;
+using Xunit;
+
+namespace Microsoft.Extensions.DependencyModel.Tests
+{
+    public class CompilationLibraryTests
+    {
+        [Fact]
+        public void ResolveReferencePathsAcceptsAdditionalResolvers()
+        {
+            var fail = new Mock<ICompilationAssemblyResolver>();
+            var success = new Mock<ICompilationAssemblyResolver>();
+            success.Setup(r => r.TryResolveAssemblyPaths(It.IsAny<CompilationLibrary>(), It.IsAny<List<string>>()))
+                .Callback((CompilationLibrary l, List<string> a) =>
+                {
+                    a.Add("Assembly");
+                })
+                .Returns(true);
+
+            var failTwo = new Mock<ICompilationAssemblyResolver>();
+
+            var resolvers = new[]
+            {
+                fail.Object,
+                success.Object,
+                failTwo.Object
+            };
+
+            var library = TestLibraryFactory.Create();
+
+            var result = library.ResolveReferencePaths(resolvers);
+
+            result.ShouldBeEquivalentTo(new[] { "Assembly" });
+
+            fail.Verify(r => r.TryResolveAssemblyPaths(It.IsAny<CompilationLibrary>(), It.IsAny<List<string>>()),
+                Times.Once());
+            success.Verify(r => r.TryResolveAssemblyPaths(It.IsAny<CompilationLibrary>(), It.IsAny<List<string>>()),
+                Times.Once());
+            failTwo.Verify(r => r.TryResolveAssemblyPaths(It.IsAny<CompilationLibrary>(), It.IsAny<List<string>>()),
+                Times.Never());
+        }
+    }
+}


### PR DESCRIPTION
This allows for callers to use their own compilation resolvers along with the default resolvers shipped in the DependencyModel.

Fix #625

@pakrym @ramarag 