### PR TITLE
Fix publish error introduced by recent UwpCoreRuntimeSdk work

### DIFF
--- a/publish/dir.props
+++ b/publish/dir.props
@@ -22,7 +22,7 @@
     <RuntimePackageFile Include="$(PackagesOutDir)**/runtime.*.nupkg" >
       <RelativeBlobPath>$(BinariesRelativePath)</RelativeBlobPath>
     </RuntimePackageFile>
-    <UWPArtifactsToUpload Include="$(MicrosoftNetCoreRuntimeAppxOutputPath)" >
+    <UWPArtifactsToUpload Include="$(UWPOutputDir)Microsoft.NET.CoreRuntime.*.appx" >
       <RelativeBlobPath>$(BinariesRelativePath)</RelativeBlobPath>
     </UWPArtifactsToUpload>
     <RidAgnosticPackageFile Include="$(PackagesOutDir)**/*.nupkg" Exclude="@(RuntimePackageFile)" >

--- a/publish/dir.props
+++ b/publish/dir.props
@@ -22,7 +22,7 @@
     <RuntimePackageFile Include="$(PackagesOutDir)**/runtime.*.nupkg" >
       <RelativeBlobPath>$(BinariesRelativePath)</RelativeBlobPath>
     </RuntimePackageFile>
-    <UWPArtifactsToUpload Include="$(UWPOutputDir)Microsoft.NET.CoreRuntime.*.appx" >
+    <UWPArtifactsToUpload Include="$(MicrosoftNetCoreRuntimeAppxOutputPath)" Condition="Exists('$(MicrosoftNetCoreRuntimeAppxOutputPath)')" >
       <RelativeBlobPath>$(BinariesRelativePath)</RelativeBlobPath>
     </UWPArtifactsToUpload>
     <RidAgnosticPackageFile Include="$(PackagesOutDir)**/*.nupkg" Exclude="@(RuntimePackageFile)" >


### PR DESCRIPTION
Modify publish/dir.props to wildcard select the CoreRuntime appx package to upload so it's not uploaded on distros where it has not been built.
