### PR TITLE
[release/2.0.0] Add virtual dir ending slash when downloading nupkgs to publish

### DIFF
--- a/publish/publish.proj
+++ b/publish/publish.proj
@@ -145,7 +145,7 @@
     <GetAzureBlobList AccountName="$(AzureAccountName)"
                       AccountKey="$(AzureAccessToken)"
                       ContainerName="$(ContainerName)"
-                      FilterblobNames="Runtime/$(SharedFrameworkNugetVersion)">
+                      FilterblobNames="Runtime/$(SharedFrameworkNugetVersion)/">
       <Output TaskParameter="BlobNames" ItemName="_BlobList" />
     </GetAzureBlobList>
     <ItemGroup>


### PR DESCRIPTION
This prevents a stabilized version from downloading all nupkgs in the blob storage container.

I don't understand why not including this slash downloads *all* nupkgs from the container rather than just those that start with `Runtime/2.0.0`, but experimentally it does. (Even if the prefix worked as expected, this would still be a breaking bug.)

For example, without the slash, the task outputs `master/Binaries/2.0.0-preview1-001939-00/[...].nupkg`

The `FinalizeBuild` task will automatically add the `/` if it doesn't exist, but `GetAzureBlobList` doesn't.

https://github.com/dotnet/core-eng/issues/1265