### PR TITLE
Add symbol signing to core-setup packages.

### DIFF
--- a/BuildToolsVersion.txt
+++ b/BuildToolsVersion.txt
@@ -1,1 +1,1 @@
-2.0.0-prerelease-01803-02
+2.0.0-prerelease-01805-01

--- a/buildpipeline/Core-Setup-Publish.json
+++ b/buildpipeline/Core-Setup-Publish.json
@@ -2,6 +2,24 @@
   "build": [
     {
       "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Install Signing Plugin",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "30666190-6959-11e5-9f96-f56098202fef",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "signType": "real",
+        "zipSources": "true",
+        "version": "",
+        "feedSource": "https://devdiv.pkgs.visualstudio.com/DefaultCollection/_packaging/MicroBuildToolset/nuget/v3/index.json"
+      }
+    },
+    {
+      "enabled": true,
       "continueOnError": true,
       "alwaysRun": false,
       "displayName": "Cleanup previous build if present",
@@ -17,6 +35,103 @@
         "arguments": "-path $(PB_SourcesDirectory)",
         "workingFolder": "",
         "inlineScript": "param($path)\n\nif (Test-Path $path){\n    # this will print out an error each time a file can't be deleted.\n    Remove-Item -Recurse -Force $path\n }\n\nif (Test-Path $path){\n    # in case vbcs is still alive\n     $p = Get-Process -Name \"VBCS\"\n     Stop-Process -InputObject $p\n }",
+        "failOnStandardError": "true"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": true,
+      "alwaysRun": false,
+      "displayName": "Cleanup previous tools source if present",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "e213ff0f-5d5c-4791-802d-52ea3e7be1f1",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "scriptType": "inlineScript",
+        "scriptName": "",
+        "arguments": "-path $(PB_VsoToolsDir)",
+        "workingFolder": "",
+        "inlineScript": "param($path)\n\nif (Test-Path $path){\n    # this will print out an error each time a file can't be deleted.\n    Remove-Item -Recurse -Force $path\n }\n\nif (Test-Path $path){\n    # in case vbcs is still alive\n     $p = Get-Process -Name \"VBCS\"\n     Stop-Process -InputObject $p\n }",
+        "failOnStandardError": "true"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": true,
+      "alwaysRun": false,
+      "displayName": "Cleanup previous tools if present",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "e213ff0f-5d5c-4791-802d-52ea3e7be1f1",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "scriptType": "inlineScript",
+        "scriptName": "",
+        "arguments": "-path $(ToolsRoot)",
+        "workingFolder": "",
+        "inlineScript": "param($path)\n\nif (Test-Path $path){\n    # this will print out an error each time a file can't be deleted.\n    Remove-Item -Recurse -Force $path\n }\n\nif (Test-Path $path){\n    # in case vbcs is still alive\n     $p = Get-Process -Name \"VBCS\"\n     Stop-Process -InputObject $p\n }",
+        "failOnStandardError": "true"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Run script $(VS140COMNTOOLS)\\VsDevCmd.bat",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "bfc8bf76-e7ac-4a8c-9a55-a944a9f632fd",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "filename": "$(VS140COMNTOOLS)\\VsDevCmd.bat",
+        "arguments": "",
+        "modifyEnvironment": "true",
+        "workingFolder": "",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Clone tools",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "filename": "git",
+        "arguments": "clone $(PB_VsoToolsRepo) $(PB_VsoToolsDir)",
+        "workingFolder": "",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Fetch symbol signing tooling",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "e213ff0f-5d5c-4791-802d-52ea3e7be1f1",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "scriptType": "filePath",
+        "scriptName": "$(PB_VsoToolsDir)\\scripts\\DotNet-Trusted-Publish\\Fetch-Tools.ps1",
+        "arguments": "$(ToolsRoot)",
+        "workingFolder": "",
+        "inlineScript": "# You can write your powershell scripts inline here. \n# You can also pass predefined and custom variables to this scripts using arguments\n\n Write-Host \"Hello World\"",
         "failOnStandardError": "true"
       }
     },
@@ -302,7 +417,7 @@
     },
     "PB_VersionsRepo": {
       "value": "versions"
-    },    
+    },
     "PB_RepoName": {
       "value": "core-setup"
     },
@@ -314,10 +429,23 @@
     },
     "TeamName": {
       "value": "DotNetCore"
+    },
+    "PB_VsoToolsRepo": {
+      "value": "https://$(PB_VsoAccountName):$(PB_VsoPassword)@devdiv.visualstudio.com/DevDiv/_git/DotNet-BuildPipeline"
+    },
+    "PB_VsoToolsDir": {
+      "value": "$(Build.SourcesDirectory)\\toolsSource"
+    },
+    "ToolsRoot": {
+      "value": "$(Build.SourcesDirectory)\\tools"
+    },
+    "SymbolCatalogCertificateId": {
+      "value": "400"
     }
   },
   "demands": [
-    "Agent.OS -equals Windows_NT"
+    "Agent.OS -equals Windows_NT",
+    "WindowsKit",
   ],
   "retentionRules": [
     {

--- a/buildpipeline/Core-Setup-Publish.json
+++ b/buildpipeline/Core-Setup-Publish.json
@@ -52,7 +52,7 @@
       "inputs": {
         "scriptType": "inlineScript",
         "scriptName": "",
-        "arguments": "-path \"$(VsoToolsDir)\"",
+        "arguments": "-path \"$(PB_VsoToolsDir)\"",
         "workingFolder": "",
         "inlineScript": "param($path)\n\nif (Test-Path $path){\n    # this will print out an error each time a file can't be deleted.\n    Remove-Item -Recurse -Force $path\n }\n\nif (Test-Path $path){\n    # in case vbcs is still alive\n     $p = Get-Process -Name \"VBCS\"\n     Stop-Process -InputObject $p\n }",
         "failOnStandardError": "true"
@@ -72,7 +72,7 @@
       "inputs": {
         "scriptType": "inlineScript",
         "scriptName": "",
-        "arguments": "-path \"$(ToolsRoot)\"",
+        "arguments": "-path \"$(PB_ToolsRoot)\"",
         "workingFolder": "",
         "inlineScript": "param($path)\n\nif (Test-Path $path){\n    # this will print out an error each time a file can't be deleted.\n    Remove-Item -Recurse -Force $path\n }\n\nif (Test-Path $path){\n    # in case vbcs is still alive\n     $p = Get-Process -Name \"VBCS\"\n     Stop-Process -InputObject $p\n }",
         "failOnStandardError": "true"
@@ -110,7 +110,7 @@
       },
       "inputs": {
         "filename": "git",
-        "arguments": "clone $(VsoToolsRepo) $(VsoToolsDir)",
+        "arguments": "clone $(PB_VsoToolsRepo) $(PB_VsoToolsDir)",
         "workingFolder": "",
         "failOnStandardError": "false"
       }
@@ -128,8 +128,8 @@
       },
       "inputs": {
         "scriptType": "filePath",
-        "scriptName": "$(VsoToolsDir)\\scripts\\DotNet-Trusted-Publish\\Fetch-Tools.ps1",
-        "arguments": "$(ToolsRoot)",
+        "scriptName": "$(PB_VsoToolsDir)\\scripts\\DotNet-Trusted-Publish\\Fetch-Tools.ps1",
+        "arguments": "$(PB_ToolsRoot)",
         "workingFolder": "",
         "inlineScript": "",
         "failOnStandardError": "true"
@@ -232,7 +232,7 @@
         "solution": "$(PB_SourcesDirectory)\\publish\\publish.proj",
         "platform": "$(PB_TargetArchitecture)",
         "configuration": "$(BuildConfiguration)",
-        "msbuildArguments": "/p:Configuration=$(BuildConfiguration) $(PB_CommonMSBuildArgs) /p:NuGetFeedUrl=$(NUGET_FEED_URL) /p:NuGetSymbolsFeedUrl=$(NUGET_SYMBOLS_FEED_URL) /p:NuGetApiKey=$(NUGET_API_KEY) /p:AzureAccountName=$(PB_AzureAccountName) /p:AzureAccessToken=$(PB_AzureAccessToken) /p:ChecksumAzureAccountName=$(PB_ChecksumAzureAccountName) /p:ChecksumAzureAccessToken=$(PB_ChecksumAzureAccessToken) /p:GitHubUser=$(PB_GitHubUser) /p:GitHubEmail=$(PB_GitHubEmail) /p:GitHubAuthToken=$(GITHUB_PASSWORD) /p:VersionsRepoOwner=$(PB_VersionsRepoOwner) /p:VersionsRepo=$(PB_VersionsRepo) /p:VersionsRepoPath=build-info/dotnet/$(PB_RepoName)/$(SourceBranch) /p:Finalize=true /flp:v=detailed;LogFile=$(PB_SourcesDirectory)\\publish.log",
+        "msbuildArguments": "/p:Configuration=$(BuildConfiguration) $(PB_CommonMSBuildArgs) /p:NuGetFeedUrl=$(NUGET_FEED_URL) /p:NuGetSymbolsFeedUrl=$(NUGET_SYMBOLS_FEED_URL) /p:NuGetApiKey=$(NUGET_API_KEY) /p:AzureAccountName=$(PB_AzureAccountName) /p:AzureAccessToken=$(PB_AzureAccessToken) /p:ChecksumAzureAccountName=$(PB_ChecksumAzureAccountName) /p:ChecksumAzureAccessToken=$(PB_ChecksumAzureAccessToken) /p:GitHubUser=$(PB_GitHubUser) /p:GitHubEmail=$(PB_GitHubEmail) /p:GitHubAuthToken=$(GITHUB_PASSWORD) /p:VersionsRepoOwner=$(PB_VersionsRepoOwner) /p:VersionsRepo=$(PB_VersionsRepo) /p:VersionsRepoPath=build-info/dotnet/$(PB_RepoName)/$(SourceBranch) /p:Finalize=true /p:VsoToolsDir=$(PB_VsoToolsDir) /flp:v=detailed;LogFile=$(PB_SourcesDirectory)\\publish.log",
         "clean": "false",
         "maximumCpuCount": "false",
         "restoreNugetPackages": "false",
@@ -430,13 +430,13 @@
     "TeamName": {
       "value": "DotNetCore"
     },
-    "VsoToolsRepo": {
+    "PB_VsoToolsRepo": {
       "value": "https://$(PB_VsoAccountName):$(PB_VsoPassword)@devdiv.visualstudio.com/DevDiv/_git/DotNet-BuildPipeline"
     },
-    "VsoToolsDir": {
+    "PB_VsoToolsDir": {
       "value": "$(Build.SourcesDirectory)\\toolsSource"
     },
-    "ToolsRoot": {
+    "PB_ToolsRoot": {
       "value": "$(Build.SourcesDirectory)\\tools"
     },
     "SymbolCatalogCertificateId": {

--- a/buildpipeline/Core-Setup-Publish.json
+++ b/buildpipeline/Core-Setup-Publish.json
@@ -32,7 +32,7 @@
       "inputs": {
         "scriptType": "inlineScript",
         "scriptName": "",
-        "arguments": "-path $(PB_SourcesDirectory)",
+        "arguments": "-path \"$(PB_SourcesDirectory)\"",
         "workingFolder": "",
         "inlineScript": "param($path)\n\nif (Test-Path $path){\n    # this will print out an error each time a file can't be deleted.\n    Remove-Item -Recurse -Force $path\n }\n\nif (Test-Path $path){\n    # in case vbcs is still alive\n     $p = Get-Process -Name \"VBCS\"\n     Stop-Process -InputObject $p\n }",
         "failOnStandardError": "true"
@@ -52,7 +52,7 @@
       "inputs": {
         "scriptType": "inlineScript",
         "scriptName": "",
-        "arguments": "-path $(PB_VsoToolsDir)",
+        "arguments": "-path \"$(VsoToolsDir)\"",
         "workingFolder": "",
         "inlineScript": "param($path)\n\nif (Test-Path $path){\n    # this will print out an error each time a file can't be deleted.\n    Remove-Item -Recurse -Force $path\n }\n\nif (Test-Path $path){\n    # in case vbcs is still alive\n     $p = Get-Process -Name \"VBCS\"\n     Stop-Process -InputObject $p\n }",
         "failOnStandardError": "true"
@@ -72,7 +72,7 @@
       "inputs": {
         "scriptType": "inlineScript",
         "scriptName": "",
-        "arguments": "-path $(ToolsRoot)",
+        "arguments": "-path \"$(ToolsRoot)\"",
         "workingFolder": "",
         "inlineScript": "param($path)\n\nif (Test-Path $path){\n    # this will print out an error each time a file can't be deleted.\n    Remove-Item -Recurse -Force $path\n }\n\nif (Test-Path $path){\n    # in case vbcs is still alive\n     $p = Get-Process -Name \"VBCS\"\n     Stop-Process -InputObject $p\n }",
         "failOnStandardError": "true"
@@ -110,7 +110,7 @@
       },
       "inputs": {
         "filename": "git",
-        "arguments": "clone $(PB_VsoToolsRepo) $(PB_VsoToolsDir)",
+        "arguments": "clone $(VsoToolsRepo) $(VsoToolsDir)",
         "workingFolder": "",
         "failOnStandardError": "false"
       }
@@ -128,10 +128,10 @@
       },
       "inputs": {
         "scriptType": "filePath",
-        "scriptName": "$(PB_VsoToolsDir)\\scripts\\DotNet-Trusted-Publish\\Fetch-Tools.ps1",
+        "scriptName": "$(VsoToolsDir)\\scripts\\DotNet-Trusted-Publish\\Fetch-Tools.ps1",
         "arguments": "$(ToolsRoot)",
         "workingFolder": "",
-        "inlineScript": "# You can write your powershell scripts inline here. \n# You can also pass predefined and custom variables to this scripts using arguments\n\n Write-Host \"Hello World\"",
+        "inlineScript": "",
         "failOnStandardError": "true"
       }
     },
@@ -430,10 +430,10 @@
     "TeamName": {
       "value": "DotNetCore"
     },
-    "PB_VsoToolsRepo": {
+    "VsoToolsRepo": {
       "value": "https://$(PB_VsoAccountName):$(PB_VsoPassword)@devdiv.visualstudio.com/DevDiv/_git/DotNet-BuildPipeline"
     },
-    "PB_VsoToolsDir": {
+    "VsoToolsDir": {
       "value": "$(Build.SourcesDirectory)\\toolsSource"
     },
     "ToolsRoot": {

--- a/publish/publish.proj
+++ b/publish/publish.proj
@@ -134,7 +134,7 @@
   </Target>
 
   <Target Name="PublishCoreHostPackagesToFeed"
-          DependsOnTargets="CheckIfAllBuildsHavePublished;DownloadCoreHostPackages;SignSymbolPackages;PushCoreHostPackagesToFeed"
+          DependsOnTargets="CheckIfAllBuildsHavePublished;DownloadCoreHostPackages;SignSymbolPackages;DoPushCoreHostPackagesToFeed"
           Condition="'@(_MissingBlobNames)' == ''">
     <Error Condition="'$(NuGetFeedUrl)' ==''" Text="Missing required property NuGetFeedUrl" />
     <Error Condition="'$(NuGetApiKey)' == ''" Text="Missing required property NuGetApiKey" />
@@ -190,7 +190,7 @@
     <Exec Command="$(PowerShellExe) -NonInteractive -ExecutionPolicy Unrestricted  -Command &quot;&amp; { &amp;&apos;$(EmbedIndexScriptLocation)&apos; $(DownloadDirectory) $(PublishDirectory) } &quot;" />
   </Target>
 
-  <Target Name="PushCoreHostPackagesToFeed">
+  <Target Name="DoPushCoreHostPackagesToFeed">
     <Error Condition="'@(_DownloadedSymbolsPackages)' != '' and '$(NuGetSymbolsFeedUrl)' == ''" Text="Missing required property NuGetSymbolsFeedUrl" />
 
     <Message Text="Pushing CoreHost packages to $(NuGetFeedUrl)" />

--- a/publish/publish.proj
+++ b/publish/publish.proj
@@ -179,8 +179,8 @@
 
   <Target Name="SignSymbolPackages" DependsOnTargets="InjectSignedSymbolCatalogIntoSymbolPackages">
     <PropertyGroup>
-      <PowerShellExe Condition=" '$(PowerShellExe)'=='' ">%WINDIR%\System32\WindowsPowerShell\v1.0\powershell.exe</PowerShellExe>
-      <EmbedIndexScriptLocation Condition=" '$(EmbedIndexScriptLocation)'=='' ">$(PB_VsoToolsDir)\scripts\DotNet-Trusted-Publish\Embed-Index.ps1</EmbedIndexScriptLocation>
+      <PowerShellExe Condition=" '$(PowerShellExe)'=='' ">powershell.exe</PowerShellExe>
+      <EmbedIndexScriptLocation Condition=" '$(EmbedIndexScriptLocation)'=='' ">$(VsoToolsDir)\scripts\DotNet-Trusted-Publish\Embed-Index.ps1</EmbedIndexScriptLocation>
     </PropertyGroup>
 
     <Exec Command="$(PowerShellExe) -NonInteractive -ExecutionPolicy Unrestricted  -Command &quot;&amp; { &amp;&apos;$(EmbedIndexScriptLocation)&apos; $(DownloadDirectory) $(PublishDirectory) } &quot;" />

--- a/publish/publish.proj
+++ b/publish/publish.proj
@@ -157,7 +157,7 @@
     <PropertyGroup>
       <DownloadDirectory Condition="'$(DownloadDirectory)' == ''">$(BinDir)PackageDownload/</DownloadDirectory>
       <PublishDirectory Condition="'$(PublishDirectory)' == ''">$(BinDir)ForPublishing/</PublishDirectory>
-	  <!-- list of packages that we want to embed symbol signatures in -->
+      <!-- list of packages that we want to embed symbol signatures in -->
       <SymbolPackagesToPublishGlob Condition="'$(SymbolPackagesToPublishGlob)' == ''">$(DownloadDirectory)/**/*.nupkg</SymbolPackagesToPublishGlob>
     </PropertyGroup>
     <MakeDir Directories="$(DownloadDirectory)"

--- a/publish/publish.proj
+++ b/publish/publish.proj
@@ -141,6 +141,7 @@
     <Error Condition="'$(AzureAccessToken)' == ''" Text="Missing required property 'AzureAccessToken'" />
     <Error Condition="'$(AzureAccountName)' == ''" Text="Missing required property 'AzureAccountName'" />
     <Error Condition="'$(ContainerName)' == ''" Text="Missing required property 'ContainerName'" />
+    <Message Condition="'$(WindowsSdkDir)' == ''" Text="Windows SDK not found.  Symbols packages will not be signed." />
   </Target>
 
   <Target Name="DownloadCoreHostPackages">
@@ -157,6 +158,9 @@
     <PropertyGroup>
       <DownloadDirectory Condition="'$(DownloadDirectory)' == ''">$(BinDir)PackageDownload/</DownloadDirectory>
       <PublishDirectory Condition="'$(PublishDirectory)' == ''">$(BinDir)ForPublishing/</PublishDirectory>
+      <!-- if we're not signing packages, publish directly from the download directory, as we won't be
+	       copying them to the indexed directory -->
+      <PublishDirectory Condition="'$(WindowsSdkDir)' == ''">$(DownloadDirectory)</PublishDirectory>
       <!-- list of packages that we want to embed symbol signatures in -->
       <SymbolPackagesToPublishGlob Condition="'$(SymbolPackagesToPublishGlob)' == ''">$(DownloadDirectory)/**/*.nupkg</SymbolPackagesToPublishGlob>
     </PropertyGroup>
@@ -177,7 +181,7 @@
     </ItemGroup>
   </Target>
 
-  <Target Name="SignSymbolPackages" DependsOnTargets="InjectSignedSymbolCatalogIntoSymbolPackages">
+  <Target Name="SignSymbolPackages" DependsOnTargets="InjectSignedSymbolCatalogIntoSymbolPackages" Condition="'$(WindowsSdkDir)' != ''">
     <PropertyGroup>
       <PowerShellExe Condition=" '$(PowerShellExe)'=='' ">powershell.exe</PowerShellExe>
       <EmbedIndexScriptLocation Condition=" '$(EmbedIndexScriptLocation)'=='' ">$(VsoToolsDir)\scripts\DotNet-Trusted-Publish\Embed-Index.ps1</EmbedIndexScriptLocation>

--- a/publish/publish.proj
+++ b/publish/publish.proj
@@ -112,7 +112,7 @@
                    ProductVersion="$(ProductVersion)"
                    CommitHash="$(LatestCommit)"
                    FinalizeContainer="Runtime/$(SharedFrameworkNugetVersion)"
-                   ForcePublish="true"                  
+                   ForcePublish="true"
                    Condition="'@(_MissingBlobNames)' == ''" />
     <Error Condition="'$(ChecksumAzureAccessToken)' == ''" Text="Missing required property 'ChecksumAzureAccessToken'" />
     <Error Condition="'$(ChecksumAzureAccountName)' == ''" Text="Missing required property 'ChecksumAzureAccountName'" />
@@ -134,14 +134,16 @@
   </Target>
 
   <Target Name="PublishCoreHostPackagesToFeed"
-          DependsOnTargets="CheckIfAllBuildsHavePublished"
+          DependsOnTargets="CheckIfAllBuildsHavePublished;DownloadCoreHostPackages;SignSymbolPackages;PushCoreHostPackagesToFeed"
           Condition="'@(_MissingBlobNames)' == ''">
     <Error Condition="'$(NuGetFeedUrl)' ==''" Text="Missing required property NuGetFeedUrl" />
     <Error Condition="'$(NuGetApiKey)' == ''" Text="Missing required property NuGetApiKey" />
     <Error Condition="'$(AzureAccessToken)' == ''" Text="Missing required property 'AzureAccessToken'" />
     <Error Condition="'$(AzureAccountName)' == ''" Text="Missing required property 'AzureAccountName'" />
     <Error Condition="'$(ContainerName)' == ''" Text="Missing required property 'ContainerName'" />
+  </Target>
 
+  <Target Name="DownloadCoreHostPackages">
     <ListAzureBlobs AccountName="$(AzureAccountName)"
                       AccountKey="$(AzureAccessToken)"
                       ContainerName="$(ContainerName)"
@@ -153,7 +155,10 @@
     </ItemGroup>
 
     <PropertyGroup>
-      <DownloadDirectory Condition="'$(DownloadDirectory)' == ''">$(BinDir)ForPublishing/</DownloadDirectory>
+      <DownloadDirectory Condition="'$(DownloadDirectory)' == ''">$(BinDir)PackageDownload/</DownloadDirectory>
+      <PublishDirectory Condition="'$(PublishDirectory)' == ''">$(BinDir)ForPublishing/</PublishDirectory>
+	  <!-- list of packages that we want to embed symbol signatures in -->
+      <SymbolPackagesToPublishGlob Condition="'$(SymbolPackagesToPublishGlob)' == ''">$(DownloadDirectory)/**/*.nupkg</SymbolPackagesToPublishGlob>
     </PropertyGroup>
     <MakeDir Directories="$(DownloadDirectory)"
              Condition="!Exists('$(DownloadDirectory)')" />
@@ -164,14 +169,26 @@
                            BlobNamePrefix="Runtime/$(SharedFrameworkNugetVersion)"
                            DownloadDirectory="$(DownloadDirectory)" />
     <ItemGroup>
-      <_DownloadedPackages Include="@(_CoreHostPackages->'$(DownloadDirectory)%(Filename)%(Extension)')" />
+      <_DownloadedPackages Include="@(_CoreHostPackages->'$(PublishDirectory)%(Filename)%(Extension)')" />
       <_DownloadedSymbolsPackages Include="%(_DownloadedPackages.Identity)" 
                                  Condition="$([System.String]::new('%(_DownloadedPackages.Identity)').EndsWith('.symbols.nupkg'))" />
       <_DownloadedStandardPackages Include="@(_DownloadedPackages)"
                                   Exclude="@(_DownloadedSymbolsPackages)" />
     </ItemGroup>
+  </Target>
+
+  <Target Name="SignSymbolPackages" DependsOnTargets="InjectSignedSymbolCatalogIntoSymbolPackages">
+    <PropertyGroup>
+      <PowerShellExe Condition=" '$(PowerShellExe)'=='' ">%WINDIR%\System32\WindowsPowerShell\v1.0\powershell.exe</PowerShellExe>
+      <EmbedIndexScriptLocation Condition=" '$(EmbedIndexScriptLocation)'=='' ">$(PB_VsoToolsDir)\scripts\DotNet-Trusted-Publish\Embed-Index.ps1</EmbedIndexScriptLocation>
+    </PropertyGroup>
+
+    <Exec Command="$(PowerShellExe) -NonInteractive -ExecutionPolicy Unrestricted  -Command &quot;&amp; { &amp;&apos;$(EmbedIndexScriptLocation)&apos; $(DownloadDirectory) $(PublishDirectory) } &quot;" />
+  </Target>
+
+  <Target Name="PushCoreHostPackagesToFeed">
     <Error Condition="'@(_DownloadedSymbolsPackages)' != '' and '$(NuGetSymbolsFeedUrl)' == ''" Text="Missing required property NuGetSymbolsFeedUrl" />
-    
+
     <Message Text="Pushing CoreHost packages to $(NuGetFeedUrl)" />
     <PropertyGroup>
       <NuGetPushCommand>$(DotnetToolCommand) nuget push --source $(NuGetFeedUrl) --api-key $(NuGetApiKey) --timeout $(NuGetPushTimeoutSeconds)</NuGetPushCommand>
@@ -184,7 +201,7 @@
     <Message Condition="'@(_DownloadedSymbolsPackages)' != ''" Text="Pushing CoreHost symbols packages to $(NuGetSymbolsFeedUrl)" />
     <Exec Condition="'@(_DownloadedSymbolsPackages)' != ''" Command="$(NuGetPushSymbolsCommand) %(_DownloadedSymbolsPackages.Identity)" />
   </Target>
-  
+
   <Target Name="PublishDebToolPackageToFeed"
           Condition="'$(PublishDebToolToFeed)' == 'true'">
     <Error Condition="'$(CliNuGetFeedUrl)' ==''" Text="Missing required property CliNuGetFeedUrl" />


### PR DESCRIPTION
- Publish.proj changes to support signing.
  - Split `PublishCoreHostPackagesToFeed` into Download, Sign, Publish targets so we can insert the symbol signing in the correct place.
  - Call Embed-Index to index symbol files and signatures.
- Build definition changes
  - Install MicroBuild Signing plugin.
  - Clean up previous copies of the tooling.
  - Clone and download symbol signing tooling.
  - Additional variables for tooling location and certificate to use for signing.
  - Run on a machine with the Windows Dev Kit so we know we have `makecat`.
  - Use VS dev command prompt init script so we know were `makecat` is.
- Updated BuildTools for latest symbol signing fixes.

Unfortunately this cannot be tested in full without being in the official build - I tested it with publishing to MyGet, Azure, and dotnet/versions removed from publish.proj.  Example package output is at \\\\crummel-server\build_debug\crummel-core-setup-publish-testing-20170614-22.  Build definition used for testing is at https://devdiv.visualstudio.com/DefaultCollection/DevDiv/_build/index?definitionId=6538&_a=completed.