### PR TITLE
Fix monikers

### DIFF
--- a/src/dir.props
+++ b/src/dir.props
@@ -26,7 +26,11 @@
     <PackageTargetRid Condition="'$(TargetRid)' == 'rhel.7.1-x64'">rhel.7-x64</PackageTargetRid>
     <PackageTargetRid Condition="'$(TargetRid)' == 'rhel.7.2-x64'">rhel.7-x64</PackageTargetRid>
     <PackageTargetRid Condition="'$(TargetRid)' == 'rhel.7.3-x64'">rhel.7-x64</PackageTargetRid>
-    <PackageTargetRid Condition="'$(TargetRid)' == 'rhel.7.2-x64'">rhel.7-x64</PackageTargetRid>    
+    <PackageTargetRid Condition="'$(TargetRid)' == 'rhel.7.2-x64'">rhel.7-x64</PackageTargetRid>
+
+    <PackageTargetMoniker>$(PackageTargetRid)</PackageTargetMoniker>
+    <PackageTargetMoniker Condition="'$(TargetRid)' == 'ubuntu.14.04-x64'">ubuntu-x64</PackageTargetMoniker>
+    <PackageTargetMoniker Condition="'$(TargetRid)' == 'debian.8-x64'">debian-x64</PackageTargetMoniker>
   </PropertyGroup>
     
 </Project>

--- a/src/pkg/packaging/deb/package.targets
+++ b/src/pkg/packaging/deb/package.targets
@@ -5,8 +5,8 @@
   <UsingTask TaskName="ReplaceFileContents" AssemblyFile="$(LocalBuildToolsTaskDir)core-setup.tasks.dll"/>
 
   <PropertyGroup>
-    <IsDebianBasedDistro Condition="$(PackageTargetRid.StartsWith('ubuntu')) or
-                                    $(PackageTargetRid.StartsWith('debian'))">true</IsDebianBasedDistro>
+    <IsDebianBasedDistro Condition="$(PackageTargetMoniker.StartsWith('ubuntu')) or
+                                    $(PackageTargetMoniker.StartsWith('debian'))">true</IsDebianBasedDistro>
     <BuildDebPackage Condition="'$(IsDebianBasedDistro)' == true and '$(TargetArchitecture)' == 'x64'">true</BuildDebPackage>
     <DebianConfigJsonName>debian_config.json</DebianConfigJsonName>
   </PropertyGroup>

--- a/src/pkg/packaging/dir.props
+++ b/src/pkg/packaging/dir.props
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <ProductMoniker>$(PackageTargetRid).$(HostFullVersion)</ProductMoniker>
+    <ProductMoniker>$(PackageTargetMoniker).$(HostFullVersion)</ProductMoniker>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
Fix product monikers for ubuntu.14.04 and debian.8, they should be `ubuntu` and `debian` respectively.