### PR TITLE
Ask Mode: Create symbols packages, add serviceable attribute, and update assembly info

### DIFF
--- a/BuildToolsVersion.txt
+++ b/BuildToolsVersion.txt
@@ -1,1 +1,1 @@
-2.0.0-prerelease-01611-07
+2.0.0-prerelease-01616-04

--- a/src/managed/CommonManaged.props
+++ b/src/managed/CommonManaged.props
@@ -6,8 +6,15 @@
   <PropertyGroup>
     <RepoRoot>$([System.IO.Path]::GetFullPath('$(MSBuildThisFileDirectory)../..'))/</RepoRoot>
     <VersionPrefix>2.0.0</VersionPrefix>
+    <AssemblyFileVersion>$(VersionPrefix)</AssemblyFileVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences>
+    <IncludeSymbols>true</IncludeSymbols>
+    <Serviceable>true</Serviceable>
+    <PackageLicenseUrl>https://github.com/dotnet/core-setup/blob/master/LICENSE.TXT</PackageLicenseUrl>
+    <PackageProjectUrl>https://dot.net</PackageProjectUrl>
+    <PackageLicenseFile>$(RepoRoot)LICENSE.TXT</PackageLicenseFile>
+    <PackageThirdPartyNoticesFile>$(RepoRoot)THIRD-PARTY-NOTICES.TXT</PackageThirdPartyNoticesFile>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -26,4 +33,17 @@
     <Reference Include="System.Core" />
   </ItemGroup>
 
+  <!-- Add required legal files to packages -->
+  <ItemGroup>
+    <Content Condition="Exists('$(PackageLicenseFile)')"
+             Include="$(PackageLicenseFile)">
+      <PackagePath />
+    </Content>
+    <Content Condition="Exists('$(PackageThirdPartyNoticesFile)')"
+             Include="$(PackageThirdPartyNoticesFile)">
+      <PackagePath />
+    </Content>
+  </ItemGroup>
+
+  <Import Condition="Exists('$(RepoRoot)Tools/versioning.props')" Project="$(RepoRoot)Tools/versioning.props" /> 
 </Project>

--- a/src/managed/dir.proj
+++ b/src/managed/dir.proj
@@ -3,19 +3,21 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 
-  <Target Name="Build">
-    <MakeDir  Condition="!Exists('$(pOutDir)')" Directories="$(pOutDir)" />
-
-    <PropertyGroup>
-      <Args>/p:Configuration=$(ConfigurationGroup)</Args>
-    </PropertyGroup>
+  <Target Name="Build"
+          DependsOnTargets="GetLatestCommitHash">
+    <MakeDir Condition="!Exists('$(pOutDir)')" Directories="$(pOutDir)" />
 
     <ItemGroup>
       <PackageProjects Include="$(MSBuildThisFileDirectory)Microsoft.DotNet.PlatformAbstractions/Microsoft.DotNet.PlatformAbstractions.csproj" />
       <PackageProjects Include="$(MSBuildThisFileDirectory)Microsoft.Extensions.DependencyModel/Microsoft.Extensions.DependencyModel.csproj" />
     </ItemGroup>
 
-    <Exec Command="$(DotnetToolCommand) build $(Args) %(PackageProjects.Identity)"
-          EnvironmentVariables="NUGET_PACKAGES=$(PackagesDir)" />
+    <PropertyGroup>
+      <BuildArgs>/p:Configuration=$(ConfigurationGroup)</BuildArgs>
+      <BuildArgs Condition="'$(LatestCommit)' != ''">$(BuildArgs) /p:LatestCommit=$(LatestCommit)</BuildArgs>
+      <BuildArgs Condition="'$(BuiltByString)' != ''">$(BuildArgs) /p:BuiltByString="$(BuiltByString)"</BuildArgs>
+    </PropertyGroup>
+
+    <Exec Command="$(DotnetToolCommand) build $(BuildArgs) %(PackageProjects.Identity)" />
   </Target>
 </Project>

--- a/src/pkg/packaging/dir.proj
+++ b/src/pkg/packaging/dir.proj
@@ -166,7 +166,7 @@
       <VersionSuffixArg>--version-suffix $(VersionSuffix)</VersionSuffixArg>
     </PropertyGroup>
 
-    <Exec Command="$(DotnetToolCommand) pack %(PackageProjects.Identity) --no-build --serviceable $(OutputArg) $(ConfigArg) $(VersionSuffixArg)"
+    <Exec Command="$(DotnetToolCommand) pack %(PackageProjects.Identity) --no-build $(OutputArg) $(ConfigArg) $(VersionSuffixArg)"
           Condition="'@(PackageProjects)' != ''" />
   </Target>
   


### PR DESCRIPTION
* Include copyright info, serviceable attribute, and produce symbols
packages for Microsoft.Extensions.DependencyModel and
Microsoft.DotNet.PlatformAbstractions

* Align AssemblyFileVersion with VersionPrefix, remove env vars from dotnet
pack

* Add license files

* small tweak to packagepath

* Add package licenseurl and projecturl

