### PR TITLE
Configure auto-update for release/2.0.0 upstream

### DIFF
--- a/dependencies.props
+++ b/dependencies.props
@@ -9,26 +9,26 @@
        These ref versions are pulled from https://github.com/dotnet/versions.
   -->
   <PropertyGroup>
-    <CoreFxCurrentRef>703d40525af4a09f5566cd3d8f334b3736b68fae</CoreFxCurrentRef>
-    <CoreClrCurrentRef>fcd99ed86a703a16698fcd0027707739c8ef3501</CoreClrCurrentRef>
-    <StandardCurrentRef>cddd078e3efc27b2fc23c38d8028e3b647cd4fe3</StandardCurrentRef>
-    <WCFCurrentRef>cddd078e3efc27b2fc23c38d8028e3b647cd4fe3</WCFCurrentRef>
+    <CoreFxCurrentRef>08ad835fac10ec04e5302ab59fda6cacdde98a60</CoreFxCurrentRef>
+    <CoreClrCurrentRef>08ad835fac10ec04e5302ab59fda6cacdde98a60</CoreClrCurrentRef>
+    <StandardCurrentRef>08ad835fac10ec04e5302ab59fda6cacdde98a60</StandardCurrentRef>
+    <WCFCurrentRef>08ad835fac10ec04e5302ab59fda6cacdde98a60</WCFCurrentRef>
   </PropertyGroup>
   
   <PropertyGroup>
-    <CoreFxVersion>4.4.0-preview2-25316-01</CoreFxVersion>
-    <PlatformPackageVersion>2.0.0-preview2-25316-01</PlatformPackageVersion>
-    <MicrosoftNETCoreRuntimeCoreCLRPackageVersion>2.0.0-preview2-25316-03</MicrosoftNETCoreRuntimeCoreCLRPackageVersion>
+    <CoreFxVersion>4.4.0-preview2-25322-03</CoreFxVersion>
+    <PlatformPackageVersion>2.0.0-preview2-25322-03</PlatformPackageVersion>
+    <MicrosoftNETCoreRuntimeCoreCLRPackageVersion>2.0.0-preview2-25322-01</MicrosoftNETCoreRuntimeCoreCLRPackageVersion>
     <MicrosoftNETCoreRuntimeJitPackageVersion>$(MicrosoftNETCoreRuntimeCoreCLRPackageVersion)</MicrosoftNETCoreRuntimeJitPackageVersion>
-    <NETStandardVersion>2.0.0-preview2-25316-01</NETStandardVersion>
+    <NETStandardVersion>2.0.0-preview2-25322-01</NETStandardVersion>
     <DiaSymReaderNativeVersion>1.4.1</DiaSymReaderNativeVersion>
-    <WcfVersion>4.4.0-preview2-25316-01</WcfVersion>
+    <WcfVersion>4.4.0-preview2-25322-02</WcfVersion>
   </PropertyGroup>
   
   <!-- Package dependency verification/auto-upgrade configuration. -->
   <PropertyGroup>
     <BaseDotNetBuildInfo>build-info/dotnet/</BaseDotNetBuildInfo>
-    <DependencyBranch>master</DependencyBranch>
+    <DependencyBranch>release/2.0.0</DependencyBranch>
     <CurrentRefXmlPath>$(MSBuildThisFileFullPath)</CurrentRefXmlPath>
   </PropertyGroup>
 


### PR DESCRIPTION
Auto-update to upstream release/2.0.0 builds. ~~CoreCLR and WCF don't have builds yet, so this PR temporarily disables upgrades from those repos.~~

See https://github.com/dotnet/core-setup/pull/2453