### PR TITLE
[release/2.0.0] Create ShippedNuGetPackage items before versions repo update

### DIFF
--- a/publish/publish.proj
+++ b/publish/publish.proj
@@ -13,11 +13,17 @@
           Condition="'$(Finalize)' == 'true'"
           DependsOnTargets="PublishCoreHostPackagesToFeed;FinalizeBuildInAzure;UpdateVersionsRepo" />
 
+  <!--
+    Target wrapping UpdatePublishedVersions: ensures that ShippedNuGetPackage items are created and
+    disables versions repo update if no auth token is defined. Otherwise, not specifying an auth
+    token would cause an error.
+  -->
   <Target Name="UpdateVersionsRepo"
           Condition="'$(GitHubAuthToken)' != ''"
-          DependsOnTargets="UpdatePublishedVersions" />
+          DependsOnTargets="ExcludeSymbolsPackagesFromPublishedVersions;
+                            UpdatePublishedVersions" />
 
-  <Target Name="ExcludeSymbolsPackagesFromPublishedVersions" BeforeTargets="UpdateVersionsRepo" >
+  <Target Name="ExcludeSymbolsPackagesFromPublishedVersions">
     <ItemGroup>
       <PackagesToShip Include="$(BinDir)/ForPublishing/*.nupkg" Exclude="$(BinDir)/ForPublishing/*.symbols.nupkg" />
       <PackagesToShip Remove="%(PackagesToShip.Identity)" Condition="$([System.String]::Copy('%(PackagesToShip.Identity)').Contains('latest'))" />


### PR DESCRIPTION
~~Make `BeforeTargets` reference the exact `UpdatePublishedVersions` target that needs the package items, rather than the placeholder `UpdateVersionsRepo`.~~

Change to use `DependsOnTargets` to order. The `BeforeTargets` pointed at the wrong target, causing the package items to be created after they were needed.

Without the `ShippedNuGetPackage` items, release/2.0.0 builds were making empty versions repo commits.

This problem was added by https://github.com/dotnet/core-setup/pull/2993 to release/2.0.0 only.