### PR TITLE
Make Signing legs use PROD pool

### DIFF
--- a/buildpipeline/Core-Setup-Signing-Windows-x64.json
+++ b/buildpipeline/Core-Setup-Signing-Windows-x64.json
@@ -486,10 +486,10 @@
   "queue": {
     "pool": {
       "id": 83,
-      "name": "DotNetCore-Test"
+      "name": "DotNet-Build"
     },
     "id": 159,
-    "name": "DotNetCore-Test"
+    "name": "DotNet-Build"
   },
   "path": "\\",
   "type": "build",

--- a/buildpipeline/Core-Setup-Signing-Windows-x86.json
+++ b/buildpipeline/Core-Setup-Signing-Windows-x86.json
@@ -489,10 +489,10 @@
   "queue": {
     "pool": {
       "id": 83,
-      "name": "DotNetCore-Test"
+      "name": "DotNet-Build"
     },
     "id": 159,
-    "name": "DotNetCore-Test"
+    "name": "DotNet-Build"
   },
   "path": "\\",
   "type": "build",


### PR DESCRIPTION
Currently we use the test pool for signing legs and we should be using PROD.