### PR TITLE
Correct spelling of dev/defaultintf branch.

### DIFF
--- a/dependencies.props
+++ b/dependencies.props
@@ -28,7 +28,7 @@
   <!-- Package dependency verification/auto-upgrade configuration. -->
   <PropertyGroup>
     <BaseDotNetBuildInfo>build-info/dotnet/</BaseDotNetBuildInfo>
-    <DependencyBranch>dev/defaultinf</DependencyBranch>
+    <DependencyBranch>dev/defaultintf</DependencyBranch>
     <CurrentRefXmlPath>$(MSBuildThisFileFullPath)</CurrentRefXmlPath>
   </PropertyGroup>
 


### PR DESCRIPTION
This was the one place I found the issue in the repo itself.