### PR TITLE
[1.1.0] Remove finalize tracking for removed build legs

### DIFF
--- a/build_projects/dotnet-host-build/PublishTargets.cs
+++ b/build_projects/dotnet-host-build/PublishTargets.cs
@@ -124,14 +124,11 @@ namespace Microsoft.DotNet.Host.Build
                         "win.arm64.version",
                         "ubuntu.x64.version",
                         "ubuntu.16.04.x64.version",
-                        "ubuntu.16.10.x64.version",
                         "rhel.x64.version",
                         "osx.x64.version",
                         "debian.x64.version",
                         "centos.x64.version",
-                        "fedora.23.x64.version",
                         "fedora.24.x64.version",
-                        "opensuse.13.2.x64.version",
                         "opensuse.42.1.x64.version"
                     };
                     
@@ -211,14 +208,11 @@ namespace Microsoft.DotNet.Host.Build
                  { "sharedfx_Windows_arm64", false },
                  { "sharedfx_Ubuntu_x64", false },
                  { "sharedfx_Ubuntu_16_04_x64", false },
-                 { "sharedfx_Ubuntu_16_10_x64", false },
                  { "sharedfx_RHEL_x64", false },
                  { "sharedfx_OSX_x64", false },
                  { "sharedfx_Debian_x64", false },
                  { "sharedfx_CentOS_x64", false },
-                 { "sharedfx_Fedora_23_x64", false },
                  { "sharedfx_Fedora_24_x64", false },
-                 { "sharedfx_openSUSE_13_2_x64", false },
                  { "sharedfx_openSUSE_42_1_x64", false }
              };
 


### PR DESCRIPTION
See https://github.com/dotnet/core-setup/pull/3075.

> Some platforms are being checked as a finalization prereq even though the legs aren't being run. See https://github.com/dotnet/core-eng/issues/1540. Removing the checks unblocks build finalization.