### PR TITLE
Exclude debian and tizen from platform manifest

### DIFF
--- a/pkg/projects/Microsoft.NETCore.App/Microsoft.NETCore.App.pkgproj
+++ b/pkg/projects/Microsoft.NETCore.App/Microsoft.NETCore.App.pkgproj
@@ -65,7 +65,9 @@
     <MSBuild Projects="@(ProjectReference)"
              Condition="'%(ProjectReference.PackageTargetRuntime)' == '$(PackageRID)' OR 
                         '%(ProjectReference.BuidOnRID)' == '$(PackageRID)' OR 
-                        ('$(IncludeAllRuntimePackagesInPlatformManifest)' == 'true' AND '%(ProjectReference.PackageTargetRuntime)' != '')"
+                        ('$(IncludeAllRuntimePackagesInPlatformManifest)' == 'true' AND
+                         '%(ProjectReference.PackageTargetRuntime)' != '' AND 
+                         '%(ProjectReference.ExcludeFromPlatformManifest)' != 'true')"
              Targets="GetPackageFiles">
       <Output TaskParameter="TargetOutputs" ItemName="SharedFrameworkRuntimeFiles" />
     </MSBuild>

--- a/pkg/projects/dir.props
+++ b/pkg/projects/dir.props
@@ -63,6 +63,10 @@
   <ItemGroup>
     <!-- Ensure we have a RID-specific package for the current build, even if it isn't in our official set -->
     <BuildRID Include="@(OfficialBuildRID)" Exclude="$(PackageRID)"/>
+    <!-- Include Unofficial Build RIDs in runtime.json's but do not include in the platform manifest -->
+    <BuildRID Include="@(UnofficialBuildRID)" Exclude="$(PackageRID)">
+      <ExcludeFromPlatformManifest>true</ExcludeFromPlatformManifest>
+    </BuildRID>
     <BuildRID Include="$(PackageRID)">
       <Platform>$(Platform)</Platform>
     </BuildRID>

--- a/pkg/projects/netcoreappRIDs.props
+++ b/pkg/projects/netcoreappRIDs.props
@@ -16,9 +16,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <OfficialBuildRID Include="debian.8-armel">
-      <Platform>armel</Platform>
-    </OfficialBuildRID>
     <OfficialBuildRID Include="linux-x64" />
     <OfficialBuildRID Include="osx-x64" />
     <OfficialBuildRID Include="win-x86">
@@ -34,9 +31,15 @@
     <OfficialBuildRID Include="linux-arm">
       <Platform>arm</Platform>
     </OfficialBuildRID>
-    <OfficialBuildRID Include="tizen.4.0.0-armel">
+
+    <!-- The following RIDs are not officically supported and are not 
+         built during official builds, however we wish to include them 
+         in our runtime.json to enable others to provide them.  -->
+    <UnofficialBuildRID Include="debian.8-armel">
       <Platform>armel</Platform>
-    </OfficialBuildRID>
-    </ItemGroup>
-    
+    </UnofficialBuildRID>
+    <UnofficialBuildRID Include="tizen.4.0.0-armel">
+      <Platform>armel</Platform>
+    </UnofficialBuildRID>
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
Debian and Tizen are not built by our build process, but we want to
include entries for them in our runtime.json.

This was interfering with another feature where we must include a list
of all files that are in all runtime packages in a manifest.  The
manifest is used when building a shared-framework app to understand
which files are part of the shared framework and should be considered
for conflict resolution.  If the application were to reference an old
package which had one of these files we want to trim it from the
application if it failed conflict resolution (was a lower version).

We cannot gather this information from debian and tizen packages since
we don't build them.  For now we will opt them out of this feature.
This is likely "good enough" for them since they won't have any unique
files that previously shipped in RID-less packages and require conflict
resolution.

A alternative solution for debian and tizen would be for them to ship
their own RID-less package with their own platform manifest.  They could
do so transparently by implicitly referencing their package for folks
that wanted this.

/cc @weshaggard @gkhanna79 @eerhardt 