### PR TITLE
Fix bad merge

### DIFF
--- a/publish/dir.props
+++ b/publish/dir.props
@@ -40,4 +40,4 @@
     <PublishRid Include="win-arm64"/>
     <PublishRid Include="osx-x64"/>
   </ItemGroup>
-  
+</Project>  


### PR DESCRIPTION
Rebasing to latest caused a bad merge in publishing.  publishing is only exercised during official builds, so it wasn't caught.