### PR TITLE
Ensure Duplicate items aren't present during publish

### DIFF
--- a/publish/dir.props
+++ b/publish/dir.props
@@ -28,10 +28,10 @@
     <RidAgnosticPackageFile Include="$(PackagesOutDir)**/*.nupkg" Exclude="@(RuntimePackageFile)" >
       <RelativeBlobPath>$(BinariesRelativePath)</RelativeBlobPath>
     </RidAgnosticPackageFile>
-    <InstallerFile Include="$(PackagesOutDir)**/*$(InstallerExtension)" >
+    <InstallerFile Include="$(PackagesOutDir)**/*$(InstallerExtension)" Condition="'$(InstallerExtension)' != ''" >
       <RelativeBlobPath>$(InstallersRelativePath)</RelativeBlobPath>
     </InstallerFile>
-    <InstallerFile Include="$(PackagesOutDir)**/*$(CombinedInstallerExtension)" >
+    <InstallerFile Include="$(PackagesOutDir)**/*$(CombinedInstallerExtension)" Condition="'$(CombinedInstallerExtension)' != ''">
       <RelativeBlobPath>$(InstallersRelativePath)</RelativeBlobPath>
     </InstallerFile>
   </ItemGroup>

--- a/publish/publish.proj
+++ b/publish/publish.proj
@@ -30,7 +30,21 @@
              BuildInParallel="true" />
   </Target>
 
+  <Target Name="EnsureUniqueItemsToUpload">
+    <ItemGroup>
+      <DedupItems Include="@(ItemsToPublish->Distinct())" />
+    </ItemGroup>
+    <PropertyGroup>
+      <CountOld>@(ItemsToPublish->Count())</CountOld>
+      <CountNew>@(DedupItems->Count())</CountNew>
+      <_HasDups Condition="'$(CountOld)' != '$(CountNew)'">true</_HasDups>
+    </PropertyGroup>
+    <Message Importance="High" Condition="'$(_HasDups)' != ''" Text="ItemsToPublish: '@(ItemsToPublish)'"/>
+    <Error Condition="'$(_HasDups)' != ''" Text="Duplicate Items Present in ItemsToPublish" />
+  </Target>
+
   <Target Name="UploadToAzure"
+          DependsOnTargets="EnsureUniqueItemsToUpload"
           Condition="'$(ItemsToPublish)' != ''">
     <Error Condition="'$(AzureAccessToken)' == ''" Text="Missing required property 'AzureAccessToken'" />
     <Error Condition="'$(AzureAccountName)' == ''" Text="Missing required property 'AzureAccountName'" />


### PR DESCRIPTION
skip ci please

@chcosta @eerhardt @rakeshsinghranchi @weshaggard @vivmishra 

This fix should fix the build break in master. The PortableBuild=true was determining the TargetRid (linux-x64) which decided the InstallerExtension and CombinedInstallerExtension (both became ''). Since these aren't set for a portable build this causes the wildcard to select everything. This is now conditioned and we also added a check for duplicates before we even try to publish.