### PR TITLE
Add files that don't match the System.*/Microsoft.* pattern to list of files to sign.

### DIFF
--- a/build_projects/dotnet-host-build/sign.proj
+++ b/build_projects/dotnet-host-build/sign.proj
@@ -35,9 +35,6 @@
       <FilesToSign Include="$(OutDir)corehost/**/hostpolicy.dll">
         <Authenticode>$(CertificateId)</Authenticode>
       </FilesToSign>
-      <FilesToSign Include="$(OutDir)corehost/**/dotnet.exe">
-        <Authenticode>$(CertificateId)</Authenticode>
-      </FilesToSign>
     </ItemGroup>
   </Target>
 

--- a/build_projects/dotnet-host-build/sign.proj
+++ b/build_projects/dotnet-host-build/sign.proj
@@ -53,16 +53,7 @@
       <FilesToSign Include="$(IntermediateOutputPath)sharedFrameworkPublish/shared/**/Microsoft.*.dll">
         <Authenticode>$(CertificateId)</Authenticode>
       </FilesToSign>
-      <FilesToSign Include="$(IntermediateOutputPath)sharedFrameworkPublish/shared/**/mscorlib.dll">
-        <Authenticode>$(CertificateId)</Authenticode>
-      </FilesToSign>
-      <FilesToSign Include="$(IntermediateOutputPath)sharedFrameworkPublish/shared/**/netstandard.dll">
-        <Authenticode>$(CertificateId)</Authenticode>
-      </FilesToSign>
       <FilesToSign Include="$(IntermediateOutputPath)sharedFrameworkPublish/shared/**/SOS.NETCore.dll">
-        <Authenticode>$(CertificateId)</Authenticode>
-      </FilesToSign>
-      <FilesToSign Include="$(IntermediateOutputPath)sharedFrameworkPublish/shared/**/System.dll">
         <Authenticode>$(CertificateId)</Authenticode>
       </FilesToSign>
       <FilesToSign Include="$(IntermediateOutputPath)sharedFrameworkPublish/shared/**/System.*.dll">

--- a/build_projects/dotnet-host-build/sign.proj
+++ b/build_projects/dotnet-host-build/sign.proj
@@ -35,6 +35,9 @@
       <FilesToSign Include="$(OutDir)corehost/**/hostpolicy.dll">
         <Authenticode>$(CertificateId)</Authenticode>
       </FilesToSign>
+      <FilesToSign Include="$(OutDir)corehost/**/dotnet.exe">
+        <Authenticode>$(CertificateId)</Authenticode>
+      </FilesToSign>
     </ItemGroup>
   </Target>
 
@@ -44,7 +47,22 @@
 
   <Target Name="GetSignSharedFrameworkCrossgenedAssembliesFiles">
     <ItemGroup>
+      <FilesToSign Include="$(IntermediateOutputPath)sharedFrameworkPublish/shared/**/clrcompression.dll">
+        <Authenticode>$(CertificateId)</Authenticode>
+      </FilesToSign>
       <FilesToSign Include="$(IntermediateOutputPath)sharedFrameworkPublish/shared/**/Microsoft.*.dll">
+        <Authenticode>$(CertificateId)</Authenticode>
+      </FilesToSign>
+      <FilesToSign Include="$(IntermediateOutputPath)sharedFrameworkPublish/shared/**/mscorlib.dll">
+        <Authenticode>$(CertificateId)</Authenticode>
+      </FilesToSign>
+      <FilesToSign Include="$(IntermediateOutputPath)sharedFrameworkPublish/shared/**/netstandard.dll">
+        <Authenticode>$(CertificateId)</Authenticode>
+      </FilesToSign>
+      <FilesToSign Include="$(IntermediateOutputPath)sharedFrameworkPublish/shared/**/SOS.NETCore.dll">
+        <Authenticode>$(CertificateId)</Authenticode>
+      </FilesToSign>
+      <FilesToSign Include="$(IntermediateOutputPath)sharedFrameworkPublish/shared/**/System.dll">
         <Authenticode>$(CertificateId)</Authenticode>
       </FilesToSign>
       <FilesToSign Include="$(IntermediateOutputPath)sharedFrameworkPublish/shared/**/System.*.dll">


### PR DESCRIPTION
Fixes clrcompression.dll and SOS.NETCore.dll not being signed.