### PR TITLE
Add Redhat6 to official build of core-setup

### DIFF
--- a/buildpipeline/pipeline.json
+++ b/buildpipeline/pipeline.json
@@ -31,6 +31,21 @@
           }
         },
         {
+          "Name": "Core-Setup-Linux-BT",
+          "Parameters": {
+            "PB_DistroRid": "rhel.6.9-x64",
+            "PB_DockerTag": "centos-6-783abde-20171304101322",
+            "PB_AdditionalBuildArguments":"-PortableBuild=false -strip-symbols",
+            "PB_PortableBuild": "false"
+          },
+          "ReportingParameters": {
+            "SubType": "LabBuild",
+            "OperatingSystem": "RedHat6",
+            "Type": "build/product/",
+            "Platform": "x64"
+          }
+        },		
+        {
           "Name": "Core-Setup-Linux-Arm-BT", 
           "Parameters": { 
             "PB_DistroRid": "ubuntu.14.04-arm", 

--- a/buildpipeline/pipeline.json
+++ b/buildpipeline/pipeline.json
@@ -33,7 +33,7 @@
         {
           "Name": "Core-Setup-Linux-BT",
           "Parameters": {
-            "PB_DistroRid": "rhel.6.9-x64",
+            "PB_DistroRid": "rhel.6-x64",
             "PB_DockerTag": "centos-6-783abde-20171304101322",
             "PB_AdditionalBuildArguments":"-PortableBuild=false -strip-symbols",
             "PB_PortableBuild": "false"

--- a/buildpipeline/pipeline.json
+++ b/buildpipeline/pipeline.json
@@ -34,7 +34,7 @@
           "Name": "Core-Setup-Linux-BT",
           "Parameters": {
             "PB_DistroRid": "rhel.6-x64",
-            "PB_DockerTag": "centos-6-783abde-20171304101322",
+            "PB_DockerTag": "centos-6-c8c9b08-20174310104313",
             "PB_AdditionalBuildArguments":"-PortableBuild=false -strip-symbols",
             "PB_PortableBuild": "false"
           },


### PR DESCRIPTION
Add Redhat6 to official build of core-setup. As it's not a portable build, it's parameter is different from rhel.7.2-x64.

Seems core-setup doesn't have test run specs in its json file, which is different from corefx and coreclr. If it actually has, please let me know and I'll enable its test run targeting on Redhat6 as well.

This is the coreclr effort to resolve dotnet/core-eng#1427.

For the reference, the corefx part of this change was merged into corefx release/2.0.0 as
dotnet/corefx@204cdd7

and the coreclr part is:
https://github.com/dotnet/coreclr/pull/13301