### PR TITLE
Add CoreLib explicitly to TPA list

### DIFF
--- a/src/corehost/cli/hostpolicy.cpp
+++ b/src/corehost/cli/hostpolicy.cpp
@@ -49,6 +49,22 @@ int run(const arguments_t& args)
         return StatusCode::CoreClrResolveFailure;
     }
 
+    // Get path in which CoreCLR is present.
+    pal::string_t clr_dir = get_directory(clr_path);
+
+    // System.Private.CoreLib.dll is expected to be next to CoreCLR.dll - add its path to the TPA list.
+    pal::string_t corelib_path = clr_dir;
+    append_path(&corelib_path, CORELIB_NAME);
+
+    // Append CoreLib path
+    if (probe_paths.tpa.back() != PATH_SEPARATOR)
+    {
+        probe_paths.tpa.push_back(PATH_SEPARATOR);
+    }
+
+    probe_paths.tpa.append(corelib_path);
+    probe_paths.tpa.push_back(PATH_SEPARATOR);
+
     pal::string_t clrjit_path = probe_paths.clrjit;
     if (clrjit_path.empty())
     {
@@ -143,7 +159,6 @@ int run(const arguments_t& args)
     assert(property_keys.size() == property_values.size());
 
     // Bind CoreCLR
-    pal::string_t clr_dir = get_directory(clr_path);
     trace::verbose(_X("CoreCLR path = '%s', CoreCLR dir = '%s'"), clr_path.c_str(), clr_dir.c_str());
     if (!coreclr::bind(clr_dir))
     {

--- a/src/corehost/common/pal.h
+++ b/src/corehost/common/pal.h
@@ -77,6 +77,8 @@
 #define LIBCORECLR_FILENAME (LIB_PREFIX _X("coreclr"))
 #define LIBCORECLR_NAME MAKE_LIBNAME("coreclr")
 
+#define CORELIB_NAME _X("System.Private.CoreLib.dll")
+
 #define LIBHOSTPOLICY_FILENAME (LIB_PREFIX _X("hostpolicy"))
 #define LIBHOSTPOLICY_NAME MAKE_LIBNAME("hostpolicy")
 


### PR DESCRIPTION
With dotnet/coreclr#11359, CoreLib is always next to CoreCLR.dll, which is under runtime-native assets category.

Since runtime-native assets are not on TPA, but we need CoreLib to be on TPA (for folks who maybe consuming TPA explicitly for their own use - even if they should not do so), we explicitly add CoreLib to be on TPA.

@jkotas PTAL