### PR TITLE
Enable building debian9 packages

### DIFF
--- a/buildpipeline/Core-Setup-Linux-BT.json
+++ b/buildpipeline/Core-Setup-Linux-BT.json
@@ -526,6 +526,96 @@
         "failOnStandardError": "false"
       }
     },
+	{
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Initialize docker - Debian 9",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "filename": "$(PB_DockerHost_ToolsDirectory)/scripts/docker/init-docker.sh",
+        "arguments": "$(DockerImageName_Debian9)",
+        "workingFolder": "$(PB_DockerHost_Sandbox)",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Init tools - Debian 9 container",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "filename": "docker",
+        "arguments": "run --rm $(DockerCommonRunArgs_Debian9) /bin/bash -c \"HOME=$(PB_GitDirectory); git clean -X -d -f; $(PB_GitDirectory)/init-tools.sh\"",
+        "workingFolder": "",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Build traversal build dependencies - Debian 9",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "filename": "docker",
+        "arguments": "run --rm $(DockerCommonRunArgs_Debian9) $(PB_GitDirectory)/Tools/msbuild.sh $(PB_GitDirectory)/build.proj /t:BuildTraversalBuildDependencies /p:DistroRid=$(DistroRid_Debian9) $(DistroSpecificMSBuildArguments)",
+        "workingFolder": "",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Package - Debian 9",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "filename": "docker",
+        "arguments": "run --rm $(DockerCommonRunArgs_Debian9) $(PB_GitDirectory)/Tools/msbuild.sh $(PB_GitDirectory)/src/pkg/packaging/dir.proj $(AdditionalMSBuildProperties) /p:DistroRid=$(DistroRid_Debian9) $(DistroSpecificMSBuildArguments)",
+        "workingFolder": "",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Publish - Debian 9",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "filename": "docker",
+        "arguments": "run --rm $(DockerCommonRunArgs_Debian9) $(PB_GitDirectory)/Tools/msbuild.sh $(PB_GitDirectory)/publish/publish.proj /p:DistroRid=$(DistroRid_Debian9) $(DistroSpecificMSBuildArguments) $(DistroSpecificMSBuildPublishArgs)",
+        "workingFolder": "",
+        "failOnStandardError": "false"
+      }
+    },
     {
       "enabled": true,
       "continueOnError": false,
@@ -749,6 +839,10 @@
       "value": null,
       "isSecret": true
     },
+	"PB_DebianId_debian9-x64": {
+      "value": null,
+      "isSecret": true
+    },
     "PB_DebianId_ubuntu1604-x64": {
       "value": null,
       "isSecret": true
@@ -866,7 +960,7 @@
       "value": "/p:AzureAccountName=$(PB_AzureAccountName) /p:AzureAccessToken=$(PB_AzureAccessToken) /p:ChecksumAzureAccountName=$(PB_ChecksumAzureAccountName) /p:ChecksumAzureAccessToken=$(PB_ChecksumAzureAccessToken) /p:DebRepoUser=$(PB_DebRepoUser) /p:DebRepoServer=$(PB_DebRepoServer) /p:DebRepoPass=$(DEB_REPO_PASSWORD) $(PB_DebianKeys)"
     },
     "PB_DebianKeys": {
-      "value": "/p:DebianId_ubuntu1404-x64=$(PB_DebianId_ubuntu1404-x64) /p:DebianId_debian8-x64=$(PB_DebianId_debian8-x64) /p:DebianId_ubuntu1604-x64=$(PB_DebianId_ubuntu1604-x64) /p:DebianId_ubuntu1610-x64=$(PB_DebianId_ubuntu1610-x64)"
+      "value": "/p:DebianId_ubuntu1404-x64=$(PB_DebianId_ubuntu1404-x64) /p:DebianId_debian8-x64=$(PB_DebianId_debian8-x64) /p:DebianId_debian9-x64=$(PB_DebianId_debian9-x64) /p:DebianId_ubuntu1604-x64=$(PB_DebianId_ubuntu1604-x64) /p:DebianId_ubuntu1610-x64=$(PB_DebianId_ubuntu1610-x64)"
     },
     "DockerTag_Ubuntu1404": {
       "value": "ubuntu-14.04-debpkg-e5cf912-20175003025046"
@@ -915,6 +1009,18 @@
     },
     "DockerCommonRunArgs_Debian8": {
       "value": "--name $(PB_DockerContainerName)$(DockerTag_Debian8) -v \"$(PB_SourcesDirectory):$(PB_GitDirectory)\" -v $(Build.StagingDirectory)/sharedFrameworkPublish/:/root/sharedFrameworkPublish/ -w=\"$(PB_GitDirectory)\" $(DockerImageName_Debian8)"
+    },
+    "DockerTag_Debian9": {
+      "value": "debian-8.2-debpkg-9f87c3c-20173003023006"
+    },
+    "DistroRid_Debian9": {
+      "value": "debian.9-$(PB_TargetArchitecture)"
+    },
+    "DockerImageName_Debian9": {
+      "value": "$(PB_DockerRepository):$(DockerTag_Debian9)"
+    },
+    "DockerCommonRunArgs_Debian9": {
+      "value": "--name $(PB_DockerContainerName)$(DockerTag_Debian9) -v \"$(PB_SourcesDirectory):$(PB_GitDirectory)\" -v $(Build.StagingDirectory)/sharedFrameworkPublish/:/root/sharedFrameworkPublish/ -w=\"$(PB_GitDirectory)\" $(DockerImageName_Debian9)"
     },
     "DockerTag_Rhel7": {
       "value": "rhel-7-rpmpkg-c982313-20174116044113"

--- a/publish/dir.props
+++ b/publish/dir.props
@@ -41,6 +41,7 @@
     <PublishRid Include="ubuntu.16.04-x64" />
     <PublishRid Include="ubuntu.16.10-x64" />
     <PublishRid Include="debian.8-x64" />
+    <PublishRid Include="debian.9-x64" />
     <PublishRid Include="linux-x64" />
     <PublishRid Include="win-x86" />
     <PublishRid Include="win-x64" />

--- a/publish/dir.targets
+++ b/publish/dir.targets
@@ -56,6 +56,9 @@
       <RepoIds Include="DebianId_debian8-x64">
         <Key>$(DebianId_debian8-x64)</Key>
       </RepoIds>
+      <RepoIds Include="DebianId_debian9-x64">
+        <Key>$(DebianId_debian9-x64)</Key>
+      </RepoIds>
       <RepoIds Include="DebianId_ubuntu1604-x64">
         <Key>$(DebianId_ubuntu1604-x64)</Key>
       </RepoIds>

--- a/src/pkg/packaging/deb/dotnet-sharedframework-debian9_config.json
+++ b/src/pkg/packaging/deb/dotnet-sharedframework-debian9_config.json
@@ -1,0 +1,41 @@
+{
+    "maintainer_name":"Microsoft",
+    "maintainer_email": "dotnetcore@microsoft.com",
+
+    "package_name": "%SHARED_FRAMEWORK_DEBIAN_PACKAGE_NAME%",
+    "install_root": "/usr/share/dotnet",
+
+    "short_description": "%SHARED_FRAMEWORK_BRAND_NAME% %SHARED_FRAMEWORK_NUGET_NAME% %SHARED_FRAMEWORK_NUGET_VERSION%",
+    "long_description": ".NET Core is a development platform that you can use to build command-line applications, microservices and modern websites. It is open source, cross-platform and is supported by Microsoft. We hope you enjoy using it! If you do, please consider joining the active community of developers that are contributing to the project on GitHub (https://github.com/dotnet/core). We happily accept issues and PRs.",
+    "homepage": "https://dotnet.github.io",
+
+    "release":{
+        "package_version":"1.0.0.0",
+        "package_revision":"1",
+        "urgency" : "low",
+        "changelog_message" : "Initial shared framework."
+    },
+
+    "control": {
+        "priority":"standard",
+        "section":"libs",
+        "architecture":"amd64"
+    },
+
+    "copyright": "2017 Microsoft",
+    "license": {
+        "type": "MIT",
+        "full_text": "Copyright (c) 2017 Microsoft\nPermission is hereby granted, free of charge, to any person obtaining a copy\nof this software and associated documentation files (the \"Software\"), to deal\nin the Software without restriction, including without limitation the rights\nto use, copy, modify, merge, publish, distribute, sublicense, and/or sell\ncopies of the Software, and to permit persons to whom the Software is\nfurnished to do so, subject to the following conditions:\nThe above copyright notice and this permission notice shall be included in all\ncopies or substantial portions of the Software.\nTHE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR\nIMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,\nFITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE\nAUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER\nLIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,\nOUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE\nSOFTWARE."
+    },
+
+    "debian_dependencies":{
+        "%HOSTFXR_DEBIAN_PACKAGE_NAME%" : {},
+        "libssl1.0.2" : {},
+        "libicu57": {} 
+    },
+
+    "debian_ignored_dependencies" : [
+        "liblldb-3.5",
+        "liblldb-3.6"
+    ]
+}

--- a/src/pkg/packaging/deb/package.targets
+++ b/src/pkg/packaging/deb/package.targets
@@ -201,6 +201,7 @@
       <InputRoot>$(SharedFrameworkPublishRoot)</InputRoot>
       <DebFile>$(SharedFrameworkInstallerFile)</DebFile>
       <ConfigJsonName>dotnet-sharedframework-debian_config.json</ConfigJsonName>
+      <ConfigJsonName  Condition="$(PackageTargetRid.StartsWith('debian.9'))">dotnet-sharedframework-debian9_config.json</ConfigJsonName>
       <ConfigJsonFile>$(debPackaginfConfigPath)$(ConfigJsonName)</ConfigJsonFile>
       <debIntermediatesDir>$(PackagesIntermediateDir)$(DebPackageName)/$(DebPackageVersion)</debIntermediatesDir>
     </PropertyGroup>


### PR DESCRIPTION
This work enables building Debian 9 packages. This is the first step towards building this new distro specific package. This PR uses Debian 8.2 docker build image with static set of pre-requisite package dependency required for Debian 9. 
