### PR TITLE
[release/2.0.0] Fix casing of OfficialBuildRID

### DIFF
--- a/pkg/projects/netcoreappRIDs.props
+++ b/pkg/projects/netcoreappRIDs.props
@@ -16,9 +16,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <OfficialBuildRid Include="debian.8-armel">
+    <OfficialBuildRID Include="debian.8-armel">
       <Platform>armel</Platform>
-    </OfficialBuildRid>
+    </OfficialBuildRID>
     <OfficialBuildRID Include="linux-x64" />
     <OfficialBuildRID Include="osx.10.12-x64" />
     <OfficialBuildRID Include="osx-x64" />
@@ -51,9 +51,9 @@
     <OfficialBuildRID Include="ubuntu.16.04-arm">
       <Platform>arm</Platform>
     </OfficialBuildRID>
-    <OfficialBuildRid Include="tizen.4.0.0-armel">
+    <OfficialBuildRID Include="tizen.4.0.0-armel">
       <Platform>armel</Platform>
-    </OfficialBuildRid>
+    </OfficialBuildRID>
     </ItemGroup>
     
 </Project>


### PR DESCRIPTION
Working around https://github.com/Microsoft/msbuild/issues/1751

Cherry-pick of 6341fc68f53e6a96c4b0f3107bbc4782867d995b

Conflicts:
	pkg/projects/netcoreappRIDs.props

Fixes #2161