### PR TITLE
Port strongname signing fixes for CoreRuntimeTask

### DIFF
--- a/signing/sign.proj
+++ b/signing/sign.proj
@@ -38,6 +38,7 @@
       </FilesToSign>
       <FilesToSign Include="$(OutDir)Microsoft.Build.Net.CoreRuntimeTask/**/Microsoft.Build.Net.CoreRuntimeTask.dll">
         <Authenticode>$(CertificateId)</Authenticode>
+        <StrongName>StrongName</StrongName>
       </FilesToSign>
     </ItemGroup>
 

--- a/src/uwp/Microsoft.Build.Net.CoreRuntimeTask/Microsoft.Build.Net.CoreRuntimeTask.csproj
+++ b/src/uwp/Microsoft.Build.Net.CoreRuntimeTask/Microsoft.Build.Net.CoreRuntimeTask.csproj
@@ -33,7 +33,7 @@
     <ContainsPackageReferences>true</ContainsPackageReferences>
     <TargetFrameworkIdentifier>.NETStandard</TargetFrameworkIdentifier>
     <RestoreOutputPath>obj</RestoreOutputPath>
-    <SkipSigning>true</SkipSigning>
+    <AssemblyKey>MSFT</AssemblyKey>
     <RestorePackages>true</RestorePackages>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the options -->


### PR DESCRIPTION
Strongname sign Microsoft.Build.Net.CoreRuntimeTask.dll to prevent MSBuild workers using an incorrect version in side-by-side VS installations.