### PR TITLE
[ARM] Update rootfs for Tizen armel

### DIFF
--- a/cross/armel/tizen/tizen.patch
+++ b/cross/armel/tizen/tizen.patch
@@ -16,18 +16,3 @@ diff -u -r a/usr/lib/libpthread.so b/usr/lib/libpthread.so
  OUTPUT_FORMAT(elf32-littlearm)
 -GROUP ( /lib/libpthread.so.0 /usr/lib/libpthread_nonshared.a )
 +GROUP ( libpthread.so.0 libpthread_nonshared.a )
-diff -u -r a/usr/lib/libpthread.so b/usr/lib/libpthread.so
---- a/etc/os-release  2016-10-17 23:39:36.000000000 +0900
-+++ b/etc/os-release  2017-01-05 14:34:39.099867682 +0900
-@@ -1,7 +1,7 @@
- NAME=Tizen
--VERSION="3.0.0 (Tizen3/Mobile)"
-+VERSION="4.0.0 (Tizen4/Mobile)"
- ID=tizen
--VERSION_ID=3.0.0
--PRETTY_NAME="Tizen 3.0.0 (Tizen3/Mobile)"
-+VERSION_ID=4.0.0
-+PRETTY_NAME="Tizen 4.0.0 (Tizen4/Mobile)"
- ANSI_COLOR="0;36"
--CPE_NAME="cpe:/o:tizen:tizen:3.0.0"
-+CPE_NAME="cpe:/o:tizen:tizen:4.0.0"

--- a/cross/armel/toolchain.cmake
+++ b/cross/armel/toolchain.cmake
@@ -17,7 +17,7 @@ set(CROSS_LINK_FLAGS "${CROSS_LINK_FLAGS} -target ${TOOLCHAIN}")
 set(CROSS_LINK_FLAGS "${CROSS_LINK_FLAGS} --sysroot=${CROSS_ROOTFS}")
 
 if("$ENV{__CrossToolChainTargetRID}" MATCHES "tizen.*")
-    set(TIZEN_TOOLCHAIN "armv7l-tizen-linux-gnueabi/4.9.2")
+    set(TIZEN_TOOLCHAIN "armv7l-tizen-linux-gnueabi/6.2.1")
     include_directories(${CROSS_ROOTFS}/usr/lib/gcc/${TIZEN_TOOLCHAIN}/include/c++/)
     include_directories(${CROSS_ROOTFS}/usr/lib/gcc/${TIZEN_TOOLCHAIN}/include/c++/armv7l-tizen-linux-gnueabi)
     add_compile_options(-Wno-deprecated-declarations) # compile-time option

--- a/tools-local/scripts/arm32_ci_script.sh
+++ b/tools-local/scripts/arm32_ci_script.sh
@@ -189,7 +189,7 @@ function cross_build_core_setup_with_docker {
         # For armel Tizen, we are going to construct RootFS on the fly.
         case $__linuxCodeName in
         tizen)
-            __dockerImage=" t2wish/dotnetcore:ubuntu1404_cross_prereqs_v4"
+            __dockerImage=" hqueue/dotnetcore:ubuntu1404_cross_prereqs_v4-tizen_rootfs"
             __runtimeOS="tizen.4.0.0"
         ;;
         *)
@@ -264,6 +264,8 @@ do
     --armel)
         __ARMRootfsImageBase="rootfs-t30.ext4"
         __buildArch="armel"
+        __skipRootFS=1
+        __rootfsDir="/crossrootfs/armel.tizen.build"
         __linuxCodeName="tizen"
         ;;
     --linuxCodeName=*)


### PR DESCRIPTION
*This PR should be merged only after all related PR in coreclr and corefx merged.*

This is required to build CoreCLR for Tizen armel as a part of .NET Core 2.0.0 for Tizen.
Existing rootfs for armel Tizen is out-of-dated and not suitable for .NET Core 2.0.0 for Tizen.

Two changes are made.
* Update rootfs for Tizen armel to recent version
* Updates CI for Tizen armel to make use of a prebuilt embedded rootfs as Ubuntu arm does.

Related PR : 
https://github.com/dotnet/coreclr/pull/11202
https://github.com/dotnet/corefx/pull/18916