### PR TITLE
[1.0.0] Remove finalize tracking for removed build legs

### DIFF
--- a/build_projects/dotnet-host-build/PublishTargets.cs
+++ b/build_projects/dotnet-host-build/PublishTargets.cs
@@ -130,8 +130,6 @@ namespace Microsoft.DotNet.Host.Build
                         "osx.x64.version",
                         "debian.x64.version",
                         "centos.x64.version",
-                        "fedora.23.x64.version",
-                        "opensuse.13.2.x64.version"
                     };
                     
                     c.BuildContext.RunTarget(nameof(PublishTargets.PublishCoreHostPackagesToFeed));
@@ -213,8 +211,6 @@ namespace Microsoft.DotNet.Host.Build
                  { "sharedfx_OSX_x64", false },
                  { "sharedfx_Debian_x64", false },
                  { "sharedfx_CentOS_x64", false },
-                 { "sharedfx_Fedora_23_x64", false },
-                 { "sharedfx_openSUSE_13_2_x64", false }
              };
 
             List<string> blobs = new List<string>(AzurePublisherTool.ListBlobs($"{Channel}/Binaries/{SharedFrameworkNugetVersion}/"));


### PR DESCRIPTION
Some platforms are being checked as a finalization prereq even though the legs aren't being run. See https://github.com/dotnet/core-eng/issues/1540. Removing the checks unblocks build finalization.