### PR TITLE
GenerateChecksums moved into BuildTools

### DIFF
--- a/publish/dir.targets
+++ b/publish/dir.targets
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <UsingTask TaskName="GenerateDebRepoUploadJsonFile" AssemblyFile="$(LocalBuildToolsTaskDir)core-setup.tasks.dll" />
-  <UsingTask TaskName="GenerateChecksums" AssemblyFile="$(LocalBuildToolsTaskDir)Microsoft.DotNet.Build.Tasks.Local.dll" />
+  <UsingTask TaskName="GenerateChecksums" AssemblyFile="$(BuildToolsTaskDir)Microsoft.DotNet.Build.Tasks.dll" />
 
   <Target Name="GatherPublishToAzureBinaries">
     <ItemGroup>


### PR DESCRIPTION
Fix build break in Core-Setup master, GenerateChecksums moved into BuildTools with https://github.com/dotnet/buildtools/commit/864caca896bae248dc1b5414bb14632d95201f35, this instance of using the task was overlooked when updating core-setup to consume buildtools in https://github.com/dotnet/core-setup/commit/674c3e3f09284c32321bd9eabd60852e02c0aefb

FYI @gkhanna79 @eerhardt 
