### PR TITLE
Update BuildTools to 2.0.0-prerelease-01721-01.

### DIFF
--- a/BuildToolsVersion.txt
+++ b/BuildToolsVersion.txt
@@ -1,1 +1,1 @@
-2.0.0-prerelease-01705-02
+2.0.0-prerelease-01721-01


### PR DESCRIPTION
This should fix the issue with "An item with the specified name already exists" in the core-setup Maestro definitions.