### PR TITLE
Fixing RIDs of Microsoft.Net.UWPCoreRuntimeSdk

### DIFF
--- a/src/pkg/projects/Microsoft.Net.UWPCoreRuntimeSdk/uwpcoreruntimesdkRIDs.props
+++ b/src/pkg/projects/Microsoft.Net.UWPCoreRuntimeSdk/uwpcoreruntimesdkRIDs.props
@@ -5,11 +5,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <OfficialBuildRID Include="win-x86">
+    <OfficialBuildRID Include="win10-x86">
       <Platform>x86</Platform>
     </OfficialBuildRID>
-    <OfficialBuildRID Include="win-x64"/>
-    <OfficialBuildRID Include="win-arm">
+    <OfficialBuildRID Include="win10-x64"/>
+    <OfficialBuildRID Include="win10-arm">
       <Platform>arm</Platform>
     </OfficialBuildRID>
   </ItemGroup>


### PR DESCRIPTION
cc: @zamont @botaberg 

Fixing RIDs of the UWPCoreRuntimeSdk package.