### PR TITLE
Add global NuGet.config that turns off the user and machine configs

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <!-- Don't use any higher level config files.
+       Our builds need to be isolated from user/machine state -->
+  <fallbackPackageFolders>
+    <clear />
+  </fallbackPackageFolders>
+  <packageSources>
+    <clear/>
+  </packageSources>
+</configuration>


### PR DESCRIPTION
This should fix our tests so they don't ever use what's in the user or machine config.

@ericstj @weshaggard @mellinoe @chcosta 