### PR TITLE
Add virtual dir ending slash when downloading nupkgs to publish

### DIFF
--- a/publish/publish.proj
+++ b/publish/publish.proj
@@ -168,7 +168,7 @@
                            AccountKey="$(AzureAccessToken)"
                            ContainerName="$(ContainerName)"
                            BlobNames="@(_CoreHostPackages)"
-                           BlobNamePrefix="Runtime/$(SharedFrameworkNugetVersion)"
+                           BlobNamePrefix="Runtime/$(SharedFrameworkNugetVersion)/"
                            DownloadDirectory="$(DownloadDirectory)" />
     <ItemGroup>
       <_DownloadedPackages Include="@(_CoreHostPackages->'$(PublishDirectory)%(Filename)%(Extension)')" />


### PR DESCRIPTION
This prevents a stabilized version from downloading all nupkgs in the blob storage container.

I don't understand why not including this slash downloads *all* nupkgs from the container rather than just those that start with `Runtime/2.0.0`, but experimentally it does. (Even if the prefix worked as expected, this would still be a breaking bug.)

For example, without the slash, the task outputs `master/Binaries/2.0.0-preview1-001939-00/[...].nupkg`

The `FinalizeBuild` task will automatically add the `/` if it doesn't exist, but `DownloadFromAzure` doesn't.