### PR TITLE
Add source to framework symbols packages

### DIFF
--- a/src/pkg/projects/Microsoft.NETCore.App/src/Microsoft.NETCore.App.depproj
+++ b/src/pkg/projects/Microsoft.NETCore.App/src/Microsoft.NETCore.App.depproj
@@ -134,6 +134,19 @@
     </ItemGroup>
     <Error Text="Unexpected System package(s) @(_secondarySystemPackages)" Condition="'@(_secondarySystemPackages)' != ''" />
 
+    <ItemGroup>
+      <!-- pick up any src our sources directory from packages contributing files -->
+      <_sourcePaths Include="@(FilesToPackage->'$(PackagesDir)\%(NuGetPackageId)\%(NuGetPackageVersion)\sources')" />
+      <_sourcePaths Include="@(FilesToPackage->'$(PackagesDir)\%(NuGetPackageId)\%(NuGetPackageVersion)\src')" />
+
+      <!-- include all source from those directories -->
+      <_sourceFile Condition="'%(_sourcePaths.Identity)' != ''" Include="%(_sourcePaths.Identity)\**\*.*" />
+      <FilesToPackage Include="@(_sourceFile)">
+        <TargetPath>src\%(RecursiveDir)%(FileName)%(Extension)</TargetPath>
+        <IsSourceCodeFile>true</IsSourceCodeFile>
+      </FilesToPackage>
+    </ItemGroup>
+
     <Message Importance="low" Text="%(FilesToPackage.PackagePath) -> @(FilesToPackage)" />
   </Target>
 

--- a/src/pkg/projects/Microsoft.NETCore.App/src/Microsoft.NETCore.App.depproj
+++ b/src/pkg/projects/Microsoft.NETCore.App/src/Microsoft.NETCore.App.depproj
@@ -136,18 +136,30 @@
 
     <ItemGroup>
       <!-- pick up any src our sources directory from packages contributing files -->
-      <_sourcePaths Include="@(FilesToPackage->'$(PackagesDir)\%(NuGetPackageId)\%(NuGetPackageVersion)\sources')" />
-      <_sourcePaths Include="@(FilesToPackage->'$(PackagesDir)\%(NuGetPackageId)\%(NuGetPackageVersion)\src')" />
+      <_sourcePathCandidate Include="@(FilesToPackage->'$(PackagesDir)\%(NuGetPackageId)\%(NuGetPackageVersion)\sources')" />
+      <_sourcePathCandidate Include="@(FilesToPackage->'$(PackagesDir)\%(NuGetPackageId)\%(NuGetPackageVersion)\src')" />
+      <_sourcePath Include="@(_sourcePathCandidate)" Condition="Exists('%(Identity)')" />
+    </ItemGroup>
 
-      <!-- include all source from those directories -->
-      <_sourceFile Condition="'%(_sourcePaths.Identity)' != ''" Include="%(_sourcePaths.Identity)\**\*.*" />
-      <FilesToPackage Include="@(_sourceFile)">
-        <TargetPath>src\%(RecursiveDir)%(FileName)%(Extension)</TargetPath>
+    <!-- on windows workaround max-path -->
+    <!-- this can be removed once we build on core MSBuild which supports long paths. -->
+    <ItemGroup Condition="'$(OsEnvironment)'=='Windows_NT'">
+      <!-- choose a shorter path name, excluding package version -->
+      <_shortSourcePath Include="@(_sourcePath->'$(ObjDir.Replace('/', '\'))src-%(NuGetPackageId)')">
+        <Original>%(_sourcePath.FullPath)</Original>
+      </_shortSourcePath>
+      <_sourcePath Remove="@(_sourcePath)" />
+      <_sourcePath Include="@(_shortSourcePath)" />
+    </ItemGroup>
+    <RemoveDir Condition="'@(_shortSourcePath)' != '' AND Exists('%(_shortSourcePath.Identity)')" Directories="%(_shortSourcePath.Identity)" />
+    <Exec Condition="'@(_shortSourcePath)' != ''" Command="mklink /J %(_shortSourcePath.Identity) %(_shortSourcePath.Original)" />
+
+    <ItemGroup>
+      <FilesToPackage Include="%(_sourcePath.Identity)\%2A%2A\%2A.%2A">
+        <TargetPath>src</TargetPath>
         <IsSourceCodeFile>true</IsSourceCodeFile>
       </FilesToPackage>
     </ItemGroup>
-
-    <Message Importance="low" Text="%(FilesToPackage.PackagePath) -> @(FilesToPackage)" />
   </Target>
 
   <!-- Prepares all items for cross-gen and replaces package file items with their cross-gen'ed equivalents -->

--- a/src/pkg/projects/Microsoft.NETCore.UniversalWindowsPlatform/src/Microsoft.NETCore.UniversalWindowsPlatform.depproj
+++ b/src/pkg/projects/Microsoft.NETCore.UniversalWindowsPlatform/src/Microsoft.NETCore.UniversalWindowsPlatform.depproj
@@ -87,6 +87,19 @@
     </ItemGroup>
     <Error Text="Unexpected System package(s) @(_secondarySystemPackages)" Condition="'@(_secondarySystemPackages)' != ''" />
 
+    <ItemGroup>
+      <!-- pick up any src our sources directory from packages contributing files -->
+      <_sourcePaths Include="@(FilesToPackage->'$(PackagesDir)\%(NuGetPackageId)\%(NuGetPackageVersion)\sources')" />
+      <_sourcePaths Include="@(FilesToPackage->'$(PackagesDir)\%(NuGetPackageId)\%(NuGetPackageVersion)\src')" />
+
+      <!-- include all source from those directories -->
+      <_sourceFile Condition="'%(_sourcePaths.Identity)' != ''" Include="%(_sourcePaths.Identity)\**\*.*" />
+      <FilesToPackage Include="@(_sourceFile)">
+        <TargetPath>src\%(RecursiveDir)%(FileName)%(Extension)</TargetPath>
+        <IsSourceCodeFile>true</IsSourceCodeFile>
+      </FilesToPackage>
+    </ItemGroup>
+
     <Message Importance="low" Text="%(FilesToPackage.PackagePath) -> @(FilesToPackage)" />
   </Target>
 

--- a/src/pkg/projects/Microsoft.NETCore.UniversalWindowsPlatform/src/Microsoft.NETCore.UniversalWindowsPlatform.depproj
+++ b/src/pkg/projects/Microsoft.NETCore.UniversalWindowsPlatform/src/Microsoft.NETCore.UniversalWindowsPlatform.depproj
@@ -89,18 +89,30 @@
 
     <ItemGroup>
       <!-- pick up any src our sources directory from packages contributing files -->
-      <_sourcePaths Include="@(FilesToPackage->'$(PackagesDir)\%(NuGetPackageId)\%(NuGetPackageVersion)\sources')" />
-      <_sourcePaths Include="@(FilesToPackage->'$(PackagesDir)\%(NuGetPackageId)\%(NuGetPackageVersion)\src')" />
+      <_sourcePathCandidate Include="@(FilesToPackage->'$(PackagesDir)\%(NuGetPackageId)\%(NuGetPackageVersion)\sources')" />
+      <_sourcePathCandidate Include="@(FilesToPackage->'$(PackagesDir)\%(NuGetPackageId)\%(NuGetPackageVersion)\src')" />
+      <_sourcePath Include="@(_sourcePathCandidate)" Condition="Exists('%(Identity)')" />
+    </ItemGroup>
 
-      <!-- include all source from those directories -->
-      <_sourceFile Condition="'%(_sourcePaths.Identity)' != ''" Include="%(_sourcePaths.Identity)\**\*.*" />
-      <FilesToPackage Include="@(_sourceFile)">
-        <TargetPath>src\%(RecursiveDir)%(FileName)%(Extension)</TargetPath>
+    <!-- on windows workaround max-path -->
+    <!-- this can be removed once we build on core MSBuild which supports long paths. -->
+    <ItemGroup Condition="'$(OsEnvironment)'=='Windows_NT'">
+      <!-- choose a shorter path name, excluding package version -->
+      <_shortSourcePath Include="@(_sourcePath->'$(ObjDir.Replace('/', '\'))src-%(NuGetPackageId)')">
+        <Original>%(_sourcePath.FullPath)</Original>
+      </_shortSourcePath>
+      <_sourcePath Remove="@(_sourcePath)" />
+      <_sourcePath Include="@(_shortSourcePath)" />
+    </ItemGroup>
+    <RemoveDir Condition="'@(_shortSourcePath)' != '' AND Exists('%(_shortSourcePath.Identity)')" Directories="%(_shortSourcePath.Identity)" />
+    <Exec Condition="'@(_shortSourcePath)' != ''" Command="mklink /J %(_shortSourcePath.Identity) %(_shortSourcePath.Original)" />
+
+    <ItemGroup>
+      <FilesToPackage Include="%(_sourcePath.Identity)\%2A%2A\%2A.%2A">
+        <TargetPath>src</TargetPath>
         <IsSourceCodeFile>true</IsSourceCodeFile>
       </FilesToPackage>
     </ItemGroup>
-
-    <Message Importance="low" Text="%(FilesToPackage.PackagePath) -> @(FilesToPackage)" />
   </Target>
 
   <Target Name="GetDependenciesToPackage" Condition="'@(DependenciesToPackage)' != ''" DependsOnTargets="ResolveNuGetPackages" Returns="@(_DependenciesToPackageWithVersion)">


### PR DESCRIPTION
Fixes #2156 

/cc @dagood @chcosta @weshaggard @joperezr 

We flow the source in transport/private packages but it wasn't getting pulled in, so it was missing from the framework symbols packages.