### PR TITLE
Fix homebrew link

### DIFF
--- a/src/pkg/packaging/osx/hostfxr/resources/cs.lproj/conclusion.html
+++ b/src/pkg/packaging/osx/hostfxr/resources/cs.lproj/conclusion.html
@@ -14,8 +14,8 @@
         </h2>
         <p>
         In order to be able to use .NET Core on OS X, you need to install <b>OpenSSL</b> version <b>1.0.1/1.0.2</b>. 
-        There are many ways to install/update your libssl. Using <a href="http://www.brew.sh">Homebrew</a> is the easiest. 
-        You can view the instructions <a href="http://brewformulas.org/Openssl">here</a> or if you're updating, <a href="https://github.com/dotnet/coreclr/blob/63766f74c4a641a274cd2933b9b7fd7bbddef2dd/Documentation/building/osx-instructions.md#openssl">on this page</a>.
+        There are many ways to install/update your libssl. Using <a href="https://brew.sh">Homebrew</a> is the easiest. 
+        You can view the instructions <a href="http://brewformulas.org/Openssl">here</a> or if you're updating, <a href="https://github.com/dotnet/coreclr/blob/master/Documentation/building/osx-instructions.md#openssl">on this page</a>.
         </p>
         </div>
 </body>

--- a/src/pkg/packaging/osx/hostfxr/resources/de.lproj/conclusion.html
+++ b/src/pkg/packaging/osx/hostfxr/resources/de.lproj/conclusion.html
@@ -14,8 +14,8 @@
         </h2>
         <p>
         In order to be able to use .NET Core on OS X, you need to install <b>OpenSSL</b> version <b>1.0.1/1.0.2</b>. 
-        There are many ways to install/update your libssl. Using <a href="http://www.brew.sh">Homebrew</a> is the easiest. 
-        You can view the instructions <a href="http://brewformulas.org/Openssl">here</a> or if you're updating, <a href="https://github.com/dotnet/coreclr/blob/63766f74c4a641a274cd2933b9b7fd7bbddef2dd/Documentation/building/osx-instructions.md#openssl">on this page</a>.
+        There are many ways to install/update your libssl. Using <a href="https://brew.sh">Homebrew</a> is the easiest. 
+        You can view the instructions <a href="http://brewformulas.org/Openssl">here</a> or if you're updating, <a href="https://github.com/dotnet/coreclr/blob/master/Documentation/building/osx-instructions.md#openssl">on this page</a>.
         </p>
         </div>
 </body>

--- a/src/pkg/packaging/osx/hostfxr/resources/en.lproj/conclusion.html
+++ b/src/pkg/packaging/osx/hostfxr/resources/en.lproj/conclusion.html
@@ -14,8 +14,8 @@
         </h2>
         <p>
         In order to be able to use .NET Core on OS X, you need to install <b>OpenSSL</b> version <b>1.0.1/1.0.2</b>. 
-        There are many ways to install/update your libssl. Using <a href="http://www.brew.sh">Homebrew</a> is the easiest. 
-        You can view the instructions <a href="http://brewformulas.org/Openssl">here</a> or if you're updating, <a href="https://github.com/dotnet/coreclr/blob/63766f74c4a641a274cd2933b9b7fd7bbddef2dd/Documentation/building/osx-instructions.md#openssl">on this page</a>.
+        There are many ways to install/update your libssl. Using <a href="https://brew.sh">Homebrew</a> is the easiest. 
+        You can view the instructions <a href="http://brewformulas.org/Openssl">here</a> or if you're updating, <a href="https://github.com/dotnet/coreclr/blob/master/Documentation/building/osx-instructions.md#openssl">on this page</a>.
         </p>
         </div>
 </body>

--- a/src/pkg/packaging/osx/hostfxr/resources/es.lproj/conclusion.html
+++ b/src/pkg/packaging/osx/hostfxr/resources/es.lproj/conclusion.html
@@ -14,8 +14,8 @@
         </h2>
         <p>
         In order to be able to use .NET Core on OS X, you need to install <b>OpenSSL</b> version <b>1.0.1/1.0.2</b>. 
-        There are many ways to install/update your libssl. Using <a href="http://www.brew.sh">Homebrew</a> is the easiest. 
-        You can view the instructions <a href="http://brewformulas.org/Openssl">here</a> or if you're updating, <a href="https://github.com/dotnet/coreclr/blob/63766f74c4a641a274cd2933b9b7fd7bbddef2dd/Documentation/building/osx-instructions.md#openssl">on this page</a>.
+        There are many ways to install/update your libssl. Using <a href="https://brew.sh">Homebrew</a> is the easiest. 
+        You can view the instructions <a href="http://brewformulas.org/Openssl">here</a> or if you're updating, <a href="https://github.com/dotnet/coreclr/blob/master/Documentation/building/osx-instructions.md#openssl">on this page</a>.
         </p>
         </div>
 </body>

--- a/src/pkg/packaging/osx/hostfxr/resources/fr.lproj/conclusion.html
+++ b/src/pkg/packaging/osx/hostfxr/resources/fr.lproj/conclusion.html
@@ -14,8 +14,8 @@
         </h2>
         <p>
         In order to be able to use .NET Core on OS X, you need to install <b>OpenSSL</b> version <b>1.0.1/1.0.2</b>. 
-        There are many ways to install/update your libssl. Using <a href="http://www.brew.sh">Homebrew</a> is the easiest. 
-        You can view the instructions <a href="http://brewformulas.org/Openssl">here</a> or if you're updating, <a href="https://github.com/dotnet/coreclr/blob/63766f74c4a641a274cd2933b9b7fd7bbddef2dd/Documentation/building/osx-instructions.md#openssl">on this page</a>.
+        There are many ways to install/update your libssl. Using <a href="https://brew.sh">Homebrew</a> is the easiest. 
+        You can view the instructions <a href="http://brewformulas.org/Openssl">here</a> or if you're updating, <a href="https://github.com/dotnet/coreclr/blob/master/Documentation/building/osx-instructions.md#openssl">on this page</a>.
         </p>
         </div>
 </body>

--- a/src/pkg/packaging/osx/hostfxr/resources/it.lproj/conclusion.html
+++ b/src/pkg/packaging/osx/hostfxr/resources/it.lproj/conclusion.html
@@ -14,8 +14,8 @@
         </h2>
         <p>
         In order to be able to use .NET Core on OS X, you need to install <b>OpenSSL</b> version <b>1.0.1/1.0.2</b>. 
-        There are many ways to install/update your libssl. Using <a href="http://www.brew.sh">Homebrew</a> is the easiest. 
-        You can view the instructions <a href="http://brewformulas.org/Openssl">here</a> or if you're updating, <a href="https://github.com/dotnet/coreclr/blob/63766f74c4a641a274cd2933b9b7fd7bbddef2dd/Documentation/building/osx-instructions.md#openssl">on this page</a>.
+        There are many ways to install/update your libssl. Using <a href="https://brew.sh">Homebrew</a> is the easiest. 
+        You can view the instructions <a href="http://brewformulas.org/Openssl">here</a> or if you're updating, <a href="https://github.com/dotnet/coreclr/blob/master/Documentation/building/osx-instructions.md#openssl">on this page</a>.
         </p>
         </div>
 </body>

--- a/src/pkg/packaging/osx/hostfxr/resources/ja.lproj/conclusion.html
+++ b/src/pkg/packaging/osx/hostfxr/resources/ja.lproj/conclusion.html
@@ -14,8 +14,8 @@
         </h2>
         <p>
         In order to be able to use .NET Core on OS X, you need to install <b>OpenSSL</b> version <b>1.0.1/1.0.2</b>. 
-        There are many ways to install/update your libssl. Using <a href="http://www.brew.sh">Homebrew</a> is the easiest. 
-        You can view the instructions <a href="http://brewformulas.org/Openssl">here</a> or if you're updating, <a href="https://github.com/dotnet/coreclr/blob/63766f74c4a641a274cd2933b9b7fd7bbddef2dd/Documentation/building/osx-instructions.md#openssl">on this page</a>.
+        There are many ways to install/update your libssl. Using <a href="https://brew.sh">Homebrew</a> is the easiest. 
+        You can view the instructions <a href="http://brewformulas.org/Openssl">here</a> or if you're updating, <a href="https://github.com/dotnet/coreclr/blob/master/Documentation/building/osx-instructions.md#openssl">on this page</a>.
         </p>
         </div>
 </body>

--- a/src/pkg/packaging/osx/hostfxr/resources/ko.lproj/conclusion.html
+++ b/src/pkg/packaging/osx/hostfxr/resources/ko.lproj/conclusion.html
@@ -14,8 +14,8 @@
         </h2>
         <p>
         In order to be able to use .NET Core on OS X, you need to install <b>OpenSSL</b> version <b>1.0.1/1.0.2</b>. 
-        There are many ways to install/update your libssl. Using <a href="http://www.brew.sh">Homebrew</a> is the easiest. 
-        You can view the instructions <a href="http://brewformulas.org/Openssl">here</a> or if you're updating, <a href="https://github.com/dotnet/coreclr/blob/63766f74c4a641a274cd2933b9b7fd7bbddef2dd/Documentation/building/osx-instructions.md#openssl">on this page</a>.
+        There are many ways to install/update your libssl. Using <a href="https://brew.sh">Homebrew</a> is the easiest. 
+        You can view the instructions <a href="http://brewformulas.org/Openssl">here</a> or if you're updating, <a href="https://github.com/dotnet/coreclr/blob/master/Documentation/building/osx-instructions.md#openssl">on this page</a>.
         </p>
         </div>
 </body>

--- a/src/pkg/packaging/osx/hostfxr/resources/pl.lproj/conclusion.html
+++ b/src/pkg/packaging/osx/hostfxr/resources/pl.lproj/conclusion.html
@@ -14,8 +14,8 @@
         </h2>
         <p>
         In order to be able to use .NET Core on OS X, you need to install <b>OpenSSL</b> version <b>1.0.1/1.0.2</b>. 
-        There are many ways to install/update your libssl. Using <a href="http://www.brew.sh">Homebrew</a> is the easiest. 
-        You can view the instructions <a href="http://brewformulas.org/Openssl">here</a> or if you're updating, <a href="https://github.com/dotnet/coreclr/blob/63766f74c4a641a274cd2933b9b7fd7bbddef2dd/Documentation/building/osx-instructions.md#openssl">on this page</a>.
+        There are many ways to install/update your libssl. Using <a href="https://brew.sh">Homebrew</a> is the easiest. 
+        You can view the instructions <a href="http://brewformulas.org/Openssl">here</a> or if you're updating, <a href="https://github.com/dotnet/coreclr/blob/master/Documentation/building/osx-instructions.md#openssl">on this page</a>.
         </p>
         </div>
 </body>

--- a/src/pkg/packaging/osx/hostfxr/resources/pt-br.lproj/conclusion.html
+++ b/src/pkg/packaging/osx/hostfxr/resources/pt-br.lproj/conclusion.html
@@ -14,8 +14,8 @@
         </h2>
         <p>
         In order to be able to use .NET Core on OS X, you need to install <b>OpenSSL</b> version <b>1.0.1/1.0.2</b>. 
-        There are many ways to install/update your libssl. Using <a href="http://www.brew.sh">Homebrew</a> is the easiest. 
-        You can view the instructions <a href="http://brewformulas.org/Openssl">here</a> or if you're updating, <a href="https://github.com/dotnet/coreclr/blob/63766f74c4a641a274cd2933b9b7fd7bbddef2dd/Documentation/building/osx-instructions.md#openssl">on this page</a>.
+        There are many ways to install/update your libssl. Using <a href="https://brew.sh">Homebrew</a> is the easiest. 
+        You can view the instructions <a href="http://brewformulas.org/Openssl">here</a> or if you're updating, <a href="https://github.com/dotnet/coreclr/blob/master/Documentation/building/osx-instructions.md#openssl">on this page</a>.
         </p>
         </div>
 </body>

--- a/src/pkg/packaging/osx/hostfxr/resources/ru.lproj/conclusion.html
+++ b/src/pkg/packaging/osx/hostfxr/resources/ru.lproj/conclusion.html
@@ -14,8 +14,8 @@
         </h2>
         <p>
         In order to be able to use .NET Core on OS X, you need to install <b>OpenSSL</b> version <b>1.0.1/1.0.2</b>. 
-        There are many ways to install/update your libssl. Using <a href="http://www.brew.sh">Homebrew</a> is the easiest. 
-        You can view the instructions <a href="http://brewformulas.org/Openssl">here</a> or if you're updating, <a href="https://github.com/dotnet/coreclr/blob/63766f74c4a641a274cd2933b9b7fd7bbddef2dd/Documentation/building/osx-instructions.md#openssl">on this page</a>.
+        There are many ways to install/update your libssl. Using <a href="https://brew.sh">Homebrew</a> is the easiest. 
+        You can view the instructions <a href="http://brewformulas.org/Openssl">here</a> or if you're updating, <a href="https://github.com/dotnet/coreclr/blob/master/Documentation/building/osx-instructions.md#openssl">on this page</a>.
         </p>
         </div>
 </body>

--- a/src/pkg/packaging/osx/hostfxr/resources/tr.lproj/conclusion.html
+++ b/src/pkg/packaging/osx/hostfxr/resources/tr.lproj/conclusion.html
@@ -14,8 +14,8 @@
         </h2>
         <p>
         In order to be able to use .NET Core on OS X, you need to install <b>OpenSSL</b> version <b>1.0.1/1.0.2</b>. 
-        There are many ways to install/update your libssl. Using <a href="http://www.brew.sh">Homebrew</a> is the easiest. 
-        You can view the instructions <a href="http://brewformulas.org/Openssl">here</a> or if you're updating, <a href="https://github.com/dotnet/coreclr/blob/63766f74c4a641a274cd2933b9b7fd7bbddef2dd/Documentation/building/osx-instructions.md#openssl">on this page</a>.
+        There are many ways to install/update your libssl. Using <a href="https://brew.sh">Homebrew</a> is the easiest. 
+        You can view the instructions <a href="http://brewformulas.org/Openssl">here</a> or if you're updating, <a href="https://github.com/dotnet/coreclr/blob/master/Documentation/building/osx-instructions.md#openssl">on this page</a>.
         </p>
         </div>
 </body>

--- a/src/pkg/packaging/osx/hostfxr/resources/zh-hans.lproj/conclusion.html
+++ b/src/pkg/packaging/osx/hostfxr/resources/zh-hans.lproj/conclusion.html
@@ -14,8 +14,8 @@
         </h2>
         <p>
         In order to be able to use .NET Core on OS X, you need to install <b>OpenSSL</b> version <b>1.0.1/1.0.2</b>. 
-        There are many ways to install/update your libssl. Using <a href="http://www.brew.sh">Homebrew</a> is the easiest. 
-        You can view the instructions <a href="http://brewformulas.org/Openssl">here</a> or if you're updating, <a href="https://github.com/dotnet/coreclr/blob/63766f74c4a641a274cd2933b9b7fd7bbddef2dd/Documentation/building/osx-instructions.md#openssl">on this page</a>.
+        There are many ways to install/update your libssl. Using <a href="https://brew.sh">Homebrew</a> is the easiest. 
+        You can view the instructions <a href="http://brewformulas.org/Openssl">here</a> or if you're updating, <a href="https://github.com/dotnet/coreclr/blob/master/Documentation/building/osx-instructions.md#openssl">on this page</a>.
         </p>
         </div>
 </body>

--- a/src/pkg/packaging/osx/hostfxr/resources/zh-hant.lproj/conclusion.html
+++ b/src/pkg/packaging/osx/hostfxr/resources/zh-hant.lproj/conclusion.html
@@ -14,8 +14,8 @@
         </h2>
         <p>
         In order to be able to use .NET Core on OS X, you need to install <b>OpenSSL</b> version <b>1.0.1/1.0.2</b>. 
-        There are many ways to install/update your libssl. Using <a href="http://www.brew.sh">Homebrew</a> is the easiest. 
-        You can view the instructions <a href="http://brewformulas.org/Openssl">here</a> or if you're updating, <a href="https://github.com/dotnet/coreclr/blob/63766f74c4a641a274cd2933b9b7fd7bbddef2dd/Documentation/building/osx-instructions.md#openssl">on this page</a>.
+        There are many ways to install/update your libssl. Using <a href="https://brew.sh">Homebrew</a> is the easiest. 
+        You can view the instructions <a href="http://brewformulas.org/Openssl">here</a> or if you're updating, <a href="https://github.com/dotnet/coreclr/blob/master/Documentation/building/osx-instructions.md#openssl">on this page</a>.
         </p>
         </div>
 </body>


### PR DESCRIPTION
* The homebrew link in the conclusion.html is broken.
* Removes "www."
* Switched to https.
* Also noticed a commit-specific GitHub link; switched to master branch.