### PR TITLE
Add RedHat6 to official builds of core-setup in master branch

### DIFF
--- a/build.proj
+++ b/build.proj
@@ -6,7 +6,7 @@
   <PropertyGroup>
     <SerializeProjects>true</SerializeProjects>
   </PropertyGroup>
-  
+
   <PropertyGroup>
     <!-- To disable the restoration of packages, set RestoreDuringBuild=false or pass /p:RestoreDuringBuild=false.-->
     <RestoreDuringBuild Condition="'$(RestoreDuringBuild)'==''">true</RestoreDuringBuild>

--- a/buildpipeline/pipeline.json
+++ b/buildpipeline/pipeline.json
@@ -31,37 +31,37 @@
           }
         },
         {
-          "Name": "Core-Setup-Linux-BT",
+          "Name": "Core-Setup-Linux-Arm-BT",
           "Parameters": {
             "PB_DistroRid": "rhel.6-x64",
             "PB_DockerTag": "centos-6-c8c9b08-20174310104313",
-            "PB_AdditionalBuildArguments":"-PortableBuild=false -strip-symbols",
+            "PB_TargetArchitecture": "x64",
+            "PB_AdditionalBuildArguments":"-TargetArchitecture=x64 -DistroRid=rhel.6-x64 -PortableBuild=false -strip-symbols",
             "PB_PortableBuild": "false"
           },
           "ReportingParameters": {
-            "SubType": "LabBuild",
             "OperatingSystem": "RedHat6",
             "Type": "build/product/",
             "Platform": "x64"
           }
-        },		
+        },
         {
-          "Name": "Core-Setup-Linux-Arm-BT", 
-          "Parameters": { 
-            "PB_DistroRid": "ubuntu.14.04-arm", 
-            "PB_DockerTag": "ubuntu-14.04-cross-0cd4667-20172211042239", 
-            "PB_TargetArchitecture": "arm", 
+          "Name": "Core-Setup-Linux-Arm-BT",
+          "Parameters": {
+            "PB_DistroRid": "ubuntu.14.04-arm",
+            "PB_DockerTag": "ubuntu-14.04-cross-0cd4667-20172211042239",
+            "PB_TargetArchitecture": "arm",
             "PB_AdditionalBuildArguments":"-TargetArchitecture=arm -DistroRid=linux-arm -DisableCrossgen=true -PortableBuild=true -SkipTests=true -CrossBuild=true -strip-symbols",
             "PB_CrossBuildArgs": "-e ROOTFS_DIR ",
-            "PB_PortableBuild": "true" 
-          }, 
-          "ReportingParameters": { 
-            "SubType": "PortableBuild", 
-            "OperatingSystem": "Ubuntu 14.04", 
-            "Type": "build/product/", 
-            "Platform": "arm" 
-          } 
-        },         
+            "PB_PortableBuild": "true"
+          },
+          "ReportingParameters": {
+            "SubType": "PortableBuild",
+            "OperatingSystem": "Ubuntu 14.04",
+            "Type": "build/product/",
+            "Platform": "arm"
+          }
+        },
         {
           "Name": "Core-Setup-OSX-BT",
           "Parameters": {

--- a/buildpipeline/pipeline.json
+++ b/buildpipeline/pipeline.json
@@ -31,6 +31,21 @@
           }
         },
         {
+          "Name": "Core-Setup-Linux-BT",
+          "Parameters": {
+            "PB_DistroRid": "rhel.6.9-x64",
+            "PB_DockerTag": "centos-6-783abde-20171304101322",
+            "PB_AdditionalBuildArguments":"-PortableBuild=false -strip-symbols",
+            "PB_PortableBuild": "false"
+          },
+          "ReportingParameters": {
+            "SubType": "LabBuild",
+            "OperatingSystem": "RedHat6",
+            "Type": "build/product/",
+            "Platform": "x64"
+          }
+        },		
+        {
           "Name": "Core-Setup-Linux-Arm-BT", 
           "Parameters": { 
             "PB_DistroRid": "ubuntu.14.04-arm", 

--- a/buildpipeline/pipeline.json
+++ b/buildpipeline/pipeline.json
@@ -33,7 +33,7 @@
         {
           "Name": "Core-Setup-Linux-BT",
           "Parameters": {
-            "PB_DistroRid": "rhel.6.9-x64",
+            "PB_DistroRid": "rhel.6-x64",
             "PB_DockerTag": "centos-6-783abde-20171304101322",
             "PB_AdditionalBuildArguments":"-PortableBuild=false -strip-symbols",
             "PB_PortableBuild": "false"

--- a/buildpipeline/pipeline.json
+++ b/buildpipeline/pipeline.json
@@ -34,7 +34,7 @@
           "Name": "Core-Setup-Linux-BT",
           "Parameters": {
             "PB_DistroRid": "rhel.6-x64",
-            "PB_DockerTag": "centos-6-783abde-20171304101322",
+            "PB_DockerTag": "centos-6-c8c9b08-20174310104313",
             "PB_AdditionalBuildArguments":"-PortableBuild=false -strip-symbols",
             "PB_PortableBuild": "false"
           },

--- a/dir.targets
+++ b/dir.targets
@@ -27,7 +27,6 @@
         <CustomTaskDependencies Include="$(BuildToolsTaskDir)Newtonsoft.Json.dll" />
         <CustomTaskDependencies Include="$(BuildToolsTaskDir)Microsoft.DotNet.PlatformAbstractions.dll" />
         <CustomTaskDependencies Include="$(PackagesDir)microsoft.extensions.dependencymodel\1.1.1\lib\$(DependencyModelTFM)\Microsoft.Extensions.DependencyModel.dll" />
-        <CustomTaskDependencies Include="$(PackagesDir)nuget.runtimemodel\4.3.0-preview2-4095\lib\$(NugetModelTFM)\NuGet.RuntimeModel.dll" />
       </ItemGroup>        
       <Copy SourceFiles="@(CustomTaskDependencies)"
             DestinationFolder="$(LocalBuildToolsTaskDir)"

--- a/dir.targets
+++ b/dir.targets
@@ -18,7 +18,7 @@
 
     <PropertyGroup>
       <DependencyModelTFM>netstandard1.3</DependencyModelTFM>
-      <DependencyModelTFM Condition="'$(MSBuildRuntimeType)' != 'Core'">net451</DependencyModelTFM>  
+      <DependencyModelTFM Condition="'$(MSBuildRuntimeType)' != 'Core'">net451</DependencyModelTFM>
     </PropertyGroup>
 
       <ItemGroup>

--- a/dir.targets
+++ b/dir.targets
@@ -18,9 +18,7 @@
 
     <PropertyGroup>
       <DependencyModelTFM>netstandard1.3</DependencyModelTFM>
-      <DependencyModelTFM Condition="'$(MSBuildRuntimeType)' != 'Core'">net451</DependencyModelTFM>
-      <NugetModelTFM>netstandard1.3</NugetModelTFM>
-      <NugetModelTFM Condition="'$(MSBuildRuntimeType)' != 'Core'">net45</NugetModelTFM>	  
+      <DependencyModelTFM Condition="'$(MSBuildRuntimeType)' != 'Core'">net451</DependencyModelTFM>  
     </PropertyGroup>
 
       <ItemGroup>

--- a/dir.targets
+++ b/dir.targets
@@ -19,12 +19,15 @@
     <PropertyGroup>
       <DependencyModelTFM>netstandard1.3</DependencyModelTFM>
       <DependencyModelTFM Condition="'$(MSBuildRuntimeType)' != 'Core'">net451</DependencyModelTFM>
+      <NugetModelTFM>netstandard1.3</NugetModelTFM>
+      <NugetModelTFM Condition="'$(MSBuildRuntimeType)' != 'Core'">net45</NugetModelTFM>	  
     </PropertyGroup>
-    
+
       <ItemGroup>
         <CustomTaskDependencies Include="$(BuildToolsTaskDir)Newtonsoft.Json.dll" />
         <CustomTaskDependencies Include="$(BuildToolsTaskDir)Microsoft.DotNet.PlatformAbstractions.dll" />
         <CustomTaskDependencies Include="$(PackagesDir)microsoft.extensions.dependencymodel\1.1.1\lib\$(DependencyModelTFM)\Microsoft.Extensions.DependencyModel.dll" />
+        <CustomTaskDependencies Include="$(PackagesDir)nuget.runtimemodel\3.5.0\lib\$(NugetModelTFM)\NuGet.RuntimeModel.dll" />
       </ItemGroup>        
       <Copy SourceFiles="@(CustomTaskDependencies)"
             DestinationFolder="$(LocalBuildToolsTaskDir)"

--- a/dir.targets
+++ b/dir.targets
@@ -27,7 +27,7 @@
         <CustomTaskDependencies Include="$(BuildToolsTaskDir)Newtonsoft.Json.dll" />
         <CustomTaskDependencies Include="$(BuildToolsTaskDir)Microsoft.DotNet.PlatformAbstractions.dll" />
         <CustomTaskDependencies Include="$(PackagesDir)microsoft.extensions.dependencymodel\1.1.1\lib\$(DependencyModelTFM)\Microsoft.Extensions.DependencyModel.dll" />
-        <CustomTaskDependencies Include="$(PackagesDir)nuget.runtimemodel\3.5.0\lib\$(NugetModelTFM)\NuGet.RuntimeModel.dll" />
+        <CustomTaskDependencies Include="$(PackagesDir)nuget.runtimemodel\4.3.0-preview2-4095\lib\$(NugetModelTFM)\NuGet.RuntimeModel.dll" />
       </ItemGroup>        
       <Copy SourceFiles="@(CustomTaskDependencies)"
             DestinationFolder="$(LocalBuildToolsTaskDir)"

--- a/dir.targets
+++ b/dir.targets
@@ -19,7 +19,7 @@
     <PropertyGroup>
       <DependencyModelTFM>netstandard1.3</DependencyModelTFM>
       <DependencyModelTFM Condition="'$(MSBuildRuntimeType)' != 'Core'">net451</DependencyModelTFM>
-      <NugetModelTFM>netstandard1.3</NugetModelTFM>
+      <NugetModelTFM>net45</NugetModelTFM>
       <NugetModelTFM Condition="'$(MSBuildRuntimeType)' != 'Core'">net45</NugetModelTFM>	  
     </PropertyGroup>
 

--- a/dir.targets
+++ b/dir.targets
@@ -19,7 +19,7 @@
     <PropertyGroup>
       <DependencyModelTFM>netstandard1.3</DependencyModelTFM>
       <DependencyModelTFM Condition="'$(MSBuildRuntimeType)' != 'Core'">net451</DependencyModelTFM>
-      <NugetModelTFM>net45</NugetModelTFM>
+      <NugetModelTFM>netstandard1.3</NugetModelTFM>
       <NugetModelTFM Condition="'$(MSBuildRuntimeType)' != 'Core'">net45</NugetModelTFM>	  
     </PropertyGroup>
 

--- a/init-tools.sh
+++ b/init-tools.sh
@@ -33,6 +33,14 @@ OSName=$(uname -s)
         Linux)
             __DOTNET_PKG=dotnet-dev-linux-x64
             OS=Linux
+			
+            if [ -e /etc/redhat-release ]; then
+                redhatRelease=$(</etc/redhat-release)
+                if [[ $redhatRelease == "CentOS release 6."* || $redhatRelease == "Red Hat Enterprise Linux Server release 6."* ]]; then
+                    __DOTNET_PKG=dotnet-dev-rhel.6-x64
+                fi
+            fi			
+			
             ;;
 
         *)

--- a/src/pkg/projects/netcoreappRIDs.props
+++ b/src/pkg/projects/netcoreappRIDs.props
@@ -17,6 +17,7 @@
 
   <ItemGroup>
     <OfficialBuildRID Include="linux-x64" />
+	<OfficialBuildRID Include="rhel.6-x64" />
     <OfficialBuildRID Include="osx-x64" />
     <OfficialBuildRID Include="win-x86">
       <Platform>x86</Platform>

--- a/src/pkg/projects/netcoreappRIDs.props
+++ b/src/pkg/projects/netcoreappRIDs.props
@@ -17,7 +17,7 @@
 
   <ItemGroup>
     <OfficialBuildRID Include="linux-x64" />
-	<OfficialBuildRID Include="rhel.6-x64" />
+    <OfficialBuildRID Include="rhel.6-x64" />
     <OfficialBuildRID Include="osx-x64" />
     <OfficialBuildRID Include="win-x86">
       <Platform>x86</Platform>


### PR DESCRIPTION
Add RedHat6 to official builds of core-setup in master branch, this is
identical to the PR to enable Rhel6 in release/2.0.0:
https://github.com/dotnet/core-setup/pull/3017