### PR TITLE
Remove item include which is causing symbols packages to be included …

### DIFF
--- a/publish/dir.props
+++ b/publish/dir.props
@@ -28,9 +28,6 @@
     <RidAgnosticPackageFile Include="$(PackagesOutDir)**/*.nupkg" Exclude="@(RuntimePackageFile)" >
       <RelativeBlobPath>$(BinariesRelativePath)</RelativeBlobPath>
     </RidAgnosticPackageFile>
-    <RidAgnosticPackageFile Include="$(PackagesOutDir)**/*$(SharedFrameworkNuGetVersion).symbols.nupkg" Exclude="@(RuntimePackageFile)" >
-      <RelativeBlobPath>$(BinariesRelativePath)</RelativeBlobPath>
-    </RidAgnosticPackageFile>
     <InstallerFile Include="$(PackagesOutDir)**/*$(InstallerExtension)" >
       <RelativeBlobPath>$(InstallersRelativePath)</RelativeBlobPath>
     </InstallerFile>


### PR DESCRIPTION
We're hitting an intermittent build break because symbols packages are getting included in the list of items to upload twice.

This line is already including all symbols (identity) packages,

```
     <RidAgnosticPackageFile Include="$(PackagesOutDir)**/*.nupkg" Exclude="@(RuntimePackageFile)" > 
       <RelativeBlobPath>$(BinariesRelativePath)</RelativeBlobPath> 
     </RidAgnosticPackageFile> 
```

which makes the next include unnecessary and leads to a timing related process lock during azure upload

```
2017-05-16T20:03:00.4328558Z ##[error]core-setup\publish\publish.proj(46,5): Error : The process cannot access the file 'E:\A\_work\443\s\core-setup\Bin\win-x64.Release\packages\Microsoft.NETCore.App.2.0.0-preview2-25316-08.symbols.nupkg' because it is being used by another process.
   at System.IO.__Error.WinIOError(Int32 errorCode, String maybeFullPath)
   at System.IO.FileStream.Init(String path, FileMode mode, FileAccess access, Int32 rights, Boolean useRights, FileShare share, Int32 bufferSize, FileOptions options, SECURITY_ATTRIBUTES secAttrs, String msgPath, Boolean bFromProxy, Boolean useLongPath, Boolean checkHost)
   at System.IO.FileStream..ctor(String path, FileMode mode, FileAccess access, FileShare share, Int32 bufferSize, FileOptions options, String msgPath, Boolean bFromProxy)
   at System.IO.FileStream..ctor(String path, FileMode mode)
   at Microsoft.DotNet.Build.Tasks.Utility.UploadClient.<UploadBlockBlobAsync>d__3.MoveNext() in E:\A\_work\443\s\core-setup\tools-local\Microsoft.DotNet.Build.Tasks.Local\UploadClient.cs:line 61
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at Microsoft.DotNet.Build.Tasks.UploadToAzure.<UploadAsync>d__21.MoveNext() in E:\A\_work\443\s\core-setup\tools-local\Microsoft.DotNet.Build.Tasks.Local\UploadToAzure.cs:line 162
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
```

/cc @gkhanna79 @eerhardt @rakeshsinghranchi @karajas @dagood 