### PR TITLE
Fix restoring the dotnet-deb-tool.

### DIFF
--- a/src/pkg/packaging/deb/package.targets
+++ b/src/pkg/packaging/deb/package.targets
@@ -12,7 +12,7 @@
   </PropertyGroup>
 
   <Target Name="InitializeDotnetDebTool">
-    <Exec Command="$(DotnetSdkToolCommand) restore $(dotnetDebToolSource)"/>
+    <Exec Command="$(SdkRestoreCommand) $(dotnetDebToolSource)"/>
     <Exec Command="$(DotnetSdkToolCommand) pack $(dotnetDebToolSource) --output $(PackagesOutDir)intermediate/ --version-suffix $(VersionSuffix)"/>
 
     <ItemGroup>
@@ -34,7 +34,7 @@
     <Copy SourceFiles="$(MSBuildThisFileDirectory)/$(toolConsumerProjectName)"
           DestinationFiles="$(consumingProjectDirectory)/$(toolConsumerProjectName)" />
 
-    <Exec Command="$(DotnetSdkToolCommand) restore -s $(dotnetDebToolPackageSource)"
+    <Exec Command="$(SdkRestoreCommand) -s $(dotnetDebToolPackageSource)"
           WorkingDirectory="$(consumingProjectDirectory)" />
 
   </Target>


### PR DESCRIPTION
With #2259, we disabled the first run experience. This broke restoring the deb-tool project that got checked in at roughly the same time.

Fixing this by using the restore command that specifies the `--packages` and all the default `--source` parameters to `dotnet restore`.

@mellinoe @chcosta @ellismg 

FYI - I'm probably going to merge this when I get green CI to unblock the official build.