### PR TITLE
Add Tizen armel CI job

### DIFF
--- a/netci.groovy
+++ b/netci.groovy
@@ -10,7 +10,7 @@ def project = GithubProject
 def branch = GithubBranchName
 def isPR = true
 
-def platformList = ['Debian8.2:x64:Debug', 'PortableLinux:x64:Release', 'Ubuntu:x64:Release', 'Ubuntu16.04:x64:Release', 'Ubuntu16.10:x64:Release', 'Ubuntu:arm:Release', 'Ubuntu16.04:arm:Release', 'OSX10.12:x64:Release', 'Windows_NT:x64:Release', 'Windows_NT:x86:Debug', 'Windows_NT:arm:Debug', 'Fedora24:x64:Debug', 'OpenSUSE42.1:x64:Debug']
+def platformList = ['Debian8.2:x64:Debug', 'PortableLinux:x64:Release', 'Ubuntu:x64:Release', 'Ubuntu16.04:x64:Release', 'Ubuntu16.10:x64:Release', 'Ubuntu:arm:Release', 'Ubuntu16.04:arm:Release', 'OSX10.12:x64:Release', 'Windows_NT:x64:Release', 'Windows_NT:x86:Debug', 'Windows_NT:arm:Debug', 'Fedora24:x64:Debug', 'OpenSUSE42.1:x64:Debug', 'Tizen:armel:Release']
 
 def static getBuildJobName(def configuration, def os, def architecture) {
     return configuration.toLowerCase() + '_' + os.toLowerCase() + '_' + architecture.toLowerCase()
@@ -37,6 +37,13 @@ platformList.each { platform ->
         if ((architecture == 'arm' || architecture == 'arm64')) {
             buildCommand += " -PortableBuild=true -SkipTests=true"
         }
+    }
+    else if (os == 'Tizen') {
+        dockerRepository = "hqueue/dotnetcore"
+        dockerContainer = "ubuntu1404_cross_prereqs_v4-tizen_rootfs"
+
+        dockerCommand = "docker run -e ROOTFS_DIR=/crossrootfs/${architecture}.tizen.build --name ${dockerContainer} --rm -v \${WORKSPACE}:${dockerWorkingDirectory} -w=${dockerWorkingDirectory} ${dockerRepository}:${dockerContainer}"
+        buildCommand = "${dockerCommand} ./build.sh -ConfigurationGroup=${configuration} -TargetArchitecture=${architecture} -DistroRid=tizen.4.0.0-${architecture} -SkipTests=true -DisableCrossgen=true -CrossBuild=true -- /p:OverridePackageSource=https:%2F%2Ftizen.myget.org/F/dotnet-core/api/v3/index.json"
     }
     else if ((os.startsWith("Ubuntu")) && 
              (architecture == 'arm' || architecture == 'armel')) {


### PR DESCRIPTION
The tizen runtime pkgs are restored from Tizen dotnet-core feed.
So, add the relevant feed by using OverridePackageSource property.

Related issue: #790 