### PR TITLE
Removing CoreCLR from uap10.1 package for both aot and non-aot runtimes

### DIFF
--- a/src/pkg/projects/Microsoft.NETCore.UniversalWindowsPlatform/src/Microsoft.NETCore.UniversalWindowsPlatform.depproj
+++ b/src/pkg/projects/Microsoft.NETCore.UniversalWindowsPlatform/src/Microsoft.NETCore.UniversalWindowsPlatform.depproj
@@ -26,9 +26,6 @@
     <PackageReference Include="Microsoft.Private.CoreFx.UAP">
       <Version>$(CoreFxVersion)</Version>
     </PackageReference>
-    <PackageReference Include="transport.Microsoft.NETCore.Runtime.CoreCLR">
-      <Version>$(MicrosoftNETCoreRuntimeCoreCLRPackageVersion)</Version>
-    </PackageReference>
     <PackageReference Include="Microsoft.NETCore.Platforms">
       <Version>$(PlatformPackageVersion)</Version>
     </PackageReference>
@@ -65,9 +62,6 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 
   <Target Name="GetFilesToPackage" DependsOnTargets="ResolveNuGetPackages" Returns="@(FilesToPackage)">
-    <ItemGroup  Condition="'$(NuGetRuntimeIdentifier)' != ''">
-      <_runtimeCLR Include="@(ReferenceCopyLocalPaths)" Condition="'%(ReferenceCopyLocalPaths.FileName)' == 'coreclr' OR '%(ReferenceCopyLocalPaths.FileName)' == 'libcoreclr'" />
-    </ItemGroup>
     <ItemGroup Condition="'$(NuGetRuntimeIdentifier)' != ''">
       <!-- RID-specific: include all runtime files -->
       <_FilesToPackage Include="@(ReferenceCopyLocalPaths)">


### PR DESCRIPTION
These changes are basically handling two different things:
 - Fixing a recent regression that caused that CoreCLR transport package contents were being includded on the aot runtime packages which is simply wrong.
 - Removing those contents from the non-aot runtime packages as well, since they won't be used in the end. We includded them here because that's the way we had it for uap10.0 on the packages that we shipped, and then we were specifically removing these references and using the CoreCLR that came from the Appx package instead. With these changes, that extra removal won't be required, as it won't be part of the package.

PTAL: @weshaggard @gkhanna79 @ericstj 
FYI: @tijoytom 

Contents that are being removed from both aot and non aot runtime packages are:
```
runtimes\[BuildRID]\lib\netstandard1.0\SOS.NETCore.dll
runtimes\[BuildRID]\native\api-ms-win-core-console-l1-1-0.dll
runtimes\[BuildRID]\native\api-ms-win-core-datetime-l1-1-0.dll
runtimes\[BuildRID]\native\api-ms-win-core-debug-l1-1-0.dll
runtimes\[BuildRID]\native\api-ms-win-core-errorhandling-l1-1-0.dll
runtimes\[BuildRID]\native\api-ms-win-core-file-l1-1-0.dll
runtimes\[BuildRID]\native\api-ms-win-core-file-l1-2-0.dll
runtimes\[BuildRID]\native\api-ms-win-core-file-l2-1-0.dll
runtimes\[BuildRID]\native\api-ms-win-core-handle-l1-1-0.dll
runtimes\[BuildRID]\native\api-ms-win-core-heap-l1-1-0.dll
runtimes\[BuildRID]\native\api-ms-win-core-interlocked-l1-1-0.dll
runtimes\[BuildRID]\native\api-ms-win-core-libraryloader-l1-1-0.dll
runtimes\[BuildRID]\native\api-ms-win-core-localization-l1-2-0.dll
runtimes\[BuildRID]\native\api-ms-win-core-memory-l1-1-0.dll
runtimes\[BuildRID]\native\api-ms-win-core-namedpipe-l1-1-0.dll
runtimes\[BuildRID]\native\api-ms-win-core-processenvironment-l1-1-0.dll
runtimes\[BuildRID]\native\api-ms-win-core-processthreads-l1-1-0.dll
runtimes\[BuildRID]\native\api-ms-win-core-processthreads-l1-1-1.dll
runtimes\[BuildRID]\native\api-ms-win-core-profile-l1-1-0.dll
runtimes\[BuildRID]\native\api-ms-win-core-rtlsupport-l1-1-0.dll
runtimes\[BuildRID]\native\api-ms-win-core-string-l1-1-0.dll
runtimes\[BuildRID]\native\api-ms-win-core-synch-l1-1-0.dll
runtimes\[BuildRID]\native\api-ms-win-core-synch-l1-2-0.dll
runtimes\[BuildRID]\native\api-ms-win-core-sysinfo-l1-1-0.dll
runtimes\[BuildRID]\native\api-ms-win-core-timezone-l1-1-0.dll
runtimes\[BuildRID]\native\api-ms-win-core-util-l1-1-0.dll
runtimes\[BuildRID]\native\api-ms-win-crt-conio-l1-1-0.dll
runtimes\[BuildRID]\native\api-ms-win-crt-convert-l1-1-0.dll
runtimes\[BuildRID]\native\api-ms-win-crt-environment-l1-1-0.dll
runtimes\[BuildRID]\native\api-ms-win-crt-filesystem-l1-1-0.dll
runtimes\[BuildRID]\native\api-ms-win-crt-heap-l1-1-0.dll
runtimes\[BuildRID]\native\api-ms-win-crt-locale-l1-1-0.dll
runtimes\[BuildRID]\native\api-ms-win-crt-math-l1-1-0.dll
runtimes\[BuildRID]\native\api-ms-win-crt-multibyte-l1-1-0.dll
runtimes\[BuildRID]\native\api-ms-win-crt-private-l1-1-0.dll
runtimes\[BuildRID]\native\api-ms-win-crt-process-l1-1-0.dll
runtimes\[BuildRID]\native\api-ms-win-crt-runtime-l1-1-0.dll
runtimes\[BuildRID]\native\api-ms-win-crt-stdio-l1-1-0.dll
runtimes\[BuildRID]\native\api-ms-win-crt-string-l1-1-0.dll
runtimes\[BuildRID]\native\api-ms-win-crt-time-l1-1-0.dll
runtimes\[BuildRID]\native\api-ms-win-crt-utility-l1-1-0.dll
runtimes\[BuildRID]\native\clretwrc.dll
runtimes\[BuildRID]\native\clrjit.dll
runtimes\[BuildRID]\native\coreclr.dll
runtimes\[BuildRID]\native\dbgshim.dll
runtimes\[BuildRID]\native\mscordaccore.dll
runtimes\[BuildRID]\native\mscordaccore_x86_x86_4.6.25402.003.dll
runtimes\[BuildRID]\native\mscordbi.dll
runtimes\[BuildRID]\native\mscorrc.debug.dll
runtimes\[BuildRID]\native\mscorrc.dll
runtimes\[BuildRID]\native\sos.dll
runtimes\[BuildRID]\native\sos_x86_x86_4.6.25402.003.dll
runtimes\[BuildRID]\native\System.Private.CoreLib.dll
runtimes\[BuildRID]\native\ucrtbase.dll
```