### PR TITLE
[Port to master] DependencyModel continue on on file not found

### DIFF
--- a/src/managed/Microsoft.Extensions.DependencyModel/Resolution/ResolverUtils.cs
+++ b/src/managed/Microsoft.Extensions.DependencyModel/Resolution/ResolverUtils.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections.Generic;
 using System.IO;
 
 namespace Microsoft.Extensions.DependencyModel.Resolution
@@ -24,19 +22,6 @@ namespace Microsoft.Extensions.DependencyModel.Resolution
                 return true;
             }
             return false;
-        }
-
-        internal static IEnumerable<string> ResolveFromPackagePath(IFileSystem fileSystem, CompilationLibrary library, string basePath)
-        {
-            foreach (var assembly in library.Assemblies)
-            {
-                string fullName;
-                if (!TryResolveAssemblyFile(fileSystem, basePath, assembly, out fullName))
-                {
-                    throw new InvalidOperationException($"Cannot find assembly file for package {library.Name} at '{fullName}'");
-                }
-                yield return fullName;
-            }
         }
 
         internal static bool TryResolveAssemblyFile(IFileSystem fileSystem, string basePath, string assemblyPath, out string fullName)


### PR DESCRIPTION
Now that we have runtime package stores, there are package paths that don't contain all of the reference assemblies.  Runtime package stores actually don't have any reference assemblies.

When DependencyModel is given a runtime package store and a NuGet cache directory (in that order), it needs to keep looking in all the package paths it is given before throwing an exception.

This is a direct port of the release/2.0.0 PR that was approved last week: https://github.com/dotnet/core-setup/pull/2285.

@gkhanna79 