### PR TITLE
Add fragile pdbs again

### DIFF
--- a/buildpipeline/Core-Setup-Signing-Windows-BT.json
+++ b/buildpipeline/Core-Setup-Signing-Windows-BT.json
@@ -136,24 +136,15 @@
       "displayName": "Build binaries",
       "timeoutInMinutes": 0,
       "task": {
-        "id": "c6c4c611-aa2e-4a33-b606-5eaba2196824",
+        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
         "versionSpec": "1.*",
         "definitionType": "task"
       },
       "inputs": {
-        "solution": "$(PB_SourcesDirectory)/src/src.builds",
-        "platform": "$(PB_TargetArchitecture)",
-        "configuration": "$(BuildConfiguration)",
-        "msbuildArguments": "$(PB_CommonMSBuildArgs)",
-        "clean": "false",
-        "maximumCpuCount": "false",
-        "restoreNugetPackages": "false",
-        "logProjectEvents": "false",
-        "createLogFile": "false",
-        "msbuildLocationMethod": "version",
-        "msbuildVersion": "latest",
-        "msbuildArchitecture": "x64",
-        "msbuildLocation": ""
+        "filename": "$(PB_SourcesDirectory)\\build.cmd",
+        "arguments": "-src-builds -- $(PB_CommonMSBuildArgs)",
+        "workingFolder": "$(PB_SourcesDirectory)",
+        "failOnStandardError": "false"
       }
     },
     {

--- a/config.json
+++ b/config.json
@@ -183,11 +183,17 @@
       }
     },
     "build":{
-      "alias":{
-        "binaries":{
+      "alias": {
+        "binaries": {
           "description": "Only builds binaries. It doesn't restore packages.",
-          "settings":{
+          "settings": {
             "RestoreDuringBuild": false
+          }
+        },
+        "src-builds": {
+          "description": "Only build src\\src.builds project",
+          "settings": {
+            "Project": "src\\src.builds"
           }
         },
         "GenerateVersion": {
@@ -197,51 +203,51 @@
             "GenerateVersionHeader": "default"
           }
         },
-        "debug":{
+        "debug": {
           "description": "Sets ConfigurationGroup=Debug or the value passed by the user.",
-          "settings":{
+          "settings": {
             "ConfigurationGroup": "Debug"
           }
         },
-        "release":{
+        "release": {
           "description": "Sets ConfigurationGroup=Release or the value passed by the user.",
-          "settings":{
+          "settings": {
             "ConfigurationGroup": "Release"
           }
         },
-        "verbose":{
+        "verbose": {
           "description": "Passes /flp:v=diag to the msbuild command or the value passed by the user.",
-          "settings":{
+          "settings": {
             "MsBuildLogging": "/flp:v=diag"
           }
         },
-        "cmakelog":{
+        "cmakelog": {
           "description": "Writes msbuild log to cmake.log",
-          "settings":{
+          "settings": {
             "MsBuildLogging": "/flp:v=diag;LogFile=msbuild-cmake.log"
           }
         },
-        "os":{
+        "os": {
           "description": "Sets OSGroup=AnyOS or the value passed by the user.",
-          "settings":{
+          "settings": {
             "OSGroup": "default"
           }
         },
-        "portable":{
+        "portable": {
           "description": "Make the build-native script generate binaries that are portable for the platform.",
           "settings": {
-            "PortableBuild":"true"
+            "PortableBuild": "true"
           }
-        },        
-        "skipTests":{
+        },
+        "skipTests": {
           "description": "Skips running tests",
-          "settings":{
+          "settings": {
             "SkipTests": "true"
           }
         },
-        "disableCrossgen":{
+        "disableCrossgen": {
           "description": "Disable crossgen during the build",
-          "settings":{
+          "settings": {
             "DisableCrossgen": "true"
           }
         }

--- a/src/dir.props
+++ b/src/dir.props
@@ -27,5 +27,11 @@
     <PackageTargetRid Condition="'$(TargetRid)' == 'rhel.7.3-x64'">rhel.7-x64</PackageTargetRid>
     <PackageTargetRid Condition="'$(TargetRid)' == 'rhel.7.2-x64'">rhel.7-x64</PackageTargetRid>    
   </PropertyGroup>
-    
+
+  <PropertyGroup>
+    <CrossGenSymbolExtension>.map</CrossGenSymbolExtension>
+    <CrossGenSymbolExtension Condition="'$(OSGroup)' == 'Windows_NT'">.ni.pdb</CrossGenSymbolExtension>
+    <!-- OSX doesn't have crossgen symbols, yet -->
+    <CrossGenSymbolExtension Condition="'$(OSGroup)' == 'OSX'"></CrossGenSymbolExtension>
+  </PropertyGroup>
 </Project>

--- a/src/pkg/packaging/dir.proj
+++ b/src/pkg/packaging/dir.proj
@@ -119,12 +119,6 @@
 
   <Target Name="GenerateTarBall"
           Condition="'$(OSGroup)'!='Windows_NT'">
-    <ItemGroup>
-      <CombinedCompressedFileSet Include="$(CombinedPublishRoot)/**" />
-      <HostFxrCompressedFileSet Include="$(HostFxrPublishRoot)/**" />
-      <SharedFrameworkCompressedFileSet Include="$(SharedFrameworkPublishRoot)/**" />
-      <SharedFrameworkSymbolsCompressedFileSet Include="$(SharedFrameworkPublishSymbolsDir)/**" />
-    </ItemGroup>
 
     <!-- tar command will throw 'file changed as we read it' on some distros.  ignore that error.
          we use -C so that we get a relative folder structure which is compressed rather than the full path -->

--- a/src/pkg/projects/Microsoft.NETCore.App/src/Microsoft.NETCore.App.depproj
+++ b/src/pkg/projects/Microsoft.NETCore.App/src/Microsoft.NETCore.App.depproj
@@ -18,6 +18,7 @@
     <IntermediateOutputPath>$(IntermediateOutputPath)$(NuGetRuntimeIdentifier)</IntermediateOutputPath>
     <RestoreOutputPath>$(IntermediateOutputPath)</RestoreOutputPath>
     <AdditionalRestoreArgs>/p:HasRuntimePackages=false /p:IntermediateOutputPath=$(IntermediateOutputPath)</AdditionalRestoreArgs>
+    <CrossGenSymbolsOutputPath>$(PackageSymbolsBinDir)/$(MSBuildProjectName)</CrossGenSymbolsOutputPath>
   </PropertyGroup>
 
   <ItemGroup>
@@ -206,9 +207,11 @@
     <Exec Command="chmod u+x $(_crossGenPath)"
           Condition="'$(OSGroup)' != 'Windows_NT'" />
     <ItemGroup>
-      <_filesToCrossGen Include="@(FilesToPackage)" 
+      <_filesToCrossGen Include="@(FilesToPackage)"
                         Condition="'%(FilesToPackage.IsNative)' != 'true' AND '%(FileName)' != 'System.Private.CoreLib' AND '%(FileName)' != 'mscorlib' AND '%(Extension)' == '.dll'">
+        <CrossGenedDirectory>$(CrossGenOutputPath)/%(TargetPath)/</CrossGenedDirectory>
         <CrossGenedPath>$(CrossGenOutputPath)/%(TargetPath)/%(FileName)%(Extension)</CrossGenedPath>
+        <CrossGenSymbolSemaphorePath>$(_crossGenIntermediatePath)/%(FileName).symbol.semaphore</CrossGenSymbolSemaphorePath>
       </_filesToCrossGen>
 
       <FilesToPackage Remove="@(_filesToCrossGen)" />
@@ -235,6 +238,9 @@
   </Target>
 
   <Target Name="CrossGen"
+          DependsOnTargets="CreateCrossGenImages;CreateCrossGenSymbols" />
+
+  <Target Name="CreateCrossGenImages"
           DependsOnTargets="PrepareForCrossGen"
           Inputs="@(_filesToCrossGen)"
           Outputs="%(_filesToCrossGen.CrossGenedPath)">
@@ -256,7 +262,53 @@
     <Exec Command="$(_crossGenPath) @$(_crossGenResponseFile)" WorkingDirectory="$(_clrDirectory)" EnvironmentVariables="COMPlus_PartialNGen=0" />
   </Target>
   
-  <Target Name="GetFilesToPackage" DependsOnTargets="ResolveNuGetPackages;GetFilesFromPackages;PrepareForCrossGen" Returns="@(FilesToPackage)" />
+  <Target Name="CreateCrossGenSymbols"
+          Condition="'$(CrossGenSymbolExtension)' != ''"
+          DependsOnTargets="CreateCrossGenImages"
+          Inputs="%(_filesToCrossGen.CrossGenedPath)"
+          Outputs="%(_filesToCrossGen.CrossGenSymbolSemaphorePath)">
+    <PropertyGroup>
+      <_crossGenSymbolsResponseFile>$(_crossGenIntermediatePath)/%(_filesToCrossGen.FileName).symbols.rsp</_crossGenSymbolsResponseFile>
+      <_crossGenSymbolsOptionName Condition="'$(OS)' == 'Windows_NT'">CreatePDB</_crossGenSymbolsOptionName>
+      <_crossGenSymbolsOptionName Condition="'$(_crossGenSymbolsOptionName)' == ''">CreatePerfMap</_crossGenSymbolsOptionName>
+      <_crossGenSymbolsOutputDirectory>$(CrossGenSymbolsOutputPath)/%(_filesToCrossGen.TargetPath)</_crossGenSymbolsOutputDirectory>
+    </PropertyGroup>
+    
+    <ItemGroup>
+      <_crossGenSymbolsArgs Include="-readytorun" />
+      <_crossGenSymbolsArgs Include="-platform_assemblies_paths %(_filesToCrossGen.CrossGenedDirectory)$(_pathSeparatorEscaped)$(_coreLibDirectory)" />
+      <_crossGenSymbolsArgs Include="-$(_crossGenSymbolsOptionName)" />
+      <_crossGenSymbolsArgs Include="$(_crossGenSymbolsOutputDirectory)" />
+      <_crossGenSymbolsArgs Include="%(_filesToCrossGen.CrossGenedPath)" />
+    </ItemGroup>
+
+    <WriteLinesToFile File="$(_crossGenSymbolsResponseFile)" Lines="@(_crossGenSymbolsArgs)" Overwrite="true" />
+    
+    <MakeDir Directories="$(_crossGenSymbolsOutputDirectory)" />
+    
+    <Exec Command="$(_crossGenPath) @$(_crossGenSymbolsResponseFile)" WorkingDirectory="$(_clrDirectory)" EnvironmentVariables="COMPlus_PartialNGen=0" />
+
+    <Touch Files="%(_filesToCrossGen.CrossGenSymbolSemaphorePath)" AlwaysCreate="true" />
+  </Target>
+
+  <!--
+    Note this target should not build anything since it will run during packaging, so it
+    cannot depend on CreateCrossGenSymbols.  It assumes that this project has already
+    gotten "Build" called on it to generate the symbol files.
+  -->
+  <Target Name="GetCrossGenSymbolsFiles"
+          Condition="'$(CrossGenSymbolExtension)' != ''">
+    <ItemGroup>
+      <FilesToPackage Include="$(CrossGenSymbolsOutputPath)/**/*$(CrossGenSymbolExtension)">
+        <IsSymbolFile>true</IsSymbolFile>
+        <TargetPath>runtimes/$(NuGetRuntimeIdentifier)/lib/$(PackageTargetFramework)</TargetPath>
+      </FilesToPackage>
+    </ItemGroup>
+  </Target>
+  
+  <Target Name="GetFilesToPackage"
+          DependsOnTargets="ResolveNuGetPackages;GetFilesFromPackages;PrepareForCrossGen;GetCrossGenSymbolsFiles"
+          Returns="@(FilesToPackage)" />
 
   <Target Name="GetDependenciesToPackage" Condition="'@(DependenciesToPackage)' != ''" DependsOnTargets="ResolveNuGetPackages" Returns="@(_DependenciesToPackageWithVersion)">
     <ItemGroup>

--- a/src/sharedFramework/sharedFramework.proj
+++ b/src/sharedFramework/sharedFramework.proj
@@ -70,6 +70,8 @@
     <ItemGroup>
       <SharedFrameworkSymbols Include="$(PackageSymbolsBinDir)Microsoft.NETCore.App/**/*.pdb" />
       <SharedFrameworkSymbols Include="$(PackageSymbolsBinDir)Microsoft.NETCore.App/**/*$(SymbolFileExtension)" />
+      <SharedFrameworkSymbols Include="$(PackageSymbolsBinDir)Microsoft.NETCore.App/**/*$(CrossGenSymbolExtension)" 
+                              Condition="'$(CrossGenSymbolExtension)' != ''" />
     </ItemGroup>
     <RemoveDir Directories="$(SharedFrameworkPublishSymbolsDir)"
                Condition="Exists('$(SharedFrameworkPublishSymbolsDir)')" />


### PR DESCRIPTION
This includes reverting the original revert.  And then adding the support for the official builds to use crossgen -CreatePDB by initializing a VS developer command prompt through run.cmd.

Probably only need to review the last commit, since the first one was already reviewed in #2397.

@chcosta @mellinoe 