### PR TITLE
Change MSBuild steps to use "Latest" instead of 15.0.

### DIFF
--- a/buildpipeline/Core-Setup-Signing-Windows-x64.json
+++ b/buildpipeline/Core-Setup-Signing-Windows-x64.json
@@ -97,7 +97,7 @@
         "logProjectEvents": "false",
         "createLogFile": "false",
         "msbuildLocationMethod": "version",
-        "msbuildVersion": "15.0",
+        "msbuildVersion": "latest",
         "msbuildArchitecture": "x64",
         "msbuildLocation": ""
       }
@@ -163,7 +163,7 @@
         "logProjectEvents": "false",
         "createLogFile": "false",
         "msbuildLocationMethod": "version",
-        "msbuildVersion": "15.0",
+        "msbuildVersion": "latest",
         "msbuildArchitecture": "x64",
         "msbuildLocation": ""
       }
@@ -209,7 +209,7 @@
         "logProjectEvents": "false",
         "createLogFile": "false",
         "msbuildLocationMethod": "version",
-        "msbuildVersion": "15.0",
+        "msbuildVersion": "latest",
         "msbuildArchitecture": "x64",
         "msbuildLocation": ""
       }
@@ -274,7 +274,7 @@
         "logProjectEvents": "false",
         "createLogFile": "false",
         "msbuildLocationMethod": "version",
-        "msbuildVersion": "15.0",
+        "msbuildVersion": "latest",
         "msbuildArchitecture": "x64",
         "msbuildLocation": ""
       }
@@ -320,7 +320,7 @@
         "logProjectEvents": "false",
         "createLogFile": "false",
         "msbuildLocationMethod": "version",
-        "msbuildVersion": "15.0",
+        "msbuildVersion": "latest",
         "msbuildArchitecture": "x64",
         "msbuildLocation": ""
       }

--- a/buildpipeline/Core-Setup-Signing-Windows-x86.json
+++ b/buildpipeline/Core-Setup-Signing-Windows-x86.json
@@ -97,7 +97,7 @@
         "logProjectEvents": "false",
         "createLogFile": "false",
         "msbuildLocationMethod": "version",
-        "msbuildVersion": "15.0",
+        "msbuildVersion": "latest",
         "msbuildArchitecture": "$(BuildArchitecture)",
         "msbuildLocation": ""
       }
@@ -163,7 +163,7 @@
         "logProjectEvents": "false",
         "createLogFile": "false",
         "msbuildLocationMethod": "version",
-        "msbuildVersion": "15.0",
+        "msbuildVersion": "latest",
         "msbuildArchitecture": "$(BuildArchitecture)",
         "msbuildLocation": ""
       }
@@ -209,7 +209,7 @@
         "logProjectEvents": "false",
         "createLogFile": "false",
         "msbuildLocationMethod": "version",
-        "msbuildVersion": "15.0",
+        "msbuildVersion": "latest",
         "msbuildArchitecture": "$(BuildArchitecture)",
         "msbuildLocation": ""
       }
@@ -274,7 +274,7 @@
         "logProjectEvents": "false",
         "createLogFile": "false",
         "msbuildLocationMethod": "version",
-        "msbuildVersion": "15.0",
+        "msbuildVersion": "latest",
         "msbuildArchitecture": "$(BuildArchitecture)",
         "msbuildLocation": ""
       }
@@ -320,7 +320,7 @@
         "logProjectEvents": "false",
         "createLogFile": "false",
         "msbuildLocationMethod": "version",
-        "msbuildVersion": "15.0",
+        "msbuildVersion": "latest",
         "msbuildArchitecture": "$(BuildArchitecture)",
         "msbuildLocation": ""
       }


### PR DESCRIPTION
A recent agent update made being unable to find the specified version of MSBuild an error instead of a warning.  The old behavior was to fall back to Latest; this change restores that.

skip ci please