### PR TITLE
Update PlatformApis to handle Gentoo Linux.

### DIFF
--- a/src/managed/Microsoft.DotNet.PlatformAbstractions/Native/PlatformApis.cs
+++ b/src/managed/Microsoft.DotNet.PlatformAbstractions/Native/PlatformApis.cs
@@ -128,6 +128,13 @@ namespace Microsoft.DotNet.PlatformAbstractions.Native
         // are backwards compatible.
         private static DistroInfo NormalizeDistroInfo(DistroInfo distroInfo)
         {
+            if (distroInfo.Id == "gentoo")
+            {
+                // Gentoo does not have versions, since they use rolling releases.
+                // Workaround this by setting VersionId to the current year and month.
+                distroInfo.VersionId = DateTime.Today.ToString("yyyy.MM");
+            }
+
             int minorVersionNumberSeparatorIndex = distroInfo.VersionId.IndexOf('.');
 
             if (distroInfo.Id == "rhel" && minorVersionNumberSeparatorIndex != -1)

--- a/src/managed/Microsoft.DotNet.PlatformAbstractions/Native/PlatformApis.cs
+++ b/src/managed/Microsoft.DotNet.PlatformAbstractions/Native/PlatformApis.cs
@@ -128,14 +128,8 @@ namespace Microsoft.DotNet.PlatformAbstractions.Native
         // are backwards compatible.
         private static DistroInfo NormalizeDistroInfo(DistroInfo distroInfo)
         {
-            if (string.IsNullOrEmpty(distroInfo.VersionId))
-            {
-                // Some distribution does not have VERSION_ID defined.
-                // Since we need it, we workaround this by giving it the value "unavailable".
-                distroInfo.VersionId = "unavailable";
-            }
-
-            int minorVersionNumberSeparatorIndex = distroInfo.VersionId.IndexOf('.');
+            // Handle if VersionId is null by just setting the index to -1.
+            int minorVersionNumberSeparatorIndex = distroInfo.VersionId?.IndexOf('.') ?? -1;
 
             if (distroInfo.Id == "rhel" && minorVersionNumberSeparatorIndex != -1)
             {

--- a/src/managed/Microsoft.DotNet.PlatformAbstractions/Native/PlatformApis.cs
+++ b/src/managed/Microsoft.DotNet.PlatformAbstractions/Native/PlatformApis.cs
@@ -128,11 +128,11 @@ namespace Microsoft.DotNet.PlatformAbstractions.Native
         // are backwards compatible.
         private static DistroInfo NormalizeDistroInfo(DistroInfo distroInfo)
         {
-            if (distroInfo.Id == "gentoo")
+            if (string.IsNullOrEmpty(distroInfo.VersionId))
             {
-                // Gentoo does not have versions, since they use rolling releases.
-                // Workaround this by setting VersionId to the current year and month.
-                distroInfo.VersionId = DateTime.Today.ToString("yyyy.MM");
+                // Some distribution does not have VERSION_ID defined.
+                // Since we need it, we workaround this by giving it the value "unavailable".
+                distroInfo.VersionId = "unavailable";
             }
 
             int minorVersionNumberSeparatorIndex = distroInfo.VersionId.IndexOf('.');

--- a/src/managed/Microsoft.DotNet.PlatformAbstractions/RuntimeEnvironment.cs
+++ b/src/managed/Microsoft.DotNet.PlatformAbstractions/RuntimeEnvironment.cs
@@ -52,6 +52,11 @@ namespace Microsoft.DotNet.PlatformAbstractions
                 case Platform.Windows:
                     return GetWindowsProductVersion();
                 case Platform.Linux:
+                    if (string.IsNullOrEmpty(OperatingSystemVersion))
+                    {
+                        return string.Empty;
+                    }
+
                     return $".{OperatingSystemVersion}";
                 case Platform.Darwin:
                     return $".{OperatingSystemVersion}";


### PR DESCRIPTION
When trying to setup the SDK on Gentoo Linux, the following stack trace it thrown, due to VERSION_ID not being inside /etc/os-release:

> Unhandled Exception: System.TypeInitializationException: The type initializer for 'Microsoft.DotNet.PlatformAbstractions.RuntimeEnvironment' threw an exception. ---> System.NullReferenceException: Object reference not set to an instance of an object.
   at Microsoft.DotNet.PlatformAbstractions.Native.PlatformApis.NormalizeDistroInfo(DistroInfo distroInfo)
   at Microsoft.DotNet.PlatformAbstractions.Native.PlatformApis.LoadDistroInfo()
   at System.Lazy`1.ViaFactory(LazyThreadSafetyMode mode)
   at System.Lazy`1.ExecutionAndPublication(LazyHelper executionAndPublication, Boolean useDefaultConstructor)
   at System.Lazy`1.CreateValue()
   at Microsoft.DotNet.PlatformAbstractions.Native.PlatformApis.GetDistroVersionId()
   at Microsoft.DotNet.PlatformAbstractions.Native.PlatformApis.GetOSVersion()
   at Microsoft.DotNet.PlatformAbstractions.RuntimeEnvironment..cctor()
   --- End of inner exception stack trace ---
   at Microsoft.DotNet.PlatformAbstractions.RuntimeEnvironment.GetRuntimeIdentifier()
   at Microsoft.DotNet.Cli.MulticoreJitProfilePathCalculator.CalculateProfileRootPath()
   at Microsoft.DotNet.Cli.MulticoreJitActivator.StartCliProfileOptimization()
   at Microsoft.DotNet.Cli.MulticoreJitActivator.TryActivateMulticoreJit()
   at Microsoft.DotNet.Cli.Program.Main(String[] args)
Aborted

This fixes issue #2380 , since it checks if we are running in Gentoo Linux, and then just set VersionId to DateTime.Today.ToString("yyyy.MM")