### PR TITLE
Versioning Cleanup

### DIFF
--- a/dir.props
+++ b/dir.props
@@ -9,8 +9,7 @@
     <MajorVersion>2</MajorVersion>
     <MinorVersion>0</MinorVersion>
     <PatchVersion>0</PatchVersion>
-    <StabilizePackageVersion>false</StabilizePackageVersion>
-    <LockHostVersion>false</LockHostVersion>
+    <StabilizePackageVersion Condition="'$(StabilizePackageVersion)' == ''">false</StabilizePackageVersion>
     <PreReleaseLabel>preview2</PreReleaseLabel>
     <ReleaseSuffix>$(PreReleaseLabel)</ReleaseSuffix>
     <ReleaseBrandSuffix>Preview 2</ReleaseBrandSuffix>
@@ -69,27 +68,52 @@
          by setting the non-official build minor version to 9 -->
     <BuildNumberMinor Condition="'$(BuildNumberMinor)' == '0'">9</BuildNumberMinor>
 
-    <StabilizePackageVersion Condition="'$(StabilizePackageVersion)' == ''">false</StabilizePackageVersion>
     <VersionSuffix Condition="'$(PreReleaseLabel)' != ''">$(PreReleaseLabel)-</VersionSuffix>
     <VersionSuffix>$(VersionSuffix)$(BuildNumberMajor)-$(BuildNumberMinor)</VersionSuffix>
-
-    <ProductVersion>$(MajorVersion).$(MinorVersion).$(PatchVersion)-$(VersionSuffix)</ProductVersion>
+    <ProductVersionSuffix Condition="'$(StabilizePackageVersion)' !='true'">-$(VersionSuffix)</ProductVersionSuffix>
+    <ProductVersion>$(MajorVersion).$(MinorVersion).$(PatchVersion)$(ProductVersionSuffix)</ProductVersion>
     <ProductionVersion>$(MajorVersion).$(MinorVersion).$(PatchVersion)</ProductionVersion>
 
-    <SharedFrameworkNugetVersion Condition="'$(StabilizePackageVersion)' == 'true'">$(ProductionVersion)</SharedFrameworkNugetVersion>
-    <SharedFrameworkNugetVersion Condition="'$(StabilizePackageVersion)' == 'false'">$(ProductVersion)</SharedFrameworkNugetVersion>
+    <SharedFrameworkNugetVersion>$(ProductVersion)</SharedFrameworkNugetVersion>
 
     <NuGetVersion>$(SharedFrameworkNugetVersion)</NuGetVersion>
-    <HostVersion>$(SharedFrameworkNugetVersion)</HostVersion>
-    <AppHostVersion>$(SharedFrameworkNugetVersion)</AppHostVersion>
-    <NetCoreAppVersion>$(SharedFrameworkNugetVersion)</NetCoreAppVersion>
-    <HostResolverVersion>$(SharedFrameworkNugetVersion)</HostResolverVersion>
-    <HostPolicyVersion>$(SharedFrameworkNugetVersion)</HostPolicyVersion>
+
+    <!--
+      By default, we are always building the nuget packages for HostPolicy, HostFXR and
+      Dotnet/AppHost. Thus, the "UseShipped*" properties (below) are always set to false.
+      
+      However, there are scenarios when some of these components will not change (e.g. during
+      servicing, we may only change HostPolicy but not HostFXR and Dotnet/AppHost). In such cases,
+      set the appropriate "UseShipped*" property below to true so that we will use the last shipped
+      version of the package. 
+    -->
+
+    <!-- The host/apphost package versions are only updated whenever there is a change in the components -->
+    <UseShippedHostPackage>false</UseShippedHostPackage>
+    <HostVersion Condition="'$(UseShippedHostPackage)' != 'true'">$(ProductVersion)</HostVersion>
+    <HostVersion Condition="'$(UseShippedHostPackage)' == 'true'">2.0.0</HostVersion>
+
+    <UseShippedAppHostPackage>false</UseShippedAppHostPackage>
+    <AppHostVersion Condition="'$(UseShippedAppHostPackage)' != 'true'">$(ProductVersion)</AppHostVersion>
+    <AppHostVersion Condition="'$(UseShippedAppHostPackage)' == 'true'">2.0.0</AppHostVersion>
     
-    <HostFullVersion>$(ProductVersion)</HostFullVersion>
-    <HostResolverFullVersion>$(ProductVersion)</HostResolverFullVersion>
-    <AppHostFullVersion>$(ProductVersion)</AppHostFullVersion>
-    <HostPolicyFullVersion>$(ProductVersion)</HostPolicyFullVersion>
+    <!-- 
+        The FXR Resolver package version is only updated whenever there is a change in it. 
+        If there is ever a need to use a shipped version of the package, then set the property
+        below to true. 
+    -->
+    <UseShippedHostResolverPackage>false</UseShippedHostResolverPackage>
+    <HostResolverVersion Condition="'$(UseShippedHostResolverPackage)' != 'true'">$(ProductVersion)</HostResolverVersion>
+    <HostResolverVersion Condition="'$(UseShippedHostResolverPackage)' == 'true'">2.0.0</HostResolverVersion>
+
+    <!-- 
+         Host Policy package version is only updated whenever there is a change in it.
+         If there is ever a need to use a shipped version of the package, then set the property
+         below to true. 
+    -->
+    <UseShippedHostPolicyPackage>false</UseShippedHostPolicyPackage>
+    <HostPolicyVersion Condition="'$(UseShippedHostPolicyPackage)' != 'true'">$(ProductVersion)</HostPolicyVersion>
+    <HostPolicyVersion Condition="'$(UseShippedHostPolicyPackage)' == 'true'">2.0.0</HostPolicyVersion>
   </PropertyGroup>
 
   <!-- Import Build tools common props file where repo-independent properties are found -->

--- a/src/corehost/Windows/gen-buildsys-win.bat
+++ b/src/corehost/Windows/gen-buildsys-win.bat
@@ -5,7 +5,7 @@ rem This file invokes cmake and generates the build system for windows.
 set argC=0
 for %%x in (%*) do Set /A argC+=1
 
-if NOT %argC%==5 GOTO :USAGE
+if NOT %argC%==8 GOTO :USAGE
 if %1=="/?" GOTO :USAGE
 
 setlocal
@@ -19,8 +19,11 @@ if /i "%3" == "x64"     (set cm_BaseRid=win7-x64&&set cm_Arch=AMD64&&set __VSStr
 if /i "%3" == "arm"     (set cm_BaseRid=win8-arm&&set cm_Arch=ARM&&set __VSString=%__VSString% ARM)
 if /i "%3" == "arm64"   (set cm_BaseRid=win10-arm64&&set cm_Arch=ARM64&&set __VSString=%__VSString% Win64)
 
-set __HostVersion=%4
-set __LatestCommit=%5
+set __LatestCommit=%4
+set __HostVersion=%5
+set __AppHostVersion=%6
+set __HostResolverVersion=%7
+set __HostPolicyVersion=%8
 
 if defined CMakePath goto DoGen
 
@@ -30,8 +33,8 @@ for /f "delims=" %%a in ('powershell -NoProfile -ExecutionPolicy ByPass "& .\Win
 popd
 
 :DoGen
-echo "%CMakePath%" %__sourceDir% %__SDKVersion% "-DCLI_CMAKE_RUNTIME_ID:STRING=%cm_BaseRid%" "-DCLI_CMAKE_HOST_VER:STRING=%__HostVersion%" "-DCLI_CMAKE_APPHOST_VER:STRING=%__HostVersion%" "-DCLI_CMAKE_HOST_FXR_VER:STRING=%__HostVersion%" "-DCLI_CMAKE_HOST_POLICY_VER:STRING=%__HostVersion%" "-DCLI_CMAKE_PKG_RID:STRING=%cm_BaseRid%" "-DCLI_CMAKE_COMMIT_HASH:STRING=%__LatestCommit%" "-DCLI_CMAKE_PLATFORM_ARCH_%cm_Arch%=1" "-DCMAKE_INSTALL_PREFIX=%__CMakeBinDir%" "-DCLI_CMAKE_RESOURCE_DIR:STRING=%__ResourcesDir%" -G "Visual Studio %__VSString%"
-"%CMakePath%" %__sourceDir% %__SDKVersion% "-DCLI_CMAKE_RUNTIME_ID:STRING=%cm_BaseRid%" "-DCLI_CMAKE_HOST_VER:STRING=%__HostVersion%" "-DCLI_CMAKE_APPHOST_VER:STRING=%__HostVersion%" "-DCLI_CMAKE_HOST_FXR_VER:STRING=%__HostVersion%" "-DCLI_CMAKE_HOST_POLICY_VER:STRING=%__HostVersion%" "-DCLI_CMAKE_PKG_RID:STRING=%cm_BaseRid%" "-DCLI_CMAKE_COMMIT_HASH:STRING=%__LatestCommit%" "-DCLI_CMAKE_PLATFORM_ARCH_%cm_Arch%=1" "-DCMAKE_INSTALL_PREFIX=%__CMakeBinDir%" "-DCLI_CMAKE_RESOURCE_DIR:STRING=%__ResourcesDir%" -G "Visual Studio %__VSString%"
+echo "%CMakePath%" %__sourceDir% %__SDKVersion% "-DCLI_CMAKE_RUNTIME_ID:STRING=%cm_BaseRid%" "-DCLI_CMAKE_HOST_VER:STRING=%__HostVersion%" "-DCLI_CMAKE_APPHOST_VER:STRING=%__AppHostVersion%" "-DCLI_CMAKE_HOST_FXR_VER:STRING=%__HostResolverVersion%" "-DCLI_CMAKE_HOST_POLICY_VER:STRING=%__HostPolicyVersion%" "-DCLI_CMAKE_PKG_RID:STRING=%cm_BaseRid%" "-DCLI_CMAKE_COMMIT_HASH:STRING=%__LatestCommit%" "-DCLI_CMAKE_PLATFORM_ARCH_%cm_Arch%=1" "-DCMAKE_INSTALL_PREFIX=%__CMakeBinDir%" "-DCLI_CMAKE_RESOURCE_DIR:STRING=%__ResourcesDir%" -G "Visual Studio %__VSString%"
+"%CMakePath%" %__sourceDir% %__SDKVersion% "-DCLI_CMAKE_RUNTIME_ID:STRING=%cm_BaseRid%" "-DCLI_CMAKE_HOST_VER:STRING=%__HostVersion%" "-DCLI_CMAKE_APPHOST_VER:STRING=%__AppHostVersion%" "-DCLI_CMAKE_HOST_FXR_VER:STRING=%__HostResolverVersion%" "-DCLI_CMAKE_HOST_POLICY_VER:STRING=%__HostPolicyVersion%" "-DCLI_CMAKE_PKG_RID:STRING=%cm_BaseRid%" "-DCLI_CMAKE_COMMIT_HASH:STRING=%__LatestCommit%" "-DCLI_CMAKE_PLATFORM_ARCH_%cm_Arch%=1" "-DCMAKE_INSTALL_PREFIX=%__CMakeBinDir%" "-DCLI_CMAKE_RESOURCE_DIR:STRING=%__ResourcesDir%" -G "Visual Studio %__VSString%"
 endlocal
 GOTO :DONE
 
@@ -41,8 +44,8 @@ GOTO :DONE
   echo "Specify the path to the top level CMake file - <ProjectK>/src/NDP"
   echo "Specify the VSVersion to be used - VS2013 or VS2015"
   echo "Specify the Target Architecture - x86, AnyCPU, ARM, or x64."
-  echo "Specify the host version"
   echo "Specify latest commit hash"
+  echo "Specify the host version, apphost version, hostresolver version, hostpolicy version"
   EXIT /B 1
 
 :DONE

--- a/src/corehost/build.cmd
+++ b/src/corehost/build.cmd
@@ -29,7 +29,10 @@ if /i [%1] == [arm64]       ( set __BuildArch=arm64&&set __VCBuildArch=arm64&&sh
 
 if /i [%1] == [rid]         ( set __TargetRid=%2&&shift&&shift&goto Arg_Loop)
 if /i [%1] == [toolsetDir]  ( set "__ToolsetDir=%2"&&shift&&shift&goto Arg_Loop)
-if /i [%1] == [version] (set __HostVersion=%2&&shift&&shift&goto Arg_Loop)
+if /i [%1] == [hostver] (set __HostVersion=%2&&shift&&shift&goto Arg_Loop)
+if /i [%1] == [apphostver] (set __AppHostVersion=%2&&shift&&shift&goto Arg_Loop)
+if /i [%1] == [fxrver] (set __HostResolverVersion=%2&&shift&&shift&goto Arg_Loop)
+if /i [%1] == [policyver] (set __HostPolicyVersion=%2&&shift&&shift&goto Arg_Loop)
 if /i [%1] == [commit] (set __CommitSha=%2&&shift&&shift&goto Arg_Loop)
 
 shift
@@ -103,9 +106,9 @@ if /i "%__BuildArch%" == "arm64" (
     call :PrivateToolSet
 )
 
-echo Calling "%__nativeWindowsDir%\gen-buildsys-win.bat %~dp0 %__VSVersion% %__BuildArch% %__HostVersion% %__CommitSha%"
+echo Calling "%__nativeWindowsDir%\gen-buildsys-win.bat %~dp0 %__VSVersion% %__BuildArch% %__CommitSha% %__HostVersion% %__AppHostVersion% %__HostResolverVersion% %__HostPolicyVersion%"
 pushd "%__IntermediatesDir%"
-call "%__nativeWindowsDir%\gen-buildsys-win.bat" %~dp0 %__VSVersion% %__BuildArch% %__HostVersion% %__CommitSha%
+call "%__nativeWindowsDir%\gen-buildsys-win.bat" %~dp0 %__VSVersion% %__BuildArch% %__CommitSha% %__HostVersion% %__AppHostVersion% %__HostResolverVersion% %__HostPolicyVersion%
 popd
 
 :CheckForProj

--- a/src/corehost/build.proj
+++ b/src/corehost/build.proj
@@ -4,7 +4,9 @@
   <Import Project="..\..\dir.targets" />
   <Import Project="..\..\dir.traversal.targets" />
 
-  <!-- Target that builds dotnet, hostfxr and hostpolicy -->
+  <!-- Target that builds dotnet, hostfxr and hostpolicy with the same version as what NetCoreApp will be built for
+       since the build produced artifacts should always version the same (even if they may not get used).
+  -->
   <Target Name="Build" DependsOnTargets="BuildCoreHostUnix;BuildCoreHostWindows" /> 
 
 
@@ -12,7 +14,7 @@
           Condition="'$(OSGroup)' != 'Windows_NT'"
           DependsOnTargets="GetLatestCommitHash">
     <PropertyGroup>
-      <BuildArgs>--arch $(TargetArchitecture) --apphostver $(HostVersion) --hostver $(HostVersion) --fxrver $(HostVersion) --policyver $(HostVersion) --commithash $(LatestCommit)</BuildArgs>
+      <BuildArgs>--arch $(TargetArchitecture) --apphostver $(AppHostVersion) --hostver $(HostVersion) --fxrver $(HostResolverVersion) --policyver $(HostPolicyVersion) --commithash $(LatestCommit)</BuildArgs>
       <BuildArgs Condition="'$(PortableBuild)' == 'true'">$(BuildArgs) -portable</BuildArgs>     
     </PropertyGroup>
     
@@ -42,7 +44,7 @@
              Properties="GenerateNativeVersionInfo=true;AssemblyName=%(HostFiles.Identity);NativeVersionFileDir=$(IntermediateOutputRootPath)hostResourceFiles\%(HostFiles.Identity);NativeVersionHeaderFile=$(IntermediateOutputRootPath)hostResourceFiles\%(HostFiles.Identity)\version_info.h"
              Targets="GenerateVersionHeader" />
     <PropertyGroup>
-      <BuildArgs>$(ConfigurationGroup) $(TargetArchitecture) version $(HostVersion) commit $(LatestCommit) rid $(TargetRid)</BuildArgs>
+      <BuildArgs>$(ConfigurationGroup) $(TargetArchitecture) apphostver $(AppHostVersion) hostver $(HostVersion) fxrver $(HostResolverVersion) policyver $(HostPolicyVersion) commit $(LatestCommit) rid $(TargetRid)</BuildArgs>
       <CustomNativeToolsetDir Condition="'$(TargetArchitecture)' == 'arm64'"> toolsetdir $(NativeToolsetDir)</CustomNativeToolsetDir>      
     </PropertyGroup>
 

--- a/src/pkg/dir.props
+++ b/src/pkg/dir.props
@@ -5,7 +5,6 @@
   <PropertyGroup>
     <Platform>$(TargetArchitecture)</Platform>
     <DotNetHostBinDir>$(BaseOutputRootPath)corehost</DotNetHostBinDir>
-    <EnsureStableVersion>$(StabilizePackageVersion)</EnsureStableVersion>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -35,13 +34,13 @@
   </ItemGroup>
 
   <Target Name="ValidateArgs" Condition="'$(CLIBuildVersion)'==''">
-    <Error Condition="'$(EnsureStableVersion)'==''" Text="EnsureStableVersion is undefined" />
     <Error Condition="'$(HostPolicyVersion)'==''" Text="HostPolicyVersion is undefined" />
     <Error Condition="'$(HostResolverVersion)'==''" Text="HostResolverVersion is undefined" />
     <Error Condition="'$(HostVersion)'==''" Text="HostVersion is undefined" />
+    <Error Condition="'$(AppHostVersion)'==''" Text="AppHostVersion is undefined" />
   </Target>
 
-  <Target Name="ValidatePreReleaseStrings" Condition="'$(EnsureStableVersion)'=='false'">
+  <Target Name="ValidatePreReleaseStrings" Condition="'$(StabilizePackageVersion)'!='true'">
     <Error Condition="'$(PreReleaseLabel)'==''" Text="PreReleaseLabel is undefined" />
     <Error Condition="'$(BuildNumberMajor)'==''" Text="BuildNumberMajor is undefined" />
     <Error Condition="'$(BuildNumberMinor)'==''" Text="BuildNumberMinor is undefined" />

--- a/src/pkg/packaging/deb/package.props
+++ b/src/pkg/packaging/deb/package.props
@@ -10,7 +10,7 @@
     <SharedHostDebPkgName>dotnet-host</SharedHostDebPkgName>
     <SharedHostDebPkgName>$(SharedHostDebPkgName.ToLower())</SharedHostDebPkgName>
     
-    <HostFxrDebPkgName>dotnet-hostfxr-$(HostVersion)</HostFxrDebPkgName>
+    <HostFxrDebPkgName>dotnet-hostfxr-$(HostResolverVersion)</HostFxrDebPkgName>
     <HostFxrDebPkgName>$(HostFxrDebPkgName.ToLower())</HostFxrDebPkgName>
     
     <SharedFxDebPkgName>dotnet-sharedframework-$(SharedFrameworkName)-$(SharedFrameworkNugetVersion)</SharedFxDebPkgName>

--- a/src/pkg/packaging/deb/package.targets
+++ b/src/pkg/packaging/deb/package.targets
@@ -121,7 +121,7 @@
   <Target Name="GenerateHostFxrDeb">
     <PropertyGroup>
       <DebPackageName>$(HostFxrDebPkgName)</DebPackageName>
-      <DebPackageVersion>$(HostVersion)</DebPackageVersion>
+      <DebPackageVersion>$(HostResolverVersion)</DebPackageVersion>
       <InputRoot>$(HostFxrPublishRoot)</InputRoot>
       <DebFile>$(HostFxrInstallerFile)</DebFile>
       <ConfigJsonName>dotnet-hostfxr-debian_config.json</ConfigJsonName>
@@ -164,7 +164,7 @@
         <ReplacementString>$(HostVersion)</ReplacementString>
       </HostFxrTokenValue>
       <HostFxrTokenValue Include="%HOSTFXR_NUGET_VERSION%">
-        <ReplacementString>$(HostVersion)</ReplacementString>
+        <ReplacementString>$(HostResolverVersion)</ReplacementString>
       </HostFxrTokenValue>
       <HostFxrTokenValue Include="%HOSTFXR_DEBIAN_PACKAGE_NAME%">
         <ReplacementString>$(DebPackageName)</ReplacementString>

--- a/src/pkg/packaging/dir.proj
+++ b/src/pkg/packaging/dir.proj
@@ -83,7 +83,7 @@
 
     <WriteLinesToFile
       File="$(OutputVersionBadge)"
-      Lines="$([System.IO.File]::ReadAllText('$(templateSvg)').Replace('ver_number', '$(HostVersion)'))"
+      Lines="$([System.IO.File]::ReadAllText('$(templateSvg)').Replace('ver_number', '$(ProductVersion)'))"
       Overwrite="true"
                       />
   </Target>

--- a/src/pkg/packaging/dir.props
+++ b/src/pkg/packaging/dir.props
@@ -13,12 +13,12 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <ProductMoniker>$(PackageTargetRid).$(HostFullVersion)</ProductMoniker>
+    <ProductMoniker>$(PackageTargetRid).$(SharedFrameworkNugetVersion)</ProductMoniker>
   </PropertyGroup>
 
   <PropertyGroup>
     <CombinedCompressedFile>dotnet-$(ProductMoniker)$(CompressedFileExtension)</CombinedCompressedFile>
-    <HostFxrCompressedFile>dotnet-hostfxr-$(ProductMoniker)$(CompressedFileExtension)</HostFxrCompressedFile>
+    <HostFxrCompressedFile>dotnet-hostfxr-$(PackageTargetRid).$(HostResolverVersion)$(CompressedFileExtension)</HostFxrCompressedFile>
     <SharedFrameworkCompressedFile>dotnet-sharedframework-$(ProductMoniker)$(CompressedFileExtension)</SharedFrameworkCompressedFile>
     <SharedFrameworkSymbolsCompressedFile>dotnet-sharedframework-symbols-$(ProductMoniker)$(CompressedFileExtension)</SharedFrameworkSymbolsCompressedFile>
   </PropertyGroup>
@@ -27,7 +27,7 @@
     <CombinedInstallerFile>$(PackagesOutDir)dotnet-$(ProductMoniker)$(CombinedInstallerExtension)</CombinedInstallerFile>
     <CombinedInstallerEngine>$(PackagesOutDir)dotnet-$(ProductMoniker)-engine.exe</CombinedInstallerEngine>
     <SharedHostInstallerFile>$(PackagesOutDir)dotnet-host-$(ProductMoniker)$(InstallerExtension)</SharedHostInstallerFile>
-    <HostFxrInstallerFile>$(PackagesOutDir)dotnet-hostfxr-$(ProductMoniker)$(InstallerExtension)</HostFxrInstallerFile>
+    <HostFxrInstallerFile>$(PackagesOutDir)dotnet-hostfxr-$(PackageTargetRid).$(HostResolverVersion)$(InstallerExtension)</HostFxrInstallerFile>
     <SharedFrameworkInstallerFile>$(PackagesOutDir)dotnet-sharedframework-$(ProductMoniker)$(InstallerExtension)</SharedFrameworkInstallerFile>
   </PropertyGroup>
 

--- a/src/pkg/packaging/osx/package.props
+++ b/src/pkg/packaging/osx/package.props
@@ -3,8 +3,8 @@
   <PropertyGroup>
     <OSXScriptRoot>$(PackagingRoot)osx/</OSXScriptRoot>
     <SharedHostComponentId>com.microsoft.dotnet.sharedhost.component.osx.x64</SharedHostComponentId>
-    <HostFxrComponentId>com.microsoft.dotnet.hostfxr.$(HostVersion).component.osx.x64</HostFxrComponentId>
-    <SharedFxComponentId>com.microsoft.dotnet.sharedframework.$(SharedFrameworkName).$(HostVersion).component.osx.x64</SharedFxComponentId>
-    <SharedPackageId>com.microsoft.dotnet.$(SharedFrameworkName).$(HostVersion).osx.x64</SharedPackageId>
+    <HostFxrComponentId>com.microsoft.dotnet.hostfxr.$(HostResolverVersion).component.osx.x64</HostFxrComponentId>
+    <SharedFxComponentId>com.microsoft.dotnet.sharedframework.$(SharedFrameworkName).$(SharedFrameworkNugetVersion).component.osx.x64</SharedFxComponentId>
+    <SharedPackageId>com.microsoft.dotnet.$(SharedFrameworkName).$(SharedFrameworkNugetVersion).osx.x64</SharedPackageId>
   </PropertyGroup>
 </Project>

--- a/src/pkg/packaging/osx/package.targets
+++ b/src/pkg/packaging/osx/package.targets
@@ -39,7 +39,7 @@
 
     <PropertyGroup>
         <InstallLocation>/usr/local/share/dotnet</InstallLocation>
-        <CommonArgs>--version $(HostVersion) --install-location $(InstallLocation)</CommonArgs>
+        <CommonArgs>--version $(SharedFrameworkNugetVersion) --install-location $(InstallLocation)</CommonArgs>
     </PropertyGroup>
 
     <Exec Command="pkgbuild --root %(OSXPackages.Root) --identifier %(OSXPackages.Id)  $(CommonArgs) --scripts %(OSXPackages.Script) %(OSXPackages.OutFile)" />
@@ -60,7 +60,7 @@
       <ConfigPattern Include="{SharedHostComponentId}" /> <ConfigReplace Include="$(SharedHostComponentId)" />
       <ConfigPattern Include="{HostFxrComponentId}" /> <ConfigReplace Include="$(HostFxrComponentId)" />
       <ConfigPattern Include="{SharedFrameworkNugetName}" /> <ConfigReplace Include="$(SharedFrameworkName)'" />
-      <ConfigPattern Include="{SharedFrameworkNugetVersion}" /> <ConfigReplace Include="$(HostVersion)" />
+      <ConfigPattern Include="{SharedFrameworkNugetVersion}" /> <ConfigReplace Include="$(SharedFrameworkNugetVersion)" />
       <ConfigPattern Include="{SharedFxBrandName}" /> <ConfigReplace Include="$(SharedFrameworkBrandName)" />
       <ConfigPattern Include="{SharedHostBrandName}" /> <ConfigReplace Include="$(SharedHostBrandName)" />
       <ConfigPattern Include="{HostFxrBrandName}" /> <ConfigReplace Include="$(HostFxrBrandName)" />      
@@ -72,7 +72,7 @@
         ReplacementPatterns="@(ConfigPattern)"
         ReplacementStrings="@(ConfigReplace)" />
     
-    <Exec Command="productbuild --version $(HostVersion) --identifier $(SharedPackageId) --package-path $(PackagesIntermediateDir) --resources $(ResourcePath) --distribution $(DistributionFile) $(OutFilePath)" />
+    <Exec Command="productbuild --version $(ProductVersion) --identifier $(SharedPackageId) --package-path $(PackagesIntermediateDir) --resources $(ResourcePath) --distribution $(DistributionFile) $(OutFilePath)" />
   </Target>
 
 </Project>

--- a/src/pkg/packaging/windows/package.targets
+++ b/src/pkg/packaging/windows/package.targets
@@ -75,8 +75,8 @@
 
       <PropertyGroup>
         <ArchParams>"$(MsiArch)" "$(TargetArchitecture)"</ArchParams>
-        <CommonParams>$(MsiVersionString) $(HostVersion) $(ArchParams)</CommonParams>
-        <SharedFxParams>$(MsiVersionString) $(SharedFrameworkName) $(HostVersion) $(SharedFxUpgradeCode) $(ArchParams)</SharedFxParams>
+        <CommonParams>$(MsiVersionString) $(SharedFrameworkNugetVersion) $(ArchParams)</CommonParams>
+        <SharedFxParams>$(MsiVersionString) $(SharedFrameworkName) $(SharedFrameworkNugetVersion) $(SharedFxUpgradeCode) $(ArchParams)</SharedFxParams>
       </PropertyGroup>
 
       <Exec Command="powershell -NoProfile -NoLogo $(WindowsScriptRoot)%(WixOutputs.Filename)\generatemsi.ps1 %(WixOutputs.InputDir) %(WixOutputs.InstallerName) $(WixToolsDir) %(WixOutputs.BrandName) $(CommonParams) %(WixOutputs.Identity) %(WixOutputs.UpgradeCode)" />
@@ -102,7 +102,7 @@
      </GenerateGuidFromName>
 
      <PropertyGroup>
-        <BundleParameters>$(ShareFXMsi) $(HostMsi) $(HostFxrMsi) $(SharedBundle) $(WixToolsDir) $(SharedBrandName) $(MsiVersionString) $(BundleDisplayVersion) $(SharedFrameworkName) $(HostVersion) $(SharedBundleCode) $(ArchParams)</BundleParameters>
+        <BundleParameters>$(ShareFXMsi) $(HostMsi) $(HostFxrMsi) $(SharedBundle) $(WixToolsDir) $(SharedBrandName) $(MsiVersionString) $(BundleDisplayVersion) $(SharedFrameworkName) $(SharedFrameworkNugetVersion) $(SharedBundleCode) $(ArchParams)</BundleParameters>
      </PropertyGroup>
 
      <Exec Command="powershell -NoProfile -NoLogo $(SharedFxBundleScript) $(BundleParameters)" />

--- a/src/pkg/projects/Microsoft.NETCore.App/Microsoft.NETCore.App.pkgproj
+++ b/src/pkg/projects/Microsoft.NETCore.App/Microsoft.NETCore.App.pkgproj
@@ -5,7 +5,7 @@
   <UsingTask TaskName="GenerateFileVersionProps" AssemblyFile="$(LocalBuildToolsTaskDir)core-setup.tasks.dll"/>
 
   <PropertyGroup>
-    <Version>$(NetCoreAppVersion)</Version>
+    <Version>$(SharedFrameworkNugetVersion)</Version>
     <NETCoreAppFramework>netcoreapp$([System.Version]::Parse('$(ProductionVersion)').ToString(2))</NETCoreAppFramework>
     <OmitDependencies>true</OmitDependencies>
     <SkipValidatePackage>true</SkipValidatePackage>
@@ -37,7 +37,7 @@
     </Dependency>
     <!-- references the host packages -->
     <Dependency Include="Microsoft.NETCore.DotNetHostPolicy">
-       <Version>$(HostPolicyFullVersion)</Version>
+       <Version>$(HostPolicyVersion)</Version>
        <TargetFramework>.NETCoreApp2.0</TargetFramework>
     </Dependency>
 

--- a/src/pkg/projects/Microsoft.NETCore.DotNetHostPolicy/Microsoft.NETCore.DotNetHostPolicy.pkgproj
+++ b/src/pkg/projects/Microsoft.NETCore.DotNetHostPolicy/Microsoft.NETCore.DotNetHostPolicy.pkgproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <Dependency Include="Microsoft.NETCore.DotNetHostResolver">
-      <Version>$(HostResolverFullVersion)</Version>
+      <Version>$(HostResolverVersion)</Version>
     </Dependency>
   </ItemGroup>   
 

--- a/src/pkg/projects/Microsoft.NETCore.DotNetHostResolver/Microsoft.NETCore.DotNetHostResolver.pkgproj
+++ b/src/pkg/projects/Microsoft.NETCore.DotNetHostResolver/Microsoft.NETCore.DotNetHostResolver.pkgproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <Dependency Include="Microsoft.NETCore.DotNetAppHost">
-      <Version>$(AppHostFullVersion)</Version>
+      <Version>$(AppHostVersion)</Version>
     </Dependency>
   </ItemGroup>
      

--- a/src/sharedFramework/sharedFramework.proj
+++ b/src/sharedFramework/sharedFramework.proj
@@ -57,11 +57,11 @@
     <Move SourceFiles="$(SharedFrameworkNameAndVersionRoot)\framework.deps.json" 
           DestinationFiles="$(SharedFrameworkNameAndVersionRoot)\$(SharedFrameworkName).deps.json" />
     
-    <!-- Copy Muxer -->
+    <!-- Use the muxer we intended to consume (either restored a shipped version or the one we built) -->
     <Copy SourceFiles="$(CoreHostLockedDir)dotnet$(ExeSuffix)" DestinationFolder="$(SharedFrameworkPublishDir)" />
 
-    <!--  CopyHostFxrToVersionedDirectory -->
-    <Copy SourceFiles="$(CoreHostLockedDir)$(LibPrefix)hostfxr$(LibSuffix)" DestinationFolder="$(SharedFrameworkPublishDir)\host\fxr\$(HostVersion)" />
+    <!--  Use the FXR Resolver we intended to consume (either restored a shipped version or the one we built) -->
+    <Copy SourceFiles="$(CoreHostLockedDir)$(LibPrefix)hostfxr$(LibSuffix)" DestinationFolder="$(SharedFrameworkPublishDir)\host\fxr\$(HostResolverVersion)" />
 
     <!-- Copy symbols to publish folder -->
     <ItemGroup>
@@ -80,7 +80,7 @@
     <!-- Generate .version file -->
     <ItemGroup>
       <VersionLines Include="$(LatestCommit)" />
-      <VersionLines Include="$(HostFullVersion)" />
+      <VersionLines Include="$(SharedFrameworkNugetVersion)" />
     </ItemGroup>
 
     <WriteLinesToFile
@@ -89,6 +89,10 @@
       Overwrite="true" />
   </Target>
 
+  <!-- TODO: Why do we need to have this is M.N.App references the expected version? However,
+             I have noticed that without this, M.N.App publish results in having an older (1.1.x)
+             hostpolicy binary.
+  -->
   <Target Name="CopyHostArtifactsToSharedFramework">
     <ItemGroup>
       <!-- Hostpolicy should be the latest and not the locked version as it is supposed to evolve for -->
@@ -125,8 +129,8 @@
     <ItemGroup>
       <ProjJsonLines Include='{' />
       <ProjJsonLines Include='  "dependencies": {' />
-      <ProjJsonLines Include='    "Microsoft.NETCore.DotNetHostResolver"  :  "$(HostFullVersion)",' />
-      <ProjJsonLines Include='    "Microsoft.NETCore.DotNetHost"  :  "$(HostFullVersion)"' />
+      <ProjJsonLines Include='    "Microsoft.NETCore.DotNetHostResolver"  :  "$(HostResolverVersion)",' />
+      <ProjJsonLines Include='    "Microsoft.NETCore.DotNetHost"  :  "$(HostVersion)"' />
       <ProjJsonLines Include='  },' />
       <ProjJsonLines Include='  "frameworks": {' />
       <ProjJsonLines Include='    "$(Framework)": {}' />

--- a/src/test/build/shared-build-targets-utils/Utils/Crossgen.cs
+++ b/src/test/build/shared-build-targets-utils/Utils/Crossgen.cs
@@ -49,15 +49,11 @@ namespace Microsoft.DotNet.Cli.Build
             // TODO-ARM-Crossgen: Add ubuntu.14.04-arm and ubuntu.16.04-arm
             if ((_targetRID == "win8-arm")  || (_targetRID == "win-arm"))
             {
-                // workaround https://github.com/dotnet/coreclr/issues/9884
-                // ridCrossgen = Path.Combine(crossgenPackagePath, "tools", "x86_arm", $"crossgen{Constants.ExeSuffix}");
-                ridCrossgen = Path.Combine(crossgenPackagePath, "tools", "x86_AnyCPU", $"crossgen{Constants.ExeSuffix}");
+                ridCrossgen = Path.Combine(crossgenPackagePath, "tools", "x86_arm", $"crossgen{Constants.ExeSuffix}");
             }
             else if ((_targetRID == "win10-arm64") || (_targetRID == "win-arm64"))
             {
-                // workaround https://github.com/dotnet/coreclr/issues/9884
-                // ridCrossgen = Path.Combine(crossgenPackagePath, "tools", "x64_arm", $"crossgen{Constants.ExeSuffix}");
-                ridCrossgen = Path.Combine(crossgenPackagePath, "tools", "x64_AnyCPU", $"crossgen{Constants.ExeSuffix}");
+                ridCrossgen = Path.Combine(crossgenPackagePath, "tools", "x64_arm", $"crossgen{Constants.ExeSuffix}");
             }
             else
             {
@@ -82,15 +78,11 @@ namespace Microsoft.DotNet.Cli.Build
             // TODO-ARM-Crossgen: Add ubuntu.14.04-arm and ubuntu.16.04-arm
             if ((_targetRID == "win8-arm")  || (_targetRID == "win-arm"))
             {
-                // workaround https://github.com/dotnet/coreclr/issues/9884
-                // jitPath = Path.Combine(jitPackagePath, "runtimes", "x86_arm", "native", $"{Constants.DynamicLibPrefix}clrjit{Constants.DynamicLibSuffix}");
-                jitPath = Path.Combine(jitPackagePath, "runtimes", "x86_AnyCPU", "native", $"{Constants.DynamicLibPrefix}clrjit{Constants.DynamicLibSuffix}");
+                jitPath = Path.Combine(jitPackagePath, "runtimes", "x86_arm", "native", $"{Constants.DynamicLibPrefix}clrjit{Constants.DynamicLibSuffix}");
             }
             else if ((_targetRID == "win10-arm64") || (_targetRID == "win-arm64")) 
             {
-                // workaround https://github.com/dotnet/coreclr/issues/9884
-                // jitPath = Path.Combine(jitPackagePath, "runtimes", "x64_arm64", "native", $"{Constants.DynamicLibPrefix}clrjit{Constants.DynamicLibSuffix}");
-                jitPath = Path.Combine(jitPackagePath, "runtimes", "x64_AnyCPU", "native", $"{Constants.DynamicLibPrefix}clrjit{Constants.DynamicLibSuffix}");
+                jitPath = Path.Combine(jitPackagePath, "runtimes", "x64_arm64", "native", $"{Constants.DynamicLibPrefix}clrjit{Constants.DynamicLibSuffix}");
             }
             
             return jitPath;


### PR DESCRIPTION
This PR cleans up various versioning variables overall and those that are required for 2.0.0 servicing eventually.

I have also fixed an issue with picking up crossgen from the correct location for cross builds.

Fixes https://github.com/dotnet/core-setup/issues/2268 and https://github.com/dotnet/core-setup/issues/2245.

@eerhardt @weshaggard PTAL

@rakeshsinghranchi PTAL at the setup changes.

CC @vivmishra 