### PR TITLE
Fix Issue 2682 - Homepage referenced in deb metadata is incorrect (master)

### DIFF
--- a/src/pkg/packaging/deb/dotnet-hostfxr-debian_config.json
+++ b/src/pkg/packaging/deb/dotnet-hostfxr-debian_config.json
@@ -7,7 +7,7 @@
 
     "short_description": "%HOSTFXR_BRAND_NAME% %HOSTFXR_NUGET_VERSION%",
     "long_description": ".NET Core is a development platform that you can use to build command-line applications, microservices and modern websites. It is open source, cross-platform and is supported by Microsoft. We hope you enjoy using it! If you do, please consider joining the active community of developers that are contributing to the project on GitHub (https://github.com/dotnet/core). We happily accept issues and PRs.",
-    "homepage": "https://dotnet.github.io/core",
+    "homepage": "https://dotnet.github.io",
 
     "release":{
         "package_version":"1.0.0.0",

--- a/src/pkg/packaging/deb/dotnet-sharedframework-debian_config.json
+++ b/src/pkg/packaging/deb/dotnet-sharedframework-debian_config.json
@@ -7,7 +7,7 @@
 
     "short_description": "%SHARED_FRAMEWORK_BRAND_NAME% %SHARED_FRAMEWORK_NUGET_NAME% %SHARED_FRAMEWORK_NUGET_VERSION%",
     "long_description": ".NET Core is a development platform that you can use to build command-line applications, microservices and modern websites. It is open source, cross-platform and is supported by Microsoft. We hope you enjoy using it! If you do, please consider joining the active community of developers that are contributing to the project on GitHub (https://github.com/dotnet/core). We happily accept issues and PRs.",
-    "homepage": "https://dotnet.github.io/core",
+    "homepage": "https://dotnet.github.io",
 
     "release":{
         "package_version":"1.0.0.0",

--- a/src/pkg/packaging/deb/dotnet-sharedhost-debian_config.json
+++ b/src/pkg/packaging/deb/dotnet-sharedhost-debian_config.json
@@ -7,7 +7,7 @@
 
     "short_description": "%SHARED_HOST_BRAND_NAME%",
     "long_description": ".NET Core is a development platform that you can use to build command-line applications, microservices and modern websites. It is open source, cross-platform and is supported by Microsoft. We hope you enjoy using it! If you do, please consider joining the active community of developers that are contributing to the project on GitHub (https://github.com/dotnet/core). We happily accept issues and PRs.",
-    "homepage": "https://dotnet.github.io/core",
+    "homepage": "https://dotnet.github.io",
 
     "release":{
         "package_version":"1.0.0.0",


### PR DESCRIPTION
PR for release/2.0.0 :  https://github.com/dotnet/core-setup/pull/2683