### PR TITLE
Add Tizen armel CI job

### DIFF
--- a/NuGet.Config
+++ b/NuGet.Config
@@ -7,6 +7,7 @@
     <add key="cli-deps" value="https://dotnet.myget.org/F/cli-deps/api/v3/index.json" />
     <add key="api.nuget.org" value="https://api.nuget.org/v3/index.json" />
     <add key="corefxlab" value="https://dotnet.myget.org/F/dotnet-corefxlab/api/v3/index.json" />
+    <add key="tizen-core" value="https://tizen.myget.org/F/dotnet-core/api/v3/index.json" />
   </packageSources>
   <disabledPackageSources>
     <clear />

--- a/netci.groovy
+++ b/netci.groovy
@@ -10,7 +10,7 @@ def project = GithubProject
 def branch = GithubBranchName
 def isPR = true
 
-def platformList = ['Debian8.2:x64:Debug', 'PortableLinux:x64:Release', 'Ubuntu:arm:Release', 'Ubuntu:x64:Release', 'Ubuntu16.04:arm:Release', 'Ubuntu16.04:x64:Release', 'Ubuntu16.10:x64:Release', 'OSX10.12:x64:Release', 'Windows_NT:x64:Release', 'Windows_NT:x86:Debug', 'Windows_NT:arm:Debug', 'Fedora24:x64:Debug', 'OpenSUSE42.1:x64:Debug']
+def platformList = ['Debian8.2:x64:Debug', 'PortableLinux:x64:Release', 'Ubuntu:arm:Release', 'Ubuntu:x64:Release', 'Ubuntu16.04:arm:Release', 'Ubuntu16.04:x64:Release', 'Ubuntu16.10:x64:Release', 'OSX10.12:x64:Release', 'Windows_NT:x64:Release', 'Windows_NT:x86:Debug', 'Windows_NT:arm:Debug', 'Fedora24:x64:Debug', 'OpenSUSE42.1:x64:Debug', 'Tizen:armel:Release']
 
 def static getBuildJobName(def configuration, def os, def architecture) {
     return configuration.toLowerCase() + '_' + os.toLowerCase() + '_' + architecture.toLowerCase()
@@ -49,6 +49,10 @@ platformList.each { platform ->
         else if (os == 'Ubuntu16.04') {
             version = "latest-or-auto-docker"
             linuxcodename = 'xenial'
+        }
+        else if (os == 'Tizen') {
+            version = "arm-cross-latest"
+            linuxcodename = 'tizen'
         }
 
         // Call the arm32_ci_script.sh script to perform the cross build by using docker

--- a/scripts/arm32_ci_script.sh
+++ b/scripts/arm32_ci_script.sh
@@ -284,12 +284,6 @@ do
     esac
 done
 
-if [[ $__linuxCodeName == "tizen" ]]; then
-    # This case does not support CI build yet.
-    # Will be enabled ASAP.
-    exit 0
-fi
-
 #Check if there are any uncommited changes in the source directory as git adds and removes patches
 if [[ $(git status -s) != "" ]]; then
    echo 'ERROR: There are some uncommited changes. To avoid losing these changes commit them and try again.'


### PR DESCRIPTION
The tizen runtime pkgs are restored from Tizen dotnet-core feed.
So, add the relevant feed to NuGet.Config.

Related issue: #790 