### PR TITLE
[release/uwp6.0] Update Microsoft.Net.UWPCoreruntimeSdk targets to help VS consume CoreRuntime

### DIFF
--- a/src/pkg/projects/Microsoft.Net.UWPCoreRuntimeSdk/contents/rid-templates/Microsoft.Net.UWPCoreRuntimeSdk.targets.template
+++ b/src/pkg/projects/Microsoft.Net.UWPCoreRuntimeSdk/contents/rid-templates/Microsoft.Net.UWPCoreRuntimeSdk.targets.template
@@ -7,5 +7,11 @@
         <Version>[AppxVersion]</Version>
         <Publisher>'CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US'</Publisher>
     </AppxPackageRegistration>
+    <DesignTimeAppxPackageRegistration
+        Include="$(MSBuildThisFileDirectory)..\tools\Appx\[AppxDisplayName].appx">
+        <Architecture>[AppxBuildArch]</Architecture>
+        <Version>[AppxVersion]</Version>
+        <Publisher>'CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US'</Publisher>
+    </DesignTimeAppxPackageRegistration>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Add DesignTimeAppxPackageRegistration MSBuild items to aid in discovery of appx packages for VS. The contract will be identical to the AppxPackageRegistration ItemGroup except it will not be conditioned on targeting CoreRuntime.
