### PR TITLE
Fix RIDPlat computation

### DIFF
--- a/src/corehost/Windows/gen-buildsys-win.bat
+++ b/src/corehost/Windows/gen-buildsys-win.bat
@@ -5,7 +5,7 @@ rem This file invokes cmake and generates the build system for windows.
 set argC=0
 for %%x in (%*) do Set /A argC+=1
 
-if NOT %argC%==8 GOTO :USAGE
+if NOT %argC%==9 GOTO :USAGE
 if %1=="/?" GOTO :USAGE
 
 setlocal
@@ -14,16 +14,22 @@ set __sourceDir=%~dp0..
 set __VSString=14 2015
 
 :: Set the target architecture to a format cmake understands. ANYCPU defaults to x64
-if /i "%3" == "x86"     (set cm_BaseRid=win7-x86&&set cm_Arch=I386&&set __VSString=%__VSString%)
-if /i "%3" == "x64"     (set cm_BaseRid=win7-x64&&set cm_Arch=AMD64&&set __VSString=%__VSString% Win64)
-if /i "%3" == "arm"     (set cm_BaseRid=win8-arm&&set cm_Arch=ARM&&set __VSString=%__VSString% ARM)
-if /i "%3" == "arm64"   (set cm_BaseRid=win10-arm64&&set cm_Arch=ARM64&&set __VSString=%__VSString% Win64)
+set __RIDArch=%3
+if /i "%3" == "x86"     (set cm_BaseRid=win7&&set cm_Arch=I386&&set __VSString=%__VSString%)
+if /i "%3" == "x64"     (set cm_BaseRid=win7&&set cm_Arch=AMD64&&set __VSString=%__VSString% Win64)
+if /i "%3" == "arm"     (set cm_BaseRid=win8&&set cm_Arch=ARM&&set __VSString=%__VSString% ARM)
+if /i "%3" == "arm64"   (set cm_BaseRid=win10&&set cm_Arch=ARM64&&set __VSString=%__VSString% Win64)
 
 set __LatestCommit=%4
 set __HostVersion=%5
 set __AppHostVersion=%6
 set __HostResolverVersion=%7
 set __HostPolicyVersion=%8
+
+:: Form the base RID to be used if we are doing a portable build
+if /i "%9" == "1"       (set cm_BaseRid=win)
+set cm_BaseRid=%cm_BaseRid%-%__RIDArch%
+echo "Computed RID for native build is %cm_BaseRid%"
 
 if defined CMakePath goto DoGen
 

--- a/src/corehost/build.cmd
+++ b/src/corehost/build.cmd
@@ -14,6 +14,7 @@ set __VCBuildArch=x86_amd64
 set CMAKE_BUILD_TYPE=Debug
 set "__LinkArgs= "
 set "__LinkLibraries= "
+set __PortableBuild=0
 
 :Arg_Loop
 if [%1] == [] goto :ToolsVersion
@@ -27,13 +28,14 @@ if /i [%1] == [x64]         ( set __BuildArch=x64&&set __VCBuildArch=x86_amd64&&
 if /i [%1] == [amd64]       ( set __BuildArch=x64&&set __VCBuildArch=x86_amd64&&shift&goto Arg_Loop)
 if /i [%1] == [arm64]       ( set __BuildArch=arm64&&set __VCBuildArch=arm64&&shift&goto Arg_Loop)
 
+if /i [%1] == [portable]    ( set __PortableBuild=1&&shift&goto Arg_Loop)
 if /i [%1] == [rid]         ( set __TargetRid=%2&&shift&&shift&goto Arg_Loop)
 if /i [%1] == [toolsetDir]  ( set "__ToolsetDir=%2"&&shift&&shift&goto Arg_Loop)
-if /i [%1] == [hostver] (set __HostVersion=%2&&shift&&shift&goto Arg_Loop)
-if /i [%1] == [apphostver] (set __AppHostVersion=%2&&shift&&shift&goto Arg_Loop)
-if /i [%1] == [fxrver] (set __HostResolverVersion=%2&&shift&&shift&goto Arg_Loop)
-if /i [%1] == [policyver] (set __HostPolicyVersion=%2&&shift&&shift&goto Arg_Loop)
-if /i [%1] == [commit] (set __CommitSha=%2&&shift&&shift&goto Arg_Loop)
+if /i [%1] == [hostver]     (set __HostVersion=%2&&shift&&shift&goto Arg_Loop)
+if /i [%1] == [apphostver]  (set __AppHostVersion=%2&&shift&&shift&goto Arg_Loop)
+if /i [%1] == [fxrver]      (set __HostResolverVersion=%2&&shift&&shift&goto Arg_Loop)
+if /i [%1] == [policyver]   (set __HostPolicyVersion=%2&&shift&&shift&goto Arg_Loop)
+if /i [%1] == [commit]      (set __CommitSha=%2&&shift&&shift&goto Arg_Loop)
 
 shift
 goto :Arg_Loop
@@ -108,7 +110,7 @@ if /i "%__BuildArch%" == "arm64" (
 
 echo Calling "%__nativeWindowsDir%\gen-buildsys-win.bat %~dp0 %__VSVersion% %__BuildArch% %__CommitSha% %__HostVersion% %__AppHostVersion% %__HostResolverVersion% %__HostPolicyVersion%"
 pushd "%__IntermediatesDir%"
-call "%__nativeWindowsDir%\gen-buildsys-win.bat" %~dp0 %__VSVersion% %__BuildArch% %__CommitSha% %__HostVersion% %__AppHostVersion% %__HostResolverVersion% %__HostPolicyVersion%
+call "%__nativeWindowsDir%\gen-buildsys-win.bat" %~dp0 %__VSVersion% %__BuildArch% %__CommitSha% %__HostVersion% %__AppHostVersion% %__HostResolverVersion% %__HostPolicyVersion% %__PortableBuild%
 popd
 
 :CheckForProj

--- a/src/corehost/build.proj
+++ b/src/corehost/build.proj
@@ -45,6 +45,7 @@
              Targets="GenerateVersionHeader" />
     <PropertyGroup>
       <BuildArgs>$(ConfigurationGroup) $(TargetArchitecture) apphostver $(AppHostVersion) hostver $(HostVersion) fxrver $(HostResolverVersion) policyver $(HostPolicyVersion) commit $(LatestCommit) rid $(TargetRid)</BuildArgs>
+      <BuildArgs Condition="'$(PortableBuild)' == 'true'">$(BuildArgs) portable</BuildArgs>  
       <CustomNativeToolsetDir Condition="'$(TargetArchitecture)' == 'arm64'"> toolsetdir $(NativeToolsetDir)</CustomNativeToolsetDir>      
     </PropertyGroup>
 

--- a/src/corehost/build.sh
+++ b/src/corehost/build.sh
@@ -35,7 +35,7 @@ init_rid_plat()
     fi
 
     if [ "$(uname -s)" == "Darwin" ]; then
-        __rid_plat=osx.10.12
+        export __rid_plat=osx.10.12
     fi
 
     if [ $__linkPortable == 1 ]; then

--- a/src/corehost/build.sh
+++ b/src/corehost/build.sh
@@ -34,9 +34,13 @@ init_rid_plat()
         fi
     fi
 
+    if [ "$(uname -s)" == "Darwin" ]; then
+        __rid_plat=osx.10.12
+    fi
+
     if [ $__linkPortable == 1 ]; then
         if [ "$(uname -s)" == "Darwin" ]; then
-        export __rid_plat="osx"
+            export __rid_plat="osx"
         else
             export __rid_plat="linux"
         fi
@@ -80,6 +84,7 @@ __CrossBuild=0
 __commit_hash=
 __portableBuildArgs=
 __configuration=Debug
+__linkPortable=0
 
 while [ "$1" != "" ]; do
         lowerI="$(echo $1 | awk '{print tolower($0)}')"
@@ -118,6 +123,7 @@ while [ "$1" != "" ]; do
             ;;
         -portable)
             __portableBuildArgs="-DCLI_CMAKE_PORTABLE_BUILD=1"
+            __linkPortable=1
             ;;
         --cross)
             __CrossBuild=1
@@ -151,11 +157,7 @@ __cmake_defines="${__cmake_defines} ${__arch_define}"
 
 # __rid_plat is the base RID that corehost is shipped for, effectively, the name of the folder in "runtimes/{__rid_plat}/native/" inside the nupkgs.
 __rid_plat=
-if [ "$(uname -s)" == "Darwin" ]; then
-    __rid_plat=osx.10.12
-else
-    init_rid_plat
-fi
+init_rid_plat
 
 if [ -z $__rid_plat ]; then
     echo "Unknown base rid (eg.: osx.10.12, ubuntu.14.04) being targeted"
@@ -169,6 +171,7 @@ fi
 
 __build_arch_lowcase=$(echo "$__build_arch" | tr '[:upper:]' '[:lower:]')
 __base_rid=$__rid_plat-$__build_arch_lowcase
+echo "Computed RID for native build is $__base_rid"
 export __CrossToolChainTargetRID=$__base_rid
 
 # Set up the environment to be used for building with clang.


### PR DESCRIPTION
While investigating https://github.com/dotnet/core-setup/issues/2280, I noticed that for portable builds, RID computed to be used for HostPolicy servicing was still distro specific (e.g win7-x64) and not portable (e.g. win-x64) that would resulted in inability to lookup serviced hostpolicy binary.

This change fixes it.

@eerhardt PTAL.