### PR TITLE
Roll fwd across hive

### DIFF
--- a/Documentation/design-docs/multilevel-sharedfx-lookup.md
+++ b/Documentation/design-docs/multilevel-sharedfx-lookup.md
@@ -80,14 +80,7 @@ At last, the coreclr is loaded into memory and called to run the application.
 
 ## Proposed changes
 
-Almost every file search is done in relation to the executable directory. It would be better to be able to search for some files in other directories as well. Suggested folders are the user location and the global .NET location. The user and global folders may vary depending on the running operational system. They are defined as follows:
-
-User location:
-
-	Windows 32-bit: %SystemDrive%\Users\username\.dotnet\x86
-	Windows 64-bit: %SystemDrive%\Users\username\.dotnet\x64
-	Unix 32-bit: /home/username/.dotnet/x86
-	Unix 64-bit: /home/username/.dotnet/x64
+Almost every file search is done in relation to the executable directory. It would be better to be able to search for some files in other directories as well, namely the global .NET location. The  global folders may vary depending on the running operational system. They are defined as follows:
 
 Global .NET location:
 
@@ -102,15 +95,13 @@ It’s being proposed that, if the specified version is defined through the conf
 
 - For productions:
 
-	1.	In relation to the user location: search for the most appropriate version by rolling forward. If it cannot be found, proceed to the next step.
-	2.	In relation to the executable directory: search for the most appropriate version by rolling forward. If it cannot be found, proceed to the next step.
-	3.	In relation to the global location: search for the most appropriate version by rolling forward. If it cannot be found, then we were not able to locate any compatible version.
+	1.	In relation to the executable directory: search for the most appropriate version by rolling forward. If it cannot be found, proceed to the next step.
+	2.	In relation to the global location: search for the most appropriate version by rolling forward. If it cannot be found, then we were not able to locate any compatible version.
 
 - For pre-releases:
 	
-	1.	In relation to the user location: search for the specified version. If it cannot be found, search for the most appropriate version by rolling forward. If no compatible version can be found, proceed to the next step.
-	2.	In relation to the executable directory: search for the specified version. If it cannot be found, search for the most appropriate version by rolling forward. If no compatible version can be found, proceed to the next step.
-	3.	In relation to the global location: search for the specified version. If it cannot be found, search for the most appropriate version by rolling forward. If no compatible version can be found, then we were not able to locate any compatible version.
+	1.	In relation to the executable directory: search for the specified version. If it cannot be found, search for the most appropriate version by rolling forward. If no compatible version can be found, proceed to the next step.
+	2.	In relation to the global location: search for the specified version. If it cannot be found, search for the most appropriate version by rolling forward. If no compatible version can be found, then we were not able to locate any compatible version.
 
 In the case that the desired version is defined through an argument, the multi-level lookup will happen as well but it will only consider the exact specified version (it will not roll forward).
 
@@ -132,6 +123,5 @@ By following similar logic, it will be possible to implement future changes in t
 
 The search would be conducted as follows:
 
-1.	In relation to the user location: search for the specified version. If it cannot be found, choose the most appropriate available version. If there’s no available version, proceed to the next step.
-2.	In relation to the executable directory: search for the specified version. If it cannot be found, choose the most appropriate available version. If there’s no available version, proceed to the next step.
-3.	In relation to the global location: search for the specified version. If it cannot be found, choose the most appropriate available version. If there’s no available version, then we were not able to find any version folder and an error message must be returned.
+1.	In relation to the executable directory: search for the specified version. If it cannot be found, choose the most appropriate available version. If there’s no available version, proceed to the next step.
+2.	In relation to the global location: search for the specified version. If it cannot be found, choose the most appropriate available version. If there’s no available version, then we were not able to find any version folder and an error message must be returned.

--- a/src/corehost/cli/args.cpp
+++ b/src/corehost/cli/args.cpp
@@ -58,11 +58,7 @@ void setup_shared_store_paths(const hostpolicy_init_t& init, const pal::string_t
     }
 
     // Global shared store dir
-    if (get_global_shared_store_dir(&args->global_shared_store))
-    {
-        append_path(&args->global_shared_store, get_arch());
-        append_path(&args->global_shared_store, init.tfm.c_str());
-    }
+    get_global_shared_store_dirs(&args->global_shared_stores, get_arch(), init.tfm);
 }
 
 bool parse_arguments(

--- a/src/corehost/cli/args.h
+++ b/src/corehost/cli/args.h
@@ -85,7 +85,7 @@ struct arguments_t
     std::vector<pal::string_t> probe_paths;
     pal::string_t managed_application;
     pal::string_t local_shared_store;
-    pal::string_t global_shared_store;
+    std::vector<pal::string_t> global_shared_stores;
     pal::string_t dotnet_shared_store;
     std::vector<pal::string_t> env_shared_store;
     int app_argc;
@@ -109,7 +109,10 @@ struct arguments_t
             }
             trace::verbose(_X("-- arguments_t: local shared store: '%s'"), local_shared_store.c_str());
             trace::verbose(_X("-- arguments_t: dotnet shared store: '%s'"), dotnet_shared_store.c_str());
-            trace::verbose(_X("-- arguments_t: global shared store: '%s'"), global_shared_store.c_str());
+            for (const auto& global_shared : global_shared_stores)
+            {
+                trace::verbose(_X("-- arguments_t: global shared store: '%s'"), global_shared.c_str());
+            }
         }
     }
 };

--- a/src/corehost/cli/deps_resolver.cpp
+++ b/src/corehost/cli/deps_resolver.cpp
@@ -162,9 +162,14 @@ void deps_resolver_t::setup_shared_store_probes(
         m_probes.push_back(probe_config_t::lookup(args.dotnet_shared_store));
     }
 
-    if (args.global_shared_store != args.dotnet_shared_store && pal::directory_exists(args.global_shared_store))
+    
+    for (const auto& global_shared : args.global_shared_stores)
     {
-        m_probes.push_back(probe_config_t::lookup(args.global_shared_store));
+        if (global_shared != args.dotnet_shared_store && pal::directory_exists(global_shared))
+        {
+            // Shared Store probe: DOTNET_SHARED_STORE
+            m_probes.push_back(probe_config_t::lookup(global_shared));
+        }
     }
 }
 

--- a/src/corehost/cli/fxr/fx_muxer.h
+++ b/src/corehost/cli/fxr/fx_muxer.h
@@ -35,7 +35,7 @@ private:
         const std::vector<pal::string_t>& probe_realpaths,
         const runtime_config_t& config,
         pal::string_t* impl_dir);
-    static void resolve_roll_forward(pal::string_t& fx_dir, const pal::string_t& fx_ver, const fx_ver_t& specified, const bool& patch_roll_fwd, const int& roll_fwd_on_no_candidate_fx);
+    static fx_ver_t resolve_framework_version(const std::vector<fx_ver_t>& version_list, const pal::string_t& fx_ver, const fx_ver_t& specified, const bool& patch_roll_fwd, const int& roll_fwd_on_no_candidate_fx);
     static pal::string_t resolve_fx_dir(host_mode_t mode, const pal::string_t& own_dir, const runtime_config_t& config, const pal::string_t& specified_fx_version, const int& roll_fwd_on_no_candidate_fx_val);
     static pal::string_t resolve_cli_version(const pal::string_t& global);
     static bool resolve_sdk_dotnet_path(const pal::string_t& own_dir, pal::string_t* cli_sdk);

--- a/src/corehost/common/pal.h
+++ b/src/corehost/common/pal.h
@@ -211,7 +211,9 @@ namespace pal
     bool getenv(const char_t* name, string_t* recv);
     bool get_default_servicing_directory(string_t* recv);
     bool get_local_dotnet_dir(string_t* recv);
-    bool get_global_dotnet_dir(string_t* recv);
+    //On Linux, we determine global location by enumerating the location where dotnet is present on path, hence there could be multiple such locations
+    //On Windows there will be only one global location
+    bool get_global_dotnet_dirs(std::vector<pal::string_t>* recv);
     bool get_default_breadcrumb_store(string_t* recv);
     bool is_path_rooted(const string_t& path);
 

--- a/src/corehost/common/pal.windows.cpp
+++ b/src/corehost/common/pal.windows.cpp
@@ -195,14 +195,16 @@ bool pal::get_default_servicing_directory(string_t* recv)
     return true;
 }
 
-bool pal::get_global_dotnet_dir(pal::string_t* dir)
+bool pal::get_global_dotnet_dirs(std::vector<pal::string_t>* dirs)
 {
-    if (!get_file_path_from_env(_X("ProgramFiles"), dir))
+    pal::string_t dir;
+    if (!get_file_path_from_env(_X("ProgramFiles"), &dir))
     {
         return false;
     }
 
-    append_path(dir, _X("dotnet"));
+    append_path(&dir, _X("dotnet"));
+    dirs->push_back(dir);
     return true;
 }
 

--- a/src/corehost/common/utils.cpp
+++ b/src/corehost/common/utils.cpp
@@ -278,13 +278,21 @@ bool get_env_shared_store_dirs(std::vector<pal::string_t>* dirs, const pal::stri
     return true;
 }
 
-bool get_global_shared_store_dir(pal::string_t* dir)
+bool get_global_shared_store_dirs(std::vector<pal::string_t>*  dirs, const pal::string_t& arch, const pal::string_t& tfm)
 {
-    if (!pal::get_global_dotnet_dir(dir))
+    std::vector<pal::string_t> global_dirs;
+    if (!pal::get_global_dotnet_dirs(&global_dirs))
     {
         return false;
     }
-    append_path(dir, RUNTIME_STORE_DIRECTORY_NAME);
+
+    for (pal::string_t dir : global_dirs)
+    {
+        append_path(&dir, RUNTIME_STORE_DIRECTORY_NAME);
+        append_path(&dir, arch.c_str());
+        append_path(&dir, tfm.c_str());
+        dirs->push_back(dir);
+    }
     return true;
 }
 

--- a/src/corehost/common/utils.h
+++ b/src/corehost/common/utils.h
@@ -41,5 +41,5 @@ bool parse_known_args(
 bool skip_utf8_bom(pal::ifstream_t* stream);
 bool get_env_shared_store_dirs(std::vector<pal::string_t>* dirs, const pal::string_t& arch, const pal::string_t& tfm);
 bool get_local_shared_store_dir(pal::string_t* recv);
-bool get_global_shared_store_dir(pal::string_t* recv);
+bool get_global_shared_store_dirs(std::vector<pal::string_t>* dirs, const pal::string_t& arch, const pal::string_t& tfm);
 #endif

--- a/src/test/HostActivationTests/GivenThatICareAboutMultilevelSharedFxLookup.cs
+++ b/src/test/HostActivationTests/GivenThatICareAboutMultilevelSharedFxLookup.cs
@@ -159,14 +159,17 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.MultilevelSharedFxLooku
                 .Pass()
                 .And
                 .HaveStdErrContaining(_exeSelectedMessage);
-
-            // Remove dummy folders from user dir
-            DeleteAvailableSharedFxVersions(_userSharedFxBaseDir, "9999.0.0");
         }
 
         [Fact]
         public void SharedFxLookup_Must_Roll_Forward_Before_Looking_Into_Another_Folder()
         {
+            //https://github.com/dotnet/core-setup/issues/1553
+            if (RuntimeEnvironment.OperatingSystemPlatform == Platform.Windows)
+            {
+                return;
+            }
+
             var fixture = PreviouslyBuiltAndRestoredPortableTestProjectFixture
                 .Copy();
 
@@ -407,6 +410,12 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.MultilevelSharedFxLooku
         [Fact]
         public void Roll_Forward_On_No_Candidate_Fx_Must_Look_Into_All_Lookup_Folders()
         {
+            //https://github.com/dotnet/core-setup/issues/1553
+            if (RuntimeEnvironment.OperatingSystemPlatform == Platform.Windows)
+            {
+                return;
+            }
+
             var fixture = PreviouslyBuiltAndRestoredPortableTestProjectFixture
                 .Copy();
 
@@ -467,6 +476,12 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.MultilevelSharedFxLooku
         [Fact]
         public void Roll_Forward_On_No_Candidate_Fx_May_Be_Enabled_Through_Runtimeconfig_Json_File()
         {
+            //https://github.com/dotnet/core-setup/issues/1553
+            if (RuntimeEnvironment.OperatingSystemPlatform == Platform.Windows)
+            {
+                return;
+            }
+
             var fixture = PreviouslyBuiltAndRestoredPortableTestProjectFixture
                 .Copy();
 
@@ -509,6 +524,12 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.MultilevelSharedFxLooku
         [Fact]
         public void Roll_Forward_On_No_Candidate_Fx_May_Be_Enabled_Through_Argument()
         {
+            //https://github.com/dotnet/core-setup/issues/1553
+            if (RuntimeEnvironment.OperatingSystemPlatform == Platform.Windows)
+            {
+                return;
+            }
+            
             var fixture = PreviouslyBuiltAndRestoredPortableTestProjectFixture
                 .Copy();
 

--- a/src/test/HostActivationTests/GivenThatICareAboutMultilevelSharedFxLookup.cs
+++ b/src/test/HostActivationTests/GivenThatICareAboutMultilevelSharedFxLookup.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.DotNet.InternalAbstractions;
+using Microsoft.DotNet.Cli.Build.Framework;
 using Newtonsoft.Json.Linq;
 using System;
 using System.IO;
@@ -14,33 +15,40 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.MultilevelSharedFxLooku
         private string _currentWorkingDir;
         private string _userDir;
         private string _executableDir;
+        private string _globalDir;
         private string _cwdSharedFxBaseDir;
         private string _userSharedFxBaseDir;
         private string _exeSharedFxBaseDir;
+        private string _globalSharedFxBaseDir;
         private string _builtSharedFxDir;
         private string _cwdSelectedMessage;
         private string _userSelectedMessage;
         private string _exeSelectedMessage;
+        private string _globalSelectedMessage;
         private string _sharedFxVersion;
-
+        private string _multilevelDir;
+        private string _builtDotnet;
+        private string _hostPolicyDllName;
+        
         public GivenThatICareAboutMultilevelSharedFxLookup()
         {
             // From the artifacts dir, it's possible to find where the sharedFrameworkPublish folder is. We need
             // to locate it because we'll copy its contents into other folders
             string artifactsDir = Environment.GetEnvironmentVariable("TEST_ARTIFACTS");
-            string builtDotnet = Path.Combine(artifactsDir, "sharedFrameworkPublish");
+            _builtDotnet = Path.Combine(artifactsDir, "sharedFrameworkPublish");
 
             // The dotnetMultilevelSharedFxLookup dir will contain some folders and files that will be
             // necessary to perform the tests
             string baseMultilevelDir = Path.Combine(artifactsDir, "dotnetMultilevelSharedFxLookup");
-            string multilevelDir = CalculateMultilevelDirectory(baseMultilevelDir);
+            _multilevelDir = CalculateMultilevelDirectory(baseMultilevelDir);
 
             // The three tested locations will be the cwd, the user folder and the exe dir. Both cwd and exe dir
             // are easily overwritten, so they will be placed inside the multilevel folder. The actual user location will
             // be used during tests
-            _currentWorkingDir = Path.Combine(multilevelDir, "cwd");
-            _userDir = Path.Combine(multilevelDir, "user");
-            _executableDir = Path.Combine(multilevelDir, "exe");
+            _currentWorkingDir = Path.Combine(_multilevelDir, "cwd");
+            _userDir = Path.Combine(_multilevelDir, "user");
+            _executableDir = Path.Combine(_multilevelDir, "exe");
+            _globalDir = Path.Combine(_multilevelDir, "global");
 
             RepoDirectories = new RepoDirectoriesProvider(builtDotnet: _executableDir);
 
@@ -48,12 +56,17 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.MultilevelSharedFxLooku
             _cwdSharedFxBaseDir = Path.Combine(_currentWorkingDir, "shared", "Microsoft.NETCore.App");
             _userSharedFxBaseDir = Path.Combine(_userDir, ".dotnet", RepoDirectories.BuildArchitecture, "shared", "Microsoft.NETCore.App");
             _exeSharedFxBaseDir = Path.Combine(_executableDir, "shared", "Microsoft.NETCore.App");
+            _globalSharedFxBaseDir = Path.Combine(_globalDir, "shared", "Microsoft.NETCore.App");
 
             // Create directories. It's necessary to copy the entire publish folder to the exe dir because
             // we'll need to build from it. The CopyDirectory method automatically creates the dest dir
             Directory.CreateDirectory(_cwdSharedFxBaseDir);
             Directory.CreateDirectory(_userSharedFxBaseDir);
-            CopyDirectory(builtDotnet, _executableDir);
+            Directory.CreateDirectory(_globalSharedFxBaseDir);
+            CopyDirectory(_builtDotnet, _executableDir);
+
+            //Copy dotnet to global directory
+            File.Copy(Path.Combine(_builtDotnet, $"dotnet{Constants.ExeSuffix}"), Path.Combine(_globalDir, $"dotnet{Constants.ExeSuffix}"), true);
 
             // Restore and build SharedFxLookupPortableApp from exe dir
             PreviouslyBuiltAndRestoredPortableTestProjectFixture = new TestProjectFixture("SharedFxLookupPortableApp", RepoDirectories)
@@ -65,14 +78,15 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.MultilevelSharedFxLooku
             // locate the builtSharedFxDir from which we can get the files contained in the version folder
             string greatestVersionSharedFxPath = fixture.BuiltDotnet.GreatestVersionSharedFxPath;
             _sharedFxVersion = (new DirectoryInfo(greatestVersionSharedFxPath)).Name;
-            _builtSharedFxDir = Path.Combine(builtDotnet, "shared", "Microsoft.NETCore.App", _sharedFxVersion);
+            _builtSharedFxDir = Path.Combine(_builtDotnet, "shared", "Microsoft.NETCore.App", _sharedFxVersion);
 
-            string hostPolicyDllName = Path.GetFileName(fixture.TestProject.HostPolicyDll);
+            _hostPolicyDllName = Path.GetFileName(fixture.TestProject.HostPolicyDll);
 
             // Trace messages used to identify from which folder the framework was picked
-            _cwdSelectedMessage = $"The expected {hostPolicyDllName} directory is [{_cwdSharedFxBaseDir}";
-            _userSelectedMessage = $"The expected {hostPolicyDllName} directory is [{_userSharedFxBaseDir}";
-            _exeSelectedMessage = $"The expected {hostPolicyDllName} directory is [{_exeSharedFxBaseDir}";
+            _cwdSelectedMessage = $"The expected {_hostPolicyDllName} directory is [{_cwdSharedFxBaseDir}";
+            _userSelectedMessage = $"The expected {_hostPolicyDllName} directory is [{_userSharedFxBaseDir}";
+            _exeSelectedMessage = $"The expected {_hostPolicyDllName} directory is [{_exeSharedFxBaseDir}";
+            _globalSelectedMessage = $"The expected {_hostPolicyDllName} directory is [{_globalSharedFxBaseDir}";
         }
 
         [Fact]
@@ -111,7 +125,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.MultilevelSharedFxLooku
             AddAvailableSharedFxVersions(_userSharedFxBaseDir, "9999.0.0");
 
             // Version: 9999.0.0
-            // User: 9999.0.0
+            // User: 9999.0.0 --> should not be picked
             // Exe: 9999.0.0
             // Expected: 9999.0.0 from user dir
             dotnet.Exec(appDll)
@@ -124,7 +138,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.MultilevelSharedFxLooku
                 .Should()
                 .Pass()
                 .And
-                .HaveStdErrContaining(_userSelectedMessage);
+                .HaveStdErrContaining(_exeSelectedMessage);
 
             // Add a dummy version in the cwd
             AddAvailableSharedFxVersions(_cwdSharedFxBaseDir, "9999.0.0");
@@ -133,7 +147,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.MultilevelSharedFxLooku
             // CWD: 9999.0.0   --> should not be picked
             // User: 9999.0.0
             // Exe: 9999.0.0
-            // Expected: 9999.0.0 from user dir
+            // Expected: 9999.0.0 from user Exe
             dotnet.Exec(appDll)
                 .WorkingDirectory(_currentWorkingDir)
                 .EnvironmentVariable("COREHOST_TRACE", "1")
@@ -144,7 +158,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.MultilevelSharedFxLooku
                 .Should()
                 .Pass()
                 .And
-                .HaveStdErrContaining(_userSelectedMessage);
+                .HaveStdErrContaining(_exeSelectedMessage);
 
             // Remove dummy folders from user dir
             DeleteAvailableSharedFxVersions(_userSharedFxBaseDir, "9999.0.0");
@@ -160,70 +174,102 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.MultilevelSharedFxLooku
             var appDll = fixture.TestProject.AppDll;
 
             // Add some dummy versions
-            AddAvailableSharedFxVersions(_userSharedFxBaseDir, "9999.0.2", "9999.0.0-dummy2");
-            AddAvailableSharedFxVersions(_exeSharedFxBaseDir, "9999.0.0", "9999.0.0-dummy0");
+            AddAvailableSharedFxVersions(_globalSharedFxBaseDir, "9999.0.2", "9999.0.0-dummy2");
+            AddAvailableSharedFxVersions(_exeSharedFxBaseDir, "9999.0.0");
 
             // Set desired version = 9999.0.0-dummy0
             string runtimeConfig = Path.Combine(fixture.TestProject.OutputDirectory, "SharedFxLookupPortableApp.runtimeconfig.json");
             SetRuntimeConfigJson(runtimeConfig, "9999.0.0-dummy0");
 
             // Version: 9999.0.0-dummy0
-            // User: 9999.0.2, 9999.0.0-dummy2
-            // Exe: 9999.0.0, 9999.0.0-dummy0
-            // Expected: 9999.0.0-dummy2 from user dir
+            // Exe: 9999.0.0
+            // global: 9999.0.2, 9999.0.0-dummy2
+            // Expected: 9999.0.0-dummy2 from global dir
             dotnet.Exec(appDll)
                 .WorkingDirectory(_currentWorkingDir)
                 .EnvironmentVariable("COREHOST_TRACE", "1")
-                .WithUserProfile(_userDir)
+                .WithGlobalLocation(_globalDir)
                 .CaptureStdOut()
                 .CaptureStdErr()
                 .Execute()
                 .Should()
                 .Pass()
                 .And
-                .HaveStdErrContaining(Path.Combine(_userSelectedMessage, "9999.0.0-dummy2"));
-
-            // Add a prerelease dummy version in userdir 
-            AddAvailableSharedFxVersions(_userSharedFxBaseDir, "9999.0.0-dummy1");
+                .HaveStdErrContaining(Path.Combine(_globalSelectedMessage, "9999.0.0-dummy2"));
+            
+            AddAvailableSharedFxVersions(_globalSharedFxBaseDir, "9999.0.0-dummy1");
 
             // Version: 9999.0.0-dummy0
-            // User: 9999.0.2, 9999.0.0-dummy1, 9999.0.0-dummy2
-            // Exe: 9999.0.0, 9999.0.0-dummy0
-            // Expected: 9999.0.0-dummy1 from User
+            // Exe: 9999.0.0
+            // global: 9999.0.2, 9999.0.0-dummy1, 9999.0.0-dummy2
+            // Expected: 9999.0.0-dummy1 from global
             dotnet.Exec(appDll)
                 .WorkingDirectory(_currentWorkingDir)
                 .EnvironmentVariable("COREHOST_TRACE", "1")
-                .WithUserProfile(_userDir)
+                .WithGlobalLocation(_globalDir)
                 .CaptureStdOut()
                 .CaptureStdErr()
                 .Execute()
                 .Should()
                 .Pass()
                 .And
-                .HaveStdErrContaining(Path.Combine(_userSelectedMessage, "9999.0.0-dummy1"));
+                .HaveStdErrContaining(Path.Combine(_globalSelectedMessage, "9999.0.0-dummy1"));
 
-            // Set desired version = 9999.0.0
+            AddAvailableSharedFxVersions(_exeSharedFxBaseDir, "9999.0.0-dummy0");
+
+            // Version: 9999.0.0-dummy0
+            // Exe: 9999.0.0, 9999.0.0-dummy0
+            // global: 9999.0.2, 9999.0.0-dummy1, 9999.0.0-dummy2
+            // Expected: 9999.0.0-dummy1 from global
+            dotnet.Exec(appDll)
+                .WorkingDirectory(_currentWorkingDir)
+                .EnvironmentVariable("COREHOST_TRACE", "1")
+                .WithGlobalLocation(_globalDir)
+                .CaptureStdOut()
+                .CaptureStdErr()
+                .Execute()
+                .Should()
+                .Pass()
+                .And
+                .HaveStdErrContaining(Path.Combine(_exeSelectedMessage, "9999.0.0-dummy0"));
+
             SetRuntimeConfigJson(runtimeConfig, "9999.0.0");
+            // Version: 9999.0.0
+            // Exe: 9999.0.0, 9999.0.0-dummy0
+            // global: 9999.0.2, 9999.0.0-dummy1, 9999.0.0-dummy2
+            // Expected: 9999.0.2 from global
+            dotnet.Exec(appDll)
+                .WorkingDirectory(_currentWorkingDir)
+                .EnvironmentVariable("COREHOST_TRACE", "1")
+                .WithGlobalLocation(_globalDir)
+                .CaptureStdOut()
+                .CaptureStdErr()
+                .Execute()
+                .Should()
+                .Pass()
+                .And
+                .HaveStdErrContaining(Path.Combine(_globalSelectedMessage, "9999.0.2"));
+
+           AddAvailableSharedFxVersions(_exeSharedFxBaseDir, "9999.0.3");
 
             // Version: 9999.0.0
-            // CWD: 9999.0.0-dummy1
-            // User: 9999.0.2, 9999.0.0-dummy2
-            // Exe: 9999.0.0, 9999.0.0-dummy0
-            // Expected: 9999.0.2 from user dir
+            // Exe: 9999.0.0, 9999.0.0-dummy0, 9999.0.3
+            // global: 9999.0.2, 9999.0.0-dummy1, 9999.0.0-dummy2
+            // Expected: 9999.0.0-dummy1 from global
             dotnet.Exec(appDll)
                 .WorkingDirectory(_currentWorkingDir)
                 .EnvironmentVariable("COREHOST_TRACE", "1")
-                .WithUserProfile(_userDir)
+                .WithGlobalLocation(_globalDir)
                 .CaptureStdOut()
                 .CaptureStdErr()
                 .Execute()
                 .Should()
                 .Pass()
                 .And
-                .HaveStdErrContaining(Path.Combine(_userSelectedMessage, "9999.0.2"));
+                .HaveStdErrContaining(Path.Combine(_exeSelectedMessage, "9999.0.3"));
 
-            // Remove dummy folders from user dir
-            DeleteAvailableSharedFxVersions(_userSharedFxBaseDir, "9999.0.2", "9999.0.0-dummy2");
+            DeleteAvailableSharedFxVersions(_exeSharedFxBaseDir, "9999.0.0", "9999.0.0-dummy0","9999.0.3");
+            DeleteAvailableSharedFxVersions(_globalSharedFxBaseDir, "9999.0.2", "9999.0.0-dummy1", "9999.0.0-dummy2");
         }
 
         [Fact]
@@ -236,17 +282,16 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.MultilevelSharedFxLooku
             var appDll = fixture.TestProject.AppDll;
 
             // Add some dummy versions
-            AddAvailableSharedFxVersions(_userSharedFxBaseDir, "9999.0.2", "9999.0.0-dummy2");
-            AddAvailableSharedFxVersions(_exeSharedFxBaseDir, "9999.0.0", "9999.0.3", "9999.0.0-dummy3");
+            AddAvailableSharedFxVersions(_exeSharedFxBaseDir, "9999.0.2", "9999.0.0-dummy2", "9999.0.0", "9999.0.3", "9999.0.0-dummy3");
+            
 
             // Version: 9999.0.0 (through --fx-version arg)
-            // User: 9999.0.2, 9999.0.0-dummy2
-            // Exe: 9999.0.0, 9999.0.3, 9999.0.0-dummy3
+            // Exe: 9999.0.2, 9999.0.0-dummy2, 9999.0.0, 9999.0.3, 9999.0.0-dummy3
+            // global: empty
             // Expected: 9999.0.0 from exe dir
             dotnet.Exec("--fx-version", "9999.0.0", appDll)
                 .WorkingDirectory(_currentWorkingDir)
                 .EnvironmentVariable("COREHOST_TRACE", "1")
-                .WithUserProfile(_userDir)
                 .CaptureStdOut()
                 .CaptureStdErr()
                 .Execute()
@@ -256,13 +301,12 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.MultilevelSharedFxLooku
                 .HaveStdErrContaining(Path.Combine(_exeSelectedMessage, "9999.0.0"));
 
             // Version: 9999.0.0-dummy1 (through --fx-version arg)
-            // User: 9999.0.2, 9999.0.0-dummy2
-            // Exe: 9999.0.0, 9999.0.3, 9999.0.0-dummy3
+            // Exe: 9999.0.2, 9999.0.0-dummy2,9999.0.0, 9999.0.3, 9999.0.0-dummy3
+            // global: empty
             // Expected: no compatible version
             dotnet.Exec("--fx-version", "9999.0.0-dummy1", appDll)
                 .WorkingDirectory(_currentWorkingDir)
                 .EnvironmentVariable("COREHOST_TRACE", "1")
-                .WithUserProfile(_userDir)
                 .CaptureStdOut()
                 .CaptureStdErr()
                 .Execute(fExpectedToFail:true)
@@ -271,8 +315,8 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.MultilevelSharedFxLooku
                 .And
                 .HaveStdErrContaining("It was not possible to find any compatible framework version");
 
-            // Remove dummy folders from user dir
-            DeleteAvailableSharedFxVersions(_userSharedFxBaseDir, "9999.0.2", "9999.0.0-dummy2");
+            
+            DeleteAvailableSharedFxVersions(_exeSharedFxBaseDir, "9999.0.0", "9999.0.3", "9999.0.0-dummy3", "9999.0.2", "9999.0.0-dummy2");
         }
 
         [Fact]
@@ -297,7 +341,6 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.MultilevelSharedFxLooku
             // Expected: 10000.1.3 from exe
             dotnet.Exec(appDll)
                 .WorkingDirectory(_currentWorkingDir)
-                .WithUserProfile(_userDir)
                 .EnvironmentVariable("DOTNET_ROLL_FORWARD_ON_NO_CANDIDATE_FX", "1")
                 .EnvironmentVariable("COREHOST_TRACE", "1")
                 .CaptureStdOut()
@@ -317,7 +360,6 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.MultilevelSharedFxLooku
             // Expected: 9999.1.1 from exe
             dotnet.Exec(appDll)
                 .WorkingDirectory(_currentWorkingDir)
-                .WithUserProfile(_userDir)
                 .EnvironmentVariable("DOTNET_ROLL_FORWARD_ON_NO_CANDIDATE_FX", "1")
                 .EnvironmentVariable("COREHOST_TRACE", "1")
                 .CaptureStdOut()
@@ -351,7 +393,6 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.MultilevelSharedFxLooku
             // Expected: no compatible version
             dotnet.Exec(appDll)
                 .WorkingDirectory(_currentWorkingDir)
-                .WithUserProfile(_userDir)
                 .EnvironmentVariable("DOTNET_ROLL_FORWARD_ON_NO_CANDIDATE_FX", "1")
                 .EnvironmentVariable("COREHOST_TRACE", "1")
                 .CaptureStdOut()
@@ -377,16 +418,37 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.MultilevelSharedFxLooku
             SetRuntimeConfigJson(runtimeConfig, "9999.0.0");
 
             // Add a dummy version in the exe dir
-            AddAvailableSharedFxVersions(_exeSharedFxBaseDir, "9999.1.0");
+            AddAvailableSharedFxVersions(_globalSharedFxBaseDir, "9999.1.0");
 
             // Version: 9999.0.0
             // 'Roll forward on no candidate fx' enabled through env var
-            // User: empty
-            // Exe: 9999.1.0
-            // Expected: 9999.1.0 from exe dir
+            // Exe: empty
+            // Global: 9999.1.0
+            // Expected: 9999.1.0 from global dir
             dotnet.Exec(appDll)
                 .WorkingDirectory(_currentWorkingDir)
-                .WithUserProfile(_userDir)
+                .WithGlobalLocation(_globalDir)
+                .EnvironmentVariable("DOTNET_ROLL_FORWARD_ON_NO_CANDIDATE_FX", "1")
+                .EnvironmentVariable("COREHOST_TRACE", "1")
+                .CaptureStdOut()
+                .CaptureStdErr()
+                .Execute()
+                .Should()
+                .Pass()
+                .And
+                .HaveStdErrContaining(_globalSelectedMessage);
+
+            // Add a dummy version in the user dir
+            AddAvailableSharedFxVersions(_exeSharedFxBaseDir, "9999.1.1");
+
+            // Version: 9999.0.0
+            // 'Roll forward on no candidate fx' enabled through env var
+            // Exe: 9999.1.1
+            // Global: 9999.1.0
+            // Expected: 9999.1.1 from exe dir
+            dotnet.Exec(appDll)
+                .WorkingDirectory(_currentWorkingDir)
+                .WithGlobalLocation(_globalDir)
                 .EnvironmentVariable("DOTNET_ROLL_FORWARD_ON_NO_CANDIDATE_FX", "1")
                 .EnvironmentVariable("COREHOST_TRACE", "1")
                 .CaptureStdOut()
@@ -397,29 +459,9 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.MultilevelSharedFxLooku
                 .And
                 .HaveStdErrContaining(_exeSelectedMessage);
 
-            // Add a dummy version in the user dir
-            AddAvailableSharedFxVersions(_userSharedFxBaseDir, "9999.1.1");
-
-            // Version: 9999.0.0
-            // 'Roll forward on no candidate fx' enabled through env var
-            // User: 9999.1.1
-            // Exe: 9999.1.0
-            // Expected: 9999.1.1 from user dir
-            dotnet.Exec(appDll)
-                .WorkingDirectory(_currentWorkingDir)
-                .WithUserProfile(_userDir)
-                .EnvironmentVariable("DOTNET_ROLL_FORWARD_ON_NO_CANDIDATE_FX", "1")
-                .EnvironmentVariable("COREHOST_TRACE", "1")
-                .CaptureStdOut()
-                .CaptureStdErr()
-                .Execute()
-                .Should()
-                .Pass()
-                .And
-                .HaveStdErrContaining(_userSelectedMessage);
-
             // Remove dummy folders from user dir
-            DeleteAvailableSharedFxVersions(_userSharedFxBaseDir, "9999.1.1");
+            DeleteAvailableSharedFxVersions(_exeSharedFxBaseDir, "9999.1.1");
+            DeleteAvailableSharedFxVersions(_globalSharedFxBaseDir, "9999.1.0");
         }
 
         [Fact]
@@ -437,8 +479,8 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.MultilevelSharedFxLooku
             SetRuntimeConfigJson(runtimeConfig, "9999.0.0", 1);
 
             // Add some dummy versions
-            AddAvailableSharedFxVersions(_userSharedFxBaseDir, "9999.1.0");
-            AddAvailableSharedFxVersions(_exeSharedFxBaseDir, "9999.0.0");
+            AddAvailableSharedFxVersions(_exeSharedFxBaseDir, "9999.1.0");
+            AddAvailableSharedFxVersions(_globalSharedFxBaseDir, "9999.0.0");
 
             // Set desired version = 9999.0.0
             // Disable 'roll forward on no candidate fx' through runtimeconfig
@@ -447,12 +489,12 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.MultilevelSharedFxLooku
 
             // Version: 9999.0.0
             // 'Roll forward on no candidate fx' disabled through runtimeconfig
-            // User: 9999.1.0
-            // Exe: 9999.0.0
-            // Expected: 9999.0.0 from exe dir
+            // Exe: 9999.1.0
+            // Global: 9999.0.0
+            // Expected: 9999.0.0 from global dir
             dotnet.Exec(appDll)
                 .WorkingDirectory(_currentWorkingDir)
-                .WithUserProfile(_userDir)
+                .WithGlobalLocation(_globalDir)
                 .EnvironmentVariable("DOTNET_ROLL_FORWARD_ON_NO_CANDIDATE_FX", "1")
                 .EnvironmentVariable("COREHOST_TRACE", "1")
                 .CaptureStdOut()
@@ -461,7 +503,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.MultilevelSharedFxLooku
                 .Should()
                 .Pass()
                 .And
-                .HaveStdErrContaining(_exeSelectedMessage);
+                .HaveStdErrContaining(_globalSelectedMessage);
         }
 
         [Fact]
@@ -479,17 +521,17 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.MultilevelSharedFxLooku
             SetRuntimeConfigJson(runtimeConfig, "9999.0.0", 0);
 
             // Add some dummy versions
-            AddAvailableSharedFxVersions(_userSharedFxBaseDir, "9999.1.0");
-            AddAvailableSharedFxVersions(_exeSharedFxBaseDir, "9999.0.0");
+            AddAvailableSharedFxVersions(_exeSharedFxBaseDir, "9999.1.1");
+            AddAvailableSharedFxVersions(_globalSharedFxBaseDir, "9999.1.2");
 
             // Version: 9999.0.0
             // 'Roll forward on no candidate fx' enabled through argument
-            // User: 9999.1.0
-            // Exe: 9999.0.0
-            // Expected: 9999.1.0 from User
+            // Exe: 9999.1.1
+            // Global: 9999.1.2
+            // Expected: 9999.1.2 from global
             dotnet.Exec("--roll-forward-on-no-candidate-fx", "1", appDll)
                 .WorkingDirectory(_currentWorkingDir)
-                .WithUserProfile(_userDir)
+                .WithGlobalLocation(_globalDir)
                 .EnvironmentVariable("COREHOST_TRACE", "1")
                 .CaptureStdOut()
                 .CaptureStdErr()
@@ -497,7 +539,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.MultilevelSharedFxLooku
                 .Should()
                 .Pass()
                 .And
-                .HaveStdErrContaining(_userSelectedMessage);
+                .HaveStdErrContaining(_globalSelectedMessage);
 
             // Set desired version = 9999.0.0
             // Enable 'roll forward on no candidate fx' through Runtimeconfig
@@ -505,12 +547,67 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.MultilevelSharedFxLooku
 
             // Version: 9999.0.0
             // 'Roll forward on no candidate fx' disabled through argument
-            // User: 9999.1.0
-            // Exe: 9999.0.0
-            // Expected: 9999.0.0 from exe dir
+            // Exe: 9999.1.1
+            // Global: 9999.1.2
+            // Expected: does not resolve FX
             dotnet.Exec("--roll-forward-on-no-candidate-fx", "0", appDll)
                 .WorkingDirectory(_currentWorkingDir)
-                .WithUserProfile(_userDir)
+                .WithGlobalLocation(_globalDir)
+                .EnvironmentVariable("DOTNET_ROLL_FORWARD_ON_NO_CANDIDATE_FX", "1")
+                .EnvironmentVariable("COREHOST_TRACE", "1")
+                .CaptureStdOut()
+                .CaptureStdErr()
+                .Execute(fExpectedToFail:true)
+                .Should()
+                .Fail()
+                .And
+                .HaveStdErrContaining("It was not possible to find any compatible framework version");
+
+        }
+
+        [Fact]
+        public void Ensure_On_NonWindows_Multiple_Global_Locations_Are_Probed()
+        {
+            //This test is only applicable on non windows as it tests probing for global
+            //locations on path
+            if (RuntimeEnvironment.OperatingSystemPlatform == Platform.Windows)
+            {
+                return;
+            }
+            
+            var fixture = PreviouslyBuiltAndRestoredPortableTestProjectFixture
+                .Copy();
+
+            var dotnet = fixture.BuiltDotnet;
+            var appDll = fixture.TestProject.AppDll;
+
+            var secondary_globalDir = Path.Combine(_multilevelDir, "secondary_global");
+            var secondary_globalSharedFxBaseDir = Path.Combine(secondary_globalDir, "shared", "Microsoft.NETCore.App");
+
+            var secondary_globalSelectedMessage = $"The expected {_hostPolicyDllName} directory is [{secondary_globalSharedFxBaseDir}";
+
+            Directory.CreateDirectory(_globalSharedFxBaseDir);
+            Directory.CreateDirectory(secondary_globalSharedFxBaseDir);
+            //Copy dotnet to global directory
+            File.Copy(Path.Combine(_builtDotnet, $"dotnet{Constants.ExeSuffix}"), Path.Combine(secondary_globalDir, $"dotnet{Constants.ExeSuffix}"), true);
+
+            // Set desired version = 9999.0.0
+            string runtimeConfig = Path.Combine(fixture.TestProject.OutputDirectory, "SharedFxLookupPortableApp.runtimeconfig.json");
+            SetRuntimeConfigJson(runtimeConfig, "9999.0.0");
+
+            // Add a dummy version in the exe dir
+            AddAvailableSharedFxVersions(_globalSharedFxBaseDir, "9999.1.0");
+
+            // Version: 9999.0.0
+            // 'Roll forward on no candidate fx' enabled through env var
+            // Exe: empty
+            // Secondary_Global: empty
+            // Global: 9999.1.0
+            // Expected: 9999.1.0 from global dir
+            dotnet.Exec(appDll)
+                .WorkingDirectory(_currentWorkingDir)
+                .WithGlobalLocation(secondary_globalDir)
+                .WithGlobalLocation(_globalDir)
                 .EnvironmentVariable("DOTNET_ROLL_FORWARD_ON_NO_CANDIDATE_FX", "1")
                 .EnvironmentVariable("COREHOST_TRACE", "1")
                 .CaptureStdOut()
@@ -519,8 +616,36 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.MultilevelSharedFxLooku
                 .Should()
                 .Pass()
                 .And
-                .HaveStdErrContaining(_exeSelectedMessage);
+                .HaveStdErrContaining(_globalSelectedMessage);
+
+            // Add a dummy version in the user dir
+            AddAvailableSharedFxVersions(secondary_globalSharedFxBaseDir, "9999.1.1");
+
+            // Version: 9999.0.0
+            // 'Roll forward on no candidate fx' enabled through env var
+            // Exe: empty
+            // Secondary_Global: 9999.1.1
+            // Global: 9999.1.0
+            // Expected: 9999.1.1 from Secondary_Global dir
+            dotnet.Exec(appDll)
+                .WorkingDirectory(_currentWorkingDir)
+                .WithGlobalLocation(secondary_globalDir)
+                .WithGlobalLocation(_globalDir)
+                .EnvironmentVariable("DOTNET_ROLL_FORWARD_ON_NO_CANDIDATE_FX", "1")
+                .EnvironmentVariable("COREHOST_TRACE", "1")
+                .CaptureStdOut()
+                .CaptureStdErr()
+                .Execute()
+                .Should()
+                .Pass()
+                .And
+                .HaveStdErrContaining(secondary_globalSelectedMessage);
+
+            // Remove dummy folders from user dir
+            DeleteAvailableSharedFxVersions(secondary_globalSharedFxBaseDir, "9999.1.1");
+            DeleteAvailableSharedFxVersions(_globalSharedFxBaseDir, "9999.1.0");
         }
+
 
         // This method adds a list of new framework version folders in the specified
         // sharedFxBaseDir. The files are copied from the _buildSharedFxDir.

--- a/src/test/TestUtils/Command.cs
+++ b/src/test/TestUtils/Command.cs
@@ -238,6 +238,42 @@ namespace Microsoft.DotNet.Cli.Build.Framework
             _process.StartInfo.Environment[userDir] = userprofile;
             return this;
         }
+        public Command SanitizeGlobalLocation()
+        {
+            if (RuntimeEnvironment.OperatingSystemPlatform != Platform.Windows)
+            {
+                var current_path = _process.StartInfo.Environment["PATH"];
+                var new_path = new System.Text.StringBuilder();
+                //Remove any global dotnet that has been set
+                foreach (var sub_path in current_path.Split(Path.PathSeparator))
+                {
+                    var candidate = Path.Combine(sub_path, "dotnet");
+                    if (!File.Exists(candidate))
+                    {
+                        new_path.Append(sub_path);
+                        new_path.Append(Path.PathSeparator);
+                    }
+                }
+                _process.StartInfo.Environment["PATH"] = new_path.ToString();
+            }
+            return this;
+        }
+        public Command WithGlobalLocation(string global)
+        {
+
+            if (RuntimeEnvironment.OperatingSystemPlatform == Platform.Windows)
+            {
+               throw new NotImplementedException("Global location override needs work ");
+            }
+            else
+            {
+                var current_path = _process.StartInfo.Environment["PATH"];
+                _process.StartInfo.Environment["PATH"] = current_path + Path.PathSeparator + global;
+            }
+
+           
+            return this;
+        }
 
         public Command EnvironmentVariable(string name, string value)
         {

--- a/src/test/TestUtils/DotNetCli.cs
+++ b/src/test/TestUtils/DotNetCli.cs
@@ -31,7 +31,8 @@ namespace Microsoft.DotNet.Cli.Build
             }
 
             return Command.Create(Path.Combine(BinPath, $"dotnet{Constants.ExeSuffix}"), newArgs)
-                .EnvironmentVariable("DOTNET_SKIP_FIRST_TIME_EXPERIENCE", "1");
+                .EnvironmentVariable("DOTNET_SKIP_FIRST_TIME_EXPERIENCE", "1")
+                .SanitizeGlobalLocation();
         }
 
         public Command Restore(params string[] args) => Exec("restore", args);


### PR DESCRIPTION
This change  disables user profile lookup of shared Fx
It also rolls forward across multiple probe locations