### PR TITLE
[release/2.0.0] Do not add MSTestResults in armel build

### DIFF
--- a/netci.groovy
+++ b/netci.groovy
@@ -93,7 +93,7 @@ platformList.each { platform ->
     Utilities.setMachineAffinity(newJob, os, version)
     Utilities.standardJobSetup(newJob, project, isPR, "*/${branch}")
 
-    if (!(architecture == 'arm')) {
+    if (!(architecture == 'arm' || architecture == 'armel') ) {
         Utilities.addMSTestResults(newJob, '**/*-testResults.trx')
     }
 


### PR DESCRIPTION
Fixed Tizen armel Release CI failure issue

Related issue: #2421 
/cc @gkhanna79 