### PR TITLE
Fix combinedinstallerfile path

### DIFF
--- a/src/pkg/packaging/windows/package.targets
+++ b/src/pkg/packaging/windows/package.targets
@@ -109,11 +109,11 @@
   </Target>
 
   <Target Name="ExtractEngineBundle">
-      <Exec Command="$(InsigniaCmd) -ib $(CombinedInstallerFile) -o $(PackagesOutDir)$(CombinedInstallerEngine)" />
+      <Exec Command="$(InsigniaCmd) -ib $(CombinedInstallerFile) -o $(CombinedInstallerEngine)" />
   </Target>
 
   <Target Name="ReattachEngineToBundle">
-      <Exec Command="$(InsigniaCmd) -ab $(CombinedInstallerEngine) $(PackagesOutDir)$(CombinedInstallerFile) -o $(PackagesOutDir)$(CombinedInstallerFile)" />
+      <Exec Command="$(InsigniaCmd) -ab $(CombinedInstallerEngine) $(CombinedInstallerFile) -o $(CombinedInstallerFile)" />
   </Target>
 
 </Project>


### PR DESCRIPTION
https://github.com/dotnet/core-setup/commit/77179251dd0c4954ff812e30e645c26cbb2a4506 made the combinedinstallerfile and combinedinstallerengine properties fully rooted paths.  Removing the `PackagesOutDir` paths from those property calls to insignia for engine extract / attach to align with that change.