### PR TITLE
Update NETCore.App dependencies for nca1.0 and nca.1.1

### DIFF
--- a/src/pkg/projects/Microsoft.NETCore.App/Microsoft.NETCore.App.pkgproj
+++ b/src/pkg/projects/Microsoft.NETCore.App/Microsoft.NETCore.App.pkgproj
@@ -22,9 +22,9 @@
          the Microsoft.NETCore.App (RID-agnostic/identity package). -->
     <IncludeAllRuntimePackagesInPlatformManifest Condition="'$(BuildFullPlatformManifest)' == 'true'">true</IncludeAllRuntimePackagesInPlatformManifest>
   </PropertyGroup>
-  
-  
+
   <Import Project="netcoreapp1.0.props" />
+  <Import Project="netcoreapp1.1.props" />
 
   <!-- Identity / Reference package content -->
   <ItemGroup Condition="'$(PackageTargetRuntime)' == ''">

--- a/src/pkg/projects/Microsoft.NETCore.App/netcoreapp1.0.props
+++ b/src/pkg/projects/Microsoft.NETCore.App/netcoreapp1.0.props
@@ -13,16 +13,22 @@
       <Version>4.0.1</Version>
     </NETCoreApp10Dependency>
     <NETCoreApp10Dependency Include="Microsoft.NETCore.DotNetHostPolicy">
-      <Version>1.0.1</Version>
+      <Version>1.0.5</Version>
+    </NETCoreApp10Dependency>
+    <NETCoreApp10Dependency Include="Microsoft.NETCore.Platforms">
+      <Version>1.0.2</Version>
     </NETCoreApp10Dependency>
     <NETCoreApp10Dependency Include="Microsoft.NETCore.Runtime.CoreCLR">
-      <Version>1.0.4</Version>
+      <Version>1.0.7</Version>
     </NETCoreApp10Dependency>
     <NETCoreApp10Dependency Include="Microsoft.VisualBasic">
       <Version>10.0.1</Version>
     </NETCoreApp10Dependency>
     <NETCoreApp10Dependency Include="NETStandard.Library">
       <Version>1.6.0</Version>
+    </NETCoreApp10Dependency>
+    <NETCoreApp10Dependency Include="runtime.native.System.Security.Cryptography">
+      <Version>4.0.1</Version>
     </NETCoreApp10Dependency>
     <NETCoreApp10Dependency Include="System.Buffers">
       <Version>4.0.0</Version>
@@ -58,13 +64,16 @@
       <Version>4.0.1</Version>
     </NETCoreApp10Dependency>
     <NETCoreApp10Dependency Include="System.Linq.Expressions">
-      <Version>4.1.0</Version>
+      <Version>4.1.1</Version>
     </NETCoreApp10Dependency>
     <NETCoreApp10Dependency Include="System.Linq.Parallel">
       <Version>4.0.1</Version>
     </NETCoreApp10Dependency>
     <NETCoreApp10Dependency Include="System.Linq.Queryable">
       <Version>4.0.1</Version>
+    </NETCoreApp10Dependency>
+    <NETCoreApp10Dependency Include="System.Net.Http">
+      <Version>4.1.2</Version>
     </NETCoreApp10Dependency>
     <NETCoreApp10Dependency Include="System.Net.NameResolution">
       <Version>4.0.0</Version>
@@ -73,7 +82,7 @@
       <Version>4.0.11</Version>
     </NETCoreApp10Dependency>
     <NETCoreApp10Dependency Include="System.Net.Security">
-      <Version>4.0.0</Version>
+      <Version>4.0.1</Version>
     </NETCoreApp10Dependency>
     <NETCoreApp10Dependency Include="System.Net.WebHeaderCollection">
       <Version>4.0.1</Version>

--- a/src/pkg/projects/Microsoft.NETCore.App/netcoreapp1.1.props
+++ b/src/pkg/projects/Microsoft.NETCore.App/netcoreapp1.1.props
@@ -6,9 +6,11 @@
     </NETCoreApp11Dependency>
     <NETCoreApp11Dependency Include="Microsoft.CodeAnalysis.CSharp">
       <Version>1.3.0</Version>
+      <Exclude>Compile</Exclude>
     </NETCoreApp11Dependency>
     <NETCoreApp11Dependency Include="Microsoft.CodeAnalysis.VisualBasic">
       <Version>1.3.0</Version>
+      <Exclude>Compile</Exclude>
     </NETCoreApp11Dependency>
     <NETCoreApp11Dependency Include="Microsoft.CSharp">
       <Version>4.3.0</Version>
@@ -99,6 +101,7 @@
     </NETCoreApp11Dependency>
     <NETCoreApp11Dependency Include="System.Runtime.Loader">
       <Version>4.3.0</Version>
+      <Exclude>Compile</Exclude>
     </NETCoreApp11Dependency>
     <NETCoreApp11Dependency Include="System.Security.Cryptography.Algorithms">
       <Version>4.3.0</Version>

--- a/src/pkg/projects/Microsoft.NETCore.App/netcoreapp1.1.props
+++ b/src/pkg/projects/Microsoft.NETCore.App/netcoreapp1.1.props
@@ -16,19 +16,22 @@
       <Version>4.3.0</Version>
     </NETCoreApp11Dependency>
     <NETCoreApp11Dependency Include="Microsoft.DiaSymReader.Native">
-      <Version>1.4.0</Version>
+      <Version>1.4.1</Version>
     </NETCoreApp11Dependency>
     <NETCoreApp11Dependency Include="Microsoft.NETCore.DotNetHostPolicy">
-      <Version>1.1.0</Version>
+      <Version>1.1.2</Version>
     </NETCoreApp11Dependency>
     <NETCoreApp11Dependency Include="Microsoft.NETCore.Runtime.CoreCLR">
-      <Version>1.1.0</Version>
+      <Version>1.1.2</Version>
     </NETCoreApp11Dependency>
     <NETCoreApp11Dependency Include="Microsoft.VisualBasic">
       <Version>10.1.0</Version>
     </NETCoreApp11Dependency>
     <NETCoreApp11Dependency Include="NETStandard.Library">
       <Version>1.6.1</Version>
+    </NETCoreApp11Dependency>
+    <NETCoreApp11Dependency Include="runtime.native.System.Security.Cryptography.OpenSsl">
+      <Version>4.3.1</Version>
     </NETCoreApp11Dependency>
     <NETCoreApp11Dependency Include="System.Buffers">
       <Version>4.3.0</Version>
@@ -43,7 +46,7 @@
       <Version>4.3.0</Version>
     </NETCoreApp11Dependency>
     <NETCoreApp11Dependency Include="System.Diagnostics.DiagnosticSource">
-      <Version>4.3.0</Version>
+      <Version>4.3.1</Version>
     </NETCoreApp11Dependency>
     <NETCoreApp11Dependency Include="System.Diagnostics.Process">
       <Version>4.3.0</Version>
@@ -72,6 +75,9 @@
     <NETCoreApp11Dependency Include="System.Linq.Queryable">
       <Version>4.3.0</Version>
     </NETCoreApp11Dependency>
+    <NETCoreApp11Dependency Include="System.Net.Http">
+      <Version>4.3.2</Version>
+    </NETCoreApp11Dependency>
     <NETCoreApp11Dependency Include="System.Net.NameResolution">
       <Version>4.3.0</Version>
     </NETCoreApp11Dependency>
@@ -79,7 +85,7 @@
       <Version>4.3.0</Version>
     </NETCoreApp11Dependency>
     <NETCoreApp11Dependency Include="System.Net.Security">
-      <Version>4.3.0</Version>
+      <Version>4.3.1</Version>
     </NETCoreApp11Dependency>
     <NETCoreApp11Dependency Include="System.Net.WebHeaderCollection">
       <Version>4.3.0</Version>


### PR DESCRIPTION
Dependencies were missing for netcoreapp1.1 due to missing import.  Fixes #2512

Update dependencies to latest stable versions to give folks serviced packages.  Related https://github.com/dotnet/standard/issues/354.

/cc @eerhardt @weshaggard @gkhanna79 