### PR TITLE
Ensure buildversion.props is evaluated before dotnet restore

### DIFF
--- a/build.proj
+++ b/build.proj
@@ -14,10 +14,10 @@
 
   <PropertyGroup>
     <TraversalBuildDependencies>
-      BatchRestorePackages;
-      ValidateExactRestore;
       CreateOrUpdateCurrentVersionFile;
       CreateVersionInfoFile;
+      BatchRestorePackages;
+      ValidateExactRestore;
       BuildCustomTasks;
     </TraversalBuildDependencies>
     <TraversalBuildDependsOn>
@@ -56,8 +56,10 @@
   </Target>
 
   <Target Name="BatchRestorePackages" Condition="'$(RestoreDuringBuild)'=='true'">
-    <Message Importance="High" Text="Restoring all packages..." />
-    <Exec Condition="'@(SdkRestoreProjects)' != ''" Command="$(DotnetRestoreCommand) &quot;%(SdkRestoreProjects.FullPath)&quot; %(SdkRestoreProjects.ExtraRestoreArgs)" StandardOutputImportance="Low" />
+    <!-- Restore packages in a separate msbuild instance so that the buildversion props file generated in
+         CreateVersionInfoFile target gets evaluated, this ensures VersionSuffix is set (especially during 
+         'dotnet restore') to work around https://github.com/NuGet/Home/issues/4337 -->
+    <MSBuild Projects="$(MSBuildThisFileDirectory)restore.proj" />
   </Target>
 
   <!-- Task from buildtools that uses lockfiles to validate that packages restored are exactly what were specified. -->

--- a/restore.proj
+++ b/restore.proj
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="dir.props" />
+
+  <Target Name="Build">
+    <Message Importance="High" Text="Restoring all packages..." />
+    <Exec Condition="'@(SdkRestoreProjects)' != ''" Command="$(DotnetRestoreCommand) &quot;%(SdkRestoreProjects.FullPath)&quot; %(SdkRestoreProjects.ExtraRestoreArgs)" StandardOutputImportance="Low" />
+  </Target>
+
+</Project>


### PR DESCRIPTION
VersionSuffix is getting set before $(BuildNumberMajor) and $(BuildNumberMinor) are being set. When creating the DependencyModel nupkg, it is getting a bad version on its p2p reference to PlatformAbstractions.

Restore projects in a separate msbuild evaluation after the buildversion.props file has been generated so that VersionSuffix is properly defined.

Workaround NuGet/Home#4337

/cc @Petermarcu @mikeharder