### PR TITLE
Fix framework assembly deployment for CoreCLR

### DIFF
--- a/src/pkg/projects/Microsoft.Net.UWPCoreRuntimeSdk/contents/identity/Microsoft.Net.CoreRuntime.targets
+++ b/src/pkg/projects/Microsoft.Net.UWPCoreRuntimeSdk/contents/identity/Microsoft.Net.CoreRuntime.targets
@@ -214,7 +214,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
   <!-- We will always inject the CLR from the framework SDK, so remove it if it was contributed through NuGet -->
   <Target Name="FilterCoreRuntimePayloadFromNuGet" AfterTargets="ResolveReferences" DependsOnTargets="ResolveNuGetPackageAssets" Condition="'$(ResolveNuGetPackages)' == 'true' AND '$(_TargetsCoreRuntime)' == 'true'">
     <PropertyGroup>
-      <_CoreRuntimePackageId Condition="'%(ReferenceCopyLocalPaths.FileName)%(ReferenceCopyLocalPaths.Extension)' == 'mscorlib.dll' OR '%(ReferenceCopyLocalPaths.FileName)%(ReferenceCopyLocalPaths.Extension)' == 'mscorlib.ni.dll'">%(ReferenceCopyLocalPaths.NuGetPackageId)</_CoreRuntimePackageId>
+      <_CoreRuntimePackageId Condition="'%(ReferenceCopyLocalPaths.FileName)%(ReferenceCopyLocalPaths.Extension)' == 'System.Private.CoreLib.dll' OR '%(ReferenceCopyLocalPaths.FileName)%(ReferenceCopyLocalPaths.Extension)' == 'System.Private.CoreLib.ni.dll'">%(ReferenceCopyLocalPaths.NuGetPackageId)</_CoreRuntimePackageId>
     </PropertyGroup>
     <ItemGroup>
       <ReferenceCopyLocalPaths Remove="@(ReferenceCopyLocalPaths)" Condition="'$(UseAppLocalCoreCLR)' != 'true' AND '%(ReferenceCopyLocalPaths.NuGetPackageId)' == '$(_CoreRuntimePackageId)' AND '$(_CoreRuntimePackageId)' != ''"/>


### PR DESCRIPTION
Before NS2.0, the framework assemblies were drawn from a variety of
individual Nuget packages. Filtering was performed to not copy a Nuget
package's contents if it was the CoreCLR runtime package, since that is
provided by an AppX package dependency. The test for "is this a CoreCLR
runtime package" was the presence of mscorlib.[ni.]dll. With NS2.0,
mscorlib is just a type forwarder in the main framework assembly payload
so the filter broke. Instead, use System.Private.CoreLib.[ni.]dll which is
now present in the CoreCLR runtime package. CoreCLR NS2.0 runtime Nuget
packages will similarly contain System.Private.CoreLib.dll.
