### PR TITLE
removing cwd for the lookup of shared fx and sdk

### DIFF
--- a/Documentation/design-docs/multilevel-sharedfx-lookup.md
+++ b/Documentation/design-docs/multilevel-sharedfx-lookup.md
@@ -80,7 +80,7 @@ At last, the coreclr is loaded into memory and called to run the application.
 
 ## Proposed changes
 
-Almost every file search is done in relation to the executable directory. It would be better to be able to search for some files in other directories as well. Suggested folders are the current working directory, the user location and the global .NET location. The user and global folders may vary depending on the running operational system. They are defined as follows:
+Almost every file search is done in relation to the executable directory. It would be better to be able to search for some files in other directories as well. Suggested folders are the user location and the global .NET location. The user and global folders may vary depending on the running operational system. They are defined as follows:
 
 User location:
 
@@ -102,17 +102,15 @@ It’s being proposed that, if the specified version is defined through the conf
 
 - For productions:
 
-	1. In relation to the current working directory: search for the most appropriate version by rolling forward. If it cannot be found, proceed to the next step.
-	2.	In relation to the user location: search for the most appropriate version by rolling forward. If it cannot be found, proceed to the next step.
-	3.	In relation to the executable directory: search for the most appropriate version by rolling forward. If it cannot be found, proceed to the next step.
-	4.	In relation to the global location: search for the most appropriate version by rolling forward. If it cannot be found, then we were not able to locate any compatible version.
+	1.	In relation to the user location: search for the most appropriate version by rolling forward. If it cannot be found, proceed to the next step.
+	2.	In relation to the executable directory: search for the most appropriate version by rolling forward. If it cannot be found, proceed to the next step.
+	3.	In relation to the global location: search for the most appropriate version by rolling forward. If it cannot be found, then we were not able to locate any compatible version.
 
 - For pre-releases:
 	
-	1.	In relation to the current working directory: search for the specified version. If it cannot be found, search for the most appropriate version by rolling forward. If no compatible version can be found, proceed to the next step.
-	2.	In relation to the user location: search for the specified version. If it cannot be found, search for the most appropriate version by rolling forward. If no compatible version can be found, proceed to the next step.
-	3.	In relation to the executable directory: search for the specified version. If it cannot be found, search for the most appropriate version by rolling forward. If no compatible version can be found, proceed to the next step.
-	4.	In relation to the global location: search for the specified version. If it cannot be found, search for the most appropriate version by rolling forward. If no compatible version can be found, then we were not able to locate any compatible version.
+	1.	In relation to the user location: search for the specified version. If it cannot be found, search for the most appropriate version by rolling forward. If no compatible version can be found, proceed to the next step.
+	2.	In relation to the executable directory: search for the specified version. If it cannot be found, search for the most appropriate version by rolling forward. If no compatible version can be found, proceed to the next step.
+	3.	In relation to the global location: search for the specified version. If it cannot be found, search for the most appropriate version by rolling forward. If no compatible version can be found, then we were not able to locate any compatible version.
 
 In the case that the desired version is defined through an argument, the multi-level lookup will happen as well but it will only consider the exact specified version (it will not roll forward).
 
@@ -134,7 +132,6 @@ By following similar logic, it will be possible to implement future changes in t
 
 The search would be conducted as follows:
 
-1.	In relation to the current working directory: search for the specified version. If it cannot be found, choose the most appropriate available version. If there’s no available version, proceed to the next step.
-2.	In relation to the user location: search for the specified version. If it cannot be found, choose the most appropriate available version. If there’s no available version, proceed to the next step.
-3.	In relation to the executable directory: search for the specified version. If it cannot be found, choose the most appropriate available version. If there’s no available version, proceed to the next step.
-4.	In relation to the global location: search for the specified version. If it cannot be found, choose the most appropriate available version. If there’s no available version, then we were not able to find any version folder and an error message must be returned.
+1.	In relation to the user location: search for the specified version. If it cannot be found, choose the most appropriate available version. If there’s no available version, proceed to the next step.
+2.	In relation to the executable directory: search for the specified version. If it cannot be found, choose the most appropriate available version. If there’s no available version, proceed to the next step.
+3.	In relation to the global location: search for the specified version. If it cannot be found, choose the most appropriate available version. If there’s no available version, then we were not able to find any version folder and an error message must be returned.

--- a/src/corehost/cli/fxr/fx_muxer.cpp
+++ b/src/corehost/cli/fxr/fx_muxer.cpp
@@ -431,25 +431,19 @@ pal::string_t fx_muxer_t::resolve_fx_dir(host_mode_t mode,
     }
 
     // Multi-level SharedFX lookup will look for the most appropriate version in several locations
-    // by following the priority rank below (from 1 to 4):
-    // 1. Current working directory
-    // 2. User directory
-    // 3. .exe directory
-    // 4. Global .NET directory
+    // by following the priority rank below:
+    //  User directory
+    // .exe directory
+    //  Global .NET directory
     // If it is not activated, then only .exe directory will be considered
 
     std::vector<pal::string_t> hive_dir;
-    pal::string_t cwd;
     pal::string_t local_dir;
     pal::string_t global_dir;
     bool multilevel_lookup = multilevel_lookup_enabled();
 
     if (multilevel_lookup)
     {
-        if (pal::getcwd(&cwd))
-        {
-            hive_dir.push_back(cwd);
-        }
         if (pal::get_local_dotnet_dir(&local_dir))
         {
             hive_dir.push_back(local_dir);
@@ -643,10 +637,6 @@ bool fx_muxer_t::resolve_sdk_dotnet_path(const pal::string_t& own_dir, const pal
 
     if (multilevel_lookup)
     {
-        if (!cwd.empty())
-        {
-            hive_dir.push_back(cwd);
-        }
         if (pal::get_local_dotnet_dir(&local_dir))
         {
             hive_dir.push_back(local_dir);

--- a/src/corehost/cli/fxr/hostfxr.cpp
+++ b/src/corehost/cli/fxr/hostfxr.cpp
@@ -118,11 +118,7 @@ SHARED_API int hostfxr_main(const int argc, const pal::char_t* argv[])
 //    working_dir
 //      The directory where the search for global.json (which can
 //      control the resolved SDK version) starts and proceeds
-//      upwards. This directory may also be searched for SDKs if
-//      multi-level lookup has not been disabled by the user's
-//      environment. This mimics the current working directory's
-//      interpretation when the dotnet exectuable resolves the SDK
-//      for CLI commands.
+//      upwards. 
 //
 //    buffer
 //      The buffer where the resolved SDK path will be written.

--- a/src/test/HostActivationTests/GivenThatICareAboutMultilevelSharedFxLookup.cs
+++ b/src/test/HostActivationTests/GivenThatICareAboutMultilevelSharedFxLookup.cs
@@ -39,14 +39,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.MultilevelSharedFxLooku
             // are easily overwritten, so they will be placed inside the multilevel folder. The actual user location will
             // be used during tests
             _currentWorkingDir = Path.Combine(multilevelDir, "cwd");
-            if (RuntimeEnvironment.OperatingSystemPlatform == Platform.Windows)
-            {
-                _userDir = Environment.GetEnvironmentVariable("USERPROFILE");
-            }
-            else
-            {
-                _userDir = Environment.GetEnvironmentVariable("HOME");
-            }
+            _userDir = Path.Combine(multilevelDir, "user");
             _executableDir = Path.Combine(multilevelDir, "exe");
 
             // SharedFxBaseDirs contain all available version folders
@@ -98,13 +91,13 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.MultilevelSharedFxLooku
             AddAvailableSharedFxVersions(_exeSharedFxBaseDir, "9999.0.0");
 
             // Version: 9999.0.0
-            // CWD: empty
             // User: empty
             // Exe: 9999.0.0
             // Expected: 9999.0.0 from exe dir
             dotnet.Exec(appDll)
                 .WorkingDirectory(_currentWorkingDir)
                 .EnvironmentVariable("COREHOST_TRACE", "1")
+                .WithUserProfile(_userDir)
                 .CaptureStdOut()
                 .CaptureStdErr()
                 .Execute()
@@ -117,13 +110,13 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.MultilevelSharedFxLooku
             AddAvailableSharedFxVersions(_userSharedFxBaseDir, "9999.0.0");
 
             // Version: 9999.0.0
-            // CWD: empty
             // User: 9999.0.0
             // Exe: 9999.0.0
             // Expected: 9999.0.0 from user dir
             dotnet.Exec(appDll)
                 .WorkingDirectory(_currentWorkingDir)
                 .EnvironmentVariable("COREHOST_TRACE", "1")
+                .WithUserProfile(_userDir)
                 .CaptureStdOut()
                 .CaptureStdErr()
                 .Execute()
@@ -136,20 +129,21 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.MultilevelSharedFxLooku
             AddAvailableSharedFxVersions(_cwdSharedFxBaseDir, "9999.0.0");
 
             // Version: 9999.0.0
-            // CWD: 9999.0.0
+            // CWD: 9999.0.0   --> should not be picked
             // User: 9999.0.0
             // Exe: 9999.0.0
-            // Expected: 9999.0.0 from cwd
+            // Expected: 9999.0.0 from user dir
             dotnet.Exec(appDll)
                 .WorkingDirectory(_currentWorkingDir)
                 .EnvironmentVariable("COREHOST_TRACE", "1")
+                .WithUserProfile(_userDir)
                 .CaptureStdOut()
                 .CaptureStdErr()
                 .Execute()
                 .Should()
                 .Pass()
                 .And
-                .HaveStdErrContaining(_cwdSelectedMessage);
+                .HaveStdErrContaining(_userSelectedMessage);
 
             // Remove dummy folders from user dir
             DeleteAvailableSharedFxVersions(_userSharedFxBaseDir, "9999.0.0");
@@ -173,13 +167,13 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.MultilevelSharedFxLooku
             SetRuntimeConfigJson(runtimeConfig, "9999.0.0-dummy0");
 
             // Version: 9999.0.0-dummy0
-            // CWD: empty
             // User: 9999.0.2, 9999.0.0-dummy2
             // Exe: 9999.0.0, 9999.0.0-dummy0
             // Expected: 9999.0.0-dummy2 from user dir
             dotnet.Exec(appDll)
                 .WorkingDirectory(_currentWorkingDir)
                 .EnvironmentVariable("COREHOST_TRACE", "1")
+                .WithUserProfile(_userDir)
                 .CaptureStdOut()
                 .CaptureStdErr()
                 .Execute()
@@ -188,24 +182,24 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.MultilevelSharedFxLooku
                 .And
                 .HaveStdErrContaining(Path.Combine(_userSelectedMessage, "9999.0.0-dummy2"));
 
-            // Add a prerelease dummy version in CWD
-            AddAvailableSharedFxVersions(_cwdSharedFxBaseDir, "9999.0.0-dummy1");
+            // Add a prerelease dummy version in userdir 
+            AddAvailableSharedFxVersions(_userSharedFxBaseDir, "9999.0.0-dummy1");
 
             // Version: 9999.0.0-dummy0
-            // CWD: 9999.0.0-dummy1
-            // User: 9999.0.2, 9999.0.0-dummy2
+            // User: 9999.0.2, 9999.0.0-dummy1, 9999.0.0-dummy2
             // Exe: 9999.0.0, 9999.0.0-dummy0
-            // Expected: 9999.0.0-dummy1 from cwd
+            // Expected: 9999.0.0-dummy1 from User
             dotnet.Exec(appDll)
                 .WorkingDirectory(_currentWorkingDir)
                 .EnvironmentVariable("COREHOST_TRACE", "1")
+                .WithUserProfile(_userDir)
                 .CaptureStdOut()
                 .CaptureStdErr()
                 .Execute()
                 .Should()
                 .Pass()
                 .And
-                .HaveStdErrContaining(Path.Combine(_cwdSelectedMessage, "9999.0.0-dummy1"));
+                .HaveStdErrContaining(Path.Combine(_userSelectedMessage, "9999.0.0-dummy1"));
 
             // Set desired version = 9999.0.0
             SetRuntimeConfigJson(runtimeConfig, "9999.0.0");
@@ -218,6 +212,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.MultilevelSharedFxLooku
             dotnet.Exec(appDll)
                 .WorkingDirectory(_currentWorkingDir)
                 .EnvironmentVariable("COREHOST_TRACE", "1")
+                .WithUserProfile(_userDir)
                 .CaptureStdOut()
                 .CaptureStdErr()
                 .Execute()
@@ -225,25 +220,6 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.MultilevelSharedFxLooku
                 .Pass()
                 .And
                 .HaveStdErrContaining(Path.Combine(_userSelectedMessage, "9999.0.2"));
-
-            // Add a production dummy version in CWD
-            AddAvailableSharedFxVersions(_cwdSharedFxBaseDir, "9999.0.1");
-
-            // Version: 9999.0.0
-            // CWD: 9999.0.1, 9999.0.0-dummy1
-            // User: 9999.0.2, 9999.0.0-dummy2
-            // Exe: 9999.0.0, 9999.0.0-dummy0
-            // Expected: 9999.0.1 from cwd
-            dotnet.Exec(appDll)
-                .WorkingDirectory(_currentWorkingDir)
-                .EnvironmentVariable("COREHOST_TRACE", "1")
-                .CaptureStdOut()
-                .CaptureStdErr()
-                .Execute()
-                .Should()
-                .Pass()
-                .And
-                .HaveStdErrContaining(Path.Combine(_cwdSelectedMessage, "9999.0.1"));
 
             // Remove dummy folders from user dir
             DeleteAvailableSharedFxVersions(_userSharedFxBaseDir, "9999.0.2", "9999.0.0-dummy2");
@@ -259,18 +235,17 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.MultilevelSharedFxLooku
             var appDll = fixture.TestProject.AppDll;
 
             // Add some dummy versions
-            AddAvailableSharedFxVersions(_cwdSharedFxBaseDir, "9999.0.1", "9999.0.0-dummy0");
             AddAvailableSharedFxVersions(_userSharedFxBaseDir, "9999.0.2", "9999.0.0-dummy2");
             AddAvailableSharedFxVersions(_exeSharedFxBaseDir, "9999.0.0", "9999.0.3", "9999.0.0-dummy3");
 
             // Version: 9999.0.0 (through --fx-version arg)
-            // CWD: 9999.0.1, 9999.0.0-dummy0
             // User: 9999.0.2, 9999.0.0-dummy2
             // Exe: 9999.0.0, 9999.0.3, 9999.0.0-dummy3
             // Expected: 9999.0.0 from exe dir
             dotnet.Exec("--fx-version", "9999.0.0", appDll)
                 .WorkingDirectory(_currentWorkingDir)
                 .EnvironmentVariable("COREHOST_TRACE", "1")
+                .WithUserProfile(_userDir)
                 .CaptureStdOut()
                 .CaptureStdErr()
                 .Execute()
@@ -280,13 +255,13 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.MultilevelSharedFxLooku
                 .HaveStdErrContaining(Path.Combine(_exeSelectedMessage, "9999.0.0"));
 
             // Version: 9999.0.0-dummy1 (through --fx-version arg)
-            // CWD: 9999.0.1, 9999.0.0-dummy0
             // User: 9999.0.2, 9999.0.0-dummy2
             // Exe: 9999.0.0, 9999.0.3, 9999.0.0-dummy3
             // Expected: no compatible version
             dotnet.Exec("--fx-version", "9999.0.0-dummy1", appDll)
                 .WorkingDirectory(_currentWorkingDir)
                 .EnvironmentVariable("COREHOST_TRACE", "1")
+                .WithUserProfile(_userDir)
                 .CaptureStdOut()
                 .CaptureStdErr()
                 .Execute(fExpectedToFail:true)
@@ -312,15 +287,16 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.MultilevelSharedFxLooku
             string runtimeConfig = Path.Combine(fixture.TestProject.OutputDirectory, "SharedFxLookupPortableApp.runtimeconfig.json");
             SetRuntimeConfigJson(runtimeConfig, "9999.0.0");
 
-            // Add some dummy versions in the cwd
-            AddAvailableSharedFxVersions(_cwdSharedFxBaseDir, "10000.1.1", "10000.1.3");
+            // Add some dummy versions in the exe
+            AddAvailableSharedFxVersions(_exeSharedFxBaseDir, "10000.1.1", "10000.1.3");
 
             // Version: 9999.0.0
             // 'Roll forward on no candidate fx' enabled through env var
-            // CWD: 10000.1.1, 10000.1.3
-            // Expected: 10000.1.3 from cwd
+            // exe: 10000.1.1, 10000.1.3
+            // Expected: 10000.1.3 from exe
             dotnet.Exec(appDll)
                 .WorkingDirectory(_currentWorkingDir)
+                .WithUserProfile(_userDir)
                 .EnvironmentVariable("DOTNET_ROLL_FORWARD_ON_NO_CANDIDATE_FX", "1")
                 .EnvironmentVariable("COREHOST_TRACE", "1")
                 .CaptureStdOut()
@@ -329,17 +305,18 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.MultilevelSharedFxLooku
                 .Should()
                 .Pass()
                 .And
-                .HaveStdErrContaining(Path.Combine(_cwdSelectedMessage, "10000.1.3"));
+                .HaveStdErrContaining(Path.Combine(_exeSelectedMessage, "10000.1.3"));
 
-            // Add a dummy version in the cwd
-            AddAvailableSharedFxVersions(_cwdSharedFxBaseDir, "9999.1.1");
+            // Add a dummy version in the exe dir 
+            AddAvailableSharedFxVersions(_exeSharedFxBaseDir, "9999.1.1");
 
             // Version: 9999.0.0
             // 'Roll forward on no candidate fx' enabled through env var
-            // CWD: 9999.1.1, 10000.1.1, 10000.1.3
-            // Expected: 9999.1.1 from cwd
+            // exe: 9999.1.1, 10000.1.1, 10000.1.3
+            // Expected: 9999.1.1 from exe
             dotnet.Exec(appDll)
                 .WorkingDirectory(_currentWorkingDir)
+                .WithUserProfile(_userDir)
                 .EnvironmentVariable("DOTNET_ROLL_FORWARD_ON_NO_CANDIDATE_FX", "1")
                 .EnvironmentVariable("COREHOST_TRACE", "1")
                 .CaptureStdOut()
@@ -348,7 +325,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.MultilevelSharedFxLooku
                 .Should()
                 .Pass()
                 .And
-                .HaveStdErrContaining(Path.Combine(_cwdSelectedMessage, "9999.1.1"));
+                .HaveStdErrContaining(Path.Combine(_exeSelectedMessage, "9999.1.1"));
         }
 
         [Fact]
@@ -364,15 +341,16 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.MultilevelSharedFxLooku
             string runtimeConfig = Path.Combine(fixture.TestProject.OutputDirectory, "SharedFxLookupPortableApp.runtimeconfig.json");
             SetRuntimeConfigJson(runtimeConfig, "9999.1.1");
 
-            // Add some dummy versions in the cwd
-            AddAvailableSharedFxVersions(_cwdSharedFxBaseDir, "9998.0.1", "9998.1.0", "9999.0.0", "9999.0.1", "9999.1.0");
+            // Add some dummy versions in the exe
+            AddAvailableSharedFxVersions(_exeSharedFxBaseDir, "9998.0.1", "9998.1.0", "9999.0.0", "9999.0.1", "9999.1.0");
 
             // Version: 9999.1.1
             // 'Roll forward on no candidate fx' enabled through env var
-            // CWD: 9998.0.1, 9998.1.0, 9999.0.0, 9999.0.1, 9999.1.0
+            // exe: 9998.0.1, 9998.1.0, 9999.0.0, 9999.0.1, 9999.1.0
             // Expected: no compatible version
             dotnet.Exec(appDll)
                 .WorkingDirectory(_currentWorkingDir)
+                .WithUserProfile(_userDir)
                 .EnvironmentVariable("DOTNET_ROLL_FORWARD_ON_NO_CANDIDATE_FX", "1")
                 .EnvironmentVariable("COREHOST_TRACE", "1")
                 .CaptureStdOut()
@@ -402,12 +380,12 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.MultilevelSharedFxLooku
 
             // Version: 9999.0.0
             // 'Roll forward on no candidate fx' enabled through env var
-            // CWD: empty
             // User: empty
             // Exe: 9999.1.0
             // Expected: 9999.1.0 from exe dir
             dotnet.Exec(appDll)
                 .WorkingDirectory(_currentWorkingDir)
+                .WithUserProfile(_userDir)
                 .EnvironmentVariable("DOTNET_ROLL_FORWARD_ON_NO_CANDIDATE_FX", "1")
                 .EnvironmentVariable("COREHOST_TRACE", "1")
                 .CaptureStdOut()
@@ -423,12 +401,12 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.MultilevelSharedFxLooku
 
             // Version: 9999.0.0
             // 'Roll forward on no candidate fx' enabled through env var
-            // CWD: empty
             // User: 9999.1.1
             // Exe: 9999.1.0
             // Expected: 9999.1.1 from user dir
             dotnet.Exec(appDll)
                 .WorkingDirectory(_currentWorkingDir)
+                .WithUserProfile(_userDir)
                 .EnvironmentVariable("DOTNET_ROLL_FORWARD_ON_NO_CANDIDATE_FX", "1")
                 .EnvironmentVariable("COREHOST_TRACE", "1")
                 .CaptureStdOut()
@@ -438,27 +416,6 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.MultilevelSharedFxLooku
                 .Pass()
                 .And
                 .HaveStdErrContaining(_userSelectedMessage);
-
-            // Add a dummy version in the cwd
-            AddAvailableSharedFxVersions(_cwdSharedFxBaseDir, "10000.0.0");
-
-            // Version: 9999.0.0
-            // 'Roll forward on no candidate fx' enabled through env var
-            // CWD: 10000.0.0
-            // User: 9999.1.1
-            // Exe: 9999.1.0
-            // Expected: 10000.0.0 from cwd
-            dotnet.Exec(appDll)
-                .WorkingDirectory(_currentWorkingDir)
-                .EnvironmentVariable("DOTNET_ROLL_FORWARD_ON_NO_CANDIDATE_FX", "1")
-                .EnvironmentVariable("COREHOST_TRACE", "1")
-                .CaptureStdOut()
-                .CaptureStdErr()
-                .Execute()
-                .Should()
-                .Pass()
-                .And
-                .HaveStdErrContaining(_cwdSelectedMessage);
 
             // Remove dummy folders from user dir
             DeleteAvailableSharedFxVersions(_userSharedFxBaseDir, "9999.1.1");
@@ -479,25 +436,8 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.MultilevelSharedFxLooku
             SetRuntimeConfigJson(runtimeConfig, "9999.0.0", 1);
 
             // Add some dummy versions
-            AddAvailableSharedFxVersions(_cwdSharedFxBaseDir, "9999.1.0");
+            AddAvailableSharedFxVersions(_userSharedFxBaseDir, "9999.1.0");
             AddAvailableSharedFxVersions(_exeSharedFxBaseDir, "9999.0.0");
-
-            // Version: 9999.0.0
-            // 'Roll forward on no candidate fx' enabled through runtimeconfig
-            // CWD: 9999.1.0
-            // User: empty
-            // Exe: 9999.0.0
-            // Expected: 9999.1.0 from cwd
-            dotnet.Exec(appDll)
-                .WorkingDirectory(_currentWorkingDir)
-                .EnvironmentVariable("COREHOST_TRACE", "1")
-                .CaptureStdOut()
-                .CaptureStdErr()
-                .Execute()
-                .Should()
-                .Pass()
-                .And
-                .HaveStdErrContaining(_cwdSelectedMessage);
 
             // Set desired version = 9999.0.0
             // Disable 'roll forward on no candidate fx' through runtimeconfig
@@ -506,12 +446,12 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.MultilevelSharedFxLooku
 
             // Version: 9999.0.0
             // 'Roll forward on no candidate fx' disabled through runtimeconfig
-            // CWD: 9999.1.0
-            // User: empty
+            // User: 9999.1.0
             // Exe: 9999.0.0
             // Expected: 9999.0.0 from exe dir
             dotnet.Exec(appDll)
                 .WorkingDirectory(_currentWorkingDir)
+                .WithUserProfile(_userDir)
                 .EnvironmentVariable("DOTNET_ROLL_FORWARD_ON_NO_CANDIDATE_FX", "1")
                 .EnvironmentVariable("COREHOST_TRACE", "1")
                 .CaptureStdOut()
@@ -538,17 +478,17 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.MultilevelSharedFxLooku
             SetRuntimeConfigJson(runtimeConfig, "9999.0.0", 0);
 
             // Add some dummy versions
-            AddAvailableSharedFxVersions(_cwdSharedFxBaseDir, "9999.1.0");
+            AddAvailableSharedFxVersions(_userSharedFxBaseDir, "9999.1.0");
             AddAvailableSharedFxVersions(_exeSharedFxBaseDir, "9999.0.0");
 
             // Version: 9999.0.0
             // 'Roll forward on no candidate fx' enabled through argument
-            // CWD: 9999.1.0
-            // User: empty
+            // User: 9999.1.0
             // Exe: 9999.0.0
-            // Expected: 9999.1.0 from cwd
+            // Expected: 9999.1.0 from User
             dotnet.Exec("--roll-forward-on-no-candidate-fx", "1", appDll)
                 .WorkingDirectory(_currentWorkingDir)
+                .WithUserProfile(_userDir)
                 .EnvironmentVariable("COREHOST_TRACE", "1")
                 .CaptureStdOut()
                 .CaptureStdErr()
@@ -556,7 +496,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.MultilevelSharedFxLooku
                 .Should()
                 .Pass()
                 .And
-                .HaveStdErrContaining(_cwdSelectedMessage);
+                .HaveStdErrContaining(_userSelectedMessage);
 
             // Set desired version = 9999.0.0
             // Enable 'roll forward on no candidate fx' through Runtimeconfig
@@ -564,12 +504,12 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.MultilevelSharedFxLooku
 
             // Version: 9999.0.0
             // 'Roll forward on no candidate fx' disabled through argument
-            // CWD: 9999.1.0
-            // User: empty
+            // User: 9999.1.0
             // Exe: 9999.0.0
             // Expected: 9999.0.0 from exe dir
             dotnet.Exec("--roll-forward-on-no-candidate-fx", "0", appDll)
                 .WorkingDirectory(_currentWorkingDir)
+                .WithUserProfile(_userDir)
                 .EnvironmentVariable("DOTNET_ROLL_FORWARD_ON_NO_CANDIDATE_FX", "1")
                 .EnvironmentVariable("COREHOST_TRACE", "1")
                 .CaptureStdOut()

--- a/src/test/build/Microsoft.DotNet.Cli.Build.Framework/Command.cs
+++ b/src/test/build/Microsoft.DotNet.Cli.Build.Framework/Command.cs
@@ -8,6 +8,7 @@ using System.IO;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using Microsoft.DotNet.InternalAbstractions;
 
 namespace Microsoft.DotNet.Cli.Build.Framework
 {
@@ -219,6 +220,22 @@ namespace Microsoft.DotNet.Cli.Build.Framework
         public Command WorkingDirectory(string projectDirectory)
         {
             _process.StartInfo.WorkingDirectory = projectDirectory;
+            return this;
+        }
+
+        public Command WithUserProfile(string userprofile)
+        {
+            string userDir;
+            if (RuntimeEnvironment.OperatingSystemPlatform == Platform.Windows)
+            {
+                userDir = "USERPROFILE";
+            }
+            else
+            {
+                userDir = "HOME";
+            }
+
+            _process.StartInfo.Environment[userDir] = userprofile;
             return this;
         }
 


### PR DESCRIPTION
port of https://github.com/dotnet/core-setup/pull/2204

remove cwd from probe locations while looking up sdk and shared FX
Also provides a unique user local location for each test