### PR TITLE
Fix VersionSuffix for the managed projects [release/2.0.0]

### DIFF
--- a/BranchInfo.props
+++ b/BranchInfo.props
@@ -1,0 +1,13 @@
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <MajorVersion>2</MajorVersion>
+    <MinorVersion>0</MinorVersion>
+    <PatchVersion>0</PatchVersion>
+    <StabilizePackageVersion Condition="'$(StabilizePackageVersion)' == ''">false</StabilizePackageVersion>
+    <PreReleaseLabel>preview2</PreReleaseLabel>
+    <ReleaseSuffix>$(PreReleaseLabel)</ReleaseSuffix>
+    <ReleaseBrandSuffix>Preview 2</ReleaseBrandSuffix>
+    <Channel>release/2.0.0</Channel>
+    <BranchName>release/2.0.0</BranchName>
+  </PropertyGroup>
+</Project>

--- a/build.proj
+++ b/build.proj
@@ -14,10 +14,9 @@
 
   <PropertyGroup>
     <TraversalBuildDependencies>
-      BatchRestorePackages;
-      ValidateExactRestore;
       CreateOrUpdateCurrentVersionFile;
       CreateVersionInfoFile;
+      BatchRestorePackages;
       BuildCustomTasks;
     </TraversalBuildDependencies>
     <TraversalBuildDependsOn>
@@ -57,19 +56,7 @@
 
   <Target Name="BatchRestorePackages" Condition="'$(RestoreDuringBuild)'=='true'">
     <Message Importance="High" Text="Restoring all packages..." />
-    <Exec Condition="'@(SdkRestoreProjects)' != ''" Command="$(DotnetRestoreCommand) &quot;%(SdkRestoreProjects.FullPath)&quot; %(SdkRestoreProjects.ExtraRestoreArgs)" StandardOutputImportance="Low" />
-  </Target>
-
-  <!-- Task from buildtools that uses lockfiles to validate that packages restored are exactly what were specified. -->
-  <UsingTask TaskName="ValidateExactRestore" AssemblyFile="$(BuildToolsTaskDir)Microsoft.DotNet.Build.Tasks.dll" />
-
-  <Target Name="ValidateExactRestore"
-          Condition="'$(AllowInexactRestore)'!='true'">
-    <ItemGroup>
-      <ProjectJsonTemplateFiles Include="$(MSBuildThisFileDirectory)**\project.json.template" />
-      <ProjectJsonsExcludingTemplateFiles Include="@(ProjectJsonFiles)" Exclude="@(ProjectJsonTemplateFiles)" />
-    </ItemGroup>
-    <ValidateExactRestore ProjectLockJsons="@(ProjectJsonsExcludingTemplateFiles->'%(RootDir)%(Directory)%(Filename).lock.json')" />
+    <Exec Condition="'@(SdkRestoreProjects)' != ''" Command="$(DotnetRestoreCommand) &quot;%(SdkRestoreProjects.FullPath)&quot;" StandardOutputImportance="Low" />
   </Target>
 
   <Import Project="dir.targets" />

--- a/dir.props
+++ b/dir.props
@@ -9,18 +9,7 @@
     <PortableBuild Condition="'$(PortableBuild)' == ''">true</PortableBuild>
   </PropertyGroup>
 
-  <!-- Branch Info -->
-  <PropertyGroup>
-    <MajorVersion>2</MajorVersion>
-    <MinorVersion>0</MinorVersion>
-    <PatchVersion>0</PatchVersion>
-    <StabilizePackageVersion Condition="'$(StabilizePackageVersion)' == ''">false</StabilizePackageVersion>
-    <PreReleaseLabel>preview2</PreReleaseLabel>
-    <ReleaseSuffix>$(PreReleaseLabel)</ReleaseSuffix>
-    <ReleaseBrandSuffix>Preview 2</ReleaseBrandSuffix>
-    <Channel>release/2.0.0</Channel>
-    <BranchName>release/2.0.0</BranchName>
-  </PropertyGroup>
+  <Import Project="$(MSBuildThisFileDirectory)BranchInfo.props" />
   
   <PropertyGroup>
     <SharedFrameworkName>Microsoft.NETCore.App</SharedFrameworkName>
@@ -138,10 +127,7 @@
   <ItemGroup>
     <SdkRestoreProjects Include="$(MSBuildThisFileDirectory)src\pkg\deps\deps.csproj" />
     <SdkRestoreProjects Include="$(MSBuildThisFileDirectory)src\managed\Microsoft.DotNet.PlatformAbstractions\Microsoft.DotNet.PlatformAbstractions.csproj" />
-    <SdkRestoreProjects Include="$(MSBuildThisFileDirectory)src\managed\Microsoft.Extensions.DependencyModel\Microsoft.Extensions.DependencyModel.csproj">
-      <!-- Workaround https://github.com/NuGet/Home/issues/4337 -->
-      <ExtraRestoreArgs>/p:VersionSuffix=$(VersionSuffix)</ExtraRestoreArgs>
-    </SdkRestoreProjects>
+    <SdkRestoreProjects Include="$(MSBuildThisFileDirectory)src\managed\Microsoft.Extensions.DependencyModel\Microsoft.Extensions.DependencyModel.csproj" />
   </ItemGroup>
   <PropertyGroup>
     <DotnetRestorePrefix Condition="'$(RunningOnUnix)' == 'true'">DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1 </DotnetRestorePrefix>

--- a/src/managed/CommonManaged.props
+++ b/src/managed/CommonManaged.props
@@ -5,7 +5,24 @@
 
   <PropertyGroup>
     <RepoRoot>$([System.IO.Path]::GetFullPath('$(MSBuildThisFileDirectory)../..'))/</RepoRoot>
-    <VersionPrefix>2.0.0</VersionPrefix>
+  </PropertyGroup>
+
+  <Import Project="$(RepoRoot)BranchInfo.props" />
+
+  <PropertyGroup>
+    <!-- Output directories -->
+    <BinDir Condition="'$(BinDir)'==''">$(RepoRoot)Bin/</BinDir>
+    <ObjDir Condition="'$(ObjDir)'==''">$(BinDir)obj/</ObjDir>
+
+    <!-- BuildVersion Properties -->
+    <TodayTimeStamp>$([System.DateTime]::Now.ToString(yyyyMMdd))</TodayTimeStamp>
+    <BuildVersionFile Condition="'$(BuildVersionFile)'==''">$(ObjDir)BuildVersion-$(TodayTimeStamp).props</BuildVersionFile>
+  </PropertyGroup>
+
+  <Import Project="$(BuildVersionFile)" />
+
+  <PropertyGroup>
+    <VersionPrefix>$(MajorVersion).$(MinorVersion).$(PatchVersion)</VersionPrefix>
     <AssemblyFileVersion>$(VersionPrefix)</AssemblyFileVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences>
@@ -15,6 +32,21 @@
     <PackageProjectUrl>https://dot.net</PackageProjectUrl>
     <PackageLicenseFile>$(RepoRoot)LICENSE.TXT</PackageLicenseFile>
     <PackageThirdPartyNoticesFile>$(RepoRoot)THIRD-PARTY-NOTICES.TXT</PackageThirdPartyNoticesFile>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(StabilizePackageVersion)' != 'true'">
+    <!-- Dev builds get a minor version, by default, of '0'.  Our tests restore packages with
+         a -* version, and include myget sources, so any package published the same day to myget
+         will conflict with the local build and override the local built package.  Prevent this
+         by setting the non-official build minor version to 9 -->
+    <BuildNumberMinor Condition="'$(BuildNumberMinor)' == '0'">9</BuildNumberMinor>
+    
+    <!-- 
+    Ensure VersionSuffix is always set (especially during 'dotnet restore')
+    to work around https://github.com/NuGet/Home/issues/4337
+     -->
+    <VersionSuffix Condition="'$(PreReleaseLabel)' != ''">$(PreReleaseLabel)-</VersionSuffix>
+    <VersionSuffix>$(VersionSuffix)$(BuildNumberMajor)-$(BuildNumberMinor)</VersionSuffix>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -45,5 +77,5 @@
     </Content>
   </ItemGroup>
 
-  <Import Condition="Exists('$(RepoRoot)Tools/versioning.props')" Project="$(RepoRoot)Tools/versioning.props" /> 
+  <Import Condition="Exists('$(RepoRoot)Tools/versioning.props')" Project="$(RepoRoot)Tools/versioning.props" />
 </Project>

--- a/src/pkg/packaging/dir.proj
+++ b/src/pkg/packaging/dir.proj
@@ -168,10 +168,9 @@
     <PropertyGroup>
       <OutputArg>--output $(PackagesOutDir)</OutputArg>
       <ConfigArg>--configuration $(ConfigurationGroup)</ConfigArg>
-      <VersionSuffixArg>--version-suffix $(VersionSuffix)</VersionSuffixArg>
     </PropertyGroup>
 
-    <Exec Command="$(DotnetToolCommand) pack %(PackageProjects.Identity) --no-build $(OutputArg) $(ConfigArg) $(VersionSuffixArg)"
+    <Exec Command="$(DotnetToolCommand) pack %(PackageProjects.Identity) --no-build $(OutputArg) $(ConfigArg)"
           Condition="'@(PackageProjects)' != ''" />
   </Target>
   


### PR DESCRIPTION
VersionSuffix is getting set before $(BuildNumberMajor) and $(BuildNumberMinor) are being set.  When creating the DependencyModel nupkg, it is getting a bad version on its p2p reference to PlatformAbstractions.

The fix is to ensure VersionSuffix is defined correctly in the projects themselves - after the obj\BuildVersion.props file is created.

Workaround https://github.com/NuGet/Home/issues/4337

/cc @Petermarcu @mikeharder 