### PR TITLE
Update uap10.1 moniker in packages to uap10.0.15138 to support NS2.0 projects in VS

### DIFF
--- a/src/pkg/projects/Microsoft.NETCore.UniversalWindowsPlatform/Microsoft.NETCore.UniversalWindowsPlatform.pkgproj
+++ b/src/pkg/projects/Microsoft.NETCore.UniversalWindowsPlatform/Microsoft.NETCore.UniversalWindowsPlatform.pkgproj
@@ -31,7 +31,7 @@
     </Dependency>
 
     <ProjectReference Include="..\Microsoft.Net.UWPCoreRuntimeSdk\Microsoft.Net.UWPCoreRuntimeSdk.pkgproj">
-      <TargetFramework>uap10.1</TargetFramework>
+      <TargetFramework>uap10.0.15138</TargetFramework>
     </ProjectReference>
 
     <!-- Add a placeholder to make sure NuGet understands we still support older versions,

--- a/src/pkg/projects/Microsoft.NETCore.UniversalWindowsPlatform/src/Microsoft.NETCore.UniversalWindowsPlatform.depproj
+++ b/src/pkg/projects/Microsoft.NETCore.UniversalWindowsPlatform/src/Microsoft.NETCore.UniversalWindowsPlatform.depproj
@@ -7,9 +7,9 @@
     <!-- we don't want any analyzers by ResolveNuGetPackageAssets 
          null-refs when this isn't set and an analyzer is in the packages -->
     <Language>unused</Language>
-    <NuGetTargetMoniker>UAP,Version=v10.1</NuGetTargetMoniker>
-    <NuGetTargetMonikerShort>uap10.1</NuGetTargetMonikerShort>
-    <PackageTargetFramework>uap10.1</PackageTargetFramework>
+    <NuGetTargetMoniker>UAP,Version=v10.0.15138</NuGetTargetMoniker>
+    <NuGetTargetMonikerShort>uap10.0.15138</NuGetTargetMonikerShort>
+    <PackageTargetFramework>uap10.0.15138</PackageTargetFramework>
     <PrimaryPackage>Microsoft.Private.CoreFx.UAP</PrimaryPackage>
     <ContainsPackageReferences>true</ContainsPackageReferences>
     <RestorePackages>true</RestorePackages>

--- a/src/pkg/projects/Microsoft.NETCore.UniversalWindowsPlatform/src/Microsoft.NETCore.UniversalWindowsPlatform.depproj
+++ b/src/pkg/projects/Microsoft.NETCore.UniversalWindowsPlatform/src/Microsoft.NETCore.UniversalWindowsPlatform.depproj
@@ -7,8 +7,8 @@
     <!-- we don't want any analyzers by ResolveNuGetPackageAssets 
          null-refs when this isn't set and an analyzer is in the packages -->
     <Language>unused</Language>
-    <NuGetTargetMoniker>UAP,Version=v10.0.15138</NuGetTargetMoniker>
-    <NuGetTargetMonikerShort>uap10.0.15138</NuGetTargetMonikerShort>
+    <NuGetTargetMoniker>UAP,Version=v10.1</NuGetTargetMoniker>
+    <NuGetTargetMonikerShort>uap10.1</NuGetTargetMonikerShort>
     <PackageTargetFramework>uap10.0.15138</PackageTargetFramework>
     <PrimaryPackage>Microsoft.Private.CoreFx.UAP</PrimaryPackage>
     <ContainsPackageReferences>true</ContainsPackageReferences>


### PR DESCRIPTION
VS is setting the NuGet TFM to the build number of the Windows SDK TargetPlatformVersion. For example, when you build in VS and need to restore your NuGet packages, you may see the following in your build output:

```
Restoring packages for UAP,Version=v10.0.10586...
```

Thus, we will set the TFM to a value that is higher than the latest released Windows SDK: `10.0.15063.0`. This will allow us to restore newer libraries for NS2.0.