### PR TITLE
Fix the TPA initialization for UWP

### DIFF
--- a/src/uwp/Host/UWPHost/HostEnvironment.h
+++ b/src/uwp/Host/UWPHost/HostEnvironment.h
@@ -181,7 +181,7 @@ public:
     {
         if (!m_tpaList.CStr()) 
         {
-            wchar_t *tpaEntries[] = {L"System.Private.CoreLib.ni.dll", L"mscorlib.ni.dll"};
+            wchar_t *tpaEntries[] = {L"System.Private.CoreLib.dll"};
             InitializeTPAList(tpaEntries, _countof(tpaEntries));
         }
 


### PR DESCRIPTION
There is no ".ni.dll" present, as R2R compiled version has the same name as IL.

@jkotas PTAL.