### PR TITLE
Fix Microsoft.NETCore.App package version file location for RID specific packages

### DIFF
--- a/src/pkg/projects/Microsoft.NETCore.App/src/Microsoft.NETCore.App.depproj
+++ b/src/pkg/projects/Microsoft.NETCore.App/src/Microsoft.NETCore.App.depproj
@@ -106,12 +106,6 @@
                        Overwrite="true"/>
   </Target>
 
-  <ItemGroup>
-    <FilesToPackage Include="$(IntermediateOutputPath)\Microsoft.NETCore.App.versions.txt">
-      <TargetPath></TargetPath>
-    </FilesToPackage>
-  </ItemGroup>
-
   <!-- Fetches all the file items from the packages that we want to redist -->
   <Target Name="GetFilesFromPackages" DependsOnTargets="GetPackagePaths">
     <ItemGroup Condition="'$(NuGetRuntimeIdentifier)' != ''">
@@ -150,6 +144,13 @@
       <_sourcePathCandidate Include="@(FilesToPackage->'$(PackagesDir)\%(NuGetPackageId)\%(NuGetPackageVersion)\sources')" />
       <_sourcePathCandidate Include="@(FilesToPackage->'$(PackagesDir)\%(NuGetPackageId)\%(NuGetPackageVersion)\src')" />
       <_sourcePath Include="@(_sourcePathCandidate)" Condition="Exists('%(Identity)')" />
+    </ItemGroup>
+
+    <!-- Add versions file with the hashes of the repos we consume -->
+    <ItemGroup>
+      <FilesToPackage Include="$(IntermediateOutputPath)\Microsoft.NETCore.App.versions.txt">
+        <TargetPath></TargetPath>
+      </FilesToPackage>
     </ItemGroup>
 
     <!-- on windows workaround max-path -->


### PR DESCRIPTION
cc: @ericstj @weshaggard 

A recent change caused the Microsoft.NETCore.App.versions.txt file to be moved now to `runtimes/$(NuGetRuntimeIdentifier)/lib/$(PackageTargetFramework)` for all RID specific packages instead of the root of the package as it should be. With this small change this gets fixed by moving it again to the root of the package.

FYI: @gkhanna79 