### PR TITLE
Add support for listing SDK versions and runtime versions 

### DIFF
--- a/src/corehost/cli/deps_entry.cpp
+++ b/src/corehost/cli/deps_entry.cpp
@@ -75,10 +75,8 @@ bool deps_entry_t::to_dir_path(const pal::string_t& base, pal::string_t* str) co
         pal::string_t ietf_dir = get_directory(pal_relative_path);
         pal::string_t ietf = ietf_dir;
 
-        // get_directory returns with DIR_SEPERATOR appended that we need to remove.
-        if (ietf.back() == DIR_SEPARATOR) {
-            ietf.pop_back();
-        }
+        // get_directory returns with DIR_SEPARATOR appended that we need to remove.
+        remove_trailing_dir_seperator(&ietf);
 
         // Extract IETF code from "lib/<netstandrd_ver>/<ietf-code>"
         ietf = get_filename(ietf);

--- a/src/corehost/cli/fxr/fx_muxer.cpp
+++ b/src/corehost/cli/fxr/fx_muxer.cpp
@@ -216,7 +216,7 @@ void handle_missing_framework_error(
     trace::error(_X("  - Check application dependencies and target a framework version installed at:"));
     trace::error(_X("      %s"), fx_ver_dirs.c_str());
     trace::error(_X("  - The .NET framework can be installed from:"));
-    trace::error(_X("      %s"), DOTNET_CORE_RUNTIME_URL);
+    trace::error(_X("      %s"), DOTNET_CORE_DOWNLOAD_RUNTIME_URL);
     trace::error(_X("  - The .NET framework and SDK can be installed from:"));
     trace::error(_X("      %s"), DOTNET_CORE_URL);
 
@@ -993,6 +993,8 @@ int muxer_usage(bool is_sdk_present)
     {
         trace::println(_X("  %-34s  %s"), (arg.option + _X(" ") + arg.argument).c_str(), arg.description.c_str());
     }
+    trace::println(_X("  --list-runtimes                     Display the installed runtimes"));
+    trace::println(_X("  --list-sdks                         Display the installed SDKs"));
 
     trace::println();
 
@@ -1004,7 +1006,6 @@ int muxer_usage(bool is_sdk_present)
         trace::println(_X("  --info                              Displays the host information"));
         trace::println();
     }
-
 
     return StatusCode::InvalidArgFailure;
 }

--- a/src/corehost/cli/libhost.cpp
+++ b/src/corehost/cli/libhost.cpp
@@ -78,7 +78,7 @@ void try_patch_roll_forward_in_dir(const pal::string_t& cur_dir, const fx_ver_t&
     pal::string_t maj_min_star = start_ver.patch_glob();
 
     std::vector<pal::string_t> list;
-    pal::readdir(path, maj_min_star, &list);
+    pal::readdir_onlydirectories(path, maj_min_star, &list);
 
     fx_ver_t max_ver = start_ver;
     fx_ver_t ver(-1, -1, -1);
@@ -112,7 +112,7 @@ void try_prerelease_roll_forward_in_dir(const pal::string_t& cur_dir, const fx_v
     pal::string_t maj_min_pat_star = start_ver.prerelease_glob();
 
     std::vector<pal::string_t> list;
-    pal::readdir(path, maj_min_pat_star, &list);
+    pal::readdir_onlydirectories(path, maj_min_pat_star, &list);
 
     fx_ver_t max_ver = start_ver;
     fx_ver_t ver(-1, -1, -1);

--- a/src/corehost/common/pal.h
+++ b/src/corehost/common/pal.h
@@ -210,7 +210,7 @@ namespace pal
     bool get_own_executable_path(string_t* recv);
     bool getenv(const char_t* name, string_t* recv);
     bool get_default_servicing_directory(string_t* recv);
-    //On Linux, we determine global location by enumerating the location where dotnet is present on path, hence there could be multiple such locations
+    //On Linux, there are no global locations
     //On Windows there will be only one global location
     bool get_global_dotnet_dirs(std::vector<pal::string_t>* recv);
     bool get_default_breadcrumb_store(string_t* recv);

--- a/src/corehost/common/pal.h
+++ b/src/corehost/common/pal.h
@@ -206,6 +206,8 @@ namespace pal
     inline bool directory_exists(const string_t& path) { return file_exists(path); }
     void readdir(const string_t& path, const string_t& pattern, std::vector<pal::string_t>* list);
     void readdir(const string_t& path, std::vector<pal::string_t>* list);
+    void readdir_onlydirectories(const string_t& path, const string_t& pattern, std::vector<pal::string_t>* list);
+    void readdir_onlydirectories(const string_t& path, std::vector<pal::string_t>* list);
 
     bool get_own_executable_path(string_t* recv);
     bool getenv(const char_t* name, string_t* recv);

--- a/src/corehost/common/pal.unix.cpp
+++ b/src/corehost/common/pal.unix.cpp
@@ -462,7 +462,7 @@ bool pal::file_exists(const pal::string_t& path)
     return (::stat(path.c_str(), &buffer) == 0);
 }
 
-void pal::readdir(const string_t& path, const string_t& pattern, std::vector<pal::string_t>* list)
+static void readdir(const pal::string_t& path, const pal::string_t& pattern, bool onlydirectories, std::vector<pal::string_t>* list)
 {
     assert(list != nullptr);
 
@@ -483,7 +483,13 @@ void pal::readdir(const string_t& path, const string_t& pattern, std::vector<pal
             switch (entry->d_type)
             {
             case DT_DIR:
+                break;
+
             case DT_REG:
+                if (onlydirectories)
+                {
+                    continue;
+                }
                 break;
 
             // Handle symlinks and file systems that do not support d_type
@@ -502,7 +508,15 @@ void pal::readdir(const string_t& path, const string_t& pattern, std::vector<pal
                         continue;
                     }
 
-                    if (!S_ISREG(sb.st_mode) && !S_ISDIR(sb.st_mode))
+                    if (onlydirectories)
+                    {
+                        if (!S_ISDIR(sb.st_mode))
+                        {
+                            continue;
+                        }
+                        break;
+                    }
+                    else if (!S_ISREG(sb.st_mode) && !S_ISDIR(sb.st_mode))
                     {
                         continue;
                     }
@@ -513,12 +527,31 @@ void pal::readdir(const string_t& path, const string_t& pattern, std::vector<pal
                 continue;
             }
 
-            files.push_back(pal::string_t(entry->d_name));
+            pal::string_t filepath(entry->d_name);
+            if (filepath != _X(".") && filepath != _X(".."))
+            {
+                files.push_back(filepath);
+            }
         }
     }
 }
 
+void pal::readdir(const string_t& path, const string_t& pattern, std::vector<pal::string_t>* list)
+{
+    ::readdir(path, pattern, false, list);
+}
+
 void pal::readdir(const pal::string_t& path, std::vector<pal::string_t>* list)
 {
-    readdir(path, _X("*"), list);
+    ::readdir(path, _X("*"), false, list);
+}
+
+void pal::readdir_onlydirectories(const pal::string_t& path, const string_t& pattern, std::vector<pal::string_t>* list)
+{
+    ::readdir(path, pattern, true, list);
+}
+
+void pal::readdir_onlydirectories(const pal::string_t& path, std::vector<pal::string_t>* list)
+{
+    ::readdir(path, _X("*"), true, list);
 }

--- a/src/corehost/common/pal.windows.cpp
+++ b/src/corehost/common/pal.windows.cpp
@@ -443,12 +443,12 @@ bool pal::file_exists(const string_t& path)
     return false;
 }
 
-void pal::readdir(const string_t& path, const string_t& pattern, std::vector<pal::string_t>* list)
+static void readdir(const pal::string_t& path, const pal::string_t& pattern, bool onlydirectories, std::vector<pal::string_t>* list)
 {
     assert(list != nullptr);
 
-    std::vector<string_t>& files = *list;
-    string_t normalized_path(path);
+    std::vector<pal::string_t>& files = *list;
+    pal::string_t normalized_path(path);
 
     if (LongFile::ShouldNormalize(normalized_path))
     {
@@ -458,7 +458,7 @@ void pal::readdir(const string_t& path, const string_t& pattern, std::vector<pal
         }
     }
 
-    string_t search_string(normalized_path);
+    pal::string_t search_string(normalized_path);
     append_path(&search_string, pattern.c_str());
 
     WIN32_FIND_DATAW data = { 0 };
@@ -470,14 +470,34 @@ void pal::readdir(const string_t& path, const string_t& pattern, std::vector<pal
     }
     do
     {
-        string_t filepath(data.cFileName);
-        files.push_back(filepath);
+        if (!onlydirectories || (data.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY))
+        {
+            pal::string_t filepath(data.cFileName);
+            if (filepath != _X(".") && filepath != _X(".."))
+            {
+                files.push_back(filepath);
+            }
+        }
     } while (::FindNextFileW(handle, &data));
     ::FindClose(handle);
 }
 
-void pal::readdir(const string_t& path, std::vector<pal::string_t>* list)
+void pal::readdir(const string_t& path, const string_t& pattern, std::vector<pal::string_t>* list)
 {
-    pal::readdir(path, _X("*"), list);
+    ::readdir(path, pattern, false, list);
 }
 
+void pal::readdir(const string_t& path, std::vector<pal::string_t>* list)
+{
+    ::readdir(path, _X("*"), false, list);
+}
+
+void pal::readdir_onlydirectories(const pal::string_t& path, const string_t& pattern, std::vector<pal::string_t>* list)
+{
+    ::readdir(path, pattern, true, list);
+}
+
+void pal::readdir_onlydirectories(const pal::string_t& path, std::vector<pal::string_t>* list)
+{
+    ::readdir(path, _X("*"), true, list);
+}

--- a/src/corehost/common/utils.cpp
+++ b/src/corehost/common/utils.cpp
@@ -150,6 +150,14 @@ pal::string_t get_directory(const pal::string_t& path)
     return ret.substr(0, pos + 1) + DIR_SEPARATOR;
 }
 
+void remove_trailing_dir_seperator(pal::string_t* dir)
+{
+    if (dir->back() == DIR_SEPARATOR)
+    {
+        dir->pop_back();
+    }
+}
+
 void replace_char(pal::string_t* path, pal::char_t match, pal::char_t repl)
 {
     int pos = 0;

--- a/src/corehost/common/utils.h
+++ b/src/corehost/common/utils.h
@@ -14,6 +14,10 @@ struct host_option
 
 #define _STRINGIFY(s) _X(s)
 #define DOTNET_CORE_URL _X("http://go.microsoft.com/fwlink/?LinkID=798306&clcid=0x409")
+
+// TODO: We need a forwarding link here
+#define DOTNET_CORE_RUNTIME_URL _X("https://www.microsoft.com/net/download/core#/runtime")
+
 #define RUNTIME_STORE_DIRECTORY_NAME _X("store")
 
 bool ends_with(const pal::string_t& value, const pal::string_t& suffix, bool match_case);
@@ -26,6 +30,7 @@ pal::string_t get_filename_without_ext(const pal::string_t& path);
 void append_path(pal::string_t* path1, const pal::char_t* path2);
 bool library_exists_in_dir(const pal::string_t& lib_dir, const pal::string_t& lib_name, pal::string_t* p_lib_path);
 bool coreclr_exists_in_dir(const pal::string_t& candidate);
+void remove_trailing_dir_seperator(pal::string_t* dir);
 void replace_char(pal::string_t* path, pal::char_t match, pal::char_t repl);
 const pal::char_t* get_arch();
 pal::string_t get_last_known_arg(

--- a/src/corehost/common/utils.h
+++ b/src/corehost/common/utils.h
@@ -14,9 +14,7 @@ struct host_option
 
 #define _STRINGIFY(s) _X(s)
 #define DOTNET_CORE_URL _X("http://go.microsoft.com/fwlink/?LinkID=798306&clcid=0x409")
-
-// TODO: We need a forwarding link here
-#define DOTNET_CORE_RUNTIME_URL _X("https://www.microsoft.com/net/download/core#/runtime")
+#define DOTNET_CORE_DOWNLOAD_RUNTIME_URL _X("https://aka.ms/dotnet-download-runtime")
 
 #define RUNTIME_STORE_DIRECTORY_NAME _X("store")
 

--- a/src/corehost/corehost.cpp
+++ b/src/corehost/corehost.cpp
@@ -99,7 +99,7 @@ pal::string_t resolve_fxr_path(const pal::string_t& own_dir)
         trace::info(_X("Reading fx resolver directory=[%s]"), fxr_dir.c_str());
 
         std::vector<pal::string_t> list;
-        pal::readdir(fxr_dir, &list);
+        pal::readdir_onlydirectories(fxr_dir, &list);
 
         fx_ver_t max_ver(-1, -1, -1);
         for (const auto& dir : list)

--- a/src/corehost/corehost.cpp
+++ b/src/corehost/corehost.cpp
@@ -162,8 +162,10 @@ int run(const int argc, const pal::char_t* argv[])
         trace::println(_X("Usage: dotnet [path-to-application]"));
         trace::println();
         trace::println(_X("Options:"));
-        trace::println(_X("  -h|--help            Display help."));
-        trace::println(_X("  --version         Display version."));
+        trace::println(_X("  -h|--help         Display help."));
+        trace::println(_X("  --version         Display SDK version."));
+        trace::println(_X("  --versions        Display the list of SDK versions."));
+        trace::println(_X("  --runtimes        Display the list of runtime versions."));
         trace::println();
         trace::println(_X("path-to-application:"));
         trace::println(_X("  The path to an application .dll file to execute."));

--- a/src/corehost/corehost.cpp
+++ b/src/corehost/corehost.cpp
@@ -163,9 +163,9 @@ int run(const int argc, const pal::char_t* argv[])
         trace::println();
         trace::println(_X("Options:"));
         trace::println(_X("  -h|--help         Display help."));
-        trace::println(_X("  --version         Display SDK version."));
-        trace::println(_X("  --versions        Display the list of SDK versions."));
-        trace::println(_X("  --runtimes        Display the list of runtime versions."));
+        trace::println(_X("  --version         Display the current SDK version."));
+        trace::println(_X("  --list-sdks       Display the list of installed SDKs."));
+        trace::println(_X("  --list-runtimes   Display the list of installed runtimes."));
         trace::println();
         trace::println(_X("path-to-application:"));
         trace::println(_X("  The path to an application .dll file to execute."));

--- a/src/corehost/corehost.cpp
+++ b/src/corehost/corehost.cpp
@@ -164,8 +164,8 @@ int run(const int argc, const pal::char_t* argv[])
         trace::println(_X("Options:"));
         trace::println(_X("  -h|--help         Display help."));
         trace::println(_X("  --version         Display the current SDK version."));
-        trace::println(_X("  --list-sdks       Display the list of installed SDKs."));
-        trace::println(_X("  --list-runtimes   Display the list of installed runtimes."));
+        trace::println(_X("  --list-sdks       Display the installed SDKs."));
+        trace::println(_X("  --list-runtimes   Display the installed runtimes."));
         trace::println();
         trace::println(_X("path-to-application:"));
         trace::println(_X("  The path to an application .dll file to execute."));

--- a/src/test/HostActivationTests/GivenThatICareAboutMultilevelSDKLookup.cs
+++ b/src/test/HostActivationTests/GivenThatICareAboutMultilevelSDKLookup.cs
@@ -195,7 +195,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.MultilevelSDKLookup
                 .HaveStdErrContaining(Path.Combine(_exeSelectedMessage, "9999.0.0-global-dummy", _dotnetSdkDllMessageTerminator));
 
             // Verify we have the expected sdk versions
-            dotnet.Exec("--versions")
+            dotnet.Exec("--list-sdks")
                 .WorkingDirectory(_currentWorkingDir)
                 .WithUserProfile(_userDir)
                 .Environment(s_DefaultEnvironment)
@@ -266,7 +266,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.MultilevelSDKLookup
                 .HaveStdErrContaining(Path.Combine(_exeSelectedMessage, "9999.0.4", _dotnetSdkDllMessageTerminator));
 
             // Verify we have the expected sdk versions
-            dotnet.Exec("--versions")
+            dotnet.Exec("--list-sdks")
                 .WorkingDirectory(_currentWorkingDir)
                 .WithUserProfile(_userDir)
                 .Environment(s_DefaultEnvironment)
@@ -370,7 +370,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.MultilevelSDKLookup
                 .HaveStdErrContaining(Path.Combine(_exeSelectedMessage, "10000.0.0", _dotnetSdkDllMessageTerminator));
 
             // Verify we have the expected sdk versions
-            dotnet.Exec("--versions")
+            dotnet.Exec("--list-sdks")
                 .WorkingDirectory(_currentWorkingDir)
                 .WithUserProfile(_userDir)
                 .Environment(s_DefaultEnvironment)

--- a/src/test/HostActivationTests/GivenThatICareAboutMultilevelSDKLookup.cs
+++ b/src/test/HostActivationTests/GivenThatICareAboutMultilevelSDKLookup.cs
@@ -193,6 +193,26 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.MultilevelSDKLookup
                 .Pass()
                 .And
                 .HaveStdErrContaining(Path.Combine(_exeSelectedMessage, "9999.0.0-global-dummy", _dotnetSdkDllMessageTerminator));
+
+            // Verify we have the expected sdk versions
+            dotnet.Exec("--versions")
+                .WorkingDirectory(_currentWorkingDir)
+                .WithUserProfile(_userDir)
+                .Environment(s_DefaultEnvironment)
+                .CaptureStdOut()
+                .Execute()
+                .Should()
+                .Pass()
+                .And
+                .HaveStdOutContaining("9999.0.0-dummy")
+                .And
+                .HaveStdOutContaining("9999.0.0-global-dummy")
+                .And
+                .HaveStdOutContaining("9999.0.1")
+                .And
+                .HaveStdOutContaining("9999.0.4")
+                .And
+                .HaveStdOutContaining("9999.0.6-dummy");
         }
 
         [Fact]
@@ -244,6 +264,19 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.MultilevelSDKLookup
                 .Pass()
                 .And
                 .HaveStdErrContaining(Path.Combine(_exeSelectedMessage, "9999.0.4", _dotnetSdkDllMessageTerminator));
+
+            // Verify we have the expected sdk versions
+            dotnet.Exec("--versions")
+                .WorkingDirectory(_currentWorkingDir)
+                .WithUserProfile(_userDir)
+                .Environment(s_DefaultEnvironment)
+                .EnvironmentVariable("DOTNET_MULTILEVEL_LOOKUP", "0")
+                .CaptureStdOut()
+                .Execute()
+                .Should()
+                .Pass()
+                .And
+                .HaveStdOutContaining("9999.0.4");
         }
 
         [Fact]
@@ -335,6 +368,26 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.MultilevelSDKLookup
                 .Pass()
                 .And
                 .HaveStdErrContaining(Path.Combine(_exeSelectedMessage, "10000.0.0", _dotnetSdkDllMessageTerminator));
+
+            // Verify we have the expected sdk versions
+            dotnet.Exec("--versions")
+                .WorkingDirectory(_currentWorkingDir)
+                .WithUserProfile(_userDir)
+                .Environment(s_DefaultEnvironment)
+                .CaptureStdOut()
+                .Execute()
+                .Should()
+                .Pass()
+                .And
+                .HaveStdOutContaining("9999.0.0")
+                .And
+                .HaveStdOutContaining("9999.0.1-dummy")
+                .And
+                .HaveStdOutContaining("9999.0.1")
+                .And
+                .HaveStdOutContaining("10000.0.0")
+                .And
+                .HaveStdOutContaining("10000.0.0-dummy");
         }
 
         // This method adds a list of new sdk version folders in the specified

--- a/src/test/HostActivationTests/GivenThatICareAboutMultilevelSharedFxLookup.cs
+++ b/src/test/HostActivationTests/GivenThatICareAboutMultilevelSharedFxLookup.cs
@@ -159,6 +159,18 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.MultilevelSharedFxLooku
                 .Pass()
                 .And
                 .HaveStdErrContaining(_exeSelectedMessage);
+
+            // Verify we have the expected runtime versions
+            dotnet.Exec("--runtimes")
+                .WorkingDirectory(_currentWorkingDir)
+                .EnvironmentVariable("COREHOST_TRACE", "1")
+                .WithUserProfile(_userDir)
+                .CaptureStdOut()
+                .Execute()
+                .Should()
+                .Pass()
+                .And
+                .HaveStdOutContaining("9999.0.0");
         }
 
         [Fact]
@@ -204,7 +216,22 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.MultilevelSharedFxLooku
                 .And
                 .HaveStdErrContaining("It was not possible to find any compatible framework version");
 
-            
+            // Verify we have the expected runtime versions
+            dotnet.Exec("--runtimes")
+                .WorkingDirectory(_currentWorkingDir)
+                .CaptureStdOut()
+                .Execute()
+                .Should()
+                .Pass()
+                .And
+                .HaveStdOutContaining("9999.0.0")
+                .And
+                .HaveStdOutContaining("9999.0.0-dummy2")
+                .And
+                .HaveStdOutContaining("9999.0.2")
+                .And
+                .HaveStdOutContaining("9999.0.3");
+
             DeleteAvailableSharedFxVersions(_exeSharedFxBaseDir, "9999.0.0", "9999.0.3", "9999.0.0-dummy3", "9999.0.2", "9999.0.0-dummy2");
         }
 
@@ -258,6 +285,21 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.MultilevelSharedFxLooku
                 .Pass()
                 .And
                 .HaveStdErrContaining(Path.Combine(_exeSelectedMessage, "9999.1.1"));
+
+            // Verify we have the expected runtime versions
+            dotnet.Exec("--runtimes")
+                .WorkingDirectory(_currentWorkingDir)
+                .EnvironmentVariable("DOTNET_ROLL_FORWARD_ON_NO_CANDIDATE_FX", "1")
+                .CaptureStdOut()
+                .Execute()
+                .Should()
+                .Pass()
+                .And
+                .HaveStdOutContaining("9999.1.1")
+                .And
+                .HaveStdOutContaining("10000.1.1")
+                .And
+                .HaveStdOutContaining("10000.1.3");
         }
 
         [Fact]
@@ -291,6 +333,25 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.MultilevelSharedFxLooku
                 .Fail()
                 .And
                 .HaveStdErrContaining("It was not possible to find any compatible framework version");
+
+            // Verify we have the expected runtime versions
+            dotnet.Exec("--runtimes")
+                .WorkingDirectory(_currentWorkingDir)
+                .EnvironmentVariable("DOTNET_ROLL_FORWARD_ON_NO_CANDIDATE_FX", "1")
+                .CaptureStdOut()
+                .Execute()
+                .Should()
+                .Pass()
+                .And
+                .HaveStdOutContaining("9998.0.1")
+                .And
+                .HaveStdOutContaining("9998.1.0")
+                .And
+                .HaveStdOutContaining("9999.0.0")
+                .And
+                .HaveStdOutContaining("9999.0.1")
+                .And
+                .HaveStdOutContaining("9999.1.0");
         }
 
         // This method adds a list of new framework version folders in the specified

--- a/src/test/HostActivationTests/GivenThatICareAboutMultilevelSharedFxLookup.cs
+++ b/src/test/HostActivationTests/GivenThatICareAboutMultilevelSharedFxLookup.cs
@@ -161,7 +161,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.MultilevelSharedFxLooku
                 .HaveStdErrContaining(_exeSelectedMessage);
 
             // Verify we have the expected runtime versions
-            dotnet.Exec("--runtimes")
+            dotnet.Exec("--list-runtimes")
                 .WorkingDirectory(_currentWorkingDir)
                 .EnvironmentVariable("COREHOST_TRACE", "1")
                 .WithUserProfile(_userDir)
@@ -217,7 +217,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.MultilevelSharedFxLooku
                 .HaveStdErrContaining("It was not possible to find any compatible framework version");
 
             // Verify we have the expected runtime versions
-            dotnet.Exec("--runtimes")
+            dotnet.Exec("--list-runtimes")
                 .WorkingDirectory(_currentWorkingDir)
                 .CaptureStdOut()
                 .Execute()
@@ -287,7 +287,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.MultilevelSharedFxLooku
                 .HaveStdErrContaining(Path.Combine(_exeSelectedMessage, "9999.1.1"));
 
             // Verify we have the expected runtime versions
-            dotnet.Exec("--runtimes")
+            dotnet.Exec("--list-runtimes")
                 .WorkingDirectory(_currentWorkingDir)
                 .EnvironmentVariable("DOTNET_ROLL_FORWARD_ON_NO_CANDIDATE_FX", "1")
                 .CaptureStdOut()
@@ -335,7 +335,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.MultilevelSharedFxLooku
                 .HaveStdErrContaining("It was not possible to find any compatible framework version");
 
             // Verify we have the expected runtime versions
-            dotnet.Exec("--runtimes")
+            dotnet.Exec("--list-runtimes")
                 .WorkingDirectory(_currentWorkingDir)
                 .EnvironmentVariable("DOTNET_ROLL_FORWARD_ON_NO_CANDIDATE_FX", "1")
                 .CaptureStdOut()


### PR DESCRIPTION
Add a dotnet.exe API to list the SDK versions and another API to list the framework versions.
Fixes https://github.com/dotnet/core-setup/issues/675

Note: the original proposal was to use "--versions" and "--runtimes", however that was too confusing as to whether "versions" meant sdks, runtimes, or both. So this was changed to `--list-sdks` and `--list-runtimes`.

Sample output for `--list-sdks`:
```
C:\git\repros\dotnet>dotnet --list-sdks
2.0.0 [C:\git\repros\dotnet\sdk]
2.0.0 [C:\Program Files\dotnet\sdk]
2.1.13 [C:\Program Files\dotnet\sdk]
```

Sample output for `--list-runtimes`:
```
C:\git\repros\Standalone\bin\Debug\netcoreapp2.0\win10-x64\publish>dotnet --list-runtimes
Extension.Example 1.2.3 [C:\git\repros\Standalone\bin\Debug\netcoreapp2.0\win10-x64\publish\shared]
Microsoft.NETCore.App 2.0.0 [C:\git\repros\Standalone\bin\Debug\netcoreapp2.0\win10-x64\publish\shared]
Microsoft.NETCore.App 2.0.0 [C:\Program Files\dotnet\shared]
```

In addition, display the installed versions when an unsupported framework error is encountered.
Fixes https://github.com/dotnet/core-setup/issues/2845
Sample output for error case:
```
It was not possible to find any compatible framework version
The specified framework 'Microsoft.NETCore.App', version '2.0.0' was not found.
  - Check application dependencies and target a framework version installed at:
      C:\Program Files\dotnet\
  - The .NET framework can be installed from:
      https://aka.ms/dotnet-download-runtime
  - The .NET framework and SDK can be installed from:
      http://go.microsoft.com/fwlink/?LinkID=798306&clcid=0x409
  - The following versions are installed:
      3.0.0 at [C:\Program Files\dotnet\shared]
```

note: the CLI repo needs to be updated to show the help for these commands. At that time, minor refactoring may occur so we help consistent formatting and wording between the core-setup and CLI.