### PR TITLE
Lookup dir

### DIFF
--- a/src/corehost/cli/args.h
+++ b/src/corehost/cli/args.h
@@ -42,6 +42,14 @@ struct probe_config_t
     {
     }
 
+    bool is_lookup() const
+    {
+        return (probe_deps_json == nullptr) &&
+            !only_runtime_assets &&
+            !only_serviceable_assets &&
+            !probe_publish_dir;
+    }
+
     static probe_config_t svc_ni(const pal::string_t& dir)
     {
         return probe_config_t(dir, nullptr, true, true, false);

--- a/src/corehost/cli/deps_resolver.cpp
+++ b/src/corehost/cli/deps_resolver.cpp
@@ -164,13 +164,16 @@ void deps_resolver_t::setup_shared_store_probes(
     }
 }
 
-pal::string_t deps_resolver_t::get_probe_directories()
+pal::string_t deps_resolver_t::get_lookup_probe_directories()
 {
     pal::string_t directories;
     for (const auto& pc : m_probes)
     {
-        directories.append(pc.probe_dir);
-        directories.push_back(PATH_SEPARATOR);
+        if (pc.is_lookup())
+        {
+            directories.append(pc.probe_dir);
+            directories.push_back(PATH_SEPARATOR);
+        }
     }
 
     return directories;

--- a/src/corehost/cli/deps_resolver.h
+++ b/src/corehost/cli/deps_resolver.h
@@ -80,7 +80,7 @@ public:
         const hostpolicy_init_t& init,
         const arguments_t& args);
 
-    pal::string_t get_probe_directories();
+    pal::string_t get_lookup_probe_directories();
 
     void setup_probe_config(
         const hostpolicy_init_t& init,

--- a/src/corehost/cli/hostpolicy.cpp
+++ b/src/corehost/cli/hostpolicy.cpp
@@ -103,7 +103,7 @@ int run(const arguments_t& args)
     pal::pal_clrstring(resolver.get_fx_deps_file(), &fx_deps);
     pal::pal_clrstring(resolver.get_deps_file() + _X(";") + resolver.get_fx_deps_file(), &deps);
 
-    pal::pal_clrstring(resolver.get_probe_directories(), &probe_directories);
+    pal::pal_clrstring(resolver.get_lookup_probe_directories(), &probe_directories);
 
     std::vector<const char*> property_values = {
         // TRUSTED_PLATFORM_ASSEMBLIES


### PR DESCRIPTION
Limiting the  probe directories which are made visible to DependencyModel.Resolution with only those that have a nuget layout

Fixes https://github.com/dotnet/core-setup/issues/2076

@gkhanna79 @eerhardt  PTAL