### PR TITLE
Add virtual dir ending slash when downloading nupkgs to publish

### DIFF
--- a/publish/publish.proj
+++ b/publish/publish.proj
@@ -148,7 +148,7 @@
     <ListAzureBlobs AccountName="$(AzureAccountName)"
                       AccountKey="$(AzureAccessToken)"
                       ContainerName="$(ContainerName)"
-                      FilterBlobNames="Runtime/$(SharedFrameworkNugetVersion)">
+                      FilterBlobNames="Runtime/$(SharedFrameworkNugetVersion)/">
       <Output TaskParameter="BlobNames" ItemName="_BlobList" />
     </ListAzureBlobs>
     <ItemGroup>
@@ -168,7 +168,7 @@
                            AccountKey="$(AzureAccessToken)"
                            ContainerName="$(ContainerName)"
                            BlobNames="@(_CoreHostPackages)"
-                           BlobNamePrefix="Runtime/$(SharedFrameworkNugetVersion)"
+                           BlobNamePrefix="Runtime/$(SharedFrameworkNugetVersion)/"
                            DownloadDirectory="$(DownloadDirectory)" />
     <ItemGroup>
       <_DownloadedPackages Include="@(_CoreHostPackages->'$(PublishDirectory)%(Filename)%(Extension)')" />


### PR DESCRIPTION
This prevents a stabilized version from downloading all nupkgs in the blob storage container.

Port of https://github.com/dotnet/core-setup/pull/2871 to master.

I verified that the BuildTools version of `ListAzureBlobs` also doesn't put a `/` on the end of `FilterBlobNames`, and ran it locally to verify the same behavior.

I added a `/` to `DownloadFromAzure` too to keep it in sync, but since we give it a list of absolute blob names it shouldn't matter. release/2.0.0 doesn't have this line because it uses a different task without the (redundant?) filter.

https://github.com/dotnet/core-eng/issues/1265