### PR TITLE
[master] Add virtual dir ending slash when finalizing build

### DIFF
--- a/tools-local/tasks/FinalizeBuild.cs
+++ b/tools-local/tasks/FinalizeBuild.cs
@@ -95,7 +95,7 @@ namespace Microsoft.DotNet.Build.Tasks
 
                 try
                 {
-                    CopyBlobs($"Runtime/{ProductVersion}", $"Runtime/{Channel}/");
+                    CopyBlobs($"Runtime/{ProductVersion}/", $"Runtime/{Channel}/");
 
                     // Generate the latest version text file
                     string sfxVersion = GetSharedFrameworkVersionFileContent();


### PR DESCRIPTION
(cherry picked from commit aea7b1cab8912f78a07408d9e95aafb9bea1e150)

Port of https://github.com/dotnet/core-setup/pull/2878 to master.

> Fixes a problem where the finalize task copied every blob during finalization, rather than just the 2.0.0 stabilized build.
> 
> Similar to https://github.com/dotnet/core-setup/pull/2871, where not having this trailing slash caused the build to try to download every blob in the container.