### PR TITLE
Fix package name in json for debian publish

### DIFF
--- a/publish/dir.targets
+++ b/publish/dir.targets
@@ -74,10 +74,10 @@
         <PackageName>dotnet-host</PackageName>
       </DebInstallerFile>
       <DebInstallerFile Include="$(HostFxrInstallerStart)$(HostResolverVersionMoniker).deb" >
-        <PackageName>dotnet-hostfxr</PackageName>
+        <PackageName>dotnet-hostfxr-$(HostResolverVersion)</PackageName>
       </DebInstallerFile>
       <DebInstallerFile Include="$(SharedFrameworkInstallerStart)$(ProductMoniker).deb">
-        <PackageName>dotnet-sharedframework</PackageName>
+        <PackageName>dotnet-sharedframework-$(SharedFrameworkName)-$(SharedFrameworkNugetVersion)</PackageName>
       </DebInstallerFile>
 
       <DebInstallerFile>


### PR DESCRIPTION
@leecow @eerhardt @chcosta @gkhanna79 @rakeshsinghranchi 

This should be the fix for getting the deb packages published with the right package name and package version. 