### PR TITLE
Compile Microsoft.Build.Net.CoreRuntimeTask with MSFT public key

### DIFF
--- a/src/uwp/Microsoft.Build.Net.CoreRuntimeTask/Microsoft.Build.Net.CoreRuntimeTask.csproj
+++ b/src/uwp/Microsoft.Build.Net.CoreRuntimeTask/Microsoft.Build.Net.CoreRuntimeTask.csproj
@@ -33,7 +33,7 @@
     <ContainsPackageReferences>true</ContainsPackageReferences>
     <TargetFrameworkIdentifier>.NETStandard</TargetFrameworkIdentifier>
     <RestoreOutputPath>obj</RestoreOutputPath>
-    <SkipSigning>true</SkipSigning>
+    <AssemblyKey>MSFT</AssemblyKey>
     <RestorePackages>true</RestorePackages>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the options -->


### PR DESCRIPTION
Strongname signing was disabled for this assembly. Opt it into signing
with the MSFT key.

My previous attempt (https://github.com/dotnet/core-setup/commit/e46a14f5c924bfcf52536436f5386b33b347eb04) was insufficient since signing was disabled in that assembly's project file.