### PR TITLE
Use ROOTFS_DIR env var to find objcopy for symstrip

### DIFF
--- a/src/corehost/CMakeLists.txt
+++ b/src/corehost/CMakeLists.txt
@@ -45,7 +45,7 @@ if (NOT WIN32)
         endif()
     else (CMAKE_SYSTEM_NAME STREQUAL Darwin)
         # Ensure that objcopy is present
-        if(DEFINED ENV{CROSSCOMPILE})
+        if(DEFINED ENV{ROOTFS_DIR})
             if(CMAKE_SYSTEM_PROCESSOR STREQUAL armv7l OR CMAKE_SYSTEM_PROCESSOR STREQUAL aarch64 OR CMAKE_SYSTEM_PROCESSOR STREQUAL i686)
                 find_program(OBJCOPY ${TOOLCHAIN}-objcopy)
             else()


### PR DESCRIPTION
Validated locally, this should fix the Ubuntu portable arm (and Tizen) build failures related to symbol stripping which were reported in https://github.com/dotnet/core-setup/pull/2436, but are also breaking official builds.

> https://github.com/dotnet/core-setup/blob/master/src/corehost/CMakeLists.txt#L48 expects CROSSCOMPILE envvar to be defined to set the correct path to objcopy command. For cross-builds, it needs to come from the ROOTFS_DIR we setup. Since it is not defined, we use the x64 (host machine) objcopy and run into the problem above.
To fix this, change the line above to look for ROOTFS_DIR envvar and I believe that should enable this for arm and armel both.

/cc @gkhanna79 @crummel 
