### PR TITLE
Allow AppBaseCompilation assembly resolver to resolve 'reference'

### DIFF
--- a/src/managed/Microsoft.Extensions.DependencyModel/Resolution/AppBaseCompilationAssemblyResolver.cs
+++ b/src/managed/Microsoft.Extensions.DependencyModel/Resolution/AppBaseCompilationAssemblyResolver.cs
@@ -45,9 +45,10 @@ namespace Microsoft.Extensions.DependencyModel.Resolution
                 string.Equals(library.Type, "msbuildproject", StringComparison.OrdinalIgnoreCase);
 
             var isPackage = string.Equals(library.Type, "package", StringComparison.OrdinalIgnoreCase);
+            var isReferenceAssembly = string.Equals(library.Type, "referenceassembly", StringComparison.OrdinalIgnoreCase);
             if (!isProject &&
                 !isPackage &&
-                !string.Equals(library.Type, "referenceassembly", StringComparison.OrdinalIgnoreCase) &&
+                !isReferenceAssembly &&
                 !string.Equals(library.Type, "reference", StringComparison.OrdinalIgnoreCase))
             {
                 return false;
@@ -57,7 +58,7 @@ namespace Microsoft.Extensions.DependencyModel.Resolution
             var isPublished = _fileSystem.Directory.Exists(refsPath);
 
             // Resolving reference assebmlies requires refs folder to exist
-            if (!isProject && !isPackage && !isPublished)
+            if (isReferenceAssembly && !isPublished)
             {
                 return false;
             }

--- a/src/managed/Microsoft.Extensions.DependencyModel/Resolution/AppBaseCompilationAssemblyResolver.cs
+++ b/src/managed/Microsoft.Extensions.DependencyModel/Resolution/AppBaseCompilationAssemblyResolver.cs
@@ -47,7 +47,8 @@ namespace Microsoft.Extensions.DependencyModel.Resolution
             var isPackage = string.Equals(library.Type, "package", StringComparison.OrdinalIgnoreCase);
             if (!isProject &&
                 !isPackage &&
-                !string.Equals(library.Type, "referenceassembly", StringComparison.OrdinalIgnoreCase))
+                !string.Equals(library.Type, "referenceassembly", StringComparison.OrdinalIgnoreCase) &&
+                !string.Equals(library.Type, "reference", StringComparison.OrdinalIgnoreCase))
             {
                 return false;
             }

--- a/src/managed/Microsoft.Extensions.DependencyModel/Resolution/AppBaseCompilationAssemblyResolver.cs
+++ b/src/managed/Microsoft.Extensions.DependencyModel/Resolution/AppBaseCompilationAssemblyResolver.cs
@@ -57,7 +57,7 @@ namespace Microsoft.Extensions.DependencyModel.Resolution
             var refsPath = Path.Combine(_basePath, RefsDirectoryName);
             var isPublished = _fileSystem.Directory.Exists(refsPath);
 
-            // Resolving reference assebmlies requires refs folder to exist
+            // Resolving reference assemblies requires refs folder to exist
             if (isReferenceAssembly && !isPublished)
             {
                 return false;

--- a/src/test/Microsoft.Extensions.DependencyModel.Tests/AppBaseResolverTests.cs
+++ b/src/test/Microsoft.Extensions.DependencyModel.Tests/AppBaseResolverTests.cs
@@ -147,6 +147,27 @@ namespace Microsoft.Extensions.DependencyModel.Tests
         }
 
         [Fact]
+        public void ResolvesDirectReferenceWithoutRefsFolder()
+        {
+            var fileSystem = FileSystemMockBuilder
+                .Create()
+                .AddFiles(BasePath, TestLibraryFactory.DefaultAssembly, TestLibraryFactory.SecondAssembly)
+                .Build();
+            var library = TestLibraryFactory.Create(
+                TestLibraryFactory.ReferenceType,
+                assemblies: TestLibraryFactory.TwoAssemblies);
+            var resolver = CreateResolver(fileSystem);
+            var assemblies = new List<string>();
+
+            var result = resolver.TryResolveAssemblyPaths(library, assemblies);
+
+            Assert.True(result);
+            assemblies.Should().HaveCount(2);
+            assemblies.Should().Contain(Path.Combine(BasePath, TestLibraryFactory.DefaultAssembly));
+            assemblies.Should().Contain(Path.Combine(BasePath, TestLibraryFactory.SecondAssembly));
+        }
+
+        [Fact]
         public void RequiresAllLibrariesToExist()
         {
             var fileSystem = FileSystemMockBuilder

--- a/src/test/Microsoft.Extensions.DependencyModel.Tests/AppBaseResolverTests.cs
+++ b/src/test/Microsoft.Extensions.DependencyModel.Tests/AppBaseResolverTests.cs
@@ -90,6 +90,23 @@ namespace Microsoft.Extensions.DependencyModel.Tests
         }
 
         [Fact]
+        public void ResolvesReferenceType()
+        {
+            var fileSystem = FileSystemMockBuilder
+                .Create()
+                .AddFiles(BasePathRefs, TestLibraryFactory.DefaultAssembly)
+                .Build();
+            var resolver = CreateResolver(fileSystem);
+            var library = TestLibraryFactory.Create(
+                TestLibraryFactory.ReferenceType,
+                assemblies: TestLibraryFactory.EmptyAssemblies);
+
+            var result = resolver.TryResolveAssemblyPaths(library, null);
+
+            Assert.True(result);
+        }
+
+        [Fact]
         public void RequiresExistingRefsFolderForNonProjects()
         {
             var fileSystem = FileSystemMockBuilder

--- a/src/test/Microsoft.Extensions.DependencyModel.Tests/TestLibraryFactory.cs
+++ b/src/test/Microsoft.Extensions.DependencyModel.Tests/TestLibraryFactory.cs
@@ -30,6 +30,7 @@ namespace Microsoft.Extensions.DependencyModel.Tests
         public static readonly string ProjectType = "project";
         public static readonly string MsBuildProjectType = "msbuildproject";
         public static readonly string ReferenceAssemblyType = "referenceassembly";
+        public static readonly string ReferenceType = "reference";
         public static readonly string PackageType = "package";
 
         public static CompilationLibrary Create(


### PR DESCRIPTION
Just allow the AppBaseCompilation resolver to move forward if the library type is 'reference.' This will allow it to find direct DLL references in the build output.

This fixes this issue which I just filed: dotnet/sdk#1500

This issue seems to be specifically related to VS 15.3. I wasn't able to figure out why exactly but this issue is reproducible with ASP.Net Core 1.1 and ASP.Net Core 2.0 in VS 2017 15.3 but seems to work fine in the earlier version of VS 2017.

Edit: This has nothing to do with Visual Studio. I just made the assumption based on the fact that I had recently upgraded.