### PR TITLE
Allow host to access long files

### DIFF
--- a/src/corehost/cli/args.cpp
+++ b/src/corehost/cli/args.cpp
@@ -100,7 +100,7 @@ bool parse_arguments(
     {
         // coreconsole mode. Find the managed app in the same directory
         pal::string_t managed_app(own_dir);
-        managed_app.push_back(DIR_SEPARATOR);
+
         managed_app.append(get_executable(own_name));
         managed_app.append(_X(".dll"));
         args.managed_application = managed_app;
@@ -132,7 +132,11 @@ bool parse_arguments(
 
         args.deps_path.reserve(app_base.length() + 1 + app_name.length() + 5);
         args.deps_path.append(app_base);
-        args.deps_path.push_back(DIR_SEPARATOR);
+
+        if (!app_base.empty() && app_base.back() != DIR_SEPARATOR)
+        {
+            args.deps_path.push_back(DIR_SEPARATOR);
+        }
         args.deps_path.append(app_name, 0, app_name.find_last_of(_X(".")));
         args.deps_path.append(_X(".deps.json"));
     }

--- a/src/corehost/cli/coreclr.cpp
+++ b/src/corehost/cli/coreclr.cpp
@@ -44,7 +44,7 @@ bool coreclr::bind(const pal::string_t& libcoreclr_path)
     pal::string_t coreclr_dll_path(libcoreclr_path);
     append_path(&coreclr_dll_path, LIBCORECLR_NAME);
 
-    if (!pal::load_library(coreclr_dll_path.c_str(), &g_coreclr))
+    if (!pal::load_library(&coreclr_dll_path, &g_coreclr))
     {
         return false;
     }

--- a/src/corehost/cli/deps_resolver.cpp
+++ b/src/corehost/cli/deps_resolver.cpp
@@ -126,7 +126,13 @@ void deps_resolver_t::get_dir_assemblies(
             }
 
             // Add entry for this asset
-            pal::string_t file_path = dir + DIR_SEPARATOR + file;
+            pal::string_t file_path = dir;
+            if (!file_path.empty() && file_path.back() != DIR_SEPARATOR)
+            {
+                file_path.push_back(DIR_SEPARATOR);
+            }
+            file_path.append(file);
+
             trace::verbose(_X("Adding %s to %s assembly set from %s"), file_name.c_str(), dir_name.c_str(), file_path.c_str());
             dir_assemblies->emplace(file_name, file_path);
         }

--- a/src/corehost/cli/dll/CMakeLists.txt
+++ b/src/corehost/cli/dll/CMakeLists.txt
@@ -45,7 +45,9 @@ set(SOURCES
 
 
 if(WIN32)
-    list(APPEND SOURCES ../../common/pal.windows.cpp)
+    list(APPEND SOURCES 
+        ../../common/pal.windows.cpp
+        ../../common/longfile.windows.cpp)
 else()
     list(APPEND SOURCES ../../common/pal.unix.cpp)
 endif()

--- a/src/corehost/cli/exe/exe.cmake
+++ b/src/corehost/cli/exe/exe.cmake
@@ -28,7 +28,9 @@ list(APPEND SOURCES
     ../../../common/utils.cpp)
 
 if(WIN32)
-    list(APPEND SOURCES ../../../common/pal.windows.cpp)
+    list(APPEND SOURCES
+        ../../../common/pal.windows.cpp
+        ../../../common/longfile.windows.cpp)
 else()
     list(APPEND SOURCES ../../../common/pal.unix.cpp)
 endif()

--- a/src/corehost/cli/fxr/CMakeLists.txt
+++ b/src/corehost/cli/fxr/CMakeLists.txt
@@ -42,7 +42,9 @@ set(SOURCES
 
 
 if(WIN32)
-    list(APPEND SOURCES ../../common/pal.windows.cpp)
+    list(APPEND SOURCES
+        ../../common/pal.windows.cpp
+        ../../common/longfile.windows.cpp)
 else()
     list(APPEND SOURCES ../../common/pal.unix.cpp)
 endif()

--- a/src/corehost/cli/fxr/fx_muxer.cpp
+++ b/src/corehost/cli/fxr/fx_muxer.cpp
@@ -171,7 +171,7 @@ pal::string_t get_deps_from_app_binary(const pal::string_t& app)
     // First append directory.
     pal::string_t deps_file;
     deps_file.assign(get_directory(app));
-    deps_file.push_back(DIR_SEPARATOR);
+
 
     // Then the app name and the file extension
     pal::string_t app_name = get_filename(app);
@@ -222,8 +222,14 @@ pal::string_t get_deps_file(
 {
     if (config.get_portable())
     {
+        pal::string_t deps_file = fx_dir;
+        
+        if (!deps_file.empty() && deps_file.back() != DIR_SEPARATOR)
+        {
+            deps_file.push_back(DIR_SEPARATOR);
+        }
         // Portable app's hostpolicy is resolved from FX deps
-        return fx_dir + DIR_SEPARATOR + config.get_fx_name() + _X(".deps.json");
+        return deps_file + config.get_fx_name() + _X(".deps.json");
     }
     else
     {

--- a/src/corehost/cli/fxr/hostfxr.cpp
+++ b/src/corehost/cli/fxr/hostfxr.cpp
@@ -29,7 +29,7 @@ int load_host_library(
     }
 
     // Load library
-    if (!pal::load_library(host_path.c_str(), h_host))
+    if (!pal::load_library(&host_path, h_host))
     {
         trace::info(_X("Load library of %s failed"), host_path.c_str());
         return StatusCode::CoreHostLibLoadFailure;

--- a/src/corehost/common/longfile.h
+++ b/src/corehost/common/longfile.h
@@ -1,0 +1,26 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#ifndef _LONG_FILE_SUPPORT
+#define _LONG_FILE_SUPPORT
+
+class LongFile
+{
+public:
+    static const pal::string_t ExtendedPrefix;
+    static const pal::string_t DevicePathPrefix;
+    static const pal::string_t UNCPathPrefix;
+    static const pal::string_t UNCExtendedPathPrefix;
+    static const pal::char_t VolumeSeparatorChar;
+    static const pal::char_t DirectorySeparatorChar;
+    static const pal::char_t AltDirectorySeparatorChar;
+public:
+    static bool IsExtended(const pal::string_t& path);
+    static bool IsUNCExtended(const pal::string_t& path);
+    static bool ContainsDirectorySeparator(const pal::string_t & path);
+    static bool IsDirectorySeparator(const pal::char_t c);
+    static bool IsPathNotFullyQualified(const pal::string_t& path);
+    static bool IsDevice(const pal::string_t& path);
+    static bool ShouldNormalize(const pal::string_t& path);
+};
+#endif //_LONG_FILE_SUPPORT

--- a/src/corehost/common/longfile.windows.cpp
+++ b/src/corehost/common/longfile.windows.cpp
@@ -1,0 +1,126 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+//The logic in this file was ported from https://github.com/dotnet/coreclr/blob/54891e0650e69f08832f75a40dc102efc6115d38/src/utilcode/longfilepathwrappers.cpp
+//Please reflect any change here into the above file too!
+#include "pal.h"
+#include "trace.h"
+#include "utils.h"
+#include "longfile.h"
+
+const pal::char_t LongFile::DirectorySeparatorChar = _X('\\');
+const pal::char_t LongFile::AltDirectorySeparatorChar = _X('/');
+const pal::char_t LongFile::VolumeSeparatorChar = _X(':');
+const pal::string_t LongFile::ExtendedPrefix = _X("\\\\?\\");
+const pal::string_t LongFile::DevicePathPrefix = _X("\\\\.\\");
+const pal::string_t LongFile::UNCExtendedPathPrefix = _X("\\\\?\\UNC\\");
+const pal::string_t LongFile::UNCPathPrefix = _X("\\\\");
+
+bool ShouldNormalizeWorker(const pal::string_t& path)
+{
+    if (path.empty() || LongFile::IsDevice(path) || LongFile::IsExtended(path) || LongFile::IsUNCExtended(path))
+        return false;
+
+    if (!LongFile::IsPathNotFullyQualified(path) && path.size() < MAX_PATH)
+        return false;
+
+    return true;
+}
+
+//For longpath names on windows, if the paths are normalized they are always prefixed with
+//extended syntax, Windows does not do any more normalizations on this string and uses it as is
+//So we should ensure that there are NO adjacent DirectorySeparatorChar 
+bool AssertRepeatingDirSeparator(const pal::string_t& path)
+{
+    if (path.empty())
+        return true;
+
+    pal::string_t path_to_check = path;
+    if (LongFile::IsDevice(path))
+    {
+        path_to_check.erase(0, LongFile::DevicePathPrefix.length());
+    }
+    else if (LongFile::IsExtended(path))
+    {
+        path_to_check.erase(0, LongFile::ExtendedPrefix.length());
+    }
+    else if (LongFile::IsUNCExtended(path))
+    {
+        path_to_check.erase(0, LongFile::UNCExtendedPathPrefix.length());
+    }
+    else if (path_to_check.compare(0, LongFile::UNCPathPrefix.length(), LongFile::UNCPathPrefix) == 0)
+    {
+        path_to_check.erase(0, LongFile::UNCPathPrefix.length());
+    }
+
+    pal::string_t dirSeparator;
+    dirSeparator.push_back(LongFile::DirectorySeparatorChar);
+    dirSeparator.push_back(LongFile::DirectorySeparatorChar);
+
+    assert(path_to_check.find(dirSeparator) == pal::string_t::npos);
+
+    pal::string_t altDirSeparator;
+    altDirSeparator.push_back(LongFile::AltDirectorySeparatorChar);
+    altDirSeparator.push_back(LongFile::AltDirectorySeparatorChar);
+
+    assert(path_to_check.find(altDirSeparator) == pal::string_t::npos);
+
+    return true;
+}
+bool  LongFile::ShouldNormalize(const pal::string_t& path)
+{
+    bool retval = ShouldNormalizeWorker(path);
+    assert(retval || AssertRepeatingDirSeparator(path));
+    return retval;
+}
+
+bool LongFile::IsExtended(const pal::string_t& path)
+{
+    return path.compare(0, ExtendedPrefix.length(), ExtendedPrefix) == 0;
+}
+
+bool LongFile::IsUNCExtended(const pal::string_t& path)
+{
+    return path.compare(0, UNCExtendedPathPrefix.length(), UNCExtendedPathPrefix) == 0;
+}
+
+bool LongFile::IsDevice(const pal::string_t& path)
+{
+    return path.compare(0, DevicePathPrefix.length(), DevicePathPrefix) == 0;
+}
+
+// Relative here means it could be relative to current directory on the relevant drive
+// NOTE: Relative segments ( \..\) are not considered relative
+// Returns true if the path specified is relative to the current drive or working directory.
+// Returns false if the path is fixed to a specific drive or UNC path.  This method does no
+// validation of the path (URIs will be returned as relative as a result).
+// Handles paths that use the alternate directory separator.  It is a frequent mistake to
+// assume that rooted paths (Path.IsPathRooted) are not relative.  This isn't the case.
+
+bool LongFile::IsPathNotFullyQualified(const pal::string_t& path)
+{
+    if (path.length() < 2)
+    {
+        return true;  // It isn't fixed, it must be relative.  There is no way to specify a fixed path with one character (or less).
+    }
+
+    if (IsDirectorySeparator(path[0]))
+    {
+        return !IsDirectorySeparator(path[1]); // There is no valid way to specify a relative path with two initial slashes
+    }
+
+    return !((path.length() >= 3)           //The only way to specify a fixed path that doesn't begin with two slashes is the drive, colon, slash format- "i.e. C:\"
+        && (path[1] == VolumeSeparatorChar)
+        && IsDirectorySeparator(path[2]));
+}
+
+bool LongFile::ContainsDirectorySeparator(const pal::string_t & path)
+{
+    return path.find(DirectorySeparatorChar) != pal::string_t::npos ||
+           path.find(AltDirectorySeparatorChar) != pal::string_t::npos;
+}
+
+bool LongFile::IsDirectorySeparator(const pal::char_t c)
+{
+    return c == DirectorySeparatorChar || c == AltDirectorySeparatorChar;
+}

--- a/src/corehost/common/pal.h
+++ b/src/corehost/common/pal.h
@@ -217,7 +217,7 @@ namespace pal
 
     int xtoi(const char_t* input);
 
-    bool load_library(const char_t* path, dll_t* dll);
+    bool load_library(const string_t* path, dll_t* dll);
     proc_t get_symbol(dll_t library, const char* name);
     void unload_library(dll_t library);
 }

--- a/src/corehost/corehost.cpp
+++ b/src/corehost/corehost.cpp
@@ -183,7 +183,7 @@ int run(const int argc, const pal::char_t* argv[])
         return StatusCode::CoreHostLibMissingFailure;
     }
 
-    if (!pal::load_library(fxr_path.c_str(), &fxr))
+    if (!pal::load_library(&fxr_path, &fxr))
     {
         trace::error(_X("The library %s was found, but loading it from %s failed"), LIBFXR_NAME, fxr_path.c_str());
         trace::error(_X("  - Installing .NET Core prerequisites might help resolve this problem."));


### PR DESCRIPTION
Fixes long path issue in the host
The core logic has been ported from https://github.com/dotnet/coreclr/blob/54891e0650e69f08832f75a40dc102efc6115d38/src/utilcode/longfilepathwrappers.cpp

fixes https://github.com/dotnet/core-setup/issues/1489