### PR TITLE
AppBaseCompilationAssemblyResolver shouldn't throw.

### DIFF
--- a/src/managed/Microsoft.Extensions.DependencyModel/Resolution/AppBaseCompilationAssemblyResolver.cs
+++ b/src/managed/Microsoft.Extensions.DependencyModel/Resolution/AppBaseCompilationAssemblyResolver.cs
@@ -84,6 +84,8 @@ namespace Microsoft.Extensions.DependencyModel.Resolution
                 directories.Add(sharedDirectory);
             }
 
+            var paths = new List<string>();
+
             foreach (var assembly in library.Assemblies)
             {
                 bool resolved = false;
@@ -93,7 +95,7 @@ namespace Microsoft.Extensions.DependencyModel.Resolution
                     string fullName;
                     if (ResolverUtils.TryResolveAssemblyFile(_fileSystem, directory, assemblyFile, out fullName))
                     {
-                        assemblies.Add(fullName);
+                        paths.Add(fullName);
                         resolved = true;
                         break;
                     }
@@ -101,17 +103,12 @@ namespace Microsoft.Extensions.DependencyModel.Resolution
 
                 if (!resolved)
                 {
-                    // throw in case when we are published app and nothing found
-                    // because we cannot rely on nuget package cache in this case
-                    if (isPublished)
-                    {
-                    throw new InvalidOperationException(
-                        $"Cannot find assembly file {assemblyFile} at '{string.Join(",", directories)}'");
-                }
                     return false;
-            }
+                }
             }
 
+            // only modify the assemblies parameter if we've resolved all files
+            assemblies?.AddRange(paths);
             return true;
         }
     }

--- a/src/test/Microsoft.Extensions.DependencyModel.Tests/AppBaseResolverTests.cs
+++ b/src/test/Microsoft.Extensions.DependencyModel.Tests/AppBaseResolverTests.cs
@@ -143,11 +143,8 @@ namespace Microsoft.Extensions.DependencyModel.Tests
             var resolver = CreateResolver(fileSystem);
             var assemblies = new List<string>();
 
-            var exception = Assert.Throws<InvalidOperationException>(() => resolver.TryResolveAssemblyPaths(library, assemblies));
-            exception.Message.Should()
-                .Contain(BasePath)
-                .And.Contain(BasePathRefs)
-                .And.Contain(TestLibraryFactory.SecondAssembly);
+            resolver.TryResolveAssemblyPaths(library, assemblies).Should().Be(false);
+            assemblies.Should().BeEmpty();
         }
 
         [Fact]
@@ -328,7 +325,7 @@ namespace Microsoft.Extensions.DependencyModel.Tests
         }
 
         [Fact]
-        public void ShouldThrowForNonResolvedInPublishedApps()
+        public void ShouldReturnFalseForNonResolvedInPublishedApps()
         {
             var fileSystem = FileSystemMockBuilder
                 .Create()
@@ -341,7 +338,8 @@ namespace Microsoft.Extensions.DependencyModel.Tests
             var resolver = CreateResolver(fileSystem);
             var assemblies = new List<string>();
 
-            Assert.Throws<InvalidOperationException>(() => resolver.TryResolveAssemblyPaths(library, assemblies));
+            resolver.TryResolveAssemblyPaths(library, assemblies).Should().Be(false);
+            assemblies.Should().BeEmpty();
         }
 
         [Fact]


### PR DESCRIPTION
There are scenarios where a compilation assembly should be resolved from places outside of the appbase folder in a published app.  We shouldn't throw early and let the other resolvers do their job.

Fix #2496

I plan on taking this bug to shiproom for 2.0 since it is blocking another 2.0 bug:  https://github.com/dotnet/sdk/issues/1216