### PR TITLE
Disable non shipping packages in coresetup

### DIFF
--- a/src/pkg/packages.builds
+++ b/src/pkg/packages.builds
@@ -20,8 +20,8 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(BuildAllpackages)' == 'false'">
-    <Project Include="$(ProjectsBasePath)Microsoft.Net.UWPCoreRuntimeSdk\Microsoft.Net.UWPCoreRuntimeSdk.builds" />
-    <Project Include="$(ProjectsBasePath)Microsoft.NETCore.UniversalWindowsPlatform\Microsoft.NETCore.UniversalWindowsPlatform.builds" />
+    <Project Include="$(ProjectsBasePath)Microsoft.Net.UWPCoreRuntimeSdk\Microsoft.Net.UWPCoreRuntimeSdk.builds" Condition="'$(_BuildUwpDependencies)' == 'true'" />
+    <Project Include="$(ProjectsBasePath)Microsoft.NETCore.UniversalWindowsPlatform\Microsoft.NETCore.UniversalWindowsPlatform.builds" Condition="'$(_BuildUwpDependencies)' == 'true'" />
   </ItemGroup>
 
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />

--- a/src/pkg/packages.builds
+++ b/src/pkg/packages.builds
@@ -7,14 +7,22 @@
          they will be built during the source build phase -->
     <AdditionalProperties>BuildPackageLibraryReferences=false</AdditionalProperties>
     <ProjectsBasePath>$(MSBuildThisFileDirectory)projects\</ProjectsBasePath>
+    <!-- Only build packages for uwp6.0 release -->
+    <BuildAllPackages>false</BuildAllPackages>
   </PropertyGroup>  
 
-  <ItemGroup>
+  <ItemGroup Condition="'$(BuildAllPackages)' != 'false'">
     <ProjectExclusions Include="$(ProjectsBasePath)*\Microsoft.NETCore.UniversalWindowsPlatform.builds" Condition="'$(_BuildUwpDependencies)' != 'true'" />
     <ProjectExclusions Include="$(ProjectsBasePath)*\Microsoft.Net.UWPCoreRuntimeSdk.builds" Condition="'$(_BuildUwpDependencies)' != 'true'" />
     <Project Include="$(ProjectsBasePath)*\*.builds" Exclude="@(ProjectExclusions)">
       <AdditionalProperties>$(AdditionalProperties)</AdditionalProperties>
     </Project>
-  </ItemGroup>  
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(BuildAllpackages)' == 'false'">
+    <Project Include="$(ProjectsBasePath)Microsoft.Net.UWPCoreRuntimeSdk\Microsoft.Net.UWPCoreRuntimeSdk.builds" />
+    <Project Include="$(ProjectsBasePath)Microsoft.NETCore.UniversalWindowsPlatform\Microsoft.NETCore.UniversalWindowsPlatform.builds" />
+  </ItemGroup>
+
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
 </Project>

--- a/src/pkg/packaging/dir.proj
+++ b/src/pkg/packaging/dir.proj
@@ -164,8 +164,12 @@
 
   <Target Name="GenerateCombinedInstallers" DependsOnTargets="InitPackage;GenerateBundles" />
 
+  <PropertyGroup>
+    <BuildAllPackages>false</BuildAllPackages>
+  </PropertyGroup>
+
   <Target Name="GenerateNugetPackages" DependsOnTargets="InitPackage" Condition="'$(UsePrebuiltPortableBinariesForInstallers)' == 'false'">
-    <ItemGroup>
+    <ItemGroup Condition="'$(BuildAllPackages)' != 'false'">
       <PackageProjects Include="$(ProjectDir)src\managed\Microsoft.DotNet.PlatformAbstractions\Microsoft.DotNet.PlatformAbstractions.csproj" />
       <PackageProjects Include="$(ProjectDir)src\managed\Microsoft.Extensions.DependencyModel\Microsoft.Extensions.DependencyModel.csproj" />
     </ItemGroup>

--- a/src/sharedFramework/sharedFramework.proj
+++ b/src/sharedFramework/sharedFramework.proj
@@ -138,6 +138,9 @@
 
     <RemoveDir Directories="$(CoreHostLockedDir)" />
 
+    <!-- Create packages directory if it doesn't exist -->
+    <MakeDir Directories="$(PackagesOutDir)" />
+
     <Exec Command="$(DotnetRestoreCommand) --source $(PackagesOutDir) $(CommonLockedHostArgs)"
           WorkingDirectory="$(LockedHostSourceRoot)" />
 

--- a/src/test/dir.props
+++ b/src/test/dir.props
@@ -5,10 +5,12 @@
   <PropertyGroup>
     <TestDir>$(ProjectDir)/src/test</TestDir>
     <TestAssetsDir>$(TestDir)/Assets</TestAssetsDir>
+    <!-- Disabling some test projects from running since on this release branch we won't be building some packages that are required for the tests to pass. -->
+    <BuildAllTests>false</BuildAllTests>
   </PropertyGroup>
 
   <ItemGroup>
-    <TestProjects Include="$(TestDir)/HostActivationTests/HostActivationTests.csproj" />
+    <TestProjects Include="$(TestDir)/HostActivationTests/HostActivationTests.csproj" Condition="'$(BuildAllTests)' != 'false'" />
     <TestProjects Include="$(TestDir)/Microsoft.Extensions.DependencyModel.Tests/Microsoft.Extensions.DependencyModel.Tests.csproj" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
cc: @weshaggard @ericstj @joshfree @danmosemsft 

Disabling all of the packages that won't ship for uwp6.0

After these changes, here are the packages built located at the bin folder:
```
bin...packages\\Microsoft.DotNet.PlatformAbstractions.2.1.0-preview1-25626-0.nupkg
bin...packages\\Microsoft.DotNet.PlatformAbstractions.2.1.0-preview1-25626-0.symbols.nupkg
bin...packages\\Microsoft.Extensions.DependencyModel.2.1.0-preview1-25626-0.nupkg
bin...packages\\Microsoft.Extensions.DependencyModel.2.1.0-preview1-25626-0.symbols.nupkg
bin...packages\\Microsoft.Net.UWPCoreRuntimeSdk.2.1.0-preview1-25626-0.nupkg
bin...packages\\Microsoft.Net.UWPCoreRuntimeSdk.2.1.0-preview1-25626-0.symbols.nupkg
bin...packages\\Microsoft.NETCore.UniversalWindowsPlatform.6.0.0-preview1-25626-0.nupkg
bin...packages\\Microsoft.NETCore.UniversalWindowsPlatform.6.0.0-preview1-25626-0.symbols.nupkg
bin...packages\\runtime.win10-x64-aot.Microsoft.NETCore.UniversalWindowsPlatform.6.0.0-preview1-25626-0.nupkg
bin...packages\\runtime.win10-x64-aot.Microsoft.NETCore.UniversalWindowsPlatform.6.0.0-preview1-25626-0.symbols.nupkg
bin...packages\\runtime.win10-x64.Microsoft.Net.UWPCoreRuntimeSdk.2.1.0-preview1-25626-0.nupkg
bin...packages\\runtime.win10-x64.Microsoft.Net.UWPCoreRuntimeSdk.2.1.0-preview1-25626-0.symbols.nupkg
bin...packages\\runtime.win10-x64.Microsoft.NETCore.UniversalWindowsPlatform.6.0.0-preview1-25626-0.nupkg
bin...packages\\runtime.win10-x64.Microsoft.NETCore.UniversalWindowsPlatform.6.0.0-preview1-25626-0.symbols.nupkg
```

@weshaggard does that look right?