### PR TITLE
Push packages before finalize, for latest.version reliability

### DIFF
--- a/publish/publish.proj
+++ b/publish/publish.proj
@@ -11,7 +11,7 @@
   
   <Target Name="PublishFinalOutput"
           Condition="'$(Finalize)' == 'true'"
-          DependsOnTargets="FinalizeBuildInAzure;PublishCoreHostPackagesToFeed;UpdatePublishedVersions" />
+          DependsOnTargets="PublishCoreHostPackagesToFeed;FinalizeBuildInAzure;UpdatePublishedVersions" />
           
   <Target Name="ExcludeSymbolsPackagesFromPublishedVersions" BeforeTargets="UpdatePublishedVersions" >
     <ItemGroup>


### PR DESCRIPTION
See https://github.com/dotnet/core-setup/issues/2765

We should consider porting this to release/2.0.0 due to the impact on downstream builds when failures happen.