### PR TITLE
Remove global location lookup support using PATH in non Windows

### DIFF
--- a/src/corehost/common/pal.unix.cpp
+++ b/src/corehost/common/pal.unix.cpp
@@ -182,57 +182,10 @@ bool is_executable(const pal::string_t& file_path)
     return ((st.st_mode & S_IEXEC) != 0);
 }
 
-static
-bool locate_dotnet_on_path(std::vector<pal::string_t>* dotnet_exes)
-{
-    pal::string_t path;
-    if (!pal::getenv(_X("PATH"), &path))
-    {
-        return false;
-    }
-    
-    pal::string_t tok;
-    pal::stringstream_t ss(path);
-    while (std::getline(ss, tok, PATH_SEPARATOR))
-    {
-        size_t start_pos = tok.find_first_not_of(_X(" \t"));
-        if (start_pos == pal::string_t::npos)
-        {
-            continue;
-        }
-
-        append_path(&tok, _X("dotnet"));
-        if (pal::realpath(&tok) && is_executable(tok))
-        {
-            dotnet_exes->push_back(tok);
-        }
-        tok.clear();
-    }
-
-    if (dotnet_exes->empty())
-    {
-        return false;
-    }
-
-    return true;
-}
-
  bool pal::get_global_dotnet_dirs(std::vector<pal::string_t>* recv)
 {
-    
-     std::vector<pal::string_t> dotnet_exes;
-    if (!locate_dotnet_on_path(&dotnet_exes))
-    {
-        return false;
-    }
-
-    for (pal::string_t path : dotnet_exes)
-    {
-        pal::string_t dir = get_directory(path);
-        recv->push_back(dir);
-    }
-
-    return true;
+    // No support for global directories in Unix.
+    return false;
 }
 
 pal::string_t trim_quotes(pal::string_t stringToCleanup)

--- a/src/test/HostActivationTests/GivenThatICareAboutMultilevelSharedFxLookup.cs
+++ b/src/test/HostActivationTests/GivenThatICareAboutMultilevelSharedFxLookup.cs
@@ -169,6 +169,11 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.MultilevelSharedFxLooku
             {
                 return;
             }
+            else
+            {
+                // Currently no support for global locations on Linux; remaining test code below is preserved for now.
+                return;
+            }
 
             var fixture = PreviouslyBuiltAndRestoredPortableTestProjectFixture
                 .Copy();
@@ -415,6 +420,11 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.MultilevelSharedFxLooku
             {
                 return;
             }
+            else
+            {
+                // Currently no support for global locations on Linux; remaining test code below is preserved for now.
+                return;
+            }
 
             var fixture = PreviouslyBuiltAndRestoredPortableTestProjectFixture
                 .Copy();
@@ -481,6 +491,11 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.MultilevelSharedFxLooku
             {
                 return;
             }
+            else
+            {
+                // Currently no support for global locations on Linux; remaining test code below is preserved for now.
+                return;
+            }
 
             var fixture = PreviouslyBuiltAndRestoredPortableTestProjectFixture
                 .Copy();
@@ -529,7 +544,12 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.MultilevelSharedFxLooku
             {
                 return;
             }
-            
+            else
+            {
+                // Currently no support for global locations on Linux; remaining test code below is preserved for now.
+                return;
+            }
+
             var fixture = PreviouslyBuiltAndRestoredPortableTestProjectFixture
                 .Copy();
 
@@ -595,7 +615,12 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.MultilevelSharedFxLooku
             {
                 return;
             }
-            
+            else
+            {
+                // Currently no support for global locations on Linux; remaining test code below is preserved for now.
+                return;
+            }
+
             var fixture = PreviouslyBuiltAndRestoredPortableTestProjectFixture
                 .Copy();
 

--- a/src/test/TestUtils/Command.cs
+++ b/src/test/TestUtils/Command.cs
@@ -238,41 +238,17 @@ namespace Microsoft.DotNet.Cli.Build.Framework
             _process.StartInfo.Environment[userDir] = userprofile;
             return this;
         }
-        public Command SanitizeGlobalLocation()
-        {
-            if (RuntimeEnvironment.OperatingSystemPlatform != Platform.Windows)
-            {
-                var current_path = _process.StartInfo.Environment["PATH"];
-                var new_path = new System.Text.StringBuilder();
-                //Remove any global dotnet that has been set
-                foreach (var sub_path in current_path.Split(Path.PathSeparator))
-                {
-                    var candidate = Path.Combine(sub_path, "dotnet");
-                    if (!File.Exists(candidate))
-                    {
-                        new_path.Append(sub_path);
-                        new_path.Append(Path.PathSeparator);
-                    }
-                }
-                _process.StartInfo.Environment["PATH"] = new_path.ToString();
-            }
-            return this;
-        }
+
         public Command WithGlobalLocation(string global)
         {
-
             if (RuntimeEnvironment.OperatingSystemPlatform == Platform.Windows)
             {
-               throw new NotImplementedException("Global location override needs work ");
+                throw new NotImplementedException("Global location override needs test improvements for Windows");
             }
             else
             {
-                var current_path = _process.StartInfo.Environment["PATH"];
-                _process.StartInfo.Environment["PATH"] = current_path + Path.PathSeparator + global;
+                throw new NotSupportedException("Global location override not supported for Linux");
             }
-
-           
-            return this;
         }
 
         public Command EnvironmentVariable(string name, string value)

--- a/src/test/TestUtils/DotNetCli.cs
+++ b/src/test/TestUtils/DotNetCli.cs
@@ -31,8 +31,7 @@ namespace Microsoft.DotNet.Cli.Build
             }
 
             return Command.Create(Path.Combine(BinPath, $"dotnet{Constants.ExeSuffix}"), newArgs)
-                .EnvironmentVariable("DOTNET_SKIP_FIRST_TIME_EXPERIENCE", "1")
-                .SanitizeGlobalLocation();
+                .EnvironmentVariable("DOTNET_SKIP_FIRST_TIME_EXPERIENCE", "1");
         }
 
         public Command Restore(params string[] args) => Exec("restore", args);


### PR DESCRIPTION
Remove support for global location lookup based on PATH for Linux\Mac

Direct port of PR https://github.com/dotnet/core-setup/pull/2633, commit https://github.com/dotnet/core-setup/commit/ad495acf4c74e4577c7de8158aa42d518bdc1c18

For issue #2611