### PR TITLE
Do not exit when unmount fails during rootfs builds

### DIFF
--- a/cross/build-rootfs.sh
+++ b/cross/build-rootfs.sh
@@ -128,10 +128,6 @@ fi
 if [ -d "$__RootfsDir" ]; then
     if [ $__SkipUnmount == 0 ]; then
         umount $__RootfsDir/*
-        if [ $? -ne 0 ]; then
-            echo "Failed to unmount RootfsDir."
-            exit 1
-        fi
     fi
     rm -rf $__RootfsDir
 fi


### PR DESCRIPTION
If rootfsdir is not mounted, it always fails to build rootfs without `--skipunmount` option.
This routine is not necessary so I removed it.

/cc @gkhanna79 