### PR TITLE
Format installer and archive file name per new guidelines

### DIFF
--- a/dir.props
+++ b/dir.props
@@ -287,9 +287,17 @@
   </PropertyGroup>
   
   <PropertyGroup>
+    <CombinedInstallerStart>$(PackagesOutDir)dotnet-runtime-</CombinedInstallerStart>
     <SharedHostInstallerStart>$(PackagesOutDir)dotnet-host-</SharedHostInstallerStart>
     <HostFxrInstallerStart>$(PackagesOutDir)dotnet-hostfxr-</HostFxrInstallerStart>
-    <SharedFrameworkInstallerStart>$(PackagesOutDir)dotnet-sharedframework-</SharedFrameworkInstallerStart>
+    <SharedFrameworkInstallerStart>$(PackagesOutDir)dotnet-runtime-</SharedFrameworkInstallerStart>
+
+    <!-- OSX specific intermediate package suffix -->
+    <InstallerStartSuffix Condition="'$(OSGroup)' == 'OSX'">internal</InstallerStartSuffix>
+    <SharedHostInstallerStart Condition="'$(OSGroup)' == 'OSX'">$(SharedHostInstallerStart)$(InstallerStartSuffix)-</SharedHostInstallerStart>
+    <HostFxrInstallerStart Condition="'$(OSGroup)' == 'OSX'">$(HostFxrInstallerStart)$(InstallerStartSuffix)-</HostFxrInstallerStart>
+    <SharedFrameworkInstallerStart Condition="'$(OSGroup)' == 'OSX'">$(SharedFrameworkInstallerStart)$(InstallerStartSuffix)-</SharedFrameworkInstallerStart>
+
   </PropertyGroup>
 
   <!-- Disable some standard properties for building our projects -->

--- a/publish/dir.targets
+++ b/publish/dir.targets
@@ -77,7 +77,7 @@
         <PackageName>dotnet-hostfxr-$(HostResolverVersion)</PackageName>
       </DebInstallerFile>
       <DebInstallerFile Include="$(SharedFrameworkInstallerStart)$(ProductMoniker).deb">
-        <PackageName>dotnet-sharedframework-$(SharedFrameworkName)-$(SharedFrameworkNugetVersion)</PackageName>
+        <PackageName>dotnet-runtime-$(SharedFrameworkName)-$(SharedFrameworkNugetVersion)</PackageName>
       </DebInstallerFile>
 
       <DebInstallerFile>

--- a/src/pkg/packaging/deb/package.props
+++ b/src/pkg/packaging/deb/package.props
@@ -13,7 +13,7 @@
     <HostFxrDebPkgName>dotnet-hostfxr-$(HostResolverVersion)</HostFxrDebPkgName>
     <HostFxrDebPkgName>$(HostFxrDebPkgName.ToLower())</HostFxrDebPkgName>
     
-    <SharedFxDebPkgName>dotnet-sharedframework-$(SharedFrameworkName)-$(SharedFrameworkNugetVersion)</SharedFxDebPkgName>
+    <SharedFxDebPkgName>dotnet-runtime-$(SharedFrameworkName)-$(SharedFrameworkNugetVersion)</SharedFxDebPkgName>
     <SharedFxDebPkgName>$(SharedFxDebPkgName.ToLower())</SharedFxDebPkgName>
   </PropertyGroup>
 </Project>

--- a/src/pkg/packaging/dir.props
+++ b/src/pkg/packaging/dir.props
@@ -22,14 +22,14 @@
 
   <PropertyGroup>
     <CombinedCompressedFile>dotnet-runtime-$(ProductMoniker)$(CompressedFileExtension)</CombinedCompressedFile>
-    <HostFxrCompressedFile>dotnet-hostfxr-$(PackageTargetRid).$(HostResolverVersion)$(CompressedFileExtension)</HostFxrCompressedFile>
-    <SharedFrameworkCompressedFile>dotnet-sharedframework-$(ProductMoniker)$(CompressedFileExtension)</SharedFrameworkCompressedFile>
-    <SharedFrameworkSymbolsCompressedFile>dotnet-sharedframework-symbols-$(ProductMoniker)$(CompressedFileExtension)</SharedFrameworkSymbolsCompressedFile>
+    <HostFxrCompressedFile>dotnet-hostfxr-internal-$(PackageTargetRid).$(HostResolverVersion)$(CompressedFileExtension)</HostFxrCompressedFile>
+    <SharedFrameworkCompressedFile>dotnet-runtime-internal-$(ProductMoniker)$(CompressedFileExtension)</SharedFrameworkCompressedFile>
+    <SharedFrameworkSymbolsCompressedFile>dotnet-runtime-symbols-$(ProductMoniker)$(CompressedFileExtension)</SharedFrameworkSymbolsCompressedFile>
   </PropertyGroup>
 
   <PropertyGroup>
-    <CombinedInstallerFile>$(PackagesOutDir)dotnet-runtime-$(ProductMoniker)$(CombinedInstallerExtension)</CombinedInstallerFile>
-    <CombinedInstallerEngine>$(PackagesOutDir)dotnet-$(ProductMoniker)-engine.exe</CombinedInstallerEngine>
+    <CombinedInstallerFile>$(CombinedInstallerStart)$(ProductMoniker)$(CombinedInstallerExtension)</CombinedInstallerFile>
+    <CombinedInstallerEngine>$(CombinedInstallerStart)$(ProductMoniker)-engine.exe</CombinedInstallerEngine>
     <SharedHostInstallerFile>$(SharedHostInstallerStart)$(ProductMoniker)$(InstallerExtension)</SharedHostInstallerFile>
     <HostFxrInstallerFile>$(HostFxrInstallerStart)$(HostResolverVersionMoniker)$(InstallerExtension)</HostFxrInstallerFile>
     <SharedFrameworkInstallerFile>$(SharedFrameworkInstallerStart)$(ProductMoniker)$(InstallerExtension)</SharedFrameworkInstallerFile>
@@ -40,6 +40,6 @@
     <ProductBrandPrefix Condition="'$(ReleaseBrandSuffix)'!=''">Microsoft .NET Core $(ProductionVersion) $(ReleaseBrandSuffix)</ProductBrandPrefix>
     <SharedHostBrandName>$(ProductBrandPrefix) Host</SharedHostBrandName>
     <HostFxrBrandName>$(ProductBrandPrefix) Host FX Resolver</HostFxrBrandName>
-    <SharedFrameworkBrandName>$(ProductBrandPrefix)  Runtime</SharedFrameworkBrandName>
+    <SharedFrameworkBrandName>$(ProductBrandPrefix) Runtime</SharedFrameworkBrandName>
   </PropertyGroup>
 </Project>

--- a/src/pkg/packaging/dir.props
+++ b/src/pkg/packaging/dir.props
@@ -16,19 +16,19 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <ProductMoniker>$(PackageTargetRid).$(SharedFrameworkNugetVersion)</ProductMoniker>
-    <HostResolverVersionMoniker>$(PackageTargetRid).$(HostResolverVersion)</HostResolverVersionMoniker>
+    <ProductMoniker>$(SharedFrameworkNugetVersion)-$(PackageTargetRid)</ProductMoniker>
+    <HostResolverVersionMoniker>$(HostResolverVersion)-$(PackageTargetRid)</HostResolverVersionMoniker>
   </PropertyGroup>
 
   <PropertyGroup>
-    <CombinedCompressedFile>dotnet-$(ProductMoniker)$(CompressedFileExtension)</CombinedCompressedFile>
+    <CombinedCompressedFile>dotnet-runtime-$(ProductMoniker)$(CompressedFileExtension)</CombinedCompressedFile>
     <HostFxrCompressedFile>dotnet-hostfxr-$(PackageTargetRid).$(HostResolverVersion)$(CompressedFileExtension)</HostFxrCompressedFile>
     <SharedFrameworkCompressedFile>dotnet-sharedframework-$(ProductMoniker)$(CompressedFileExtension)</SharedFrameworkCompressedFile>
     <SharedFrameworkSymbolsCompressedFile>dotnet-sharedframework-symbols-$(ProductMoniker)$(CompressedFileExtension)</SharedFrameworkSymbolsCompressedFile>
   </PropertyGroup>
 
   <PropertyGroup>
-    <CombinedInstallerFile>$(PackagesOutDir)dotnet-$(ProductMoniker)$(CombinedInstallerExtension)</CombinedInstallerFile>
+    <CombinedInstallerFile>$(PackagesOutDir)dotnet-runtime-$(ProductMoniker)$(CombinedInstallerExtension)</CombinedInstallerFile>
     <CombinedInstallerEngine>$(PackagesOutDir)dotnet-$(ProductMoniker)-engine.exe</CombinedInstallerEngine>
     <SharedHostInstallerFile>$(SharedHostInstallerStart)$(ProductMoniker)$(InstallerExtension)</SharedHostInstallerFile>
     <HostFxrInstallerFile>$(HostFxrInstallerStart)$(HostResolverVersionMoniker)$(InstallerExtension)</HostFxrInstallerFile>


### PR DESCRIPTION
Guidance for naming convention : https://github.com/dotnet/designs/issues/2 

This commit takes care of the following : 
1. Shifting rid to the end
2. Adding runtime to the bundle packages and archives

**Pending**:
1. Updating the rid , for e.g. for Windows : win10-{arch} , osx : macos.10.12-x64 . 
2. Renaming sharedframework artifacts to "runtime" . This needs further discussion as it will collide with bundle installer name.

This needs further discussion as portable assets as of today do not carry OS version number.

With this change :
for e.g.
Bundle:
dotnet-runtime-2.0.0-preview2-25319-9-win-x86.exe

MSIs:
dotnet-host-2.0.0-preview2-23519-9-win-x86.msi
dotnet-hostfxr-2.0.0-preview2-23519-9-win-x86.msi
dotnet-sharedframework-2.0.0-preview2-23519-9-win-x86.msi

Archive:
dotnet-host-2.0.0-preview2-23519-9-win-x86.zip
dotnet-hostfxr-2.0.0-preview2-23519-9-win-x86.zip
dotnet-sharedframework-2.0.0-preview2-23519-9-win-x86.zip
dotnet-runtime-2.0.0-preview2-25319-9-win-x86.zip

Note: Ask for name format update is for installers and archives only .
