### PR TITLE
Fix docker invocation in CI.

### DIFF
--- a/netci.groovy
+++ b/netci.groovy
@@ -48,8 +48,8 @@ platformList.each { platform ->
         else if (os == 'Ubuntu16.04') {
             dockerContainer = "ubuntu-16.04-cross-ef0ac75-20175511035548"
         }
-        dockerCommand = "docker run --name ${dockerContainer} --rm -v \${WORKSPACE}:${dockerWorkingDirectory} -w=${dockerWorkingDirectory} ${dockerRepository}:${dockerContainer}"
-        buildCommand = "${dockerCommand} -e ROOTFS_DIR=/crossrootfs/${architecture} ./build.sh -ConfigurationGroup=${configuration} -TargetArchitecture=${architecture} -PortableBuild=true -DistroRid=linux-${architecture} -SkipTests=true -DisableCrossgen=true${crossbuildargs}"
+        dockerCommand = "docker run --name ${dockerContainer} --rm -v \${WORKSPACE}:${dockerWorkingDirectory} -w=${dockerWorkingDirectory} -e=ROOTFS_DIR=/crossrootfs/${architecture} ${dockerRepository}:${dockerContainer}"
+        buildCommand = "${dockerCommand} ./build.sh -ConfigurationGroup=${configuration} -TargetArchitecture=${architecture} -PortableBuild=true -DistroRid=linux-${architecture} -SkipTests=true -DisableCrossgen=true${crossbuildargs}"
     }
     else if (os == "Ubuntu") {
         dockerContainer = "ubuntu-14.04-debpkg-e5cf912-20175003025046"


### PR DESCRIPTION
The -e switch to set an environment variable must come before the
image name, otherwise docker treats is as part of the command to run
in the container.