### PR TITLE
Fix publish by importing the targets file that has GetLatestCommitHash.

### DIFF
--- a/publish/dir.targets
+++ b/publish/dir.targets
@@ -65,4 +65,6 @@
                           Exclude="@(_FoundBlobNames)" />
     </ItemGroup>
   </Target>
+
+  <Import Project="..\dir.targets" />
 </Project>


### PR DESCRIPTION
The official build is broken with my last change with error:

`error MSB4057: The target "GetLatestCommitHash" does not exist in the project.`

Fixing this by importing the right .targets file.

@chcosta 