### PR TITLE
Sign UWP artifacts

### DIFF
--- a/buildpipeline/Core-Setup-Windows-BT.json
+++ b/buildpipeline/Core-Setup-Windows-BT.json
@@ -222,7 +222,7 @@
       "enabled": true,
       "continueOnError": false,
       "alwaysRun": false,
-      "displayName": "Sign MSI and cab",
+      "displayName": "Sign MSI, cab, and Appx",
       "timeoutInMinutes": 0,
       "task": {
         "id": "c6c4c611-aa2e-4a33-b606-5eaba2196824",

--- a/signing/baseline.props
+++ b/signing/baseline.props
@@ -5,5 +5,10 @@
     <BinInspectBaselineFile Include=".%2A\\apphost\.exe" />
     <!-- wixstdba is internal to the engine bundle and does not get signed -->
     <BinInspectBaselineFile Include=".%2A\\wixstdba\.dll" />
+    <!--
+        Baseline Microsoft.NET.CoreRuntime.#.#.appx we place in Microsoft.Net.UWPCoreRuntimeSdk.2.1.0-preview1-25429-03.nupkg.
+        BinInspect cannot handle .appx files. The contents of the Appx in this case are signed CoreCLR binaries.
+    -->
+    <BinInspectBaselineFile Include=".%2A\\Microsoft.NET.CoreRuntime\..%2A\.appx" />
   </ItemGroup>
 </Project>

--- a/signing/sign.proj
+++ b/signing/sign.proj
@@ -72,9 +72,6 @@
       <FilesToSign Include="$(OutDir)packages/**/*.cab">
         <Authenticode>$(CertificateId)</Authenticode>
       </FilesToSign>
-      <FilesToSign Include="$(UWPOutputDir)*.appx">
-        <Authenticode>$(CertificateId)</Authenticode>
-      </FilesToSign>
     </ItemGroup>
   </Target>
 

--- a/signing/sign.proj
+++ b/signing/sign.proj
@@ -72,6 +72,9 @@
       <FilesToSign Include="$(OutDir)packages/**/*.cab">
         <Authenticode>$(CertificateId)</Authenticode>
       </FilesToSign>
+      <FilesToSign Include="$(UWPOutputDir)*.appx">
+        <Authenticode>$(CertificateId)</Authenticode>
+      </FilesToSign>
     </ItemGroup>
   </Target>
 

--- a/signing/sign.proj
+++ b/signing/sign.proj
@@ -57,9 +57,6 @@
       <FilesToSign Include="$(UWPOutputDir)*.exe">
         <Authenticode>$(CertificateId)</Authenticode>
       </FilesToSign>
-      <FilesToSign Include="$(UWPOutputDir)*.appx">
-        <Authenticode>$(CertificateId)</Authenticode>
-      </FilesToSign>
     </ItemGroup>
   </Target>
 

--- a/signing/sign.proj
+++ b/signing/sign.proj
@@ -49,6 +49,18 @@
         <Authenticode>$(CertificateId)</Authenticode>
       </FilesToSign>
     </ItemGroup>
+
+    <ItemGroup>
+      <FilesToSign Include="$(UWPOutputDir)*.dll">
+        <Authenticode>$(CertificateId)</Authenticode>
+      </FilesToSign>
+      <FilesToSign Include="$(UWPOutputDir)*.exe">
+        <Authenticode>$(CertificateId)</Authenticode>
+      </FilesToSign>
+      <FilesToSign Include="$(UWPOutputDir)*.appx">
+        <Authenticode>$(CertificateId)</Authenticode>
+      </FilesToSign>
+    </ItemGroup>
   </Target>
 
   <Target Name="SignMsiAndCab" DependsOnTargets="GetSignMsiAndCabFiles">
@@ -90,22 +102,4 @@
     </ItemGroup>
   </Target>
 
-  <Target Name="SignUwpFiles" DependsOnTargets="GetSignUwpFiles">
-    <CallTarget Targets="SignFiles" />
-  </Target>
-
-  <Target Name="GetSignUwpFiles">
-    <ItemGroup>
-      <FilesToSign Include="$(UWPOutputDir)*.dll">
-        <Authenticode>$(CertificateId)</Authenticode>
-      </FilesToSign>
-      <FilesToSign Include="$(UWPOutputDir)*.exe">
-        <Authenticode>$(CertificateId)</Authenticode>
-      </FilesToSign>
-      <FilesToSign Include="$(UWPOutputDir)*.appx">
-        <Authenticode>$(CertificateId)</Authenticode>
-      </FilesToSign>
-    </ItemGroup>
-  </Target>
-  
 </Project>

--- a/tools-local/tasks/ValidateBinInspectResults.cs
+++ b/tools-local/tasks/ValidateBinInspectResults.cs
@@ -52,7 +52,7 @@ namespace Microsoft.DotNet.Build.Tasks
             {
                 foreach(var baselineFile in BaselineFiles)
                 {
-                    IEnumerable<XElement> baselineExcluded = errorRows.Where(f => Regex.IsMatch(f.Descendants(s_NameElement).First().Value), baselineFile.ItemSpec, RegExOptions.IgnoreCase);
+                    IEnumerable<XElement> baselineExcluded = errorRows.Where(f => Regex.IsMatch(f.Descendants(s_NameElement).First().Value), baselineFile.ItemSpec, RegexOptions.IgnoreCase);
                     foreach(var baselineExclude in baselineExcluded)
                     {
                         baselineExcludeElements.Add(baselineExclude);

--- a/tools-local/tasks/ValidateBinInspectResults.cs
+++ b/tools-local/tasks/ValidateBinInspectResults.cs
@@ -52,7 +52,7 @@ namespace Microsoft.DotNet.Build.Tasks
             {
                 foreach(var baselineFile in BaselineFiles)
                 {
-                    IEnumerable<XElement> baselineExcluded = errorRows.Where(f => Regex.IsMatch(f.Descendants(s_NameElement).First().Value), baselineFile.ItemSpec, RegexOptions.IgnoreCase);
+                    IEnumerable<XElement> baselineExcluded = errorRows.Where(f => Regex.IsMatch(f.Descendants(s_NameElement).First().Value, baselineFile.ItemSpec, RegexOptions.IgnoreCase));
                     foreach(var baselineExclude in baselineExcluded)
                     {
                         baselineExcludeElements.Add(baselineExclude);

--- a/tools-local/tasks/ValidateBinInspectResults.cs
+++ b/tools-local/tasks/ValidateBinInspectResults.cs
@@ -52,8 +52,7 @@ namespace Microsoft.DotNet.Build.Tasks
             {
                 foreach(var baselineFile in BaselineFiles)
                 {
-                    Regex ignoreRegEx = new Regex(baselineFile.ItemSpec);
-                    IEnumerable<XElement> baselineExcluded = errorRows.Where(f => ignoreRegEx.IsMatch(f.Descendants(s_NameElement).First().Value));
+                    IEnumerable<XElement> baselineExcluded = errorRows.Where(f => Regex.IsMatch(f.Descendants(s_NameElement).First().Value), baselineFile.ItemSpec, RegExOptions.IgnoreCase);
                     foreach(var baselineExclude in baselineExcluded)
                     {
                         baselineExcludeElements.Add(baselineExclude);


### PR DESCRIPTION
These are mostly @nattress 's changes, with the exception that I moved this section...

```
      <FilesToSign Include="$(UWPOutputDir)*.appx"> 
        <Authenticode>$(CertificateId)</Authenticode> 
      </FilesToSign> 
```

The appx files are produced during the "Build NuGet Packages" step, so they wouldn't be available for signing during the binaries phase.

FYI @joshfree @zamont @nattress 