### PR TITLE
Use appropriate prefix/suffix when deleting unrequired binaries

### DIFF
--- a/build_projects/shared-build-targets-utils/Utils/PublishMutationUtilties.cs
+++ b/build_projects/shared-build-targets-utils/Utils/PublishMutationUtilties.cs
@@ -22,7 +22,7 @@ namespace Microsoft.DotNet.Cli.Build
             foreach (var binaryName in binariesToBeDeleted)
             {
                 File.Delete(Path.Combine(path, $"{binaryName}{Constants.ExeSuffix}"));
-                File.Delete(Path.Combine(path, $"{binaryName}.dll"));
+                File.Delete(Path.Combine(path, $"{Constants.DynamicLibPrefix}{binaryName}{Constants.DynamicLibSuffix}"));
                 File.Delete(Path.Combine(path, $"{binaryName}.pdb"));
             }
 


### PR DESCRIPTION
60230cc#diff-906b5578c0cbf081f1f173d5922e4a16 does not account for platform-specific prefix/suffix to be applied before deleting unrequired binaries.

Fixes https://github.com/dotnet/core-setup/issues/1908

@ramarag PTAL

CC @eerhardt 