### PR TITLE
Moving clrcompression.dll to the nativeassets folder on the UWP metapackage

### DIFF
--- a/src/pkg/projects/Microsoft.NETCore.UniversalWindowsPlatform/src/Microsoft.NETCore.UniversalWindowsPlatform.depproj
+++ b/src/pkg/projects/Microsoft.NETCore.UniversalWindowsPlatform/src/Microsoft.NETCore.UniversalWindowsPlatform.depproj
@@ -73,7 +73,7 @@
       </_FilesToPackage>
       <_FilesToPackage>
         <TargetPath Condition="'%(_FilesToPackage.IsNative)' != 'true'">runtimes/$(NuGetRuntimeIdentifier)/lib/$(PackageTargetFramework)</TargetPath>
-        <TargetPath Condition="'%(_FilesToPackage.IsNative)' == 'true'">runtimes/$(NuGetRuntimeIdentifier)/native</TargetPath>
+        <TargetPath Condition="'%(_FilesToPackage.IsNative)' == 'true'">runtimes/$(NuGetRuntimeIdentifier)/nativeassets/$(PackageTargetFramework)</TargetPath>
       </_FilesToPackage>
     </ItemGroup>
 


### PR DESCRIPTION
Fixes #2719 
cc: @ericstj @zamont 

As suggested by @ericstj [comment](https://github.com/dotnet/core-setup/issues/2719#issuecomment-310438943) with this change we will be able now to use the metapackage for a UAP10.0 app as well.