### PR TITLE
Release build failure: Increase timeout to allow core-setup downloads to complete

### DIFF
--- a/tools-local/Microsoft.DotNet.Build.Tasks.Local/DownloadBlobFromAzure.cs
+++ b/tools-local/Microsoft.DotNet.Build.Tasks.Local/DownloadBlobFromAzure.cs
@@ -53,6 +53,7 @@ namespace Microsoft.DotNet.Build.Tasks
 
             using (HttpClient client = new HttpClient())
             {
+                client.Timeout = TimeSpan.FromMinutes(10);
                 try
                 {
                     Func<HttpRequestMessage> createRequest = () =>


### PR DESCRIPTION
These builds download a huge amount of data by opening literally hundreds of simultaneous connections.  In the official build logs, some of these requests end up at the end of the queue and timeout while waiting their turn.  Most of those eventually get a turn, but some of them don't.  I'm raising the timeout 6 fold (the default timeout is 100 seconds), and hoping that's enough.