### PR TITLE
Remove unecessary generateversionsourcefile and init-tools steps from offical build definitions

### DIFF
--- a/buildpipeline/Core-Setup-Linux-Arm-BT.json
+++ b/buildpipeline/Core-Setup-Linux-Arm-BT.json
@@ -114,42 +114,6 @@
       "enabled": true,
       "continueOnError": false,
       "alwaysRun": false,
-      "displayName": "Init tools",
-      "timeoutInMinutes": 0,
-      "task": {
-        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
-        "versionSpec": "1.*",
-        "definitionType": "task"
-      },
-      "inputs": {
-        "filename": "docker",
-        "arguments": "run --rm $(DockerCommonRunArgs) $(PB_GitDirectory)/init-tools.sh",
-        "workingFolder": "",
-        "failOnStandardError": "false"
-      }
-    },
-    {
-      "enabled": true,
-      "continueOnError": false,
-      "alwaysRun": false,
-      "displayName": "Generate version assets",
-      "timeoutInMinutes": 0,
-      "task": {
-        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
-        "versionSpec": "1.*",
-        "definitionType": "task"
-      },
-      "inputs": {
-        "filename": "docker",
-        "arguments": "run --rm $(DockerCommonRunArgs) $(PB_GitDirectory)/Tools/msbuild.sh $(PB_GitDirectory)/build.proj /t:GenerateVersionSourceFile /p:GenerateVersionSourceFile=true /p:OfficialBuildId=$(OfficialBuildId)",
-        "workingFolder": "",
-        "failOnStandardError": "false"
-      }
-    },
-    {
-      "enabled": true,
-      "continueOnError": false,
-      "alwaysRun": false,
       "displayName": "Build",
       "timeoutInMinutes": 0,
       "task": {
@@ -239,6 +203,16 @@
     }
   ],
   "options": [
+    {
+      "enabled": false,
+      "definition": {
+        "id": "5d58cc01-7c75-450c-be18-a388ddb129ec"
+      },
+      "inputs": {
+        "branchFilters": "[\"+refs/heads/*\"]",
+        "additionalFields": "{}"
+      }
+    },
     {
       "enabled": false,
       "definition": {
@@ -388,10 +362,10 @@
       "isSecret": true
     },
     "PB_DistroRid": {
-      "value": "ubuntu.14.04-x64"
+      "value": "ubuntu.14.04-arm"
     },
     "PB_TargetArchitecture": {
-      "value": "x64"
+      "value": "arm"
     },
     "PB_AdditionalBuildArguments": {
       "value": ""
@@ -432,7 +406,7 @@
       "deleteTestResults": true
     }
   ],
-  "buildNumberFormat": "$(date:yyyyMMdd)$(rev:-rr)-$(PB_DockerTag)",
+  "buildNumberFormat": "$(date:yyyyMMdd)$(rev:-rr)",
   "jobAuthorizationScope": "projectCollection",
   "jobTimeoutInMinutes": 90,
   "jobCancelTimeoutInMinutes": 5,
@@ -474,6 +448,7 @@
     "description": "Visual Studio and DevDiv team project for git source code repositories.  Work items will be added for Adams, Dev14 work items are tracked in vstfdevdiv.  ",
     "url": "https://devdiv.visualstudio.com/DefaultCollection/_apis/projects/0bdbc590-a062-4c3f-b0f6-9383f67865ee",
     "state": "wellFormed",
-    "revision": 418097676
+    "revision": 418097676,
+    "visibility": "private"
   }
 }

--- a/buildpipeline/Core-Setup-Linux-BT.json
+++ b/buildpipeline/Core-Setup-Linux-BT.json
@@ -114,42 +114,6 @@
       "enabled": true,
       "continueOnError": false,
       "alwaysRun": false,
-      "displayName": "Init tools",
-      "timeoutInMinutes": 0,
-      "task": {
-        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
-        "versionSpec": "1.*",
-        "definitionType": "task"
-      },
-      "inputs": {
-        "filename": "docker",
-        "arguments": "run --rm $(DockerCommonRunArgs) $(PB_GitDirectory)/init-tools.sh",
-        "workingFolder": "",
-        "failOnStandardError": "false"
-      }
-    },
-    {
-      "enabled": true,
-      "continueOnError": false,
-      "alwaysRun": false,
-      "displayName": "Generate version assets",
-      "timeoutInMinutes": 0,
-      "task": {
-        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
-        "versionSpec": "1.*",
-        "definitionType": "task"
-      },
-      "inputs": {
-        "filename": "docker",
-        "arguments": "run --rm $(DockerCommonRunArgs) $(PB_GitDirectory)/Tools/msbuild.sh $(PB_GitDirectory)/build.proj /t:GenerateVersionSourceFile /p:GenerateVersionSourceFile=true /p:OfficialBuildId=$(OfficialBuildId)",
-        "workingFolder": "",
-        "failOnStandardError": "false"
-      }
-    },
-    {
-      "enabled": true,
-      "continueOnError": false,
-      "alwaysRun": false,
       "displayName": "Build",
       "timeoutInMinutes": 0,
       "task": {
@@ -188,7 +152,6 @@
       "alwaysRun": false,
       "displayName": "Copy built Portable binaries to staging directory",
       "timeoutInMinutes": 0,
-      "condition": "succeeded()",
       "task": {
         "id": "5bfb729a-a7c8-4a78-a7c3-8d717bb7c13c",
         "versionSpec": "2.*",
@@ -209,7 +172,6 @@
       "alwaysRun": false,
       "displayName": "Initialize docker - Ubuntu14.04",
       "timeoutInMinutes": 0,
-      "condition": "succeeded()",
       "task": {
         "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
         "versionSpec": "1.*",
@@ -228,7 +190,6 @@
       "alwaysRun": false,
       "displayName": "Init tools - Ubuntu14.04",
       "timeoutInMinutes": 0,
-      "condition": "succeeded()",
       "task": {
         "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
         "versionSpec": "1.*",
@@ -247,7 +208,6 @@
       "alwaysRun": false,
       "displayName": "Build traversal build dependencies - Ubuntu 14.04",
       "timeoutInMinutes": 0,
-      "condition": "succeeded()",
       "task": {
         "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
         "versionSpec": "1.*",
@@ -266,7 +226,6 @@
       "alwaysRun": false,
       "displayName": "Package - Ubuntu 14.04 ",
       "timeoutInMinutes": 0,
-      "condition": "succeeded()",
       "task": {
         "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
         "versionSpec": "1.*",
@@ -285,7 +244,6 @@
       "alwaysRun": false,
       "displayName": "Publish - Ubuntu 14.04 ",
       "timeoutInMinutes": 0,
-      "condition": "succeeded()",
       "task": {
         "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
         "versionSpec": "1.*",
@@ -304,7 +262,6 @@
       "alwaysRun": false,
       "displayName": "Initialize docker - Ubuntu16.04",
       "timeoutInMinutes": 0,
-      "condition": "succeeded()",
       "task": {
         "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
         "versionSpec": "1.*",
@@ -323,7 +280,6 @@
       "alwaysRun": false,
       "displayName": "Init tools - Ubuntu16.04 ",
       "timeoutInMinutes": 0,
-      "condition": "succeeded()",
       "task": {
         "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
         "versionSpec": "1.*",
@@ -342,7 +298,6 @@
       "alwaysRun": false,
       "displayName": "Build traversal build dependencies -Ubuntu 16.04 ",
       "timeoutInMinutes": 0,
-      "condition": "succeeded()",
       "task": {
         "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
         "versionSpec": "1.*",
@@ -361,7 +316,6 @@
       "alwaysRun": false,
       "displayName": "Package - Ubuntu 16.04",
       "timeoutInMinutes": 0,
-      "condition": "succeeded()",
       "task": {
         "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
         "versionSpec": "1.*",
@@ -380,7 +334,6 @@
       "alwaysRun": false,
       "displayName": "Publish - Ubuntu 16.04 ",
       "timeoutInMinutes": 0,
-      "condition": "succeeded()",
       "task": {
         "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
         "versionSpec": "1.*",
@@ -399,7 +352,6 @@
       "alwaysRun": false,
       "displayName": "Initialize docker - Ubuntu16.10",
       "timeoutInMinutes": 0,
-      "condition": "succeeded()",
       "task": {
         "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
         "versionSpec": "1.*",
@@ -418,7 +370,6 @@
       "alwaysRun": false,
       "displayName": "Init tools - Ubuntu16.10",
       "timeoutInMinutes": 0,
-      "condition": "succeeded()",
       "task": {
         "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
         "versionSpec": "1.*",
@@ -437,7 +388,6 @@
       "alwaysRun": false,
       "displayName": "Build traversal build dependencies - Ubuntu 16.10",
       "timeoutInMinutes": 0,
-      "condition": "succeeded()",
       "task": {
         "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
         "versionSpec": "1.*",
@@ -456,7 +406,6 @@
       "alwaysRun": false,
       "displayName": "Package - Ubuntu 16.10",
       "timeoutInMinutes": 0,
-      "condition": "succeeded()",
       "task": {
         "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
         "versionSpec": "1.*",
@@ -475,7 +424,6 @@
       "alwaysRun": false,
       "displayName": "Publish - Ubuntu 16.10",
       "timeoutInMinutes": 0,
-      "condition": "succeeded()",
       "task": {
         "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
         "versionSpec": "1.*",
@@ -494,7 +442,6 @@
       "alwaysRun": false,
       "displayName": "Initialize docker - Debian 8",
       "timeoutInMinutes": 0,
-      "condition": "succeeded()",
       "task": {
         "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
         "versionSpec": "1.*",
@@ -513,7 +460,6 @@
       "alwaysRun": false,
       "displayName": "Init tools - Debian 8 container",
       "timeoutInMinutes": 0,
-      "condition": "succeeded()",
       "task": {
         "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
         "versionSpec": "1.*",
@@ -532,7 +478,6 @@
       "alwaysRun": false,
       "displayName": "Build traversal build dependencies - Debian 8",
       "timeoutInMinutes": 0,
-      "condition": "succeeded()",
       "task": {
         "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
         "versionSpec": "1.*",
@@ -551,7 +496,6 @@
       "alwaysRun": false,
       "displayName": "Package - Debian 8",
       "timeoutInMinutes": 0,
-      "condition": "succeeded()",
       "task": {
         "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
         "versionSpec": "1.*",
@@ -570,7 +514,6 @@
       "alwaysRun": false,
       "displayName": "Publish - Debian 8",
       "timeoutInMinutes": 0,
-      "condition": "succeeded()",
       "task": {
         "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
         "versionSpec": "1.*",
@@ -589,7 +532,6 @@
       "alwaysRun": false,
       "displayName": "Initialize docker - Rhel7",
       "timeoutInMinutes": 0,
-      "condition": "succeeded()",
       "task": {
         "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
         "versionSpec": "1.*",
@@ -608,7 +550,6 @@
       "alwaysRun": false,
       "displayName": "Init tools - Rhel7",
       "timeoutInMinutes": 0,
-      "condition": "succeeded()",
       "task": {
         "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
         "versionSpec": "1.*",
@@ -627,7 +568,6 @@
       "alwaysRun": false,
       "displayName": "Build traversal build dependencies - Rhel7",
       "timeoutInMinutes": 0,
-      "condition": "succeeded()",
       "task": {
         "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
         "versionSpec": "1.*",
@@ -646,7 +586,6 @@
       "alwaysRun": false,
       "displayName": "Package - Rhel7",
       "timeoutInMinutes": 0,
-      "condition": "succeeded()",
       "task": {
         "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
         "versionSpec": "1.*",
@@ -665,7 +604,6 @@
       "alwaysRun": false,
       "displayName": "Publish - Rhel7",
       "timeoutInMinutes": 0,
-      "condition": "succeeded()",
       "task": {
         "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
         "versionSpec": "1.*",
@@ -735,6 +673,16 @@
     }
   ],
   "options": [
+    {
+      "enabled": false,
+      "definition": {
+        "id": "5d58cc01-7c75-450c-be18-a388ddb129ec"
+      },
+      "inputs": {
+        "branchFilters": "[\"+refs/heads/*\"]",
+        "additionalFields": "{}"
+      }
+    },
     {
       "enabled": false,
       "definition": {
@@ -891,7 +839,7 @@
       "isSecret": true
     },
     "PB_DistroRid": {
-      "value": "ubuntu.14.04-x64"
+      "value": "ubuntu.14.04-$(PB_TargetArchitecture)"
     },
     "PB_TargetArchitecture": {
       "value": "x64"
@@ -936,7 +884,7 @@
       "value": "ubuntu-16.04-debpkg-e5cf912-20174703024721"
     },
     "DistroRid_Ubuntu1604": {
-      "value": "ubuntu.16.04-x64"
+      "value": "ubuntu.16.04-$(PB_TargetArchitecture)"
     },
     "DockerImageName_Ubuntu1604": {
       "value": "$(PB_DockerRepository):$(DockerTag_Ubuntu1604)"
@@ -948,7 +896,7 @@
       "value": "ubuntu-16.10-debpkg-ec863bb-20170003030028"
     },
     "DistroRid_Ubuntu1610": {
-      "value": "ubuntu.16.10-x64"
+      "value": "ubuntu.16.10-$(PB_TargetArchitecture)"
     },
     "DockerImageName_Ubuntu1610": {
       "value": "$(PB_DockerRepository):$(DockerTag_Ubuntu1610)"
@@ -960,7 +908,7 @@
       "value": "debian-8.2-debpkg-9f87c3c-20173003023006"
     },
     "DistroRid_Debian8": {
-      "value": "debian.8-x64"
+      "value": "debian.8-$(PB_TargetArchitecture)"
     },
     "DockerImageName_Debian8": {
       "value": "$(PB_DockerRepository):$(DockerTag_Debian8)"
@@ -972,7 +920,7 @@
       "value": "rhel-7-rpmpkg-c982313-20174116044113"
     },
     "DistroRid_Rhel7": {
-      "value": "rhel.7-x64"
+      "value": "rhel.7-$(PB_TargetArchitecture)"
     },
     "DockerImageName_Rhel7": {
       "value": "$(PB_DockerRepository):$(DockerTag_Rhel7)"
@@ -1010,7 +958,7 @@
       "deleteTestResults": true
     }
   ],
-  "buildNumberFormat": "$(date:yyyyMMdd)$(rev:-rr)-$(PB_DockerTag)",
+  "buildNumberFormat": "$(date:yyyyMMdd)$(rev:-rr)",
   "jobAuthorizationScope": "projectCollection",
   "jobTimeoutInMinutes": 90,
   "jobCancelTimeoutInMinutes": 5,
@@ -1052,6 +1000,7 @@
     "description": "Visual Studio and DevDiv team project for git source code repositories.  Work items will be added for Adams, Dev14 work items are tracked in vstfdevdiv.  ",
     "url": "https://devdiv.visualstudio.com/DefaultCollection/_apis/projects/0bdbc590-a062-4c3f-b0f6-9383f67865ee",
     "state": "wellFormed",
-    "revision": 418097676
+    "revision": 418097676,
+    "visibility": "private"
   }
 }

--- a/buildpipeline/Core-Setup-OSX-BT.json
+++ b/buildpipeline/Core-Setup-OSX-BT.json
@@ -58,42 +58,6 @@
       "enabled": true,
       "continueOnError": false,
       "alwaysRun": false,
-      "displayName": "Init tools",
-      "timeoutInMinutes": 0,
-      "task": {
-        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
-        "versionSpec": "1.*",
-        "definitionType": "task"
-      },
-      "inputs": {
-        "filename": "$(PB_SourcesDirectory)/init-tools.sh",
-        "arguments": "",
-        "workingFolder": "$(PB_SourcesDirectory)",
-        "failOnStandardError": "false"
-      }
-    },
-    {
-      "enabled": true,
-      "continueOnError": false,
-      "alwaysRun": false,
-      "displayName": "Generate version assets",
-      "timeoutInMinutes": 0,
-      "task": {
-        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
-        "versionSpec": "1.*",
-        "definitionType": "task"
-      },
-      "inputs": {
-        "filename": "$(PB_SourcesDirectory)/Tools/msbuild.sh",
-        "arguments": "$(PB_SourcesDirectory)/build.proj /t:GenerateVersionSourceFile /p:GenerateVersionSourceFile=true /p:OfficialBuildId=$(OfficialBuildId)",
-        "workingFolder": "$(PB_SourcesDirectory)",
-        "failOnStandardError": "false"
-      }
-    },
-    {
-      "enabled": true,
-      "continueOnError": false,
-      "alwaysRun": false,
       "displayName": "Build",
       "timeoutInMinutes": 0,
       "task": {
@@ -146,6 +110,16 @@
     }
   ],
   "options": [
+    {
+      "enabled": false,
+      "definition": {
+        "id": "5d58cc01-7c75-450c-be18-a388ddb129ec"
+      },
+      "inputs": {
+        "branchFilters": "[\"+refs/heads/*\"]",
+        "additionalFields": "{}"
+      }
+    },
     {
       "enabled": false,
       "definition": {
@@ -316,6 +290,7 @@
     "description": "Visual Studio and DevDiv team project for git source code repositories.  Work items will be added for Adams, Dev14 work items are tracked in vstfdevdiv.  ",
     "url": "https://devdiv.visualstudio.com/DefaultCollection/_apis/projects/0bdbc590-a062-4c3f-b0f6-9383f67865ee",
     "state": "wellFormed",
-    "revision": 418097676
+    "revision": 418097676,
+    "visibility": "private"
   }
 }

--- a/buildpipeline/Core-Setup-Windows-Arm-BT.json
+++ b/buildpipeline/Core-Setup-Windows-Arm-BT.json
@@ -78,43 +78,6 @@
       "enabled": true,
       "continueOnError": false,
       "alwaysRun": false,
-      "displayName": "Run init-tools.cmd",
-      "timeoutInMinutes": 0,
-      "task": {
-        "id": "bfc8bf76-e7ac-4a8c-9a55-a944a9f632fd",
-        "versionSpec": "1.*",
-        "definitionType": "task"
-      },
-      "inputs": {
-        "filename": "$(PB_SourcesDirectory)\\init-tools.cmd",
-        "arguments": "",
-        "modifyEnvironment": "false",
-        "workingFolder": "$(PB_SourcesDirectory)",
-        "failOnStandardError": "false"
-      }
-    },
-    {
-      "enabled": true,
-      "continueOnError": false,
-      "alwaysRun": false,
-      "displayName": "Generate version assets",
-      "timeoutInMinutes": 0,
-      "task": {
-        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
-        "versionSpec": "1.*",
-        "definitionType": "task"
-      },
-      "inputs": {
-        "filename": "$(PB_SourcesDirectory)\\build.cmd",
-        "arguments": "-- /t:GenerateVersionSourceFile /p:GenerateVersionSourceFile=true /p:OfficialBuildId=$(OfficialBuildId) $(PB_CommonMSBuildArgs)",
-        "workingFolder": "$(PB_SourcesDirectory)",
-        "failOnStandardError": "false"
-      }
-    },
-    {
-      "enabled": true,
-      "continueOnError": false,
-      "alwaysRun": false,
       "displayName": "Build traversal build dependencies",
       "timeoutInMinutes": 0,
       "task": {
@@ -160,6 +123,10 @@
       },
       "inputs": {
         "solution": "$(PB_SourcesDirectory)\\sign.proj",
+        "msbuildLocationMethod": "version",
+        "msbuildVersion": "latest",
+        "msbuildArchitecture": "x64",
+        "msbuildLocation": "",
         "platform": "$(PB_TargetArchitecture)",
         "configuration": "$(BuildConfiguration)",
         "msbuildArguments": "/t:SignBinaries $(MsbuildSigningArguments) $(PB_CommonMSBuildArgs)",
@@ -167,11 +134,7 @@
         "maximumCpuCount": "false",
         "restoreNugetPackages": "false",
         "logProjectEvents": "false",
-        "createLogFile": "false",
-        "msbuildLocationMethod": "version",
-        "msbuildVersion": "latest",
-        "msbuildArchitecture": "x64",
-        "msbuildLocation": ""
+        "createLogFile": "false"
       }
     },
     {
@@ -187,6 +150,10 @@
       },
       "inputs": {
         "solution": "$(PB_SourcesDirectory)\\src\\pkg\\dir.proj",
+        "msbuildLocationMethod": "version",
+        "msbuildVersion": "latest",
+        "msbuildArchitecture": "x64",
+        "msbuildLocation": "",
         "platform": "$(PB_TargetArchitecture)",
         "configuration": "$(BuildConfiguration)",
         "msbuildArguments": "$(PB_CommonMSBuildArgs) /p:BuildFullPlatformManifest=$(PB_BuildFullPlatformManifest) /flp:v=detailed;LogFile=$(PB_SourcesDirectory)\\packages.log",
@@ -194,11 +161,7 @@
         "maximumCpuCount": "false",
         "restoreNugetPackages": "false",
         "logProjectEvents": "false",
-        "createLogFile": "false",
-        "msbuildLocationMethod": "version",
-        "msbuildVersion": "latest",
-        "msbuildArchitecture": "x64",
-        "msbuildLocation": ""
+        "createLogFile": "false"
       }
     },
     {
@@ -214,6 +177,10 @@
       },
       "inputs": {
         "solution": "$(PB_SourcesDirectory)\\src\\sharedFramework\\sharedFramework.proj",
+        "msbuildLocationMethod": "version",
+        "msbuildVersion": "latest",
+        "msbuildArchitecture": "x64",
+        "msbuildLocation": "",
         "platform": "$(PB_TargetArchitecture)",
         "configuration": "$(BuildConfiguration)",
         "msbuildArguments": "$(PB_CommonMSBuildArgs) /flp:v=detailed;LogFile=$(PB_SourcesDirectory)\\sharedframework.log",
@@ -221,11 +188,7 @@
         "maximumCpuCount": "false",
         "restoreNugetPackages": "false",
         "logProjectEvents": "false",
-        "createLogFile": "false",
-        "msbuildLocationMethod": "version",
-        "msbuildVersion": "latest",
-        "msbuildArchitecture": "x64",
-        "msbuildLocation": ""
+        "createLogFile": "false"
       }
     },
     {
@@ -241,6 +204,10 @@
       },
       "inputs": {
         "solution": "$(PB_SourcesDirectory)\\src\\pkg\\packaging\\dir.proj",
+        "msbuildLocationMethod": "version",
+        "msbuildVersion": "latest",
+        "msbuildArchitecture": "x64",
+        "msbuildLocation": "",
         "platform": "$(PB_TargetArchitecture)",
         "configuration": "$(BuildConfiguration)",
         "msbuildArguments": "$(PB_CommonMSBuildArgs) /flp:v=detailed;LogFile=$(PB_SourcesDirectory)\\packaging.log",
@@ -248,11 +215,7 @@
         "maximumCpuCount": "false",
         "restoreNugetPackages": "false",
         "logProjectEvents": "false",
-        "createLogFile": "true",
-        "msbuildLocationMethod": "version",
-        "msbuildVersion": "latest",
-        "msbuildArchitecture": "x64",
-        "msbuildLocation": ""
+        "createLogFile": "true"
       }
     },
     {
@@ -268,6 +231,10 @@
       },
       "inputs": {
         "solution": "$(PB_SourcesDirectory)\\publish\\publish.proj",
+        "msbuildLocationMethod": "version",
+        "msbuildVersion": "latest",
+        "msbuildArchitecture": "x64",
+        "msbuildLocation": "",
         "platform": "$(PB_TargetArchitecture)",
         "configuration": "$(BuildConfiguration)",
         "msbuildArguments": "$(PB_CommonMSBuildArgs) /p:AzureAccountName=$(PB_AzureAccountName) /p:AzureAccessToken=$(PB_AzureAccessToken) /p:ChecksumAzureAccountName=$(PB_ChecksumAzureAccountName) /p:ChecksumAzureAccessToken=$(PB_ChecksumAzureAccessToken)",
@@ -275,11 +242,7 @@
         "maximumCpuCount": "false",
         "restoreNugetPackages": "false",
         "logProjectEvents": "false",
-        "createLogFile": "false",
-        "msbuildLocationMethod": "version",
-        "msbuildVersion": "latest",
-        "msbuildArchitecture": "x64",
-        "msbuildLocation": ""
+        "createLogFile": "false"
       }
     },
     {
@@ -295,6 +258,10 @@
       },
       "inputs": {
         "solution": "$(PB_SourcesDirectory)\\Tools\\scripts\\vstsagent\\cleanupagent.proj",
+        "msbuildLocationMethod": "version",
+        "msbuildVersion": "latest",
+        "msbuildArchitecture": "x64",
+        "msbuildLocation": "",
         "platform": "$(PB_TargetArchitecture)",
         "configuration": "$(BuildConfiguration)",
         "msbuildArguments": "/p:AgentDirectory=$(Agent.HomeDirectory) /p:DoClean=$(PB_CleanAgent)",
@@ -302,11 +269,7 @@
         "maximumCpuCount": "false",
         "restoreNugetPackages": "false",
         "logProjectEvents": "false",
-        "createLogFile": "false",
-        "msbuildLocationMethod": "version",
-        "msbuildVersion": "latest",
-        "msbuildArchitecture": "x64",
-        "msbuildLocation": ""
+        "createLogFile": "false"
       }
     },
     {
@@ -343,6 +306,16 @@
     }
   ],
   "options": [
+    {
+      "enabled": false,
+      "definition": {
+        "id": "5d58cc01-7c75-450c-be18-a388ddb129ec"
+      },
+      "inputs": {
+        "branchFilters": "[\"+refs/heads/*\"]",
+        "additionalFields": "{}"
+      }
+    },
     {
       "enabled": false,
       "definition": {
@@ -419,10 +392,7 @@
       "value": "400"
     },
     "PB_DistroRid": {
-      "value": "win-x64"
-    },
-    "RID": {
-      "value": "win-x64",
+      "value": "win-$(PB_TargetArchitecture)",
       "allowOverride": true
     },
     "MsbuildSigningArguments": {
@@ -435,14 +405,14 @@
       "value": "false"
     },
     "PB_PortableBuild": {
-      "value": "false",
+      "value": "true",
       "allowOverride": true
     },
     "PB_SourcesDirectory": {
       "value": "$(Build.SourcesDirectory)\\core-setup"
     },
     "PB_ChecksumAzureAccountName": {
-       "value": "dotnetclichecksums"
+      "value": "dotnetclichecksums"
     },
     "PB_ChecksumAzureAccessToken": {
       "value": null,
@@ -557,6 +527,7 @@
     "description": "Visual Studio and DevDiv team project for git source code repositories.  Work items will be added for Adams, Dev14 work items are tracked in vstfdevdiv.  ",
     "url": "https://devdiv.visualstudio.com/DefaultCollection/_apis/projects/0bdbc590-a062-4c3f-b0f6-9383f67865ee",
     "state": "wellFormed",
-    "revision": 418097676
+    "revision": 418097676,
+    "visibility": "private"
   }
 }

--- a/buildpipeline/Core-Setup-Windows-BT.json
+++ b/buildpipeline/Core-Setup-Windows-BT.json
@@ -78,43 +78,6 @@
       "enabled": true,
       "continueOnError": false,
       "alwaysRun": false,
-      "displayName": "Run init-tools.cmd",
-      "timeoutInMinutes": 0,
-      "task": {
-        "id": "bfc8bf76-e7ac-4a8c-9a55-a944a9f632fd",
-        "versionSpec": "1.*",
-        "definitionType": "task"
-      },
-      "inputs": {
-        "filename": "$(PB_SourcesDirectory)\\init-tools.cmd",
-        "arguments": "",
-        "modifyEnvironment": "false",
-        "workingFolder": "$(PB_SourcesDirectory)",
-        "failOnStandardError": "false"
-      }
-    },
-    {
-      "enabled": true,
-      "continueOnError": false,
-      "alwaysRun": false,
-      "displayName": "Generate version assets",
-      "timeoutInMinutes": 0,
-      "task": {
-        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
-        "versionSpec": "1.*",
-        "definitionType": "task"
-      },
-      "inputs": {
-        "filename": "$(PB_SourcesDirectory)\\build.cmd",
-        "arguments": "-- /t:GenerateVersionSourceFile /p:GenerateVersionSourceFile=true /p:OfficialBuildId=$(OfficialBuildId) $(PB_CommonMSBuildArgs)",
-        "workingFolder": "$(PB_SourcesDirectory)",
-        "failOnStandardError": "false"
-      }
-    },
-    {
-      "enabled": true,
-      "continueOnError": false,
-      "alwaysRun": false,
       "displayName": "Build traversal build dependencies",
       "timeoutInMinutes": 0,
       "task": {
@@ -160,6 +123,10 @@
       },
       "inputs": {
         "solution": "$(PB_SourcesDirectory)\\sign.proj",
+        "msbuildLocationMethod": "version",
+        "msbuildVersion": "latest",
+        "msbuildArchitecture": "x64",
+        "msbuildLocation": "",
         "platform": "$(PB_TargetArchitecture)",
         "configuration": "$(BuildConfiguration)",
         "msbuildArguments": "/t:SignBinaries $(MsbuildSigningArguments) $(PB_CommonMSBuildArgs)",
@@ -167,11 +134,7 @@
         "maximumCpuCount": "false",
         "restoreNugetPackages": "false",
         "logProjectEvents": "false",
-        "createLogFile": "false",
-        "msbuildLocationMethod": "version",
-        "msbuildVersion": "latest",
-        "msbuildArchitecture": "x64",
-        "msbuildLocation": ""
+        "createLogFile": "false"
       }
     },
     {
@@ -187,6 +150,10 @@
       },
       "inputs": {
         "solution": "$(PB_SourcesDirectory)\\src\\pkg\\dir.proj",
+        "msbuildLocationMethod": "version",
+        "msbuildVersion": "latest",
+        "msbuildArchitecture": "x64",
+        "msbuildLocation": "",
         "platform": "$(PB_TargetArchitecture)",
         "configuration": "$(BuildConfiguration)",
         "msbuildArguments": "$(PB_CommonMSBuildArgs) /p:BuildFullPlatformManifest=$(PB_BuildFullPlatformManifest) /flp:v=detailed;LogFile=$(PB_SourcesDirectory)\\packages.log",
@@ -194,11 +161,7 @@
         "maximumCpuCount": "false",
         "restoreNugetPackages": "false",
         "logProjectEvents": "false",
-        "createLogFile": "false",
-        "msbuildLocationMethod": "version",
-        "msbuildVersion": "latest",
-        "msbuildArchitecture": "x64",
-        "msbuildLocation": ""
+        "createLogFile": "false"
       }
     },
     {
@@ -214,6 +177,10 @@
       },
       "inputs": {
         "solution": "$(PB_SourcesDirectory)\\src\\sharedFramework\\sharedFramework.proj",
+        "msbuildLocationMethod": "version",
+        "msbuildVersion": "latest",
+        "msbuildArchitecture": "x64",
+        "msbuildLocation": "",
         "platform": "$(PB_TargetArchitecture)",
         "configuration": "$(BuildConfiguration)",
         "msbuildArguments": "$(PB_CommonMSBuildArgs) /flp:v=detailed;LogFile=$(PB_SourcesDirectory)\\sharedframework.log",
@@ -221,11 +188,7 @@
         "maximumCpuCount": "false",
         "restoreNugetPackages": "false",
         "logProjectEvents": "false",
-        "createLogFile": "false",
-        "msbuildLocationMethod": "version",
-        "msbuildVersion": "latest",
-        "msbuildArchitecture": "x64",
-        "msbuildLocation": ""
+        "createLogFile": "false"
       }
     },
     {
@@ -241,6 +204,10 @@
       },
       "inputs": {
         "solution": "$(PB_SourcesDirectory)\\src\\pkg\\packaging\\dir.proj",
+        "msbuildLocationMethod": "version",
+        "msbuildVersion": "latest",
+        "msbuildArchitecture": "x64",
+        "msbuildLocation": "",
         "platform": "$(PB_TargetArchitecture)",
         "configuration": "$(BuildConfiguration)",
         "msbuildArguments": "/t:BuildInstallers $(PB_CommonMSBuildArgs) /flp:v=detailed;LogFile=$(PB_SourcesDirectory)\\packaging.log",
@@ -248,11 +215,7 @@
         "maximumCpuCount": "false",
         "restoreNugetPackages": "false",
         "logProjectEvents": "false",
-        "createLogFile": "true",
-        "msbuildLocationMethod": "version",
-        "msbuildVersion": "latest",
-        "msbuildArchitecture": "x64",
-        "msbuildLocation": ""
+        "createLogFile": "true"
       }
     },
     {
@@ -268,6 +231,10 @@
       },
       "inputs": {
         "solution": "$(PB_SourcesDirectory)\\sign.proj",
+        "msbuildLocationMethod": "version",
+        "msbuildVersion": "latest",
+        "msbuildArchitecture": "x64",
+        "msbuildLocation": "",
         "platform": "$(PB_TargetArchitecture)",
         "configuration": "$(BuildConfiguration)",
         "msbuildArguments": "/t:SignMsiAndCab $(PB_CommonMSBuildArgs) $(MsbuildSigningArguments)",
@@ -275,11 +242,7 @@
         "maximumCpuCount": "false",
         "restoreNugetPackages": "false",
         "logProjectEvents": "false",
-        "createLogFile": "false",
-        "msbuildLocationMethod": "version",
-        "msbuildVersion": "latest",
-        "msbuildArchitecture": "x64",
-        "msbuildLocation": ""
+        "createLogFile": "false"
       }
     },
     {
@@ -295,6 +258,10 @@
       },
       "inputs": {
         "solution": "$(PB_SourcesDirectory)\\src\\pkg\\packaging\\dir.proj",
+        "msbuildLocationMethod": "version",
+        "msbuildVersion": "latest",
+        "msbuildArchitecture": "x64",
+        "msbuildLocation": "",
         "platform": "$(PB_TargetArchitecture)",
         "configuration": "$(BuildConfiguration)",
         "msbuildArguments": "/t:BuildCombinedInstallers $(PB_CommonMSBuildArgs) /flp:v=detailed;LogFile=$(PB_SourcesDirectory)\\createbundles.log",
@@ -302,11 +269,7 @@
         "maximumCpuCount": "false",
         "restoreNugetPackages": "false",
         "logProjectEvents": "false",
-        "createLogFile": "false",
-        "msbuildLocationMethod": "version",
-        "msbuildVersion": "latest",
-        "msbuildArchitecture": "x64",
-        "msbuildLocation": ""
+        "createLogFile": "false"
       }
     },
     {
@@ -322,6 +285,10 @@
       },
       "inputs": {
         "solution": "$(PB_SourcesDirectory)\\src\\pkg\\packaging\\dir.proj",
+        "msbuildLocationMethod": "version",
+        "msbuildVersion": "latest",
+        "msbuildArchitecture": "x64",
+        "msbuildLocation": "",
         "platform": "$(PB_TargetArchitecture)",
         "configuration": "$(BuildConfiguration)",
         "msbuildArguments": "/t:ExtractEngineBundle $(PB_CommonMSBuildArgs) /flp:v=detailed;LogFile=$(PB_SourcesDirectory)\\extractengine.log",
@@ -329,11 +296,7 @@
         "maximumCpuCount": "false",
         "restoreNugetPackages": "false",
         "logProjectEvents": "false",
-        "createLogFile": "false",
-        "msbuildLocationMethod": "version",
-        "msbuildVersion": "latest",
-        "msbuildArchitecture": "x64",
-        "msbuildLocation": ""
+        "createLogFile": "false"
       }
     },
     {
@@ -349,6 +312,10 @@
       },
       "inputs": {
         "solution": "$(PB_SourcesDirectory)\\sign.proj",
+        "msbuildLocationMethod": "version",
+        "msbuildVersion": "latest",
+        "msbuildArchitecture": "x64",
+        "msbuildLocation": "",
         "platform": "$(PB_TargetArchitecture)",
         "configuration": "$(BuildConfiguration)",
         "msbuildArguments": "/t:SignEngine $(MsbuildSigningArguments) $(PB_CommonMSBuildArgs) /flp:v=detailed;LogFile=$(PB_SourcesDirectory)\\signengine.log",
@@ -356,11 +323,7 @@
         "maximumCpuCount": "false",
         "restoreNugetPackages": "false",
         "logProjectEvents": "false",
-        "createLogFile": "false",
-        "msbuildLocationMethod": "version",
-        "msbuildVersion": "latest",
-        "msbuildArchitecture": "x64",
-        "msbuildLocation": ""
+        "createLogFile": "false"
       }
     },
     {
@@ -376,6 +339,10 @@
       },
       "inputs": {
         "solution": "$(PB_SourcesDirectory)\\src\\pkg\\packaging\\dir.proj",
+        "msbuildLocationMethod": "version",
+        "msbuildVersion": "latest",
+        "msbuildArchitecture": "x64",
+        "msbuildLocation": "",
         "platform": "$(PB_TargetArchitecture)",
         "configuration": "$(BuildConfiguration)",
         "msbuildArguments": "/t:ReattachEngineToBundle $(PB_CommonMSBuildArgs) /flp:v=detailed;LogFile=$(PB_SourcesDirectory)\\reattachengine.log",
@@ -383,11 +350,7 @@
         "maximumCpuCount": "false",
         "restoreNugetPackages": "false",
         "logProjectEvents": "false",
-        "createLogFile": "false",
-        "msbuildLocationMethod": "version",
-        "msbuildVersion": "latest",
-        "msbuildArchitecture": "x64",
-        "msbuildLocation": ""
+        "createLogFile": "false"
       }
     },
     {
@@ -403,6 +366,10 @@
       },
       "inputs": {
         "solution": "$(PB_SourcesDirectory)\\sign.proj",
+        "msbuildLocationMethod": "version",
+        "msbuildVersion": "latest",
+        "msbuildArchitecture": "x64",
+        "msbuildLocation": "",
         "platform": "$(PB_TargetArchitecture)",
         "configuration": "$(BuildConfiguration)",
         "msbuildArguments": "/t:SignBundle $(MsbuildSigningArguments) $(PB_CommonMSBuildArgs) /flp:v=detailed;LogFile=$(PB_SourcesDirectory)\\signbundle.log",
@@ -410,11 +377,7 @@
         "maximumCpuCount": "false",
         "restoreNugetPackages": "false",
         "logProjectEvents": "false",
-        "createLogFile": "false",
-        "msbuildLocationMethod": "version",
-        "msbuildVersion": "latest",
-        "msbuildArchitecture": "x64",
-        "msbuildLocation": ""
+        "createLogFile": "false"
       }
     },
     {
@@ -430,6 +393,10 @@
       },
       "inputs": {
         "solution": "$(PB_SourcesDirectory)\\src\\test\\dir.proj",
+        "msbuildLocationMethod": "version",
+        "msbuildVersion": "latest",
+        "msbuildArchitecture": "x64",
+        "msbuildLocation": "",
         "platform": "$(PB_TargetArchitecture)",
         "configuration": "$(BuildConfiguration)",
         "msbuildArguments": "$(PB_CommonMSBuildArgs) /flp:v=diag;LogFile=$(PB_SourcesDirectory)\\tests.log",
@@ -437,11 +404,7 @@
         "maximumCpuCount": "false",
         "restoreNugetPackages": "false",
         "logProjectEvents": "false",
-        "createLogFile": "false",
-        "msbuildLocationMethod": "version",
-        "msbuildVersion": "latest",
-        "msbuildArchitecture": "x64",
-        "msbuildLocation": ""
+        "createLogFile": "false"
       }
     },
     {
@@ -457,6 +420,10 @@
       },
       "inputs": {
         "solution": "$(PB_SourcesDirectory)\\publish\\publish.proj",
+        "msbuildLocationMethod": "version",
+        "msbuildVersion": "latest",
+        "msbuildArchitecture": "x64",
+        "msbuildLocation": "",
         "platform": "$(PB_TargetArchitecture)",
         "configuration": "$(BuildConfiguration)",
         "msbuildArguments": "$(PB_CommonMSBuildArgs) /p:AzureAccountName=$(PB_AzureAccountName) /p:AzureAccessToken=$(PB_AzureAccessToken) /p:PublishRidAgnosticPackages=$(PB_PublishRidAgnosticPackages) /p:BuildFullPlatformManifest=$(PB_BuildFullPlatformManifest) /p:ChecksumAzureAccountName=$(PB_ChecksumAzureAccountName) /p:ChecksumAzureAccessToken=$(PB_ChecksumAzureAccessToken) /flp:v=detailed;LogFile=$(PB_SourcesDirectory)\\publish.log",
@@ -464,11 +431,7 @@
         "maximumCpuCount": "false",
         "restoreNugetPackages": "false",
         "logProjectEvents": "false",
-        "createLogFile": "false",
-        "msbuildLocationMethod": "version",
-        "msbuildVersion": "latest",
-        "msbuildArchitecture": "x64",
-        "msbuildLocation": ""
+        "createLogFile": "false"
       }
     },
     {
@@ -484,6 +447,10 @@
       },
       "inputs": {
         "solution": "$(PB_SourcesDirectory)\\Tools\\scripts\\vstsagent\\cleanupagent.proj",
+        "msbuildLocationMethod": "version",
+        "msbuildVersion": "latest",
+        "msbuildArchitecture": "x64",
+        "msbuildLocation": "",
         "platform": "$(PB_TargetArchitecture)",
         "configuration": "$(BuildConfiguration)",
         "msbuildArguments": "/p:AgentDirectory=$(Agent.HomeDirectory) /p:DoClean=$(PB_CleanAgent)",
@@ -491,11 +458,7 @@
         "maximumCpuCount": "false",
         "restoreNugetPackages": "false",
         "logProjectEvents": "false",
-        "createLogFile": "false",
-        "msbuildLocationMethod": "version",
-        "msbuildVersion": "latest",
-        "msbuildArchitecture": "x64",
-        "msbuildLocation": ""
+        "createLogFile": "false"
       }
     },
     {
@@ -532,6 +495,16 @@
     }
   ],
   "options": [
+    {
+      "enabled": false,
+      "definition": {
+        "id": "5d58cc01-7c75-450c-be18-a388ddb129ec"
+      },
+      "inputs": {
+        "branchFilters": "[\"+refs/heads/*\"]",
+        "additionalFields": "{}"
+      }
+    },
     {
       "enabled": false,
       "definition": {
@@ -614,10 +587,7 @@
       "value": "400"
     },
     "PB_DistroRid": {
-      "value": "win-x64"
-    },
-    "RID": {
-      "value": "win-x64",
+      "value": "win-$(PB_TargetArchitecture)",
       "allowOverride": true
     },
     "MsbuildSigningArguments": {
@@ -630,7 +600,7 @@
       "value": "false"
     },
     "PB_PortableBuild": {
-      "value": "false",
+      "value": "true",
       "allowOverride": true
     },
     "NUGET_SYMBOLS_FEED_URL": {
@@ -752,6 +722,7 @@
     "description": "Visual Studio and DevDiv team project for git source code repositories.  Work items will be added for Adams, Dev14 work items are tracked in vstfdevdiv.  ",
     "url": "https://devdiv.visualstudio.com/DefaultCollection/_apis/projects/0bdbc590-a062-4c3f-b0f6-9383f67865ee",
     "state": "wellFormed",
-    "revision": 418097676
+    "revision": 418097676,
+    "visibility": "private"
   }
 }


### PR DESCRIPTION
Fixes https://github.com/dotnet/core-setup/issues/2265

Validated that these steps are not necessary with private official build runs of individual legs

