### PR TITLE
Fix finalization, use sharedframeworknugetversion and sharedhostnugetversion

### DIFF
--- a/publish/publish.proj
+++ b/publish/publish.proj
@@ -59,6 +59,8 @@
                    SemaphoreBlob="$(Channel)/Binaries/sharedFxPublishSemaphore"
                    Channel="$(Channel)"
                    Version="$(SharedFrameworkNugetVersion)"
+                   SharedFrameworkNugetVersion="$(SharedFrameworkNugetVersion)"
+                   SharedHostNuGetVersion="$(HostVersion)"
                    PublishRids="@(PublishRid)"
                    FinalizeContainer="$(Channel)/Binaries/$(SharedFrameworkNugetVersion)"
                    ForcePublish="true"                  

--- a/tools-local/tasks/FinalizeBuild.cs
+++ b/tools-local/tasks/FinalizeBuild.cs
@@ -45,8 +45,6 @@ namespace Microsoft.DotNet.Build.Tasks
 
         public override bool Execute()
         {
-            Console.WriteLine("Attach for finalization");
-            Console.ReadLine();
             ParseConnectionString();
 
             if (Log.HasLoggedErrors)


### PR DESCRIPTION
Finalization was busted because the regex was trying to match the version and would match

Linux-x**64.2.0**.0-prerelease2-23505-01.tar.gz

instead of

Linux-x64.**2.0.0-prerelease2-23505-01**.tar.gz

Fix this by following similar semantics previously used, and explicitly pass the sharedframework version as well as host version to the finalization.

I validated this locally and was able to publish the latest drop with the correct filenames, links on core-setup\readme.md now work (finally)

/cc @eerhardt @karajas 