### PR TITLE
Remove centos from PublishRids

### DIFF
--- a/publish/dir.props
+++ b/publish/dir.props
@@ -49,6 +49,5 @@
     <PublishRid Include="win-arm64" />
     <PublishRid Include="linux-arm" />
     <PublishRid Include="rhel.7-x64" />
-    <PublishRid Include="centos.7-x64" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
skip ci please

This is to remove centos from the publish rids which are used to evaluate the build legs. I am not removing any of the TargetsCentos condition based things as they also apply to RHEL.

/cc @vivmishra @weshaggard @rakeshsinghranchi @chcosta 