### PR TITLE
[release/2.0.0] Push packages before finalize, for latest.version reliability

### DIFF
--- a/publish/publish.proj
+++ b/publish/publish.proj
@@ -11,7 +11,7 @@
   
   <Target Name="PublishFinalOutput"
           Condition="'$(Finalize)' == 'true'"
-          DependsOnTargets="FinalizeBuildInAzure;PublishCoreHostPackagesToFeed;UpdatePublishedVersions" />
+          DependsOnTargets="PublishCoreHostPackagesToFeed;FinalizeBuildInAzure;UpdatePublishedVersions" />
           
   <Target Name="ExcludeSymbolsPackagesFromPublishedVersions" BeforeTargets="UpdatePublishedVersions" >
     <ItemGroup>


### PR DESCRIPTION
Fixes https://github.com/dotnet/core-setup/issues/2765 by porting https://github.com/dotnet/core-setup/pull/2766 to `release/2.0.0`.

> ASP.NET depends on this file changing only when packages are on MyGet, but because `FinalizeBuildInAzure` happens before `PublishCoreHostPackagesToFeed` package publishing can fail after the file update.