### PR TITLE
Propagate *.ni.pdb files generated from CoreCLR build.

### DIFF
--- a/src/pkg/projects/dir.targets
+++ b/src/pkg/projects/dir.targets
@@ -18,6 +18,8 @@
       <WindowsNativeFile Include="@(File)"
                          Condition="'%(File.Extension)' == '.dll' OR '%(File.Extension)' == '.exe'" />
       <WindowsSymbolFile Include="@(File -> '%(RootDir)%(Directory)%(Filename).pdb')" />
+      <!-- Crossgened files (on windows) have both a *.pdb and a *.ni.pdb symbol file.  Include the *.ni.pdb file as well if it exists. -->
+      <WindowsSymbolFile Include="@(File -> '%(RootDir)%(Directory)%(Filename).ni.pdb')" />
       <ExistingWindowsSymbolFile Include="@(WindowsSymbolFile)" Condition="Exists('%(Identity)')" />
 
       <NonWindowsNativeFile Include="@(File)"


### PR DESCRIPTION
The CoreCLR build makes *.ni.pdb files that also need to propagate to the ultimate NetCore.app package.

@dagood 