### PR TITLE
Change publishrid list for current active build legs

### DIFF
--- a/publish/dir.props
+++ b/publish/dir.props
@@ -17,28 +17,23 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PublishRid Include="win7-x64"/>
-    <PublishRid Include="win7-x86"/>
-    <PublishRid Include="win8-arm"/>
-    <PublishRid Include="win10-arm64"/>
-    <PublishRid Include="osx.10.12-x64"/>
     <PublishRid Include="ubuntu.14.04-x64"/>
     <PublishRid Include="ubuntu.16.04-x64"/>
-    <PublishRid Include="ubuntu.14.04-arm"/>
-    <PublishRid Include="ubuntu.16.04-arm"/>
     <PublishRid Include="ubuntu.16.10-x64"/>
-    <PublishRid Include="rhel.7-x64"/>
     <PublishRid Include="debian.8-x64"/>
-    <PublishRid Include="fedora.23-x64"/>
-    <PublishRid Include="fedora.24-x64"/>
-    <PublishRid Include="opensuse.42.1-x64"/>
-    <PublishRid Include="linux-x64"/>
-    <PublishRid Include="linux-arm"/>
-    <PublishRid Include="linux-arm64"/>
-    <PublishRid Include="win-x86"/>
-    <PublishRid Include="win-x64"/>
+    <PublishRid Include="linux-x64_portable"/>
+    <PublishRid Include="win-x86_portable"/>
+    <PublishRid Include="win-x64_portable"/>
+    <PublishRid Include="osx-x64_portable"/>
+<!-- Not currently producing arm builds 
     <PublishRid Include="win-arm"/>
     <PublishRid Include="win-arm64"/>
-    <PublishRid Include="osx-x64"/>
+    <PublishRid Include="linux-arm"/>
+    <PublishRid Include="linux-arm64"/>
+    <PublishRid Include="ubuntu.14.04-arm"/>
+    <PublishRid Include="ubuntu.16.04-arm"/>
+    <PublishRid Include="win8-arm"/>
+    <PublishRid Include="win10-arm64"/>
+-->    
   </ItemGroup>
 </Project>  

--- a/publish/dir.props
+++ b/publish/dir.props
@@ -21,10 +21,10 @@
     <PublishRid Include="ubuntu.16.04-x64"/>
     <PublishRid Include="ubuntu.16.10-x64"/>
     <PublishRid Include="debian.8-x64"/>
-    <PublishRid Include="linux-x64_portable"/>
-    <PublishRid Include="win-x86_portable"/>
-    <PublishRid Include="win-x64_portable"/>
-    <PublishRid Include="osx-x64_portable"/>
+    <PublishRid Include="linux-x64"/>
+    <PublishRid Include="win-x86"/>
+    <PublishRid Include="win-x64"/>
+    <PublishRid Include="osx-x64"/>
 <!-- Not currently producing arm builds 
     <PublishRid Include="win-arm"/>
     <PublishRid Include="win-arm64"/>


### PR DESCRIPTION
Changes publishrid list to reflect what we're currently actively building in core-setup official builds.  With this change, Finalization will actually occur during core-setup official builds.  This change disables checking for arm legs and removes non-portable rids we're no longer producing.