### PR TITLE
Update .NET Native tools to 25610-00

### DIFF
--- a/dependencies.props
+++ b/dependencies.props
@@ -17,11 +17,11 @@
   
   <PropertyGroup>
     <MicrosoftPrivateCoreFxNETCoreAppPackageVersion>4.5.0-preview1-25531-01</MicrosoftPrivateCoreFxNETCoreAppPackageVersion>
-    <MicrosoftPrivateCoreFxUAPPackageVersion>4.5.0-preview1-25610-01</MicrosoftPrivateCoreFxUAPPackageVersion>
+    <MicrosoftPrivateCoreFxUAPPackageVersion>4.5.0-preview1-25608-01</MicrosoftPrivateCoreFxUAPPackageVersion>
     <PlatformPackageVersion>2.1.0-preview1-25610-01</PlatformPackageVersion>
     <MicrosoftNETCoreRuntimeCoreCLRPackageVersion>2.1.0-preview1-25610-02</MicrosoftNETCoreRuntimeCoreCLRPackageVersion>
     <MicrosoftNETCoreRuntimeJitPackageVersion>$(MicrosoftNETCoreRuntimeCoreCLRPackageVersion)</MicrosoftNETCoreRuntimeJitPackageVersion>
-    <MicrosoftNetNativeCompilerPackageVersion>2.0.0-preview-25607-01</MicrosoftNetNativeCompilerPackageVersion>
+    <MicrosoftNetNativeCompilerPackageVersion>2.0.0-preview-25610-00</MicrosoftNetNativeCompilerPackageVersion>
     <NETStandardVersion>2.1.0-preview1-25609-01</NETStandardVersion>
     <DiaSymReaderNativeVersion>1.4.1</DiaSymReaderNativeVersion>
     <WcfVersion>4.5.0-preview1-25610-02</WcfVersion>


### PR DESCRIPTION
Also, set the CoreFX package version to 25608-01 to match the package
used to build .NET Native, so that the shared framework is valid.
