### PR TITLE
Ensure DOTNET_SKIP_FIRST_TIME_EXPERIENCE is on no matter how the tests are executed.

### DIFF
--- a/src/test/build/shared-build-targets-utils/Utils/DotNetCli.cs
+++ b/src/test/build/shared-build-targets-utils/Utils/DotNetCli.cs
@@ -32,7 +32,8 @@ namespace Microsoft.DotNet.Cli.Build
                 newArgs.Insert(0, "-v");
             }
 
-            return Command.Create(Path.Combine(BinPath, $"dotnet{Constants.ExeSuffix}"), newArgs);
+            return Command.Create(Path.Combine(BinPath, $"dotnet{Constants.ExeSuffix}"), newArgs)
+                .EnvironmentVariable("DOTNET_SKIP_FIRST_TIME_EXPERIENCE", "1");
         }
 
         public Command Restore(params string[] args) => Exec("restore", args);


### PR DESCRIPTION
We are now using the 2.0 SDK in our tests.  The 2.0 SDK's first time experience now changes the AppData/Roaming/NuGet/NuGet.config file for the current user.  We turn the first time experience off in `run.cmd`, which ensures this doesn't happen during builds.

However, when we run the tests in VSO official builds, we are not using `run.cmd`.  Instead we are just invoking msbuild directly.

This fix ensures that the first time experience is always off, no matter how we run the tests.

@chcosta @mellinoe @weshaggard 

Note: I'm working with @chcosta on thinking about a "more global" setting for this that works across dev machine, Jenkins, and VSO.  This setting should be 100% off all the time in our builds, everywhere.