### PR TITLE
Sign PlatformAbstractions and DependencyModel binaries

### DIFF
--- a/dir.props
+++ b/dir.props
@@ -267,6 +267,7 @@
     <IntermediateOutputRootPath Condition="'$(IntermediateOutputRootPath)' == ''">$(BaseIntermediateOutputPath)$(OSPlatformConfig)\</IntermediateOutputRootPath>
     <IntermediateOutputPath Condition="'$(IntermediateOutputPath)' == ''">$(IntermediateOutputRootPath)$(MSBuildProjectName)\</IntermediateOutputPath>
 
+    <ForPackagingDir>$(IntermediateOutputRootPath)sign/forPackaging/</ForPackagingDir>
     <CoreHostOutputDir>$(BaseOutputRootPath)corehost\</CoreHostOutputDir>
 
     <PackagesBasePath Condition="'$(PackagesBasePath)'==''">$(BinDir)$(OSPlatformConfig)/</PackagesBasePath>

--- a/dir.props
+++ b/dir.props
@@ -267,7 +267,6 @@
     <IntermediateOutputRootPath Condition="'$(IntermediateOutputRootPath)' == ''">$(BaseIntermediateOutputPath)$(OSPlatformConfig)\</IntermediateOutputRootPath>
     <IntermediateOutputPath Condition="'$(IntermediateOutputPath)' == ''">$(IntermediateOutputRootPath)$(MSBuildProjectName)\</IntermediateOutputPath>
 
-    <ForPackagingDir>$(IntermediateOutputRootPath)sign/forPackaging/</ForPackagingDir>
     <CoreHostOutputDir>$(BaseOutputRootPath)corehost\</CoreHostOutputDir>
 
     <PackagesBasePath Condition="'$(PackagesBasePath)'==''">$(BinDir)$(OSPlatformConfig)/</PackagesBasePath>

--- a/src/dir.props
+++ b/src/dir.props
@@ -4,7 +4,7 @@
 
   <PropertyGroup>
     <CoreHostLockedDir>$(CoreHostOutputDir)locked\</CoreHostLockedDir>
-    <IntermediateOutputForPackaging>$(IntermediateOutputRootPath)sign/forPackaging</IntermediateOutputForPackaging>
+    <IntermediateOutputForPackaging>$(IntermediateOutputRootPath)sign/forPackaging/</IntermediateOutputForPackaging>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/dir.props
+++ b/src/dir.props
@@ -4,7 +4,7 @@
 
   <PropertyGroup>
     <CoreHostLockedDir>$(CoreHostOutputDir)locked\</CoreHostLockedDir>
-    <IntermediateOutputForPackaging>$(IntermediateOutputRootPath)forPackaging</IntermediateOutputForPackaging>
+    <IntermediateOutputForPackaging>$(IntermediateOutputRootPath)sign/forPackaging</IntermediateOutputForPackaging>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/managed/dir.proj
+++ b/src/managed/dir.proj
@@ -16,7 +16,7 @@
       <BuildArgs>/p:Configuration=$(ConfigurationGroup)</BuildArgs>
       <BuildArgs Condition="'$(LatestCommit)' != ''">$(BuildArgs) /p:LatestCommit=$(LatestCommit)</BuildArgs>
       <BuildArgs Condition="'$(BuiltByString)' != ''">$(BuildArgs) /p:BuiltByString="$(BuiltByString)"</BuildArgs>
-      <BuildArgs>$(BuildArgs) /p:BaseOutputPath=$(ForPackagingDir)</BuildArgs>
+      <BuildArgs>$(BuildArgs) /p:BaseOutputPath=$(IntermediateOutputForPackaging)</BuildArgs>
     </PropertyGroup>
 
     <Exec Command="$(DotnetToolCommand) build $(BuildArgs) %(PackageProjects.Identity)" />

--- a/src/managed/dir.proj
+++ b/src/managed/dir.proj
@@ -16,6 +16,7 @@
       <BuildArgs>/p:Configuration=$(ConfigurationGroup)</BuildArgs>
       <BuildArgs Condition="'$(LatestCommit)' != ''">$(BuildArgs) /p:LatestCommit=$(LatestCommit)</BuildArgs>
       <BuildArgs Condition="'$(BuiltByString)' != ''">$(BuildArgs) /p:BuiltByString="$(BuiltByString)"</BuildArgs>
+      <BuildArgs>$(BuildArgs) /p:BaseOutputPath=$(ForPackagingDir)</BuildArgs>
     </PropertyGroup>
 
     <Exec Command="$(DotnetToolCommand) build $(BuildArgs) %(PackageProjects.Identity)" />

--- a/src/pkg/packaging/dir.proj
+++ b/src/pkg/packaging/dir.proj
@@ -171,7 +171,7 @@
       <VersionSuffixArg>--version-suffix $(VersionSuffix)</VersionSuffixArg>
     </PropertyGroup>
 
-    <Exec Command="$(DotnetToolCommand) pack %(PackageProjects.Identity) --no-build $(OutputArg) $(ConfigArg) $(VersionSuffixArg)"
+    <Exec Command="$(DotnetToolCommand) pack %(PackageProjects.Identity) --no-build $(OutputArg) $(ConfigArg) $(VersionSuffixArg) /p:BaseOutputPath=$(ForPackagingDir)"
           Condition="'@(PackageProjects)' != ''" />
   </Target>
   

--- a/src/pkg/packaging/dir.proj
+++ b/src/pkg/packaging/dir.proj
@@ -171,7 +171,7 @@
       <VersionSuffixArg>--version-suffix $(VersionSuffix)</VersionSuffixArg>
     </PropertyGroup>
 
-    <Exec Command="$(DotnetToolCommand) pack %(PackageProjects.Identity) --no-build $(OutputArg) $(ConfigArg) $(VersionSuffixArg) /p:BaseOutputPath=$(ForPackagingDir)"
+    <Exec Command="$(DotnetToolCommand) pack %(PackageProjects.Identity) --no-build $(OutputArg) $(ConfigArg) $(VersionSuffixArg) /p:BaseOutputPath=$(IntermediateOutputForPackaging)"
           Condition="'@(PackageProjects)' != ''" />
   </Target>
   


### PR DESCRIPTION
Microsoft.DotNet.PlatformAbstractions and Microsoft.Extensions.DependencyModel dll's were not getting signed because they were not output to a "signable" output folder, and they were not part of the "FilesToSign".

I'm not a huge fan of having to explicitly pass the `BaseOutputPath`  property to both the `dotnet build` and `dotnet pack` commands separately; but, I think this is the most targeted fix we can make for release/2.0.0.  In master, once `dir.props` is broken apart into smaller consumable chunks, we can just import the relevant chunk in `src\managed\CommonManaged.props`.

/cc @eerhardt @gkhanna79 @Petermarcu 