### PR TITLE
[release/uwp6.0] Use ResourceHandlingTask to extract embedded resources for portable class libraries (#3114)

### DIFF
--- a/src/pkg/projects/Microsoft.Net.UWPCoreRuntimeSdk/contents/identity/Microsoft.Net.CoreRuntime.targets
+++ b/src/pkg/projects/Microsoft.Net.UWPCoreRuntimeSdk/contents/identity/Microsoft.Net.CoreRuntime.targets
@@ -38,6 +38,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
 
   <PropertyGroup>
     <BeforeRunGatekeeperTargets>ComputeWireUpCoreRuntimeGates</BeforeRunGatekeeperTargets>
+    <NetCoreGeneratePrisForPortableLibraries>true</NetCoreGeneratePrisForPortableLibraries>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
Porting change from master

* Add property <NetCoreGeneratePrisForPortableLibraries> to CoreRuntime.targets and re-write ResourceHandlingTask to extract ResW files from embedded resources in non-Framework assemblies as well, since current ResGen breaks on NS2.0 C# UWP libraries. Behavior for non-Framework resources are written to match ResGen behavior

* Address PR feedback for ResourceHandlingTask change
