### PR TITLE
Add target to validate runtime-specific packages

### DIFF
--- a/src/pkg/projects/Microsoft.NETCore.App/Microsoft.NETCore.App.pkgproj
+++ b/src/pkg/projects/Microsoft.NETCore.App/Microsoft.NETCore.App.pkgproj
@@ -53,6 +53,9 @@
     <File Include="$(PlatformManifestFile)">
       <TargetPath>build/$(NETCoreAppFramework)</TargetPath>
     </File>
+    <File Include="$(MSBuildProjectName).targets">
+      <TargetPath>build/$(NETCoreAppFramework)</TargetPath>
+    </File>
   </ItemGroup>
 
   <!-- Redistributed package content from other nuget packages-->
@@ -75,6 +78,7 @@
     
     <GenerateFileVersionProps Files="@(SharedFrameworkRuntimeFiles)"
                               PackageId="$(Id)"
+                              PackageVersion="$(Version)"
                               PlatformManifestFile="$(PlatformManifestFile)"
                               PropsFile="$(PropsFile)"
                               PreferredPackages="$(Id);@(RuntimeDependency)" />

--- a/src/pkg/projects/Microsoft.NETCore.App/Microsoft.NETCore.App.targets
+++ b/src/pkg/projects/Microsoft.NETCore.App/Microsoft.NETCore.App.targets
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <Target Name="EnsureNETCoreAppRuntime" 
+          Condition="'$(RuntimeIdentifier)' != '' AND '$(EnsureNETCoreAppRuntime)' != 'false'" 
+          AfterTargets="RunResolvePackageDependencies">
+    <ItemGroup>
+      <_netCoreAppPackageDependencies 
+          Include="@(PackageDependencies->WithMetadataValue('ParentPackage', '$(MSBuildThisFileName)/$(_Microsoft_NETCore_App_Version)'))" />
+      <_activeRIDNetCoreAppPackageDependencies 
+          Include="@(_netCoreAppPackageDependencies->WithMetadataValue('ParentTarget', '$(NuGetTargetMoniker)/$(RuntimeIdentifier)'))" />
+      <_activeTFMNetCoreAppPackageDependencies 
+          Include="@(_netCoreAppPackageDependencies->WithMetadataValue('ParentTarget', '$(NuGetTargetMoniker)'))" />
+      <_ridSpecificNetCoreAppPackageDependencies 
+          Include="@(_activeRIDNetCoreAppPackageDependencies)" 
+          Exclude="@(_activeTFMNetCoreAppPackageDependencies)" />
+    </ItemGroup>
+    
+    <Error Condition="'@(_ridSpecificNetCoreAppPackageDependencies)' == ''"
+           Text="Project is targeting runtime '$(RuntimeIdentifier)' but did not resolve any runtime-specific packages for the '$(MSBuildThisFileName)' package.  This runtime may not be supported by .NET Core." />
+  </Target>
+</Project>

--- a/src/pkg/projects/Microsoft.NETCore.UniversalWindowsPlatform/Microsoft.NETCore.UniversalWindowsPlatform.pkgproj
+++ b/src/pkg/projects/Microsoft.NETCore.UniversalWindowsPlatform/Microsoft.NETCore.UniversalWindowsPlatform.pkgproj
@@ -61,6 +61,7 @@
     
     <GenerateFileVersionProps Files="@(UapRuntimeFiles)"
                               PackageId="$(Id)"
+                              PackageVersion="$(Version)"
                               PlatformManifestFile="$(PlatformManifestFile)"
                               PropsFile="$(PropsFile)"
                               PreferredPackages="$(Id);@(RuntimeDependency)" />

--- a/tools-local/tasks/GenerateFileVersionProps.cs
+++ b/tools-local/tasks/GenerateFileVersionProps.cs
@@ -22,6 +22,9 @@ namespace Microsoft.DotNet.Build.Tasks
         public string PackageId { get; set; }
 
         [Required]
+        public string PackageVersion { get; set; }
+
+        [Required]
         public string PlatformManifestFile { get; set; }
 
         [Required]
@@ -105,6 +108,8 @@ namespace Microsoft.DotNet.Build.Tasks
             var propertyGroup = props.AddPropertyGroup();
             propertyGroup.AddProperty(PreferredPackagesProperty, PreferredPackages);
 
+            var versionPropertyName = $"_{PackageId.Replace(".", "_")}_Version";
+            propertyGroup.AddProperty(versionPropertyName, PackageVersion);
 
             props.Save(PropsFile);
 


### PR DESCRIPTION
Fixes #1755

We no longer have guardrails to make sure runtime matches compile time.  This implements a smaller check to ensure that MS.NETCore.App has some runtime-specific package brought in.

I've made the check suppressible.

Note that I have not made the change to UWP since it is still on project.json-based tools. 

/cc @Petermarcu @joperezr 

