### PR TITLE
Fix finalize build by using RIDs for the .svg file, but the same legacy monikers for the .version files.

### DIFF
--- a/publish/dir.props
+++ b/publish/dir.props
@@ -6,7 +6,7 @@
     <ContainerName Condition="'$(ContainerName)' == ''">dotnet</ContainerName>
     <NuGetPushTimeoutSeconds Condition="'$(NuGetPushTimeoutSeconds)' == ''">3600</NuGetPushTimeoutSeconds>
   </PropertyGroup>
-    
+
   <ItemGroup>
     <InstallerFile Include="$(PackagesOutDir)*$(SharedFrameworkNuGetVersion)$(InstallerExtension)" />
     <InstallerFile Include="$(PackagesOutDir)*$(SharedFrameworkNuGetVersion)$(CombinedInstallerExtension)" />
@@ -18,23 +18,55 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PublishVersionFile Include="ubuntu.x64"/>
-    <PublishVersionFile Include="ubuntu.16.04.x64"/>
-    <PublishVersionFile Include="ubuntu.16.10.x64"/>
-    <PublishVersionFile Include="debian.x64"/>
-    <PublishVersionFile Include="linux.x64"/>
-    <PublishVersionFile Include="win.x86"/>
-    <PublishVersionFile Include="win.x64"/>
-    <PublishVersionFile Include="osx.x64"/>
-<!-- Not currently producing arm builds 
-    <PublishVersionFile Include="win.arm"/>
-    <PublishVersionFile Include="win.arm64"/>
-    <PublishVersionFile Include="linux.arm"/>
-    <PublishVersionFile Include="linux.arm64"/>
-    <PublishVersionFile Include="ubuntu.14.04.arm"/>
-    <PublishVersionFile Include="ubuntu.16.04.arm"/>
-    <PublishVersionFile Include="win8.arm"/>
-    <PublishVersionFile Include="win10.arm64"/>
--->    
+    <PublishRid Include="ubuntu.14.04-x64">
+      <VersionFileName>ubuntu.x64</VersionFileName>
+    </PublishRid>
+    <PublishRid Include="ubuntu.16.04-x64">
+      <VersionFileName>ubuntu.16.04.x64</VersionFileName>
+    </PublishRid>
+    <PublishRid Include="ubuntu.16.10-x64">
+      <VersionFileName>ubuntu.16.10.x64</VersionFileName>
+    </PublishRid>
+    <PublishRid Include="debian.8-x64">
+      <VersionFileName>debian.x64</VersionFileName>
+    </PublishRid>
+    <PublishRid Include="linux-x64">
+      <VersionFileName>linux.x64</VersionFileName>
+    </PublishRid>
+    <PublishRid Include="win-x86">
+      <VersionFileName>win.x86</VersionFileName>
+    </PublishRid>
+    <PublishRid Include="win-x64">
+      <VersionFileName>win.x64</VersionFileName>
+    </PublishRid>
+    <PublishRid Include="osx-x64">
+      <VersionFileName>osx.x64</VersionFileName>
+    </PublishRid>
+    <!-- Not currently producing arm builds 
+    <PublishRid Include="win-arm">
+      <VersionFileName>win.arm</VersionFileName>
+    </PublishRid>
+    <PublishRid Include="win-arm64">
+      <VersionFileName>win.arm64</VersionFileName>
+    </PublishRid>
+    <PublishRid Include="linux-arm">
+      <VersionFileName>linux.arm</VersionFileName>
+    </PublishRid>
+    <PublishRid Include="linux-arm64">
+      <VersionFileName>linux.arm64</VersionFileName>
+    </PublishRid>
+    <PublishRid Include="ubuntu.14.04-arm">
+      <VersionFileName>ubuntu.14.04.arm</VersionFileName>
+    </PublishRid>
+    <PublishRid Include="ubuntu.16.04-arm">
+      <VersionFileName>ubuntu.16.04.arm</VersionFileName>
+    </PublishRid>
+    <PublishRid Include="win8-arm">
+      <VersionFileName>win8.arm</VersionFileName>
+    </PublishRid>
+    <PublishRid Include="win10-arm64">
+      <VersionFileName>win10.arm64</VersionFileName>
+    </PublishRid>
+-->
   </ItemGroup>
-</Project>  
+</Project>

--- a/publish/dir.targets
+++ b/publish/dir.targets
@@ -61,7 +61,7 @@
     </GetAzureBlobList>
     <ItemGroup>
       <_FoundBlobNames Include="%(_BlobNames.FileName)%(_BlobNames.Extension)" Condition="'%(_BlobNames.Extension)' == '.svg'" />
-      <_MissingBlobNames Include="@(PublishVersionFile->'sharedfx_%(Identity)_$(ConfigurationGroup)_version_badge.svg')" 
+      <_MissingBlobNames Include="@(PublishRid->'sharedfx_%(Identity)_$(ConfigurationGroup)_version_badge.svg')" 
                           Exclude="@(_FoundBlobNames)" />
     </ItemGroup>
   </Target>

--- a/publish/publish.proj
+++ b/publish/publish.proj
@@ -51,7 +51,7 @@
     <Error Condition="'$(AzureAccountName)' == ''" Text="Missing required property 'AzureAccountName'" />
     <Error Condition="'$(ContainerName)' == ''" Text="Missing required property 'ContainerName'" />
     <Error Condition="'$(LatestCommit)' == ''" Text="Missing required property 'LatestCommit'" />
-    <Error Condition="'@(PublishVersionFile)' == ''" Text="Missing required item 'PublishVersionFile'" />
+    <Error Condition="'@(PublishRid)' == ''" Text="Missing required item 'PublishRid'" />
           
     <Message Importance="High" Text="Finalizing Build" />
     <!-- Ensure all publish pieces are present and then publish to Azure Latest container -->
@@ -63,7 +63,7 @@
                    Version="$(SharedFrameworkNugetVersion)"
                    SharedFrameworkNugetVersion="$(SharedFrameworkNugetVersion)"
                    SharedHostNuGetVersion="$(HostVersion)"
-                   PublishVersionFiles="@(PublishVersionFile)"
+                   PublishRids="@(PublishRid)"
                    CommitHash="$(LatestCommit)"
                    FinalizeContainer="$(Channel)/Binaries/$(SharedFrameworkNugetVersion)"
                    ForcePublish="true"                  

--- a/tools-local/tasks/FinalizeBuild.cs
+++ b/tools-local/tasks/FinalizeBuild.cs
@@ -37,7 +37,7 @@ namespace Microsoft.DotNet.Build.Tasks
         [Required]
         public string Version { get; set; }
         [Required]
-        public ITaskItem [] PublishVersionFiles { get; set; }
+        public ITaskItem [] PublishRids { get; set; }
         [Required]
         public string CommitHash { get; set; }
         public bool ForcePublish { get; set; }
@@ -99,7 +99,7 @@ namespace Microsoft.DotNet.Build.Tasks
                     CopyBlobs($"{Channel}/Installers/{SharedHostNugetVersion}", $"{Channel}/Installers/Latest/");
 
                     // Generate the Sharedfx Version text files
-                    List<string> versionFiles = PublishVersionFiles.Select(p => $"{p.ItemSpec}.version").ToList();
+                    List<string> versionFiles = PublishRids.Select(p => $"{p.GetMetadata("VersionFileName")}.version").ToList();
 
                     string sfxVersion = GetSharedFrameworkVersionFileContent();
                     foreach(string version in versionFiles)


### PR DESCRIPTION
@chcosta 

Regular note that I'm going to merge this when green to unblock the official builds.