### PR TITLE
Revert "Generate crossgen symbols for the shared framework."

### DIFF
--- a/src/dir.props
+++ b/src/dir.props
@@ -27,11 +27,5 @@
     <PackageTargetRid Condition="'$(TargetRid)' == 'rhel.7.3-x64'">rhel.7-x64</PackageTargetRid>
     <PackageTargetRid Condition="'$(TargetRid)' == 'rhel.7.2-x64'">rhel.7-x64</PackageTargetRid>    
   </PropertyGroup>
-
-  <PropertyGroup>
-    <CrossGenSymbolExtension>.map</CrossGenSymbolExtension>
-    <CrossGenSymbolExtension Condition="'$(OSGroup)' == 'Windows_NT'">.ni.pdb</CrossGenSymbolExtension>
-    <!-- OSX doesn't have crossgen symbols, yet -->
-    <CrossGenSymbolExtension Condition="'$(OSGroup)' == 'OSX'"></CrossGenSymbolExtension>
-  </PropertyGroup>
+    
 </Project>

--- a/src/pkg/packaging/dir.proj
+++ b/src/pkg/packaging/dir.proj
@@ -119,6 +119,12 @@
 
   <Target Name="GenerateTarBall"
           Condition="'$(OSGroup)'!='Windows_NT'">
+    <ItemGroup>
+      <CombinedCompressedFileSet Include="$(CombinedPublishRoot)/**" />
+      <HostFxrCompressedFileSet Include="$(HostFxrPublishRoot)/**" />
+      <SharedFrameworkCompressedFileSet Include="$(SharedFrameworkPublishRoot)/**" />
+      <SharedFrameworkSymbolsCompressedFileSet Include="$(SharedFrameworkPublishSymbolsDir)/**" />
+    </ItemGroup>
 
     <!-- tar command will throw 'file changed as we read it' on some distros.  ignore that error.
          we use -C so that we get a relative folder structure which is compressed rather than the full path -->

--- a/src/pkg/projects/Microsoft.NETCore.App/src/Microsoft.NETCore.App.depproj
+++ b/src/pkg/projects/Microsoft.NETCore.App/src/Microsoft.NETCore.App.depproj
@@ -18,7 +18,6 @@
     <IntermediateOutputPath>$(IntermediateOutputPath)$(NuGetRuntimeIdentifier)</IntermediateOutputPath>
     <RestoreOutputPath>$(IntermediateOutputPath)</RestoreOutputPath>
     <AdditionalRestoreArgs>/p:HasRuntimePackages=false /p:IntermediateOutputPath=$(IntermediateOutputPath)</AdditionalRestoreArgs>
-    <CrossGenSymbolsOutputPath>$(PackageSymbolsBinDir)/$(MSBuildProjectName)</CrossGenSymbolsOutputPath>
   </PropertyGroup>
 
   <ItemGroup>
@@ -207,11 +206,9 @@
     <Exec Command="chmod u+x $(_crossGenPath)"
           Condition="'$(OSGroup)' != 'Windows_NT'" />
     <ItemGroup>
-      <_filesToCrossGen Include="@(FilesToPackage)"
+      <_filesToCrossGen Include="@(FilesToPackage)" 
                         Condition="'%(FilesToPackage.IsNative)' != 'true' AND '%(FileName)' != 'System.Private.CoreLib' AND '%(FileName)' != 'mscorlib' AND '%(Extension)' == '.dll'">
-        <CrossGenedDirectory>$(CrossGenOutputPath)/%(TargetPath)/</CrossGenedDirectory>
         <CrossGenedPath>$(CrossGenOutputPath)/%(TargetPath)/%(FileName)%(Extension)</CrossGenedPath>
-        <CrossGenSymbolSemaphorePath>$(_crossGenIntermediatePath)/%(FileName).symbol.semaphore</CrossGenSymbolSemaphorePath>
       </_filesToCrossGen>
 
       <FilesToPackage Remove="@(_filesToCrossGen)" />
@@ -238,9 +235,6 @@
   </Target>
 
   <Target Name="CrossGen"
-          DependsOnTargets="CreateCrossGenImages;CreateCrossGenSymbols" />
-
-  <Target Name="CreateCrossGenImages"
           DependsOnTargets="PrepareForCrossGen"
           Inputs="@(_filesToCrossGen)"
           Outputs="%(_filesToCrossGen.CrossGenedPath)">
@@ -262,53 +256,7 @@
     <Exec Command="$(_crossGenPath) @$(_crossGenResponseFile)" WorkingDirectory="$(_clrDirectory)" EnvironmentVariables="COMPlus_PartialNGen=0" />
   </Target>
   
-  <Target Name="CreateCrossGenSymbols"
-          Condition="'$(CrossGenSymbolExtension)' != ''"
-          DependsOnTargets="CreateCrossGenImages"
-          Inputs="%(_filesToCrossGen.CrossGenedPath)"
-          Outputs="%(_filesToCrossGen.CrossGenSymbolSemaphorePath)">
-    <PropertyGroup>
-      <_crossGenSymbolsResponseFile>$(_crossGenIntermediatePath)/%(_filesToCrossGen.FileName).symbols.rsp</_crossGenSymbolsResponseFile>
-      <_crossGenSymbolsOptionName Condition="'$(OS)' == 'Windows_NT'">CreatePDB</_crossGenSymbolsOptionName>
-      <_crossGenSymbolsOptionName Condition="'$(_crossGenSymbolsOptionName)' == ''">CreatePerfMap</_crossGenSymbolsOptionName>
-      <_crossGenSymbolsOutputDirectory>$(CrossGenSymbolsOutputPath)/%(_filesToCrossGen.TargetPath)</_crossGenSymbolsOutputDirectory>
-    </PropertyGroup>
-    
-    <ItemGroup>
-      <_crossGenSymbolsArgs Include="-readytorun" />
-      <_crossGenSymbolsArgs Include="-platform_assemblies_paths %(_filesToCrossGen.CrossGenedDirectory)$(_pathSeparatorEscaped)$(_coreLibDirectory)" />
-      <_crossGenSymbolsArgs Include="-$(_crossGenSymbolsOptionName)" />
-      <_crossGenSymbolsArgs Include="$(_crossGenSymbolsOutputDirectory)" />
-      <_crossGenSymbolsArgs Include="%(_filesToCrossGen.CrossGenedPath)" />
-    </ItemGroup>
-
-    <WriteLinesToFile File="$(_crossGenSymbolsResponseFile)" Lines="@(_crossGenSymbolsArgs)" Overwrite="true" />
-    
-    <MakeDir Directories="$(_crossGenSymbolsOutputDirectory)" />
-    
-    <Exec Command="$(_crossGenPath) @$(_crossGenSymbolsResponseFile)" WorkingDirectory="$(_clrDirectory)" EnvironmentVariables="COMPlus_PartialNGen=0" />
-
-    <Touch Files="%(_filesToCrossGen.CrossGenSymbolSemaphorePath)" AlwaysCreate="true" />
-  </Target>
-
-  <!--
-    Note this target should not build anything since it will run during packaging, so it
-    cannot depend on CreateCrossGenSymbols.  It assumes that this project has already
-    gotten "Build" called on it to generate the symbol files.
-  -->
-  <Target Name="GetCrossGenSymbolsFiles"
-          Condition="'$(CrossGenSymbolExtension)' != ''">
-    <ItemGroup>
-      <FilesToPackage Include="$(CrossGenSymbolsOutputPath)/**/*$(CrossGenSymbolExtension)">
-        <IsSymbolFile>true</IsSymbolFile>
-        <TargetPath>runtimes/$(NuGetRuntimeIdentifier)/lib/$(PackageTargetFramework)</TargetPath>
-      </FilesToPackage>
-    </ItemGroup>
-  </Target>
-  
-  <Target Name="GetFilesToPackage"
-          DependsOnTargets="ResolveNuGetPackages;GetFilesFromPackages;PrepareForCrossGen;GetCrossGenSymbolsFiles"
-          Returns="@(FilesToPackage)" />
+  <Target Name="GetFilesToPackage" DependsOnTargets="ResolveNuGetPackages;GetFilesFromPackages;PrepareForCrossGen" Returns="@(FilesToPackage)" />
 
   <Target Name="GetDependenciesToPackage" Condition="'@(DependenciesToPackage)' != ''" DependsOnTargets="ResolveNuGetPackages" Returns="@(_DependenciesToPackageWithVersion)">
     <ItemGroup>

--- a/src/sharedFramework/sharedFramework.proj
+++ b/src/sharedFramework/sharedFramework.proj
@@ -70,8 +70,6 @@
     <ItemGroup>
       <SharedFrameworkSymbols Include="$(PackageSymbolsBinDir)Microsoft.NETCore.App/**/*.pdb" />
       <SharedFrameworkSymbols Include="$(PackageSymbolsBinDir)Microsoft.NETCore.App/**/*$(SymbolFileExtension)" />
-      <SharedFrameworkSymbols Include="$(PackageSymbolsBinDir)Microsoft.NETCore.App/**/*$(CrossGenSymbolExtension)" 
-                              Condition="'$(CrossGenSymbolExtension)' != ''" />
     </ItemGroup>
     <RemoveDir Directories="$(SharedFrameworkPublishSymbolsDir)"
                Condition="Exists('$(SharedFrameworkPublishSymbolsDir)')" />


### PR DESCRIPTION
Reverts dotnet/core-setup#2397

This change broke on our official build machines.  Reverting.

@chcosta @gkhanna79 @weshaggard 