### PR TITLE
Specify content-type for .svg and .version files

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,9 +60,9 @@ Daily Builds
 
 [win-x64-badge-master]: https://dotnetcli.blob.core.windows.net/dotnet/master/Binaries/Latest/sharedfx_win-x64_Release_version_badge.svg
 [win-x64-version-master]: https://dotnetcli.blob.core.windows.net/dotnet/master/dnvm/latest.sharedfx.win-x64.version
-[win-x64-installer-master]: https://dotnetcli.blob.core.windows.net/dotnet/master/Installers/Latest/dotnet-win-x64.latest.exe
-[win-x64-zip-master]: https://dotnetcli.blob.core.windows.net/dotnet/master/Binaries/Latest/dotnet-win-x64.latest.zip
-[win-x64-symbols-zip-master]: https://dotnetcli.blob.core.windows.net/dotnet/master/Binaries/Latest/dotnet-sharedframework-symbols-win-x64.latest.zip
+[win-x64-installer-master]: https://dotnetcli.blob.core.windows.net/dotnet/master/Installers/Latest/dotnet-win-x64-latest.exe
+[win-x64-zip-master]: https://dotnetcli.blob.core.windows.net/dotnet/master/Binaries/Latest/dotnet-win-x64-latest.zip
+[win-x64-symbols-zip-master]: https://dotnetcli.blob.core.windows.net/dotnet/master/Binaries/Latest/dotnet-sharedframework-symbols-win-x64-latest.zip
 
 [win-x64-badge-1.1.X]: https://dotnetcli.blob.core.windows.net/dotnet/release/1.1.0/Binaries/Latest/sharedfx_Windows_x64_Release_version_badge.svg
 [win-x64-version-1.1.X]: https://dotnetcli.blob.core.windows.net/dotnet/release/1.1.0/dnvm/latest.sharedfx.win.x64.version
@@ -76,9 +76,9 @@ Daily Builds
 
 [win-x86-badge-master]: https://dotnetcli.blob.core.windows.net/dotnet/master/Binaries/Latest/sharedfx_win-x86_Release_version_badge.svg
 [win-x86-version-master]: https://dotnetcli.blob.core.windows.net/dotnet/master/dnvm/latest.sharedfx.win-x86.version
-[win-x86-installer-master]: https://dotnetcli.blob.core.windows.net/dotnet/master/Installers/Latest/dotnet-win-x86.latest.exe
-[win-x86-zip-master]: https://dotnetcli.blob.core.windows.net/dotnet/master/Binaries/Latest/dotnet-win-x86.latest.zip
-[win-x86-symbols-zip-master]: https://dotnetcli.blob.core.windows.net/dotnet/master/Binaries/Latest/dotnet-sharedframework-symbols-win-x86.latest.zip
+[win-x86-installer-master]: https://dotnetcli.blob.core.windows.net/dotnet/master/Installers/Latest/dotnet-win-x86-latest.exe
+[win-x86-zip-master]: https://dotnetcli.blob.core.windows.net/dotnet/master/Binaries/Latest/dotnet-win-x86-latest.zip
+[win-x86-symbols-zip-master]: https://dotnetcli.blob.core.windows.net/dotnet/master/Binaries/Latest/dotnet-sharedframework-symbols-win-x86-latest.zip
 
 [win-x86-badge-1.1.X]: https://dotnetcli.blob.core.windows.net/dotnet/release/1.1.0/Binaries/Latest/sharedfx_Windows_x86_Release_version_badge.svg
 [win-x86-version-1.1.X]: https://dotnetcli.blob.core.windows.net/dotnet/release/1.1.0/dnvm/latest.sharedfx.win.x86.version
@@ -92,19 +92,19 @@ Daily Builds
 
 [win-arm-badge-master]: https://dotnetcli.blob.core.windows.net/dotnet/master/Binaries/Latest/sharedfx_win_arm_Release_version_badge.svg
 [win-arm-version-master]: https://dotnetcli.blob.core.windows.net/dotnet/master/dnvm/latest.sharedfx.win.arm.version
-[win-arm-zip-master]: https://dotnetcli.blob.core.windows.net/dotnet/master/Binaries/Latest/dotnet-win-arm.latest.zip
-[win-arm-symbols-zip-master]: https://dotnetcli.blob.core.windows.net/dotnet/master/Binaries/Latest/dotnet-sharedframework-symbols-win-arm.latest.zip
+[win-arm-zip-master]: https://dotnetcli.blob.core.windows.net/dotnet/master/Binaries/Latest/dotnet-win-arm-latest.zip
+[win-arm-symbols-zip-master]: https://dotnetcli.blob.core.windows.net/dotnet/master/Binaries/Latest/dotnet-sharedframework-symbols-win-arm-latest.zip
 
 [win-arm64-badge-master]: https://dotnetcli.blob.core.windows.net/dotnet/master/Binaries/Latest/sharedfx_win_arm64_Release_version_badge.svg
 [win-arm64-version-master]: https://dotnetcli.blob.core.windows.net/dotnet/master/dnvm/latest.sharedfx.win.arm64.version
-[win-arm64-zip-master]: https://dotnetcli.blob.core.windows.net/dotnet/master/Binaries/Latest/dotnet-win-arm64.latest.zip
-[win-arm64-symbols-zip-master]: https://dotnetcli.blob.core.windows.net/dotnet/master/Binaries/Latest/dotnet-sharedframework-symbols-win-arm64.latest.zip
+[win-arm64-zip-master]: https://dotnetcli.blob.core.windows.net/dotnet/master/Binaries/Latest/dotnet-win-arm64-latest.zip
+[win-arm64-symbols-zip-master]: https://dotnetcli.blob.core.windows.net/dotnet/master/Binaries/Latest/dotnet-sharedframework-symbols-win-arm64-latest.zip
 
 [osx-badge-master]: https://dotnetcli.blob.core.windows.net/dotnet/master/Binaries/Latest/sharedfx_osx-x64_Release_version_badge.svg
 [osx-version-master]: https://dotnetcli.blob.core.windows.net/dotnet/master/dnvm/latest.sharedfx.osx-x64.version
-[osx-installer-master]: https://dotnetcli.blob.core.windows.net/dotnet/master/Installers/Latest/dotnet-osx-x64.latest.pkg
-[osx-targz-master]: https://dotnetcli.blob.core.windows.net/dotnet/master/Binaries/Latest/dotnet-osx-x64.latest.tar.gz
-[osx-symbols-targz-master]: https://dotnetcli.blob.core.windows.net/dotnet/master/Binaries/Latest/dotnet-sharedframework-symbols-osx-x64.latest.tar.gz
+[osx-installer-master]: https://dotnetcli.blob.core.windows.net/dotnet/master/Installers/Latest/dotnet-osx-x64-latest.pkg
+[osx-targz-master]: https://dotnetcli.blob.core.windows.net/dotnet/master/Binaries/Latest/dotnet-osx-x64.latest-tar.gz
+[osx-symbols-targz-master]: https://dotnetcli.blob.core.windows.net/dotnet/master/Binaries/Latest/dotnet-sharedframework-symbols-osx-x64-latest.tar.gz
 
 [osx-badge-1.1.X]: https://dotnetcli.blob.core.windows.net/dotnet/release/1.1.0/Binaries/Latest/sharedfx_OSX_x64_Release_version_badge.svg
 [osx-version-1.1.X]: https://dotnetcli.blob.core.windows.net/dotnet/release/1.1.0/dnvm/latest.sharedfx.osx.x64.version
@@ -119,21 +119,21 @@ Daily Builds
 
 [linux-x64-badge-master]: https://dotnetcli.blob.core.windows.net/dotnet/master/Binaries/Latest/sharedfx_linux-x64_Release_version_badge.svg
 [linux-x64-version-master]: https://dotnetcli.blob.core.windows.net/dotnet/master/dnvm/latest.sharedfx.linux-x64.version
-[linux-x64-targz-master]: https://dotnetcli.blob.core.windows.net/dotnet/master/Binaries/Latest/dotnet-linux-x64.latest.tar.gz
-[linux-x64-symbols-targz-master]: https://dotnetcli.blob.core.windows.net/dotnet/master/Binaries/Latest/dotnet-sharedframework-symbols-linux-x64.latest.tar.gz
+[linux-x64-targz-master]: https://dotnetcli.blob.core.windows.net/dotnet/master/Binaries/Latest/dotnet-linux-x64-latest.tar.gz
+[linux-x64-symbols-targz-master]: https://dotnetcli.blob.core.windows.net/dotnet/master/Binaries/Latest/dotnet-sharedframework-symbols-linux-x64-latest.tar.gz
 
 [linux-arm-badge-master]: https://dotnetcli.blob.core.windows.net/dotnet/master/Binaries/Latest/sharedfx_linux_arm_Release_version_badge.svg
-[linux-arm-version-master]: https://dotnetcli.blob.core.windows.net/dotnet/master/dnvm/latest.sharedfx.linux.arm.version
-[linux-arm-targz-master]: https://dotnetcli.blob.core.windows.net/dotnet/master/Binaries/Latest/dotnet-linux-arm.latest.tar.gz
-[linux-arm-symbols-targz-master]: https://dotnetcli.blob.core.windows.net/dotnet/master/Binaries/Latest/dotnet-sharedframework-symbols-linux-arm.latest.tar.gz
+[linux-arm-version-master]: https://dotnetcli.blob.core.windows.net/dotnet/master/dnvm/latest.sharedfx.linux-arm.version
+[linux-arm-targz-master]: https://dotnetcli.blob.core.windows.net/dotnet/master/Binaries/Latest/dotnet-linux-arm-latest.tar.gz
+[linux-arm-symbols-targz-master]: https://dotnetcli.blob.core.windows.net/dotnet/master/Binaries/Latest/dotnet-sharedframework-symbols-linux-arm-latest.tar.gz
 
 [ubuntu-14.04-badge-master]: https://dotnetcli.blob.core.windows.net/dotnet/master/Binaries/Latest/sharedfx_ubuntu.14.04-x64_Release_version_badge.svg
 [ubuntu-14.04-version-master]: https://dotnetcli.blob.core.windows.net/dotnet/master/dnvm/latest.sharedfx.ubuntu-x64.version
-[ubuntu-14.04-host-master]: https://dotnetcli.blob.core.windows.net/dotnet/master/Installers/Latest/dotnet-host-ubuntu-x64.latest.deb
-[ubuntu-14.04-hostfxr-master]: https://dotnetcli.blob.core.windows.net/dotnet/master/Installers/Latest/dotnet-hostfxr-ubuntu-x64.latest.deb
-[ubuntu-14.04-sharedfx-master]: https://dotnetcli.blob.core.windows.net/dotnet/master/Installers/Latest/dotnet-sharedframework-ubuntu-x64.latest.deb
-[ubuntu-14.04-targz-master]: https://dotnetcli.blob.core.windows.net/dotnet/master/Binaries/Latest/dotnet-ubuntu-x64.latest.tar.gz
-[ubuntu-14.04-symbols-targz-master]: https://dotnetcli.blob.core.windows.net/dotnet/master/Binaries/Latest/dotnet-sharedframework-symbols-ubuntu-x64.latest.tar.gz
+[ubuntu-14.04-host-master]: https://dotnetcli.blob.core.windows.net/dotnet/master/Installers/Latest/dotnet-host-ubuntu-x64-latest.deb
+[ubuntu-14.04-hostfxr-master]: https://dotnetcli.blob.core.windows.net/dotnet/master/Installers/Latest/dotnet-hostfxr-ubuntu-x64-latest.deb
+[ubuntu-14.04-sharedfx-master]: https://dotnetcli.blob.core.windows.net/dotnet/master/Installers/Latest/dotnet-sharedframework-ubuntu-x64-latest.deb
+[ubuntu-14.04-targz-master]: https://dotnetcli.blob.core.windows.net/dotnet/master/Binaries/Latest/dotnet-ubuntu-x64-latest.tar.gz
+[ubuntu-14.04-symbols-targz-master]: https://dotnetcli.blob.core.windows.net/dotnet/master/Binaries/Latest/dotnet-sharedframework-symbols-ubuntu-x64-latest.tar.gz
 
 [ubuntu-14.04-badge-1.1.X]: https://dotnetcli.blob.core.windows.net/dotnet/release/1.1.0/Binaries/Latest/sharedfx_Ubuntu_x64_Release_version_badge.svg
 [ubuntu-14.04-version-1.1.X]: https://dotnetcli.blob.core.windows.net/dotnet/release/1.1.0/dnvm/latest.sharedfx.ubuntu.x64.version
@@ -152,11 +152,11 @@ Daily Builds
 
 [ubuntu-16.04-badge-master]: https://dotnetcli.blob.core.windows.net/dotnet/master/Binaries/Latest/sharedfx_ubuntu.16.04-x64_Release_version_badge.svg
 [ubuntu-16.04-version-master]: https://dotnetcli.blob.core.windows.net/dotnet/master/dnvm/latest.sharedfx.ubuntu.16.04-x64.version
-[ubuntu-16.04-host-master]: https://dotnetcli.blob.core.windows.net/dotnet/master/Installers/Latest/dotnet-host-ubuntu.16.04-x64.latest.deb
-[ubuntu-16.04-hostfxr-master]: https://dotnetcli.blob.core.windows.net/dotnet/master/Installers/Latest/dotnet-hostfxr-ubuntu.16.04-x64.latest.deb
-[ubuntu-16.04-sharedfx-master]: https://dotnetcli.blob.core.windows.net/dotnet/master/Installers/Latest/dotnet-sharedframework-ubuntu.16.04-x64.latest.deb
-[ubuntu-16.04-targz-master]: https://dotnetcli.blob.core.windows.net/dotnet/master/Binaries/Latest/dotnet-ubuntu.16.04-x64.latest.tar.gz
-[ubuntu-16.04-symbols-targz-master]: https://dotnetcli.blob.core.windows.net/dotnet/master/Binaries/Latest/dotnet-sharedframework-symbols-ubuntu.16.04-x64.latest.tar.gz
+[ubuntu-16.04-host-master]: https://dotnetcli.blob.core.windows.net/dotnet/master/Installers/Latest/dotnet-host-ubuntu.16.04-x64-latest.deb
+[ubuntu-16.04-hostfxr-master]: https://dotnetcli.blob.core.windows.net/dotnet/master/Installers/Latest/dotnet-hostfxr-ubuntu.16.04-x64-latest.deb
+[ubuntu-16.04-sharedfx-master]: https://dotnetcli.blob.core.windows.net/dotnet/master/Installers/Latest/dotnet-sharedframework-ubuntu.16.04-x64-latest.deb
+[ubuntu-16.04-targz-master]: https://dotnetcli.blob.core.windows.net/dotnet/master/Binaries/Latest/dotnet-ubuntu.16.04-x64-latest.tar.gz
+[ubuntu-16.04-symbols-targz-master]: https://dotnetcli.blob.core.windows.net/dotnet/master/Binaries/Latest/dotnet-sharedframework-symbols-ubuntu.16.04-x64-latest.tar.gz
 
 [ubuntu-16.04-badge-1.1.X]: https://dotnetcli.blob.core.windows.net/dotnet/release/1.1.0/Binaries/Latest/sharedfx_Ubuntu_16_04_x64_Release_version_badge.svg
 [ubuntu-16.04-version-1.1.X]: https://dotnetcli.blob.core.windows.net/dotnet/release/1.1.0/dnvm/latest.sharedfx.ubuntu.16.04.x64.version
@@ -175,11 +175,11 @@ Daily Builds
 
 [ubuntu-16.10-badge-master]: https://dotnetcli.blob.core.windows.net/dotnet/master/Binaries/Latest/sharedfx_ubuntu.16.10-x64_Release_version_badge.svg
 [ubuntu-16.10-version-master]: https://dotnetcli.blob.core.windows.net/dotnet/master/dnvm/latest.sharedfx.ubuntu.16.10-x64.version
-[ubuntu-16.10-host-master]: https://dotnetcli.blob.core.windows.net/dotnet/master/Installers/Latest/dotnet-host-ubuntu.16.10-x64.latest.deb
-[ubuntu-16.10-hostfxr-master]: https://dotnetcli.blob.core.windows.net/dotnet/master/Installers/Latest/dotnet-hostfxr-ubuntu.16.10-x64.latest.deb
-[ubuntu-16.10-sharedfx-master]: https://dotnetcli.blob.core.windows.net/dotnet/master/Installers/Latest/dotnet-sharedframework-ubuntu.16.10-x64.latest.deb
-[ubuntu-16.10-targz-master]: https://dotnetcli.blob.core.windows.net/dotnet/master/Binaries/Latest/dotnet-ubuntu.16.10-x64.latest.tar.gz
-[ubuntu-16.10-symbols-targz-master]: https://dotnetcli.blob.core.windows.net/dotnet/master/Binaries/Latest/dotnet-sharedframework-symbols-ubuntu.16.10-x64.latest.tar.gz
+[ubuntu-16.10-host-master]: https://dotnetcli.blob.core.windows.net/dotnet/master/Installers/Latest/dotnet-host-ubuntu.16.10-x64-latest.deb
+[ubuntu-16.10-hostfxr-master]: https://dotnetcli.blob.core.windows.net/dotnet/master/Installers/Latest/dotnet-hostfxr-ubuntu.16.10-x64-latest.deb
+[ubuntu-16.10-sharedfx-master]: https://dotnetcli.blob.core.windows.net/dotnet/master/Installers/Latest/dotnet-sharedframework-ubuntu.16.10-x64-latest.deb
+[ubuntu-16.10-targz-master]: https://dotnetcli.blob.core.windows.net/dotnet/master/Binaries/Latest/dotnet-ubuntu.16.10-x64-latest.tar.gz
+[ubuntu-16.10-symbols-targz-master]: https://dotnetcli.blob.core.windows.net/dotnet/master/Binaries/Latest/dotnet-sharedframework-symbols-ubuntu.16.10-x64-latest.tar.gz
 
 [ubuntu-16.10-badge-1.1.X]: https://dotnetcli.blob.core.windows.net/dotnet/release/1.1.0/Binaries/Latest/sharedfx_Ubuntu_16_10_x64_Release_version_badge.svg
 [ubuntu-16.10-version-1.1.X]: https://dotnetcli.blob.core.windows.net/dotnet/release/1.1.0/dnvm/latest.sharedfx.ubuntu.16.10.x64.version
@@ -191,11 +191,11 @@ Daily Builds
 
 [debian-8.2-badge-master]: https://dotnetcli.blob.core.windows.net/dotnet/master/Binaries/Latest/sharedfx_debian.8-x64_Release_version_badge.svg
 [debian-8.2-version-master]: https://dotnetcli.blob.core.windows.net/dotnet/master/dnvm/latest.sharedfx.debian.8-x64.version
-[debian-8.2-host-master]: https://dotnetcli.blob.core.windows.net/dotnet/master/Installers/Latest/dotnet-host-debian-x64.latest.deb
-[debian-8.2-hostfxr-master]: https://dotnetcli.blob.core.windows.net/dotnet/master/Installers/Latest/dotnet-hostfxr-debian-x64.latest.deb
-[debian-8.2-sharedfx-master]: https://dotnetcli.blob.core.windows.net/dotnet/master/Installers/Latest/dotnet-sharedframework-debian-x64.latest.deb
-[debian-8.2-targz-master]: https://dotnetcli.blob.core.windows.net/dotnet/master/Binaries/Latest/dotnet-debian-x64.latest.tar.gz
-[debian-8.2-symbols-targz-master]: https://dotnetcli.blob.core.windows.net/dotnet/master/Binaries/Latest/dotnet-sharedframework-symbols-debian-x64.latest.tar.gz
+[debian-8.2-host-master]: https://dotnetcli.blob.core.windows.net/dotnet/master/Installers/Latest/dotnet-host-debian-x64-latest.deb
+[debian-8.2-hostfxr-master]: https://dotnetcli.blob.core.windows.net/dotnet/master/Installers/Latest/dotnet-hostfxr-debian-x64-latest.deb
+[debian-8.2-sharedfx-master]: https://dotnetcli.blob.core.windows.net/dotnet/master/Installers/Latest/dotnet-sharedframework-debian-x64-latest.deb
+[debian-8.2-targz-master]: https://dotnetcli.blob.core.windows.net/dotnet/master/Binaries/Latest/dotnet-debian-x64-latest.tar.gz
+[debian-8.2-symbols-targz-master]: https://dotnetcli.blob.core.windows.net/dotnet/master/Binaries/Latest/dotnet-sharedframework-symbols-debian-x64-latest.tar.gz
 
 [debian-8.2-badge-1.1.X]: https://dotnetcli.blob.core.windows.net/dotnet/release/1.1.0/Binaries/Latest/sharedfx_Debian_x64_Release_version_badge.svg
 [debian-8.2-version-1.1.X]: https://dotnetcli.blob.core.windows.net/dotnet/release/1.1.0/dnvm/latest.sharedfx.debian.x64.version

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Daily Builds
 
 
 [win-x64-badge-master]: https://dotnetcli.blob.core.windows.net/dotnet/master/Binaries/Latest/sharedfx_win-x64_Release_version_badge.svg
-[win-x64-version-master]: https://dotnetcli.blob.core.windows.net/dotnet/master/dnvm/latest.sharedfx.win,x64.version
+[win-x64-version-master]: https://dotnetcli.blob.core.windows.net/dotnet/master/dnvm/latest.sharedfx.win-x64.version
 [win-x64-installer-master]: https://dotnetcli.blob.core.windows.net/dotnet/master/Installers/Latest/dotnet-win-x64.latest.exe
 [win-x64-zip-master]: https://dotnetcli.blob.core.windows.net/dotnet/master/Binaries/Latest/dotnet-win-x64.latest.zip
 [win-x64-symbols-zip-master]: https://dotnetcli.blob.core.windows.net/dotnet/master/Binaries/Latest/dotnet-sharedframework-symbols-win-x64.latest.zip
@@ -75,7 +75,7 @@ Daily Builds
 [win-x64-zip-preview]: https://dotnetcli.blob.core.windows.net/dotnet/preview/Binaries/Latest/dotnet-win-x64.latest.zip
 
 [win-x86-badge-master]: https://dotnetcli.blob.core.windows.net/dotnet/master/Binaries/Latest/sharedfx_win-x86_Release_version_badge.svg
-[win-x86-version-master]: https://dotnetcli.blob.core.windows.net/dotnet/master/dnvm/latest.sharedfx.win.x86.version
+[win-x86-version-master]: https://dotnetcli.blob.core.windows.net/dotnet/master/dnvm/latest.sharedfx.win-x86.version
 [win-x86-installer-master]: https://dotnetcli.blob.core.windows.net/dotnet/master/Installers/Latest/dotnet-win-x86.latest.exe
 [win-x86-zip-master]: https://dotnetcli.blob.core.windows.net/dotnet/master/Binaries/Latest/dotnet-win-x86.latest.zip
 [win-x86-symbols-zip-master]: https://dotnetcli.blob.core.windows.net/dotnet/master/Binaries/Latest/dotnet-sharedframework-symbols-win-x86.latest.zip
@@ -101,7 +101,7 @@ Daily Builds
 [win-arm64-symbols-zip-master]: https://dotnetcli.blob.core.windows.net/dotnet/master/Binaries/Latest/dotnet-sharedframework-symbols-win-arm64.latest.zip
 
 [osx-badge-master]: https://dotnetcli.blob.core.windows.net/dotnet/master/Binaries/Latest/sharedfx_osx-x64_Release_version_badge.svg
-[osx-version-master]: https://dotnetcli.blob.core.windows.net/dotnet/master/dnvm/latest.sharedfx.osx.x64.version
+[osx-version-master]: https://dotnetcli.blob.core.windows.net/dotnet/master/dnvm/latest.sharedfx.osx-x64.version
 [osx-installer-master]: https://dotnetcli.blob.core.windows.net/dotnet/master/Installers/Latest/dotnet-osx-x64.latest.pkg
 [osx-targz-master]: https://dotnetcli.blob.core.windows.net/dotnet/master/Binaries/Latest/dotnet-osx-x64.latest.tar.gz
 [osx-symbols-targz-master]: https://dotnetcli.blob.core.windows.net/dotnet/master/Binaries/Latest/dotnet-sharedframework-symbols-osx-x64.latest.tar.gz
@@ -118,7 +118,7 @@ Daily Builds
 
 
 [linux-x64-badge-master]: https://dotnetcli.blob.core.windows.net/dotnet/master/Binaries/Latest/sharedfx_linux-x64_Release_version_badge.svg
-[linux-x64-version-master]: https://dotnetcli.blob.core.windows.net/dotnet/master/dnvm/latest.sharedfx.linux.x64.version
+[linux-x64-version-master]: https://dotnetcli.blob.core.windows.net/dotnet/master/dnvm/latest.sharedfx.linux-x64.version
 [linux-x64-targz-master]: https://dotnetcli.blob.core.windows.net/dotnet/master/Binaries/Latest/dotnet-linux-x64.latest.tar.gz
 [linux-x64-symbols-targz-master]: https://dotnetcli.blob.core.windows.net/dotnet/master/Binaries/Latest/dotnet-sharedframework-symbols-linux-x64.latest.tar.gz
 
@@ -128,7 +128,7 @@ Daily Builds
 [linux-arm-symbols-targz-master]: https://dotnetcli.blob.core.windows.net/dotnet/master/Binaries/Latest/dotnet-sharedframework-symbols-linux-arm.latest.tar.gz
 
 [ubuntu-14.04-badge-master]: https://dotnetcli.blob.core.windows.net/dotnet/master/Binaries/Latest/sharedfx_ubuntu.14.04-x64_Release_version_badge.svg
-[ubuntu-14.04-version-master]: https://dotnetcli.blob.core.windows.net/dotnet/master/dnvm/latest.sharedfx.ubuntu.x64.version
+[ubuntu-14.04-version-master]: https://dotnetcli.blob.core.windows.net/dotnet/master/dnvm/latest.sharedfx.ubuntu-x64.version
 [ubuntu-14.04-host-master]: https://dotnetcli.blob.core.windows.net/dotnet/master/Installers/Latest/dotnet-host-ubuntu-x64.latest.deb
 [ubuntu-14.04-hostfxr-master]: https://dotnetcli.blob.core.windows.net/dotnet/master/Installers/Latest/dotnet-hostfxr-ubuntu-x64.latest.deb
 [ubuntu-14.04-sharedfx-master]: https://dotnetcli.blob.core.windows.net/dotnet/master/Installers/Latest/dotnet-sharedframework-ubuntu-x64.latest.deb
@@ -151,7 +151,7 @@ Daily Builds
 
 
 [ubuntu-16.04-badge-master]: https://dotnetcli.blob.core.windows.net/dotnet/master/Binaries/Latest/sharedfx_ubuntu.16.04-x64_Release_version_badge.svg
-[ubuntu-16.04-version-master]: https://dotnetcli.blob.core.windows.net/dotnet/master/dnvm/latest.sharedfx.ubuntu.16.04.x64.version
+[ubuntu-16.04-version-master]: https://dotnetcli.blob.core.windows.net/dotnet/master/dnvm/latest.sharedfx.ubuntu.16.04-x64.version
 [ubuntu-16.04-host-master]: https://dotnetcli.blob.core.windows.net/dotnet/master/Installers/Latest/dotnet-host-ubuntu.16.04-x64.latest.deb
 [ubuntu-16.04-hostfxr-master]: https://dotnetcli.blob.core.windows.net/dotnet/master/Installers/Latest/dotnet-hostfxr-ubuntu.16.04-x64.latest.deb
 [ubuntu-16.04-sharedfx-master]: https://dotnetcli.blob.core.windows.net/dotnet/master/Installers/Latest/dotnet-sharedframework-ubuntu.16.04-x64.latest.deb
@@ -174,7 +174,7 @@ Daily Builds
 
 
 [ubuntu-16.10-badge-master]: https://dotnetcli.blob.core.windows.net/dotnet/master/Binaries/Latest/sharedfx_ubuntu.16.10-x64_Release_version_badge.svg
-[ubuntu-16.10-version-master]: https://dotnetcli.blob.core.windows.net/dotnet/master/dnvm/latest.sharedfx.ubuntu.16.10.x64.version
+[ubuntu-16.10-version-master]: https://dotnetcli.blob.core.windows.net/dotnet/master/dnvm/latest.sharedfx.ubuntu.16.10-x64.version
 [ubuntu-16.10-host-master]: https://dotnetcli.blob.core.windows.net/dotnet/master/Installers/Latest/dotnet-host-ubuntu.16.10-x64.latest.deb
 [ubuntu-16.10-hostfxr-master]: https://dotnetcli.blob.core.windows.net/dotnet/master/Installers/Latest/dotnet-hostfxr-ubuntu.16.10-x64.latest.deb
 [ubuntu-16.10-sharedfx-master]: https://dotnetcli.blob.core.windows.net/dotnet/master/Installers/Latest/dotnet-sharedframework-ubuntu.16.10-x64.latest.deb
@@ -190,7 +190,7 @@ Daily Builds
 
 
 [debian-8.2-badge-master]: https://dotnetcli.blob.core.windows.net/dotnet/master/Binaries/Latest/sharedfx_debian.8-x64_Release_version_badge.svg
-[debian-8.2-version-master]: https://dotnetcli.blob.core.windows.net/dotnet/master/dnvm/latest.sharedfx.debian.8.x64.version
+[debian-8.2-version-master]: https://dotnetcli.blob.core.windows.net/dotnet/master/dnvm/latest.sharedfx.debian.8-x64.version
 [debian-8.2-host-master]: https://dotnetcli.blob.core.windows.net/dotnet/master/Installers/Latest/dotnet-host-debian-x64.latest.deb
 [debian-8.2-hostfxr-master]: https://dotnetcli.blob.core.windows.net/dotnet/master/Installers/Latest/dotnet-hostfxr-debian-x64.latest.deb
 [debian-8.2-sharedfx-master]: https://dotnetcli.blob.core.windows.net/dotnet/master/Installers/Latest/dotnet-sharedframework-debian-x64.latest.deb

--- a/tools-local/Microsoft.DotNet.Build.Tasks.Local/AzureHelper.cs
+++ b/tools-local/Microsoft.DotNet.Build.Tasks.Local/AzureHelper.cs
@@ -29,6 +29,8 @@ namespace Microsoft.DotNet.Build.Tasks.Utility
         public const string DateHeaderString = "x-ms-date";
         public const string VersionHeaderString = "x-ms-version";
         public const string AuthorizationHeaderString = "Authorization";
+        public const string CacheControlString = "x-ms-blob-cache-control";
+        public const string ContentTypeString = "x-ms-blob-content-type";
 
         public enum SasAccessType
         {

--- a/tools-local/Microsoft.DotNet.Build.Tasks.Local/UploadClient.cs
+++ b/tools-local/Microsoft.DotNet.Build.Tasks.Local/UploadClient.cs
@@ -139,13 +139,15 @@ namespace Microsoft.DotNet.Build.Tasks.Utility
                     var req = new HttpRequestMessage(HttpMethod.Put, blockListUploadUrl);
                     req.Headers.Add(AzureHelper.DateHeaderString, dt1.ToString("R", CultureInfo.InvariantCulture));
                     req.Headers.Add(AzureHelper.VersionHeaderString, AzureHelper.StorageApiVersion);
-                    if(!string.IsNullOrEmpty(DetermineContentTypeBasedOnFileExtension(filePath)))
+                    string contentType = DetermineContentTypeBasedOnFileExtension(filePath);
+                    if (!string.IsNullOrEmpty(contentType))
                     {
-                        req.Headers.Add(AzureHelper.ContentTypeString, DetermineContentTypeBasedOnFileExtension(filePath));
+                        req.Headers.Add(AzureHelper.ContentTypeString, contentType);
                     }
-                    if (!string.IsNullOrEmpty(DetermineCacheControlBasedOnFileExtension(filePath)))
+                    string cacheControl = DetermineCacheControlBasedOnFileExtension(filePath);
+                    if (!string.IsNullOrEmpty(cacheControl))
                     {
-                        req.Headers.Add(AzureHelper.CacheControlString, DetermineCacheControlBasedOnFileExtension(filePath));
+                        req.Headers.Add(AzureHelper.CacheControlString, cacheControl);
                     }
 
                     var body = new StringBuilder("<?xml version=\"1.0\" encoding=\"UTF-8\"?><BlockList>");

--- a/tools-local/Microsoft.DotNet.Build.Tasks.Local/UploadClient.cs
+++ b/tools-local/Microsoft.DotNet.Build.Tasks.Local/UploadClient.cs
@@ -47,7 +47,8 @@ namespace Microsoft.DotNet.Build.Tasks.Utility
             string filePath,
             string destinationBlob)
         {
-           
+            System.Console.WriteLine($"attach for {filePath}");
+            System.Console.ReadLine();
             string resourceUrl = string.Format("https://{0}.blob.core.windows.net/{1}", AccountName, ContainerName);
 
             string fileName = destinationBlob;
@@ -88,9 +89,7 @@ namespace Microsoft.DotNet.Build.Tasks.Utility
                         {
                             DateTime dt = DateTime.UtcNow;
                             var req = new HttpRequestMessage(HttpMethod.Put, blockUploadUrl);
-                            req.Headers.Add(
-                                AzureHelper.DateHeaderString,
-                                dt.ToString("R", CultureInfo.InvariantCulture));
+                            req.Headers.Add(AzureHelper.DateHeaderString, dt.ToString("R", CultureInfo.InvariantCulture));
                             req.Headers.Add(AzureHelper.VersionHeaderString, AzureHelper.StorageApiVersion);
                             req.Headers.Add(
                                 AzureHelper.AuthorizationHeaderString,
@@ -142,6 +141,14 @@ namespace Microsoft.DotNet.Build.Tasks.Utility
                     var req = new HttpRequestMessage(HttpMethod.Put, blockListUploadUrl);
                     req.Headers.Add(AzureHelper.DateHeaderString, dt1.ToString("R", CultureInfo.InvariantCulture));
                     req.Headers.Add(AzureHelper.VersionHeaderString, AzureHelper.StorageApiVersion);
+                    if(!string.IsNullOrEmpty(DetermineContentTypeBasedOnFileExtension(filePath)))
+                    {
+                        req.Headers.Add(AzureHelper.ContentTypeString, DetermineContentTypeBasedOnFileExtension(filePath));
+                    }
+                    if (!string.IsNullOrEmpty(DetermineCacheControlBasedOnFileExtension(filePath)))
+                    {
+                        req.Headers.Add(AzureHelper.CacheControlString, DetermineCacheControlBasedOnFileExtension(filePath));
+                    }
 
                     var body = new StringBuilder("<?xml version=\"1.0\" encoding=\"UTF-8\"?><BlockList>");
                     foreach (object item in blockIds)
@@ -160,7 +167,7 @@ namespace Microsoft.DotNet.Build.Tasks.Utility
                             string.Empty,
                             string.Empty,
                             bodyData.Length.ToString(),
-                            ""));
+                            string.Empty));
                     Stream postStream = new MemoryStream();
                     postStream.Write(bodyData, 0, bodyData.Length);
                     postStream.Seek(0, SeekOrigin.Begin);
@@ -178,6 +185,26 @@ namespace Microsoft.DotNet.Build.Tasks.Utility
                         await response.Content.ReadAsStringAsync());
                 }
             }
+        }
+        private string DetermineContentTypeBasedOnFileExtension(string filename)
+        {
+            if(Path.GetExtension(filename) == ".svg")
+            {
+                return "image/svg+xml";
+            }
+            else if(Path.GetExtension(filename) == ".version")
+            {
+                return "text/plain";
+            }
+            return string.Empty;
+        }
+        private string DetermineCacheControlBasedOnFileExtension(string filename)
+        {
+            if(Path.GetExtension(filename) == ".svg")
+            {
+                return "No-Cache";
+            }
+            return string.Empty;
         }
     }
 }

--- a/tools-local/Microsoft.DotNet.Build.Tasks.Local/UploadClient.cs
+++ b/tools-local/Microsoft.DotNet.Build.Tasks.Local/UploadClient.cs
@@ -47,8 +47,6 @@ namespace Microsoft.DotNet.Build.Tasks.Utility
             string filePath,
             string destinationBlob)
         {
-            System.Console.WriteLine($"attach for {filePath}");
-            System.Console.ReadLine();
             string resourceUrl = string.Format("https://{0}.blob.core.windows.net/{1}", AccountName, ContainerName);
 
             string fileName = destinationBlob;


### PR DESCRIPTION
Fix readme links, and specify the content-type for .svg and .version files so that they display correctly on the readme.md page.  