### PR TITLE
Fixing the build break by putting our custom task NuGet dependencies in the right spot.

### DIFF
--- a/src/sharedFramework/sharedFramework.proj
+++ b/src/sharedFramework/sharedFramework.proj
@@ -117,7 +117,8 @@
     <ProcessSharedFrameworkDeps AssetsFilePath="$(SharedFrameworkAssetsFile)"
                                 DepsFilePath="$(SharedFrameworkDepsFile)"
                                 PackagesToRemove="@(TrimPkgsFromDeps)"
-                                Runtime="$(RuntimeGraphGeneratorRuntime)" />
+                                Runtime="$(RuntimeGraphGeneratorRuntime)"
+                                BuildToolsTaskDir="$(BuildToolsTaskDir)" />
   </Target>
 
   <Target Name="RestoreLockedCoreHost">

--- a/tools-local/tasks/ProcessSharedFrameworkDeps.cs
+++ b/tools-local/tasks/ProcessSharedFrameworkDeps.cs
@@ -8,7 +8,7 @@ using System.Linq;
 
 namespace Microsoft.DotNet.Build.Tasks
 {
-    public class ProcessSharedFrameworkDeps : Task
+    public partial class ProcessSharedFrameworkDeps : Task
     {
         [Required]
         public string AssetsFilePath { get; set; }
@@ -22,7 +22,19 @@ namespace Microsoft.DotNet.Build.Tasks
         [Required]
         public string Runtime { get; set; }
 
+        [Required]
+        public string BuildToolsTaskDir { get; set; }
+
         public override bool Execute()
+        {
+            EnsureInitialized(BuildToolsTaskDir);
+
+            ExecuteCore();
+
+            return true;
+        }
+
+        private void ExecuteCore()
         {
             DependencyContext context;
             using (var depsStream = File.OpenRead(DepsFilePath))
@@ -54,8 +66,8 @@ namespace Microsoft.DotNet.Build.Tasks
             {
                 new DependencyContextWriter().Write(context, depsStream);
             }
-
-            return true;
         }
+
+        partial void EnsureInitialized(string buildToolsTaskDir);
     }
 }

--- a/tools-local/tasks/core-setup.tasks.csproj
+++ b/tools-local/tasks/core-setup.tasks.csproj
@@ -25,6 +25,7 @@
   </ItemGroup>
   <ItemGroup Condition="'$(TargetGroup)' == 'net45'">
     <Compile Include="net45/FileUtilities.net45.cs" />
+    <Compile Include="net45/ProcessSharedFrameworkDeps.net45.cs" />
     <TargetingPackReference Include="System" />
     <TargetingPackReference Include="System.Core" />
     <TargetingPackReference Include="System.Net.Http" />

--- a/tools-local/tasks/net45/ProcessSharedFrameworkDeps.net45.cs
+++ b/tools-local/tasks/net45/ProcessSharedFrameworkDeps.net45.cs
@@ -1,0 +1,25 @@
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+using Microsoft.Extensions.DependencyModel;
+using NuGet.Common;
+using NuGet.ProjectModel;
+using System;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+
+namespace Microsoft.DotNet.Build.Tasks
+{
+    public partial class ProcessSharedFrameworkDeps
+    {
+        partial void EnsureInitialized(string buildToolsTaskDir)
+        {
+            // ensure the build tools AssemblyResolver is enabled, so we get the correct assembly unification
+            // even if the build tools assembly hasn't been loaded yet.
+            string buildTasksPath = Path.Combine(buildToolsTaskDir, "Microsoft.DotNet.Build.Tasks.dll");
+            Assembly buildTasksAssembly = Assembly.Load(AssemblyName.GetAssemblyName(buildTasksPath));
+            Type assemblyResolver = buildTasksAssembly.GetType("Microsoft.DotNet.Build.Common.Desktop.AssemblyResolver");
+            assemblyResolver.GetMethod("Enable").Invoke(null, new object[] { });
+        }
+    }
+}


### PR DESCRIPTION
@chcosta @weshaggard @karajas @mellinoe 

hopefully when we move the custom task to use the 2.0 SDK, we can just "publish" it, and this kind of stuff won't be necessary.