### PR TITLE
Revert "remove trailing DIR_SEPARATOR from APP_CONTEXT_BASE_DIRECTORY"

### DIFF
--- a/src/corehost/cli/hostpolicy.cpp
+++ b/src/corehost/cli/hostpolicy.cpp
@@ -80,11 +80,7 @@ int run(const arguments_t& args)
     // Note: these variables' lifetime should be longer than coreclr_initialize.
     std::vector<char> tpa_paths_cstr, app_base_cstr, native_dirs_cstr, resources_dirs_cstr, fx_deps, deps, clrjit_path_cstr, probe_directories;
     pal::pal_clrstring(probe_paths.tpa, &tpa_paths_cstr);
-
-    //removing trailing directory seperator for app compat reasons
-    pal::string_t trimmed_app_dir = trim_end(args.app_dir, DIR_SEPARATOR);
-    pal::pal_clrstring(trimmed_app_dir, &app_base_cstr);
-
+    pal::pal_clrstring(args.app_dir, &app_base_cstr);
     pal::pal_clrstring(probe_paths.native, &native_dirs_cstr);
     pal::pal_clrstring(probe_paths.resources, &resources_dirs_cstr);
 

--- a/src/corehost/common/utils.cpp
+++ b/src/corehost/common/utils.cpp
@@ -129,7 +129,11 @@ pal::string_t get_filename(const pal::string_t& path)
 
 pal::string_t get_directory(const pal::string_t& path)
 {
-    pal::string_t ret = trim_end(path, DIR_SEPARATOR);
+    pal::string_t ret = path;
+    while (!ret.empty() && ret.back() == DIR_SEPARATOR)
+    {
+        ret.pop_back();
+    }
 
     // Find the last dir separator
     auto path_sep = ret.find_last_of(DIR_SEPARATOR);
@@ -282,16 +286,6 @@ bool get_global_shared_store_dir(pal::string_t* dir)
     }
     append_path(dir, RUNTIME_STORE_DIRECTORY_NAME);
     return true;
-}
-
-pal::string_t trim_end(const pal::string_t& path, pal::char_t elem)
-{
-    pal::string_t ret = path;
-    while (!ret.empty() && ret.back() == elem)
-    {
-        ret.pop_back();
-    }
-    return ret;
 }
 
 bool get_local_shared_store_dir(pal::string_t* dir)

--- a/src/corehost/common/utils.h
+++ b/src/corehost/common/utils.h
@@ -42,5 +42,4 @@ bool skip_utf8_bom(pal::ifstream_t* stream);
 bool get_env_shared_store_dirs(std::vector<pal::string_t>* dirs, const pal::string_t& arch, const pal::string_t& tfm);
 bool get_local_shared_store_dir(pal::string_t* recv);
 bool get_global_shared_store_dir(pal::string_t* recv);
-pal::string_t trim_end(const pal::string_t& path, pal::char_t elem);
 #endif


### PR DESCRIPTION
As per https://github.com/dotnet/core-setup/issues/2176#issuecomment-298938175
This reverts commit 8ef546301462dea5a369e0836a2f2f05e225c8ce.(https://github.com/dotnet/core-setup/pull/2178)

cc @gkhanna79 @danmosemsft 