### PR TITLE
Build UWPShim as a Store App

### DIFF
--- a/src/uwp/CopyWin32Resources/CMakeLists.txt
+++ b/src/uwp/CopyWin32Resources/CMakeLists.txt
@@ -1,5 +1,8 @@
 include_directories("${CLI_CMAKE_RESOURCE_DIR}/copywin32resources")
 
+add_compile_options(/MT)
+
+
 add_executable(CopyWin32Resources
   CopyWin32Resources.cpp
   native.rc

--- a/src/uwp/Host/CMakeLists.txt
+++ b/src/uwp/Host/CMakeLists.txt
@@ -1,2 +1,1 @@
 add_subdirectory(UWPHost)
-add_subdirectory(UWPShim)

--- a/src/uwp/Host/UWPHost/CMakeLists.txt
+++ b/src/uwp/Host/UWPHost/CMakeLists.txt
@@ -1,5 +1,7 @@
 include_directories("${CLI_CMAKE_RESOURCE_DIR}/uwphost")
 
+add_compile_options(/MT)
+
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 
 set(UWPHost_SOURCES 

--- a/src/uwp/Host/UWPShim/CMakeLists.txt
+++ b/src/uwp/Host/UWPShim/CMakeLists.txt
@@ -1,4 +1,15 @@
-include_directories("${CLI_CMAKE_RESOURCE_DIR}/uwpshim") 
+include(../../../settings.cmake)
+
+add_definitions(-DUNICODE)
+add_definitions(-D_UNICODE)
+set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /SUBSYSTEM:WINDOWS")
+set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /ENTRY:wmain")
+set(CMAKE_EXE_LINKER_FLAGS_DEBUG "/NODEFAULTLIB:libucrt.lib /DEFAULTLIB:ucrt.lib")
+
+include_directories("${CLI_CMAKE_RESOURCE_DIR}/uwpshim")
+link_directories(${UWPHOST_LIB_PATH})
+set (PLATFORM STORE)
+
 add_executable(UWPShim
   uwpshim.cpp
   native.rc
@@ -6,6 +17,7 @@ add_executable(UWPShim
 
 target_link_libraries(UWPShim
     UWPHost
+    vcruntime
 )
 
 install(TARGETS UWPShim DESTINATION .)

--- a/src/uwp/Host/UWPShim/UWPShim.cpp
+++ b/src/uwp/Host/UWPShim/UWPShim.cpp
@@ -24,14 +24,149 @@ extern HRESULT ExecuteAssembly(_In_z_ wchar_t *entryPointAssemblyFileName, int a
 do { errno_t x = (EXPR); if(FAILED(x)) { return (x); } } while (0)
 #endif
 
-int __cdecl wmain(const int argc, const wchar_t* argv[])
-{
 
+// Alternative implementation to CommandLineToArgvW, which is not available to Store profile
+// apps (including this UWP shim).
+LPWSTR *SegmentCommandLine(LPCWSTR lpCmdLine, int *pNumArgs)
+{
+    *pNumArgs = 0;
+
+    int nch = (int)wcslen(lpCmdLine);
+
+    // Calculate the worst-case storage requirement. (One pointer for
+    // each argument, plus storage for the arguments themselves.)
+    int cbAlloc = (nch+1)*sizeof(LPWSTR) + sizeof(wchar_t)*(nch + 1);
+    
+    LPWSTR pAlloc = (LPWSTR)malloc(cbAlloc);
+    if (!pAlloc)
+        return NULL;
+
+    LPWSTR *argv = (LPWSTR*) pAlloc;  // We store the argv pointers in the first halt
+    LPWSTR  pdst = (LPWSTR)( ((BYTE*)pAlloc) + sizeof(LPWSTR)*(nch+1) ); // A running pointer to second half to store arguments
+    LPCWSTR psrc = lpCmdLine;
+    wchar_t   c;
+    BOOL    inquote;
+    BOOL    copychar;
+    int     numslash;
+
+    // First, parse the program name (argv[0]). Argv[0] is parsed under
+    // special rules. Anything up to the first whitespace outside a quoted
+    // subtring is accepted. Backslashes are treated as normal characters.
+    argv[ (*pNumArgs)++ ] = pdst;
+    inquote = FALSE;
+    do {
+        if (*psrc == L'"' )
+        {
+            inquote = !inquote;
+            c = *psrc++;
+            continue;
+        }
+        *pdst++ = *psrc;
+
+        c = *psrc++;
+
+    } while ( (c != L'\0' && (inquote || (c != L' ' && c != L'\t'))) );
+
+    if ( c == L'\0' ) {
+        psrc--;
+    } else {
+        *(pdst-1) = L'\0';
+    }
+
+    inquote = FALSE;
+
+
+
+    /* loop on each argument */
+    for(;;)
+    {
+        if ( *psrc )
+        {
+            while (*psrc == L' ' || *psrc == L'\t')
+            {
+                ++psrc;
+            }
+        }
+
+        if (*psrc == L'\0')
+            break;              /* end of args */
+
+        /* scan an argument */
+        argv[ (*pNumArgs)++ ] = pdst;
+
+        /* loop through scanning one argument */
+        for (;;)
+        {
+            copychar = 1;
+            /* Rules: 2N backslashes + " ==> N backslashes and begin/end quote
+               2N+1 backslashes + " ==> N backslashes + literal "
+               N backslashes ==> N backslashes */
+            numslash = 0;
+            while (*psrc == L'\\')
+            {
+                /* count number of backslashes for use below */
+                ++psrc;
+                ++numslash;
+            }
+            if (*psrc == L'"')
+            {
+                /* if 2N backslashes before, start/end quote, otherwise
+                   copy literally */
+                if (numslash % 2 == 0)
+                {
+                    if (inquote && psrc[1] == L'"')
+                    {
+                        psrc++;    /* Double quote inside quoted string */
+                    }
+                    else
+                    {
+                        /* skip first quote char and copy second */
+                        copychar = 0;       /* don't copy quote */
+                        inquote = !inquote;
+                    }
+                }
+                numslash /= 2;          /* divide numslash by two */
+            }
+    
+            /* copy slashes */
+            while (numslash--)
+            {
+                *pdst++ = L'\\';
+            }
+    
+            /* if at end of arg, break loop */
+            if (*psrc == L'\0' || (!inquote && (*psrc == L' ' || *psrc == L'\t')))
+                break;
+    
+            /* copy character into argument */
+            if (copychar)
+            {
+                *pdst++ = *psrc;
+            }
+            ++psrc;
+        }
+
+        /* null-terminate the argument */
+
+        *pdst++ = L'\0';          /* terminate string */
+    }
+
+    /* We put one last argument in -- a null ptr */
+    argv[ (*pNumArgs) ] = NULL;
+
+    return argv;
+}
+
+int __cdecl wmain()
+{
     DWORD exitCode = -1;
+    int argc;
+    LPCWSTR* wszArglist = const_cast<LPCWSTR*>(SegmentCommandLine(GetCommandLineW(), &argc));
+    
     if (argc < 2)
     {
         // Invalid number of arguments
-        return -1;
+        return exitCode;
     }
     
     // This module is merely a shim to figure out what the actual EntryPoint assembly is and call the Host with 
@@ -40,12 +175,12 @@ int __cdecl wmain(const int argc, const wchar_t* argv[])
     // 1) Current module lives under the "CoreRuntime" subfolder of the AppX package installation folder.
     // 2) It has the same name as the EntryPoint assembly that will reside in the parent folder (i.e. the AppX package installation folder).
     
-    const wchar_t* pActivationModulePath = argv[0];
+    const wchar_t* pActivationModulePath = wszArglist[0];
 
     const wchar_t *pLastSlash = wcsrchr(pActivationModulePath, L'\\');
     if (pLastSlash == NULL)
     {
-        return -1;
+        return exitCode;
     }
     
     wchar_t entryPointAssemblyFileName[MAX_PATH];
@@ -53,7 +188,7 @@ int __cdecl wmain(const int argc, const wchar_t* argv[])
     IfFailRet(wcscat_s(entryPointAssemblyFileName, MAX_PATH, L"\\entrypoint"));
     IfFailRet(wcscat_s(entryPointAssemblyFileName, MAX_PATH, pLastSlash));
     
-    auto success = ExecuteAssembly(entryPointAssemblyFileName, argc-1, &(argv[1]), &exitCode);
+    auto success = ExecuteAssembly(entryPointAssemblyFileName, argc-1, &(wszArglist[1]), &exitCode);
 
     return exitCode;
 }

--- a/src/uwp/Windows/gen-buildsys-win.bat
+++ b/src/uwp/Windows/gen-buildsys-win.bat
@@ -13,10 +13,9 @@ echo %2
 echo %3
 echo %4
 echo %5
-echo %6
 
 setlocal
-set __sourceDir=%~dp0..
+set __sourceDir=%1
 :: VS 2015 is the minimum supported toolset
 set __VSString=14 2015
 
@@ -35,19 +34,19 @@ if defined CMakePath goto DoGen
 
 :: Eval the output from probe-win1.ps1
 pushd "%__sourceDir%"
-for /f "delims=" %%a in ('powershell -NoProfile -ExecutionPolicy ByPass "& .\Windows\probe-win.ps1"') do %%a
+for /f "delims=" %%a in ('powershell -NoProfile -ExecutionPolicy ByPass "& %~dp0\probe-win.ps1"') do %%a
 popd
 
 :DoGen
-echo "%CMakePath%" %__sourceDir% %__SDKVersion% "-DCLI_CMAKE_PKG_RID:STRING=%cm_BaseRid%" "-DCLI_CMAKE_PLATFORM_ARCH_%cm_Arch%=1" "-DCMAKE_INSTALL_PREFIX=%__OutputDir%" "-DCLI_CMAKE_RESOURCE_DIR:STRING=%__ResourcesDir%" -G "Visual Studio %__VSString%"
+echo "%CMakePath%" %__sourceDir% %__SDKVersion% %__CMAKE_SYSTEM% %__CMAKE_CUSTOM_DEFINES% "-DCLI_CMAKE_PKG_RID:STRING=%cm_BaseRid%" "-DCLI_CMAKE_PLATFORM_ARCH_%cm_Arch%=1" "-DCMAKE_INSTALL_PREFIX=%__OutputDir%" "-DCLI_CMAKE_RESOURCE_DIR:STRING=%__ResourcesDir%" -G "Visual Studio %__VSString%"
 
-"%CMakePath%" %__sourceDir% %__SDKVersion% "-DCLI_CMAKE_PKG_RID:STRING=%cm_BaseRid%" "-DCLI_CMAKE_PLATFORM_ARCH_%cm_Arch%=1" "-DCMAKE_INSTALL_PREFIX=%__OutputDir%" "-DCLI_CMAKE_RESOURCE_DIR:STRING=%__ResourcesDir%" -G "Visual Studio %__VSString%"
+"%CMakePath%" %__sourceDir% %__SDKVersion% %__CMAKE_SYSTEM% %__CMAKE_CUSTOM_DEFINES% "-DCLI_CMAKE_PKG_RID:STRING=%cm_BaseRid%" "-DCLI_CMAKE_PLATFORM_ARCH_%cm_Arch%=1" "-DCMAKE_INSTALL_PREFIX=%__OutputDir%" "-DCLI_CMAKE_RESOURCE_DIR:STRING=%__ResourcesDir%" -G "Visual Studio %__VSString%"
 endlocal
 GOTO :DONE
 
 :USAGE
   echo "Usage..."
-  echo "gen-buildsys-win.bat <path to top level CMakeLists.txt> <VSVersion> <Target Architecture> <Commit Hash> <NativeResourceDir> <OutputDir>"
+  echo "gen-buildsys-win.bat <path to top level CMakeLists.txt> <Target Architecture> <Commit Hash> <NativeResourceDir> <OutputDir>"
   EXIT /B 1
 
 :DONE

--- a/src/uwp/build.proj
+++ b/src/uwp/build.proj
@@ -26,7 +26,7 @@
 
     <ItemGroup>
       <CMakeOutput Include="$(IntermediateOutputRootPath)uwphost\host\uwphost\$(ConfigurationGroup)\uwphost.dll" />
-      <CMakeOutput Include="$(IntermediateOutputRootPath)uwphost\host\uwpshim\$(ConfigurationGroup)\uwpshim.exe" />
+      <CMakeOutput Include="$(IntermediateOutputRootPath)uwpshim\$(ConfigurationGroup)\uwpshim.exe" />
       <CMakeOutput Include="$(IntermediateOutputRootPath)uwphost\copywin32resources\$(ConfigurationGroup)\copywin32resources.exe" />
     </ItemGroup>
     


### PR DESCRIPTION
Alter build of UWPShim so it is a Windows Store exe instead of a desktop command line application. This prevents a command window popping up when running CoreCLR apps in VS.
This requires splitting the uwp cmake build into two pieces: a desktop piece for CopyWin32Resources and UWPHost, and a Store app piece for UWPShim
Statically link vcruntime.lib into CopyWin32Resources and UWPHost to avoid a runtime requirement that vcruntime140.dll is present.
