### PR TITLE
[RHEL6] Enable build from latest corefx release/2.0.0 on RHEL 6

### DIFF
--- a/dependencies.props
+++ b/dependencies.props
@@ -17,7 +17,7 @@
 
   <PropertyGroup>
     <PlatformPackageVersion>2.0.0</PlatformPackageVersion>
-    <MicrosoftPrivateCoreFxNETCoreAppPackageVersion>4.4.0-preview3-25519-03</MicrosoftPrivateCoreFxNETCoreAppPackageVersion>
+    <MicrosoftPrivateCoreFxNETCoreAppPackageVersion>4.4.0-preview3-25526-01</MicrosoftPrivateCoreFxNETCoreAppPackageVersion>
     <MicrosoftPrivateCoreFxUAPPackageVersion>4.4.0-preview3-25519-03</MicrosoftPrivateCoreFxUAPPackageVersion>
     <MicrosoftNETCoreRuntimeCoreCLRPackageVersion>2.0.0</MicrosoftNETCoreRuntimeCoreCLRPackageVersion>
     <MicrosoftNETCoreRuntimeJitPackageVersion>$(MicrosoftNETCoreRuntimeCoreCLRPackageVersion)</MicrosoftNETCoreRuntimeJitPackageVersion>


### PR DESCRIPTION
This is a change to make sure that when building  for RHEL 6 and using current release/2.0.0 corefx branch, the build picks the right package from corefx.