### PR TITLE
Fix Debian package build

### DIFF
--- a/src/pkg/packaging/deb/dotnet-sharedframework-debian_config.json
+++ b/src/pkg/packaging/deb/dotnet-sharedframework-debian_config.json
@@ -30,8 +30,7 @@
 
     "debian_dependencies":{
         "%HOSTFXR_DEBIAN_PACKAGE_NAME%" : {},
-        "libssl1.0.0" : {},
-        "libcurl3" : {}
+        "%LIBICU_PACKAGE_NAME%": {} 
     },
 
     "debian_ignored_dependencies" : [

--- a/src/pkg/packaging/deb/dotnet-sharedframework-debian_config.json
+++ b/src/pkg/packaging/deb/dotnet-sharedframework-debian_config.json
@@ -30,6 +30,7 @@
 
     "debian_dependencies":{
         "%HOSTFXR_DEBIAN_PACKAGE_NAME%" : {},
+        "libssl1.0.0" : {},
         "%LIBICU_PACKAGE_NAME%": {} 
     },
 

--- a/src/pkg/packaging/deb/package.targets
+++ b/src/pkg/packaging/deb/package.targets
@@ -216,6 +216,12 @@
     <RemoveDir Condition="Exists('$(debIntermediatesDir)')" Directories="$(debIntermediatesDir)" />
     <MakeDir Directories="$(debIntermediatesDir)" />
 
+    <!-- Compute ICU Version --> 
+    <Exec Command="apt-cache search --names-only '^libicu[0-9]+$' | cut -d' ' -f1" 
+          ConsoleToMSBuild="true"> 
+       <Output TaskParameter="ConsoleOutput" PropertyName="LibIcuPackageName" /> 
+    </Exec> 
+
     <!-- Create empty debian layout -->
     <RemoveDir Condition="Exists('$(debLayoutDirectory)')" Directories="$(debLayoutDirectory)" />
     <MakeDir Directories="$(debLayoutDirectory)" />
@@ -248,6 +254,10 @@
       <SharedFrameworkTokenValue Include="%SHARED_FRAMEWORK_BRAND_NAME%">
         <ReplacementString>$(SharedFrameworkBrandName)</ReplacementString>
       </SharedFrameworkTokenValue>
+      <SharedFrameworkTokenValue Include="%LIBICU_PACKAGE_NAME%"> 
+        <ReplacementString>$(LibIcuPackageName)</ReplacementString> 
+      </SharedFrameworkTokenValue> 
+
     </ItemGroup>
 
     <ReplaceFileContents InputFile="$(ConfigJsonFile)"


### PR DESCRIPTION
- {shlibs:Depends} will pick up the correct packages for anything we link
  against so we don't need to include libssl and libcurl in the json config
  files.
- Add an explicit dependency on ICU (the runtime no longer links against it
  directly so dh_shlibdeps wasn't picking it up).