### PR TITLE
DependencyModel continue on on file not found

### DIFF
--- a/src/Microsoft.Extensions.DependencyModel/Resolution/ResolverUtils.cs
+++ b/src/Microsoft.Extensions.DependencyModel/Resolution/ResolverUtils.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections.Generic;
 using System.IO;
 
 namespace Microsoft.Extensions.DependencyModel.Resolution
@@ -24,19 +22,6 @@ namespace Microsoft.Extensions.DependencyModel.Resolution
                 return true;
             }
             return false;
-        }
-
-        internal static IEnumerable<string> ResolveFromPackagePath(IFileSystem fileSystem, CompilationLibrary library, string basePath)
-        {
-            foreach (var assembly in library.Assemblies)
-            {
-                string fullName;
-                if (!TryResolveAssemblyFile(fileSystem, basePath, assembly, out fullName))
-                {
-                    throw new InvalidOperationException($"Cannot find assembly file for package {library.Name} at '{fullName}'");
-                }
-                yield return fullName;
-            }
         }
 
         internal static bool TryResolveAssemblyFile(IFileSystem fileSystem, string basePath, string assemblyPath, out string fullName)

--- a/test/Microsoft.Extensions.DependencyModel.Tests/PackageResolverTest.cs
+++ b/test/Microsoft.Extensions.DependencyModel.Tests/PackageResolverTest.cs
@@ -70,7 +70,6 @@ namespace Microsoft.Extensions.DependencyModel.Tests
             assemblies.Should().Contain(Path.Combine(packagePath, F.SecondAssemblyPath));
         }
 
-
         [Fact]
         public void FailsWhenOneOfAssembliesNotFound()
         {
@@ -83,10 +82,33 @@ namespace Microsoft.Extensions.DependencyModel.Tests
             var resolver = new PackageCompilationAssemblyResolver(fileSystem,  new string[] { PackagesPath });
             var assemblies = new List<string>();
 
-            var exception = Assert.Throws<InvalidOperationException>(() => resolver.TryResolveAssemblyPaths(library, assemblies));
-            exception.Message.Should()
-                .Contain(F.SecondAssemblyPath)
-                .And.Contain(library.Name);
+            resolver.TryResolveAssemblyPaths(library, assemblies)
+                .Should().BeFalse();
+
+            assemblies.Should().BeEmpty();
+        }
+
+        [Fact]
+        public void KeepsLookingWhenOneOfAssembliesNotFound()
+        {
+            var packagePath1 = GetPackagesPath(F.DefaultPackageName, F.DefaultVersion);
+            var secondPath = "secondPath";
+            var packagePath2 = GetPackagesPath(secondPath, F.DefaultPackageName, F.DefaultVersion);
+            var fileSystem = FileSystemMockBuilder.Create()
+                .AddFiles(packagePath1, F.DefaultAssemblyPath)
+                .AddFiles(packagePath2, F.DefaultAssemblyPath, F.SecondAssemblyPath)
+                .Build();
+            var library = F.Create(assemblies: F.TwoAssemblies);
+
+            var resolver = new PackageCompilationAssemblyResolver(fileSystem, new string[] { PackagesPath, secondPath });
+            var assemblies = new List<string>();
+
+            resolver.TryResolveAssemblyPaths(library, assemblies)
+                .Should().BeTrue();
+
+            assemblies.Should().HaveCount(2);
+            assemblies.Should().Contain(Path.Combine(packagePath2, F.DefaultAssemblyPath));
+            assemblies.Should().Contain(Path.Combine(packagePath2, F.SecondAssemblyPath));
         }
 
         private static string GetPackagesPath(string id, string version)


### PR DESCRIPTION
Now that we have runtime package stores, there are package paths that don't contain all of the reference assemblies.  Runtime package stores actually don't have any reference assemblies.

When DependencyModel is given a runtime package store and a NuGet cache directory (in that order), it needs to keep looking in all the package paths it is given before throwing an exception.

@ramarag @pakrym 

/cc @gkhanna79 @Petermarcu 