### PR TITLE
Move sign legs to PROD

### DIFF
--- a/buildpipeline/Core-Setup-Signing-Windows-x64.json
+++ b/buildpipeline/Core-Setup-Signing-Windows-x64.json
@@ -516,10 +516,10 @@
   "queue": {
     "pool": {
       "id": 83,
-      "name": "DotNetCore-Test"
+      "name": "DotNet-Build"
     },
     "id": 159,
-    "name": "DotNetCore-Test"
+    "name": "DotNet-Build"
   },
   "path": "\\",
   "type": "build",

--- a/buildpipeline/Core-Setup-Signing-Windows-x64.json
+++ b/buildpipeline/Core-Setup-Signing-Windows-x64.json
@@ -518,7 +518,7 @@
       "id": 83,
       "name": "DotNet-Build"
     },
-    "id": 159,
+    "id": 36,
     "name": "DotNet-Build"
   },
   "path": "\\",

--- a/buildpipeline/Core-Setup-Signing-Windows-x64.json
+++ b/buildpipeline/Core-Setup-Signing-Windows-x64.json
@@ -515,7 +515,7 @@
   "quality": "definition",
   "queue": {
     "pool": {
-      "id": 83,
+      "id": 39,
       "name": "DotNet-Build"
     },
     "id": 36,

--- a/buildpipeline/Core-Setup-Signing-Windows-x86.json
+++ b/buildpipeline/Core-Setup-Signing-Windows-x86.json
@@ -489,10 +489,10 @@
   "queue": {
     "pool": {
       "id": 83,
-      "name": "DotNetCore-Test"
+      "name": "DotNet-Build"
     },
     "id": 159,
-    "name": "DotNetCore-Test"
+    "name": "DotNet-Build"
   },
   "path": "\\",
   "type": "build",

--- a/buildpipeline/Core-Setup-Signing-Windows-x86.json
+++ b/buildpipeline/Core-Setup-Signing-Windows-x86.json
@@ -491,7 +491,7 @@
       "id": 83,
       "name": "DotNet-Build"
     },
-    "id": 159,
+    "id": 36,
     "name": "DotNet-Build"
   },
   "path": "\\",

--- a/buildpipeline/Core-Setup-Signing-Windows-x86.json
+++ b/buildpipeline/Core-Setup-Signing-Windows-x86.json
@@ -488,7 +488,7 @@
   "quality": "definition",
   "queue": {
     "pool": {
-      "id": 83,
+      "id": 39,
       "name": "DotNet-Build"
     },
     "id": 36,


### PR DESCRIPTION
Current sign build legs use the test pool. Moving them to use PROD's