### PR TITLE
Allow AppBaseCompilation assembly resolver to resolve 'reference' (#3…

### DIFF
--- a/src/managed/CommonManaged.props
+++ b/src/managed/CommonManaged.props
@@ -5,7 +5,7 @@
 
   <PropertyGroup>
     <RepoRoot>$([System.IO.Path]::GetFullPath('$(MSBuildThisFileDirectory)../..'))/</RepoRoot>
-    <VersionPrefix>2.0.0</VersionPrefix>
+    <VersionPrefix>2.0.1</VersionPrefix>
     <AssemblyFileVersion>$(VersionPrefix)</AssemblyFileVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences>

--- a/src/managed/Microsoft.Extensions.DependencyModel/Microsoft.Extensions.DependencyModel.csproj
+++ b/src/managed/Microsoft.Extensions.DependencyModel/Microsoft.Extensions.DependencyModel.csproj
@@ -8,7 +8,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\Microsoft.DotNet.PlatformAbstractions\Microsoft.DotNet.PlatformAbstractions.csproj" />
+    <!-- Since Microsoft.DotNet.PlatformAbstractions isn't being serviced, take a dependency on the shipped package. -->
+    <!--<ProjectReference Include="..\Microsoft.DotNet.PlatformAbstractions\Microsoft.DotNet.PlatformAbstractions.csproj" />-->
+    <PackageReference Include="Microsoft.DotNet.PlatformAbstractions" Version="2.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
   </ItemGroup>
 

--- a/src/managed/Microsoft.Extensions.DependencyModel/Resolution/AppBaseCompilationAssemblyResolver.cs
+++ b/src/managed/Microsoft.Extensions.DependencyModel/Resolution/AppBaseCompilationAssemblyResolver.cs
@@ -45,9 +45,11 @@ namespace Microsoft.Extensions.DependencyModel.Resolution
                 string.Equals(library.Type, "msbuildproject", StringComparison.OrdinalIgnoreCase);
 
             var isPackage = string.Equals(library.Type, "package", StringComparison.OrdinalIgnoreCase);
+            var isReferenceAssembly = string.Equals(library.Type, "referenceassembly", StringComparison.OrdinalIgnoreCase);
             if (!isProject &&
                 !isPackage &&
-                !string.Equals(library.Type, "referenceassembly", StringComparison.OrdinalIgnoreCase))
+                !isReferenceAssembly &&
+                !string.Equals(library.Type, "reference", StringComparison.OrdinalIgnoreCase))
             {
                 return false;
             }
@@ -55,8 +57,8 @@ namespace Microsoft.Extensions.DependencyModel.Resolution
             var refsPath = Path.Combine(_basePath, RefsDirectoryName);
             var isPublished = _fileSystem.Directory.Exists(refsPath);
 
-            // Resolving reference assebmlies requires refs folder to exist
-            if (!isProject && !isPackage && !isPublished)
+            // Resolving reference assemblies requires refs folder to exist
+            if (isReferenceAssembly && !isPublished)
             {
                 return false;
             }

--- a/src/pkg/packaging/dir.proj
+++ b/src/pkg/packaging/dir.proj
@@ -169,9 +169,13 @@
   </PropertyGroup>
 
   <Target Name="GenerateNugetPackages" DependsOnTargets="InitPackage" Condition="'$(UsePrebuiltPortableBinariesForInstallers)' == 'false'">
+    <ItemGroup>
+      <!-- The list of packages we are servicing -->
+      <PackageProjects Include="$(ProjectDir)src\managed\Microsoft.Extensions.DependencyModel\Microsoft.Extensions.DependencyModel.csproj" />
+    </ItemGroup>
+
     <ItemGroup Condition="'$(BuildAllPackages)' == 'true'">
       <PackageProjects Include="$(ProjectDir)src\managed\Microsoft.DotNet.PlatformAbstractions\Microsoft.DotNet.PlatformAbstractions.csproj" />
-      <PackageProjects Include="$(ProjectDir)src\managed\Microsoft.Extensions.DependencyModel\Microsoft.Extensions.DependencyModel.csproj" />
     </ItemGroup>
 
     <PropertyGroup>

--- a/src/test/Microsoft.Extensions.DependencyModel.Tests/AppBaseResolverTests.cs
+++ b/src/test/Microsoft.Extensions.DependencyModel.Tests/AppBaseResolverTests.cs
@@ -90,6 +90,23 @@ namespace Microsoft.Extensions.DependencyModel.Tests
         }
 
         [Fact]
+        public void ResolvesReferenceType()
+        {
+            var fileSystem = FileSystemMockBuilder
+                .Create()
+                .AddFiles(BasePathRefs, TestLibraryFactory.DefaultAssembly)
+                .Build();
+            var resolver = CreateResolver(fileSystem);
+            var library = TestLibraryFactory.Create(
+                TestLibraryFactory.ReferenceType,
+                assemblies: TestLibraryFactory.EmptyAssemblies);
+
+            var result = resolver.TryResolveAssemblyPaths(library, null);
+
+            Assert.True(result);
+        }
+
+        [Fact]
         public void RequiresExistingRefsFolderForNonProjects()
         {
             var fileSystem = FileSystemMockBuilder
@@ -118,6 +135,27 @@ namespace Microsoft.Extensions.DependencyModel.Tests
             var library = TestLibraryFactory.Create(
                TestLibraryFactory.ProjectType,
                assemblies: TestLibraryFactory.TwoAssemblies);
+            var resolver = CreateResolver(fileSystem);
+            var assemblies = new List<string>();
+
+            var result = resolver.TryResolveAssemblyPaths(library, assemblies);
+
+            Assert.True(result);
+            assemblies.Should().HaveCount(2);
+            assemblies.Should().Contain(Path.Combine(BasePath, TestLibraryFactory.DefaultAssembly));
+            assemblies.Should().Contain(Path.Combine(BasePath, TestLibraryFactory.SecondAssembly));
+        }
+
+        [Fact]
+        public void ResolvesDirectReferenceWithoutRefsFolder()
+        {
+            var fileSystem = FileSystemMockBuilder
+                .Create()
+                .AddFiles(BasePath, TestLibraryFactory.DefaultAssembly, TestLibraryFactory.SecondAssembly)
+                .Build();
+            var library = TestLibraryFactory.Create(
+                TestLibraryFactory.ReferenceType,
+                assemblies: TestLibraryFactory.TwoAssemblies);
             var resolver = CreateResolver(fileSystem);
             var assemblies = new List<string>();
 

--- a/src/test/Microsoft.Extensions.DependencyModel.Tests/TestLibraryFactory.cs
+++ b/src/test/Microsoft.Extensions.DependencyModel.Tests/TestLibraryFactory.cs
@@ -30,6 +30,7 @@ namespace Microsoft.Extensions.DependencyModel.Tests
         public static readonly string ProjectType = "project";
         public static readonly string MsBuildProjectType = "msbuildproject";
         public static readonly string ReferenceAssemblyType = "referenceassembly";
+        public static readonly string ReferenceType = "reference";
         public static readonly string PackageType = "package";
 
         public static CompilationLibrary Create(


### PR DESCRIPTION
Shiproom mail to be sent for approval.

Direct port of https://github.com/dotnet/core-setup/pull/3065

For issue https://github.com/dotnet/core-setup/issues/2981

Fixes InvalidOperationException "Cannot find compilation library location for package" issue with having direct assembly references.

