### PR TITLE
Improve error message when assembly not found in runtime store

### DIFF
--- a/src/corehost/cli/deps_entry.h
+++ b/src/corehost/cli/deps_entry.h
@@ -21,6 +21,7 @@ struct deps_entry_t
 
     static const std::array<const pal::char_t*, deps_entry_t::asset_types::count> s_known_asset_types;
 
+    pal::string_t deps_file;
     pal::string_t library_type;
     pal::string_t library_name;
     pal::string_t library_version;

--- a/src/corehost/cli/deps_format.cpp
+++ b/src/corehost/cli/deps_format.cpp
@@ -47,10 +47,13 @@ pal::string_t deps_json_t::get_optional_path(
 }
 
 void deps_json_t::reconcile_libraries_with_targets(
+    const pal::string_t& deps_path,
     const json_value& json,
     const std::function<bool(const pal::string_t&)>& library_exists_fn,
     const std::function<const std::vector<pal::string_t>&(const pal::string_t&, int, bool*)>& get_rel_paths_by_asset_type_fn)
 {
+    pal::string_t deps_file = get_filename(deps_path);
+
     const auto& libraries = json.at(_X("libraries")).as_object();
     for (const auto& library : libraries)
     {
@@ -98,6 +101,7 @@ void deps_json_t::reconcile_libraries_with_targets(
                 entry.relative_path = rel_path;
                 entry.is_serviceable = serviceable;
                 entry.is_rid_specific = rid_specific;
+                entry.deps_file = deps_file;
 
                 // TODO: Deps file does not follow spec. It uses '\\', should use '/'
                 replace_char(&entry.relative_path, _X('\\'), _X('/'));
@@ -260,7 +264,7 @@ bool deps_json_t::process_targets(const json_value& json, const pal::string_t& t
     return true;
 }
 
-bool deps_json_t::load_portable(const json_value& json, const pal::string_t& target_name, const rid_fallback_graph_t& rid_fallback_graph)
+bool deps_json_t::load_portable(const pal::string_t& deps_path, const json_value& json, const pal::string_t& target_name, const rid_fallback_graph_t& rid_fallback_graph)
 {
     if (!process_runtime_targets(json, target_name, rid_fallback_graph, &m_rid_assets))
     {
@@ -302,12 +306,12 @@ bool deps_json_t::load_portable(const json_value& json, const pal::string_t& tar
         return empty;
     };
 
-    reconcile_libraries_with_targets(json, package_exists, get_relpaths);
+    reconcile_libraries_with_targets(deps_path, json, package_exists, get_relpaths);
 
     return true;
 }
 
-bool deps_json_t::load_standalone(const json_value& json, const pal::string_t& target_name)
+bool deps_json_t::load_standalone(const pal::string_t& deps_path, const json_value& json, const pal::string_t& target_name)
 {
     if (!process_targets(json, target_name, &m_assets))
     {
@@ -323,7 +327,7 @@ bool deps_json_t::load_standalone(const json_value& json, const pal::string_t& t
         return m_assets.libs[package].by_type[type_index].vec;
     };
 
-    reconcile_libraries_with_targets(json, package_exists, get_relpaths);
+    reconcile_libraries_with_targets(deps_path, json, package_exists, get_relpaths);
 
     const auto& json_object = json.as_object();
     const auto iter = json_object.find(_X("runtimes"));
@@ -414,7 +418,7 @@ bool deps_json_t::load(bool portable, const pal::string_t& deps_path, const rid_
 
         trace::verbose(_X("Loading deps file... %s as portable=[%d]"), deps_path.c_str(), portable);
 
-        return (portable) ? load_portable(json, name, rid_fallback_graph) : load_standalone(json, name);
+        return (portable) ? load_portable(deps_path, json, name, rid_fallback_graph) : load_standalone(deps_path, json, name);
     }
     catch (const std::exception& je)
     {

--- a/src/corehost/cli/deps_format.h
+++ b/src/corehost/cli/deps_format.h
@@ -70,13 +70,14 @@ public:
 	const deps_entry_t& try_ni(const deps_entry_t& entry) const;
 
 private:
-    bool load_standalone(const json_value& json, const pal::string_t& target_name);
-    bool load_portable(const json_value& json, const pal::string_t& target_name, const rid_fallback_graph_t& rid_fallback_graph);
+    bool load_standalone(const pal::string_t& deps_path, const json_value& json, const pal::string_t& target_name);
+    bool load_portable(const pal::string_t& deps_path, const json_value& json, const pal::string_t& target_name, const rid_fallback_graph_t& rid_fallback_graph);
     bool load(bool portable, const pal::string_t& deps_path, const rid_fallback_graph_t& rid_fallback_graph);
     bool process_runtime_targets(const json_value& json, const pal::string_t& target_name, const rid_fallback_graph_t& rid_fallback_graph, rid_specific_assets_t* p_assets);
     bool process_targets(const json_value& json, const pal::string_t& target_name, deps_assets_t* p_assets);
 
     void reconcile_libraries_with_targets(
+        const pal::string_t& deps_path,
         const json_value& json,
         const std::function<bool(const pal::string_t&)>& library_exists_fn,
         const std::function<const std::vector<pal::string_t>&(const pal::string_t&, int, bool*)>& get_rel_paths_by_asset_type_fn);

--- a/src/corehost/cli/deps_resolver.cpp
+++ b/src/corehost/cli/deps_resolver.cpp
@@ -262,8 +262,8 @@ bool deps_resolver_t::probe_deps_entry(const deps_entry_t& entry, const pal::str
             continue;
         }
         pal::string_t probe_dir = config.probe_dir;
-       
-		if (config.probe_deps_json)
+
+        if (config.probe_deps_json)
         {
             // If the deps json has the package name and version, then someone has already done rid selection and
             // put the right asset in the dir. So checking just package name and version would suffice.
@@ -305,15 +305,19 @@ bool deps_resolver_t::probe_deps_entry(const deps_entry_t& entry, const pal::str
 
 bool report_missing_assembly_in_manifest(const deps_entry_t& entry)
 {
+    trace::error(_X(
+        "Error:\n"
+        "  An assembly specified in the application dependencies manifest (%s) was not found:\n"
+        "    package: '%s', version: '%s'\n"
+        "    path: '%s'"),
+        entry.deps_file.c_str(), entry.library_name.c_str(), entry.library_version.c_str(), entry.relative_path.c_str());
+
     if (!entry.runtime_store_manifest_list.empty())
     {
-        trace::error(_X("Error: assembly specified in the dependencies manifest was not found probably due to missing runtime store associated with %s -- package: '%s', version: '%s', path: '%s'"), 
-                entry.runtime_store_manifest_list.c_str(), entry.library_name.c_str(), entry.library_version.c_str(), entry.relative_path.c_str());
-    }
-    else
-    {
-        trace::error(_X("Error: assembly specified in the dependencies manifest was not found -- package: '%s', version: '%s', path: '%s'"), 
-                entry.library_name.c_str(), entry.library_version.c_str(), entry.relative_path.c_str());
+        trace::error(_X(
+            "  This assembly was expected to be in the local runtime store as the application was published using the following target manifest files:\n"
+            "    %s"),
+            entry.runtime_store_manifest_list.c_str());
     }
 
     return false;

--- a/src/test/HostActivationTests/GivenThatICareAboutLightupAppActivation.cs
+++ b/src/test/HostActivationTests/GivenThatICareAboutLightupAppActivation.cs
@@ -63,11 +63,15 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.LightupApp
             dotnet.Exec("exec", "--additional-deps", libDepsJson, appDll)
                 .CaptureStdErr()
                 .CaptureStdOut()
-                .Execute(fExpectedToFail:true)
+                .Execute(fExpectedToFail: true)
                 .Should()
                 .Fail()
                 .And
-                .HaveStdErrContaining("Error: assembly specified in the dependencies manifest was not found -- package: \'LightupLib\', version: \'1.0.0\', path: \'LightupLib.dll\'");
+                .HaveStdErrContaining(
+                    "Error:" + Environment.NewLine +
+                    "  An assembly specified in the application dependencies manifest (LightupLib.deps.json) was not found:" + Environment.NewLine +
+                    "    package: \'LightupLib\', version: \'1.0.0\'" + Environment.NewLine +
+                    "    path: \'LightupLib.dll\'");
         }
 
         // Attempt to run the app with lightup deps.json specified and lightup library present in the expected 


### PR DESCRIPTION
Direct port of PR https://github.com/dotnet/core-setup/pull/2571

Improve the error message when an assembly is missing from runtime store by adding the deps file name and improved formatting.

fixes #2523