### PR TITLE
Remove Debian Armel

### DIFF
--- a/src/pkg/projects/netcoreappRIDs.props
+++ b/src/pkg/projects/netcoreappRIDs.props
@@ -35,9 +35,6 @@
     <!-- The following RIDs are not officically supported and are not 
          built during official builds, however we wish to include them 
          in our runtime.json to enable others to provide them.  -->
-    <UnofficialBuildRID Include="debian.8-armel">
-      <Platform>armel</Platform>
-    </UnofficialBuildRID>
     <UnofficialBuildRID Include="tizen.4.0.0-armel">
       <Platform>armel</Platform>
     </UnofficialBuildRID>


### PR DESCRIPTION
Confirmed with @jyoungyun that we no longer need Debian.8-Armel, so removing it from the package.

@ericstj @weshaggard PTAL.

CC @eerhardt 