### PR TITLE
Use manually-cloned repo for CrossBuild pkg dir

### DIFF
--- a/buildpipeline/Core-Setup-CrossBuild.json
+++ b/buildpipeline/Core-Setup-CrossBuild.json
@@ -66,7 +66,7 @@
         "definitionType": "task"
       },
       "inputs": {
-        "SourceFolder": "pkg",
+        "SourceFolder": "$(PB_RepoName)/pkg",
         "Contents": "**",
         "TargetFolder": "$(DockerHost_Sandbox)",
         "CleanTargetFolder": "false",


### PR DESCRIPTION
This avoids interference from changes in the master branch.

@Petermarcu @gkhanna79 