### PR TITLE
Cherry-pick remaining changes for "Sign ARM binaries in pipeline"

### DIFF
--- a/src/pkg/packaging/dir.proj
+++ b/src/pkg/packaging/dir.proj
@@ -12,7 +12,9 @@
     </PackageTargets>
   </PropertyGroup>
 
-  <Target Name="Build" DependsOnTargets="$(PackageTargets)" Condition="'$(DOTNET_BUILD_SKIP_PACKAGING)' != 'true'" />
+  <Target Name="Build" DependsOnTargets="BuildInstallers;BuildCombinedInstallers" Condition="'$(DOTNET_BUILD_SKIP_PACKAGING)' != 'true'" />
+  <Target Name="BuildInstallers" DependsOnTargets="$(PackageTargets)" Condition="'$(DOTNET_BUILD_SKIP_PACKAGING)' != 'true'" />
+  <Target Name="BuildCombinedInstallers" DependsOnTargets="GenerateCombinedInstallers" Condition="'$(DOTNET_BUILD_SKIP_PACKAGING)' != 'true'" />
 
   <Target Name="InitPackage">
     <ItemGroup>
@@ -148,13 +150,14 @@
   <PropertyGroup>
    <InstallerDependsOn>
      GenerateMsis;
-     GenerateBundles;
      GeneratePkgs;
      GenerateDebs;
      GenerateRpms;
    </InstallerDependsOn>
   </PropertyGroup>
   <Target Name="GenerateInstallers" DependsOnTargets="InitPackage;$(InstallerDependsOn)" />
+
+  <Target Name="GenerateCombinedInstallers" DependsOnTargets="InitPackage;GenerateBundles" />
 
   <Target Name="GenerateNugetPackages" DependsOnTargets="InitPackage" Condition="'$(UsePrebuiltPortableBinariesForInstallers)' == 'false'">
     <ItemGroup>

--- a/src/pkg/packaging/windows/package.targets
+++ b/src/pkg/packaging/windows/package.targets
@@ -6,7 +6,19 @@
     <UsingTask TaskName="GenerateGuidFromName" AssemblyFile="$(LocalBuildToolsTaskDir)core-setup.tasks.dll" />
     <UsingTask TaskName="ZipFileExtractToDirectory" AssemblyFile="$(BuildToolsTaskDir)Microsoft.DotNet.Build.Tasks.dll"/>
 
+    <Target Name="GenerateMsiVersionString">
+      <GenerateMsiVersion
+        Major="$(MajorVersion)"
+        Minor="$(MinorVersion)"
+        Patch="$(PatchVersion)"
+        BuildNumberMajor="$(BuildNumberMajor)"
+        BuildNumberMinor="$(BuildNumberMajor)">
+        <Output TaskParameter="MsiVersion" PropertyName="MsiVersionString" />
+      </GenerateMsiVersion>
+    </Target>
+
     <Target Name="GenerateMsis"
+            DependsOnTargets="GenerateMsiVersionString"
             Condition="'$(OSGroup)' == 'Windows_NT' and '$(GenerateMSI)' == 'true'">
       
       <PropertyGroup>
@@ -60,15 +72,6 @@
       <RemoveDir Directories="$(WixObjRoot)" />
       <MakeDir Directories="$(WixObjRoot);@(WixOutputs);@(WixOutputs2)" />
 
-      <GenerateMsiVersion
-        Major="$(MajorVersion)"
-        Minor="$(MinorVersion)"
-        Patch="$(PatchVersion)"
-        BuildNumberMajor="$(BuildNumberMajor)"
-        BuildNumberMinor="$(BuildNumberMajor)">
-        <Output TaskParameter="MsiVersion" PropertyName="MsiVersionString" />
-      </GenerateMsiVersion>
-
       <GenerateGuidFromName Name="$(SharedFrameworkInstallerFile)">
         <Output TaskParameter="GeneratedGui" PropertyName="SharedFxUpgradeCode" />
       </GenerateGuidFromName>
@@ -85,7 +88,7 @@
   </Target>
 
   <Target Name="GenerateBundles"
-          DependsOnTargets="GetBundleDisplayVersion"
+          DependsOnTargets="GetBundleDisplayVersion;GenerateMsiVersionString"
           Condition="'$(OSGroup)' == 'Windows_NT' and '$(GenerateMSI)' == 'true'">
      <PropertyGroup>
         <SharedFxBundleScript>$(WindowsScriptRoot)sharedframework\generatebundle.ps1</SharedFxBundleScript>


### PR DESCRIPTION
I cherry-picked `a574014861010bf7dbedcd001599a809cb4f0a3a`, and it cleanly pulled in the changes which release/2.0.0 appears to be missing, so this gives me confidence that the original port was just a partial port and this should fix the build break we were seeing ...

```
core-setup\src\pkg\packaging\dir.proj (0, 0)
core-setup\src\pkg\packaging\dir.proj(0,0): Error MSB4057: The target "BuildInstallers" does not exist in the project.
```

/cc @gkhanna79 @wtgodbe 