### PR TITLE
Make Cross Builds work

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -151,7 +151,7 @@ esac
 
 __BuildType=Debug
 __BuildArch=x64
-__IncludeTests=Include_Tests
+__SkipTests=false
 __VerboseBuild=0
 __CrossBuild=0
 __PortableBuild=0
@@ -209,7 +209,7 @@ while :; do
             ;;
 
         skiptests)
-            __IncludeTests=
+            __SkipTests=true
             ;;
     esac
 
@@ -222,7 +222,7 @@ initHostDistroRid
 # init the target distro name
 initTargetDistroRid
 
-__RunArgs="-TargetArchitecture=$__BuildArch -ConfigurationGroup=$__BuildType -OSGroup=$__HostOS -DistroRid=$__DistroRid"
+__RunArgs="-TargetArchitecture=$__BuildArch -ConfigurationGroup=$__BuildType -OSGroup=$__HostOS -DistroRid=$__DistroRid -SkipTests=$__SkipTests"
 
 if [ $__PortableBuild == 1 ]; then
   __RunArgs="$__RunArgs -PortableBuild=True"

--- a/dir.props
+++ b/dir.props
@@ -223,7 +223,6 @@
 
   <PropertyGroup>
     <Framework>netcoreapp2.0</Framework>
-    <Framework Condition="'$(TargetArchitecture)' == 'arm64'">netcoreapp1.1</Framework>
   </PropertyGroup>
   
   <PropertyGroup Condition="'$(TargetRid)' == '' and '$(OSGroup)' == 'Windows_NT'">

--- a/src/corehost/build.proj
+++ b/src/corehost/build.proj
@@ -43,11 +43,12 @@
              Targets="GenerateVersionHeader" />
     <PropertyGroup>
       <BuildArgs>$(ConfigurationGroup) $(TargetArchitecture) version $(HostVersion) commit $(LatestCommit) rid $(TargetRid)</BuildArgs>
+      <CustomNativeToolsetDir Condition="'$(TargetArchitecture)' == 'arm64'"> toolsetdir $(NativeToolsetDir)</CustomNativeToolsetDir>      
     </PropertyGroup>
 
     <!-- Run script that invokes Cmake to create VS files, and then calls msbuild to compile them -->
     <Message Text="$(MSBuildProjectDirectory)\build.cmd $(BuildArgs)" Importance="High"/>
-    <Exec Command="$(MSBuildProjectDirectory)\build.cmd $(BuildArgs)" />
+    <Exec Command="$(MSBuildProjectDirectory)\build.cmd $(BuildArgs)$(CustomNativeToolsetDir)" />
 
     <ItemGroup>
       <CMakeOutput Include="$(IntermediateOutputRootPath)corehost\cli\exe\dotnet\$(ConfigurationGroup)\dotnet.exe" />

--- a/src/pkg/packaging/windows/package.props
+++ b/src/pkg/packaging/windows/package.props
@@ -7,8 +7,8 @@
     <WixToolsDir>$(IntermediateOutputRootPath)WixTools.$(WixVersion)</WixToolsDir>
     <WixObjRoot>$(IntermediateOutputRootPath)wix/</WixObjRoot>
     <MsiArch>$(TargetArchitecture)</MsiArch>
-    <MsiArch Condition="'$(TargetArchitecture)' == 'arm'">x86</MsiArch>
-    <MsiArch Condition="'$(TargetArchitecture)' == 'arm64'">x64</MsiArch>    
+    <GenerateMSI>true</GenerateMSI>
+    <GenerateMSI Condition="'$(TargetArchitecture)' == 'arm' or '$(TargetArchitecture)' == 'arm64'">false</GenerateMSI>
     <InsigniaCmd>$(WixToolsDir)\insignia.exe</InsigniaCmd>
   </PropertyGroup>
 </Project>

--- a/src/pkg/packaging/windows/package.targets
+++ b/src/pkg/packaging/windows/package.targets
@@ -7,7 +7,7 @@
     <UsingTask TaskName="ZipFileExtractToDirectory" AssemblyFile="$(BuildToolsTaskDir)Microsoft.DotNet.Build.Tasks.dll"/>
 
     <Target Name="GenerateMsis"
-            Condition="'$(OSGroup)' == 'Windows_NT'">
+            Condition="'$(OSGroup)' == 'Windows_NT' and '$(GenerateMSI)' == 'true'">
       
       <PropertyGroup>
         <WixVersion Condition="'$(WixVersion)' == ''">3.10.2</WixVersion>
@@ -86,7 +86,7 @@
 
   <Target Name="GenerateBundles"
           DependsOnTargets="GetBundleDisplayVersion"
-          Condition="'$(OSGroup)' == 'Windows_NT'">
+          Condition="'$(OSGroup)' == 'Windows_NT' and '$(GenerateMSI)' == 'true'">
      <PropertyGroup>
         <SharedFxBundleScript>$(WindowsScriptRoot)sharedframework\generatebundle.ps1</SharedFxBundleScript>
         <ShareFXMsi>$(SharedFrameworkInstallerFile)</ShareFXMsi>
@@ -108,11 +108,11 @@
      <Exec Command="powershell -NoProfile -NoLogo $(SharedFxBundleScript) $(BundleParameters)" />
   </Target>
 
-  <Target Name="ExtractEngineBundle">
+  <Target Name="ExtractEngineBundle" Condition="'$(OSGroup)' == 'Windows_NT' and '$(GenerateMSI)' == 'true'">
       <Exec Command="$(InsigniaCmd) -ib $(CombinedInstallerFile) -o $(CombinedInstallerEngine)" />
   </Target>
 
-  <Target Name="ReattachEngineToBundle">
+  <Target Name="ReattachEngineToBundle" Condition="'$(OSGroup)' == 'Windows_NT' and '$(GenerateMSI)' == 'true'">
       <Exec Command="$(InsigniaCmd) -ab $(CombinedInstallerEngine) $(CombinedInstallerFile) -o $(CombinedInstallerFile)" />
   </Target>
 

--- a/src/pkg/projects/Microsoft.NETCore.App/src/Microsoft.NETCore.App.depproj
+++ b/src/pkg/projects/Microsoft.NETCore.App/src/Microsoft.NETCore.App.depproj
@@ -36,8 +36,8 @@
     </ItemGroup>
 
     <PropertyGroup>
-      <_crossDir Condition="'$(NuGetRuntimeIdentifier)' == 'win8-arm'">/x86_arm</_crossDir>
-      <_crossDir Condition="'$(NuGetRuntimeIdentifier)' == 'win10-arm64'">/x64_arm64</_crossDir>
+      <_crossDir Condition="'$(NuGetRuntimeIdentifier)' == 'win8-arm' or '$(NuGetRuntimeIdentifier)' == 'win-arm'">/x86_arm</_crossDir>
+      <_crossDir Condition="'$(NuGetRuntimeIdentifier)' == 'win10-arm64' or '$(NuGetRuntimeIdentifier)' == 'win-arm64'">/x64_arm64</_crossDir>
     </PropertyGroup>
 
     <PropertyGroup Condition="'@(_runtimeCLR)' != ''">

--- a/src/pkg/projects/Microsoft.NETCore.UniversalWindowsPlatform/Microsoft.NETCore.UniversalWindowsPlatform.builds
+++ b/src/pkg/projects/Microsoft.NETCore.UniversalWindowsPlatform/Microsoft.NETCore.UniversalWindowsPlatform.builds
@@ -3,7 +3,7 @@
   <Import Project="dir.props" />
 
   <ItemGroup>
-    <Project Include="Microsoft.NETCore.UniversalWindowsPlatform.pkgproj" />
+    <Project Include="Microsoft.NETCore.UniversalWindowsPlatform.pkgproj" Condition="'$(Platform)' != 'arm64'"/>
   </ItemGroup>
 
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />

--- a/src/pkg/projects/Microsoft.NETCore.UniversalWindowsPlatform/src/Microsoft.NETCore.UniversalWindowsPlatform.builds
+++ b/src/pkg/projects/Microsoft.NETCore.UniversalWindowsPlatform/src/Microsoft.NETCore.UniversalWindowsPlatform.builds
@@ -1,9 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <BuildOnUnknownPlatforms>false</BuildOnUnknownPlatforms>
+  </PropertyGroup>
+
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
 
   <ItemGroup>
-    <Project Include="Microsoft.NETCore.UniversalWindowsPlatform.depproj" />
+    <Project Include="Microsoft.NETCore.UniversalWindowsPlatform.depproj" Condition="'$(Platform)' != 'arm64'" />
   </ItemGroup>
 
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />

--- a/src/pkg/projects/dir.props
+++ b/src/pkg/projects/dir.props
@@ -73,15 +73,16 @@
   <Import Project="$(RIDPropsFile)" />
 
   <ItemGroup>
+    <_buildingOnRID Include="$(PackageRID)" Condition="'$(BuildOnUnknownPlatforms)' != 'false'">
+      <Platform>$(Platform)</Platform>
+    </_buildingOnRID>
     <!-- Ensure we have a RID-specific package for the current build, even if it isn't in our official set -->
-    <BuildRID Include="@(OfficialBuildRID)" Exclude="$(PackageRID)"/>
+    <BuildRID Include="@(OfficialBuildRID)" Exclude="@(_buildingOnRID)"/>
     <!-- Include Unofficial Build RIDs in runtime.json's but do not include in the platform manifest -->
-    <BuildRID Include="@(UnofficialBuildRID)" Exclude="$(PackageRID)">
+    <BuildRID Include="@(UnofficialBuildRID)" Exclude="@(_buildingOnRID)">
       <ExcludeFromPlatformManifest>true</ExcludeFromPlatformManifest>
     </BuildRID>
-    <BuildRID Include="$(PackageRID)">
-      <Platform>$(Platform)</Platform>
-    </BuildRID>
+    <BuildRID Include="@(_buildingOnRID)"/>
   </ItemGroup>
   
   <PropertyGroup>


### PR DESCRIPTION
Linux Arm build cannot run tests and skiptests was not propagating the intent correctly. With this change, "./build.sh arm cross -portable skiptests" results in a clean Linux arm build.

Fixes https://github.com/dotnet/core-setup/issues/2194 and https://github.com/dotnet/core-setup/issues/2267

@chcosta PTAL