### PR TITLE
Fix dependency model deps

### DIFF
--- a/build.proj
+++ b/build.proj
@@ -55,7 +55,7 @@
     <Exec Command="$(DnuRestoreCommand) %(DnuRestoreDirs.AdditionalArgs) %(DnuRestoreDirs.Identity)" StandardOutputImportance="Low" CustomErrorRegularExpression="^Unable to locate .*" />
 
     <!-- SDK project restore. Eventually this should be the only group being restored. -->
-    <Exec Condition="'@(SdkRestoreProjects)' != ''" Command="$(SdkRestoreCommand) &quot;%(SdkRestoreProjects.FullPath)&quot;" StandardOutputImportance="Low" />
+    <Exec Condition="'@(SdkRestoreProjects)' != ''" Command="$(SdkRestoreCommand) &quot;%(SdkRestoreProjects.FullPath)&quot; %(SdkRestoreProjects.ExtraRestoreArgs)" StandardOutputImportance="Low" />
   </Target>
 
   <!-- Task from buildtools that uses lockfiles to validate that packages restored are exactly what were specified. -->

--- a/dir.props
+++ b/dir.props
@@ -123,7 +123,10 @@
     <DnuRestoreDirs Include="$(MSBuildThisFileDirectory)src/pkg/deps" />
 
     <SdkRestoreProjects Include="$(MSBuildThisFileDirectory)src\managed\Microsoft.DotNet.PlatformAbstractions\Microsoft.DotNet.PlatformAbstractions.csproj" />
-    <SdkRestoreProjects Include="$(MSBuildThisFileDirectory)src\managed\Microsoft.Extensions.DependencyModel\Microsoft.Extensions.DependencyModel.csproj" />
+    <SdkRestoreProjects Include="$(MSBuildThisFileDirectory)src\managed\Microsoft.Extensions.DependencyModel\Microsoft.Extensions.DependencyModel.csproj">
+      <!-- Workaround https://github.com/NuGet/Home/issues/4337 -->
+      <ExtraRestoreArgs>/p:VersionSuffix=$(VersionSuffix)</ExtraRestoreArgs>
+    </SdkRestoreProjects>
   </ItemGroup>
 
   <PropertyGroup>

--- a/src/managed/CommonManaged.props
+++ b/src/managed/CommonManaged.props
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <!-- Don't import props files above this folder since they don't work with the .NET Core SDK. -->
+  <!--<Import Project="..\dir.props" />-->
+
+  <PropertyGroup>
+    <RepoRoot>$([System.IO.Path]::GetFullPath('$(MSBuildThisFileDirectory)../..'))/</RepoRoot>
+    <VersionPrefix>2.0.0</VersionPrefix>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <AssemblyOriginatorKeyFile>$(RepoRoot)tools-local/setuptools/Key.snk</AssemblyOriginatorKeyFile>
+    <SignAssembly>true</SignAssembly>
+    <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <RepositoryType>git</RepositoryType>
+    <RepositoryUrl>git://github.com/dotnet/core-setup</RepositoryUrl>
+  </PropertyGroup>
+
+  <ItemGroup Condition=" '$(TargetFrameworkIdentifier)' == '.NETFramework' ">
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+  </ItemGroup>
+
+</Project>

--- a/src/managed/Microsoft.DotNet.PlatformAbstractions/Microsoft.DotNet.PlatformAbstractions.csproj
+++ b/src/managed/Microsoft.DotNet.PlatformAbstractions/Microsoft.DotNet.PlatformAbstractions.csproj
@@ -1,21 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), CommonManaged.props))\CommonManaged.props" />
 
   <PropertyGroup>
     <Description>Abstractions for making code that uses file system and environment testable.</Description>
-    <VersionPrefix>2.0.0</VersionPrefix>
     <TargetFrameworks>net45;netstandard1.3</TargetFrameworks>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <AssemblyOriginatorKeyFile>../../../tools-local/setuptools/Key.snk</AssemblyOriginatorKeyFile>
-    <SignAssembly>true</SignAssembly>
-    <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
-    <RepositoryType>git</RepositoryType>
-    <RepositoryUrl>git://github.com/dotnet/core-setup</RepositoryUrl>
   </PropertyGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">
-    <Reference Include="Microsoft.CSharp" />
-  </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">
     <PackageReference Include="System.AppContext" Version="4.1.0" />

--- a/src/managed/Microsoft.Extensions.DependencyModel/Microsoft.Extensions.DependencyModel.csproj
+++ b/src/managed/Microsoft.Extensions.DependencyModel/Microsoft.Extensions.DependencyModel.csproj
@@ -1,25 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), CommonManaged.props))\CommonManaged.props" />
 
   <PropertyGroup>
     <Description>Abstractions for reading `.deps` files.</Description>
-    <VersionPrefix>2.0.0</VersionPrefix>
     <TargetFrameworks>net451;netstandard1.3;netstandard1.6</TargetFrameworks>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <AssemblyOriginatorKeyFile>../../../tools-local/setuptools/Key.snk</AssemblyOriginatorKeyFile>
-    <SignAssembly>true</SignAssembly>
-    <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
-    <RepositoryType>git</RepositoryType>
-    <RepositoryUrl>git://github.com/dotnet/core-setup</RepositoryUrl>
-    <PackageTargetFallback Condition=" '$(TargetFramework)' == 'netstandard1.3' Or '$(TargetFramework)' == 'netstandard1.6' ">$(PackageTargetFallback);portable-net45+wp80+win8+wpa81+dnxcore50</PackageTargetFallback>
   </PropertyGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.DotNet.PlatformAbstractions\Microsoft.DotNet.PlatformAbstractions.csproj" />
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net451' ">
-    <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' Or '$(TargetFramework)' == 'netstandard1.6' ">


### PR DESCRIPTION
- Fix DependencyModel and PlatformAbstractions to not depend on NETStandard.Library.
- Fix DependencyModel's dependency on PlatformAbstractions to use a pre-release version.

@mellinoe @chcosta 