### PR TITLE
Use dotnet nuget to push to myget feed

### DIFF
--- a/dir.props
+++ b/dir.props
@@ -64,7 +64,7 @@
     <!-- Dev builds get a minor version, by default, of '0'.  Our tests restore packages with
          a -* version, and include myget sources, so any package published the same day to myget
          will conflict with the local build and override the local built package.  Prevent this
-         by setting the non-official build minor version to 99 -->
+         by setting the non-official build minor version to 9 -->
     <BuildNumberMinor Condition="'$(BuildNumberMinor)' == '0'">9</BuildNumberMinor>
 
     <StabilizePackageVersion Condition="'$(StabilizePackageVersion)' == ''">false</StabilizePackageVersion>

--- a/dir.props
+++ b/dir.props
@@ -61,6 +61,12 @@
 
   <!-- Versioning --> 
   <PropertyGroup>
+    <!-- Dev builds get a minor version, by default, of '0'.  Our tests restore packages with
+         a -* version, and include myget sources, so any package published the same day to myget
+         will conflict with the local build and override the local built package.  Prevent this
+         by setting the non-official build minor version to 99 -->
+    <BuildNumberMinor Condition="'$(BuildNumberMinor)' == '0'">9</BuildNumberMinor>
+
     <StabilizePackageVersion Condition="'$(StabilizePackageVersion)' == ''">false</StabilizePackageVersion>
     <VersionSuffix Condition="'$(PreReleaseLabel)' != ''">$(PreReleaseLabel)-</VersionSuffix>
     <VersionSuffix>$(VersionSuffix)$(BuildNumberMajor)-$(BuildNumberMinor)</VersionSuffix>

--- a/dir.props
+++ b/dir.props
@@ -87,11 +87,6 @@
   <!-- Import Build tools common props file where repo-independent properties are found -->
   <Import Condition="Exists('$(ToolsDir)Build.Common.props')" Project="$(ToolsDir)Build.Common.props" />
 
-  <!-- Common nuget properties -->
-  <PropertyGroup>
-    <NuGetToolPath Condition="'$(NuGetToolPath)'==''">$(ToolsDir)NuGet.CommandLine/NuGet.exe</NuGetToolPath>
-  </PropertyGroup>
-
   <!-- list of nuget package sources passed to dnu -->
   <ItemGroup>
     <!-- Need to escape double forward slash (%2F) or MSBuild will normalize to one slash on Unix. -->

--- a/publish/publish.proj
+++ b/publish/publish.proj
@@ -106,8 +106,8 @@
     
     <Message Text="Pushing CoreHost packages to $(NuGetFeedUrl)" />
     <PropertyGroup>
-      <NuGetPushCommand>$(NuGetToolPath) push -Source $(NuGetFeedUrl) -ApiKey $(NuGetApiKey) -Timeout $(NuGetPushTimeoutSeconds)</NuGetPushCommand>
-      <NuGetPushSymbolsCommand>$(NuGetToolPath) push -Source $(NuGetSymbolsFeedUrl) -ApiKey $(NuGetApiKey) -Timeout $(NuGetPushTimeoutSeconds)</NuGetPushSymbolsCommand>
+      <NuGetPushCommand>$(DotnetSdkToolCommand) nuget push --source $(NuGetFeedUrl) --api-key $(NuGetApiKey) --timeout $(NuGetPushTimeoutSeconds)</NuGetPushCommand>
+      <NuGetPushSymbolsCommand>$(DotnetSdkToolCommand) nuget push --source $(NuGetSymbolsFeedUrl) --api-key $(NuGetApiKey) --timeout $(NuGetPushTimeoutSeconds)</NuGetPushSymbolsCommand>
     </PropertyGroup>
 
       <!-- ToDo: look at moving this to an msbuild task so that we can include retry logic, parallelize it, and hide the api key -->

--- a/publish/publish.proj
+++ b/publish/publish.proj
@@ -111,7 +111,6 @@
     </PropertyGroup>
 
       <!-- ToDo: look at moving this to an msbuild task so that we can include retry logic, parallelize it, and hide the api key -->
-      <!-- ToDo: may not be able to take a dependency on NuGet -->
     <Exec Command="$(NuGetPushCommand) %(_DownloadedStandardPackages.Identity)" />
 
     <Message Condition="'@(_DownloadedSymbolsPackages)' != ''" Text="Pushing CoreHost symbols packages to $(NuGetSymbolsFeedUrl)" />


### PR DESCRIPTION
Now that we have the updated cli in core-setup, use it to push to myget feed instead of a dependency on nuget.