### PR TITLE
Revert "Fix deb package naming"

### DIFF
--- a/src/pkg/packaging/deb/package.props
+++ b/src/pkg/packaging/deb/package.props
@@ -10,10 +10,10 @@
     <SharedHostDebPkgName>dotnet-host</SharedHostDebPkgName>
     <SharedHostDebPkgName>$(SharedHostDebPkgName.ToLower())</SharedHostDebPkgName>
     
-    <HostFxrDebPkgName>dotnet-hostfxr</HostFxrDebPkgName>
+    <HostFxrDebPkgName>dotnet-hostfxr-$(HostResolverVersion)</HostFxrDebPkgName>
     <HostFxrDebPkgName>$(HostFxrDebPkgName.ToLower())</HostFxrDebPkgName>
     
-    <SharedFxDebPkgName>dotnet-sharedframework</SharedFxDebPkgName>
+    <SharedFxDebPkgName>dotnet-sharedframework-$(SharedFrameworkName)-$(SharedFrameworkNugetVersion)</SharedFxDebPkgName>
     <SharedFxDebPkgName>$(SharedFxDebPkgName.ToLower())</SharedFxDebPkgName>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Reverts dotnet/core-setup#2390.

This change was not correct.  We need the hostfxr and shared framework packages to be side-by-side installs.  That way you can install 2.0 and 2.1, and have them both installed at the same time.