### PR TITLE
Sign PlatformAbstractions and DependencyModel binaries

### DIFF
--- a/src/dir.props
+++ b/src/dir.props
@@ -4,7 +4,7 @@
 
   <PropertyGroup>
     <CoreHostLockedDir>$(CoreHostOutputDir)locked\</CoreHostLockedDir>
-    <IntermediateOutputForPackaging>$(IntermediateOutputRootPath)forPackaging</IntermediateOutputForPackaging>
+    <IntermediateOutputForPackaging>$(IntermediateOutputRootPath)sign/forPackaging/</IntermediateOutputForPackaging>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/managed/dir.proj
+++ b/src/managed/dir.proj
@@ -16,6 +16,7 @@
       <BuildArgs>/p:Configuration=$(ConfigurationGroup)</BuildArgs>
       <BuildArgs Condition="'$(LatestCommit)' != ''">$(BuildArgs) /p:LatestCommit=$(LatestCommit)</BuildArgs>
       <BuildArgs Condition="'$(BuiltByString)' != ''">$(BuildArgs) /p:BuiltByString="$(BuiltByString)"</BuildArgs>
+      <BuildArgs>$(BuildArgs) /p:BaseOutputPath=$(IntermediateOutputForPackaging)</BuildArgs>
     </PropertyGroup>
 
     <Exec Command="$(DotnetToolCommand) build $(BuildArgs) %(PackageProjects.Identity)" />

--- a/src/pkg/packaging/dir.proj
+++ b/src/pkg/packaging/dir.proj
@@ -171,7 +171,7 @@
       <VersionSuffixArg>--version-suffix $(VersionSuffix)</VersionSuffixArg>
     </PropertyGroup>
 
-    <Exec Command="$(DotnetToolCommand) pack %(PackageProjects.Identity) --no-build $(OutputArg) $(ConfigArg) $(VersionSuffixArg)"
+    <Exec Command="$(DotnetToolCommand) pack %(PackageProjects.Identity) --no-build $(OutputArg) $(ConfigArg) $(VersionSuffixArg) /p:BaseOutputPath=$(IntermediateOutputForPackaging)"
           Condition="'@(PackageProjects)' != ''" />
   </Target>
   


### PR DESCRIPTION
Back porting change from release/2.0.0

https://github.com/dotnet/core-setup/pull/2652#pullrequestreview-42997946

/cc @gkhanna79 @eerhardt 