### PR TITLE
Fix install block

### DIFF
--- a/src/pkg/packaging/osx/sharedframework/shared-framework-distribution-template.xml
+++ b/src/pkg/packaging/osx/sharedframework/shared-framework-distribution-template.xml
@@ -6,9 +6,9 @@
     <welcome file="welcome.html" mime-type="text/html" />
     <conclusion file="conclusion.html" mime-type="text/html" />
     <volume-check>
-        <allowed-os-version>
-            <os-version min="10.10" />
-        </allowed-os-version>
+        <allowed-os-versions>
+            <os-version min="10.12" />
+        </allowed-os-versions>
     </volume-check>
     <choices-outline>
         <line choice="{SharedFxComponentId}.pkg" />


### PR DESCRIPTION
Installation block doesn't work due to a typo. Also update to 10.12 as
minimum version

Porting fix for #2768 
