### PR TITLE
Make the LinuxArm cross build use ROOTFS_DIR

### DIFF
--- a/buildpipeline/Core-Setup-Linux-BT.json
+++ b/buildpipeline/Core-Setup-Linux-BT.json
@@ -159,7 +159,7 @@
       },
       "inputs": {
         "filename": "docker",
-        "arguments": "run --rm $(DockerCommonRunArgs) $(PB_GitDirectory)/build.sh -OfficialBuildId=$(OfficialBuildId) $(PB_BuildArguments)",
+        "arguments": "run --rm $(PB_CrossBuildArgs) $(DockerCommonRunArgs) $(PB_GitDirectory)/build.sh -OfficialBuildId=$(OfficialBuildId) $(PB_BuildArguments)",
         "workingFolder": "$(PB_SourcesDirectory)",
         "failOnStandardError": "false"
       }
@@ -333,6 +333,13 @@
     },
     "SourceVersion": {
       "value": "HEAD"
+    },
+    "ROOTFS_DIR": {
+      "value": "/crossrootfs/$(PB_TargetArchitecture)"
+    },
+    "PB_CrossBuildArgs": {
+      "value": "",
+      "allowOverride": true
     },
     "DockerCommonRunArgs": {
       "value": "--name $(PB_DockerContainerName) -v \"$(PB_SourcesDirectory):$(PB_GitDirectory)\" -w=\"$(PB_GitDirectory)\" $(PB_DockerImageName)"

--- a/buildpipeline/Core-Setup-Linux-BT.json
+++ b/buildpipeline/Core-Setup-Linux-BT.json
@@ -159,7 +159,7 @@
       },
       "inputs": {
         "filename": "docker",
-        "arguments": "run --rm $(PB_CrossBuildArgs) $(DockerCommonRunArgs) $(PB_GitDirectory)/build.sh -OfficialBuildId=$(OfficialBuildId) $(PB_BuildArguments)",
+        "arguments": "run --rm $(PB_CrossBuildArgs)$(DockerCommonRunArgs) $(PB_GitDirectory)/build.sh -OfficialBuildId=$(OfficialBuildId) $(PB_BuildArguments)",
         "workingFolder": "$(PB_SourcesDirectory)",
         "failOnStandardError": "false"
       }

--- a/buildpipeline/pipeline.json
+++ b/buildpipeline/pipeline.json
@@ -99,6 +99,7 @@
             "PB_DockerTag": "ubuntu-14.04-cross-0cd4667-20172211042239", 
             "PB_TargetArchitecture": "arm", 
             "PB_AdditionalBuildArguments":"arm cross disablecrossgen -portable skiptests", 
+            "PB_CrossBuildArgs": "-e ROOTFS_DIR",
             "PB_PortableBuild": "true" 
           }, 
           "ReportingParameters": { 

--- a/buildpipeline/pipeline.json
+++ b/buildpipeline/pipeline.json
@@ -99,7 +99,7 @@
             "PB_DockerTag": "ubuntu-14.04-cross-0cd4667-20172211042239", 
             "PB_TargetArchitecture": "arm", 
             "PB_AdditionalBuildArguments":"arm cross disablecrossgen -portable skiptests", 
-            "PB_CrossBuildArgs": "-e ROOTFS_DIR",
+            "PB_CrossBuildArgs": "-e ROOTFS_DIR ",
             "PB_PortableBuild": "true" 
           }, 
           "ReportingParameters": { 


### PR DESCRIPTION
skip ci please

Linux Arm official build definition needs to pass ROOTFS_DIR to pickup the cross toolset. Otherwise, it will build x64 binaries.

@eerhardt PTAL

CC @chcosta 