### PR TITLE
Support all resource types in ResourceHandlingTask

### DIFF
--- a/src/uwp/Microsoft.Build.Net.CoreRuntimeTask/ResourceHandlingTask.cs
+++ b/src/uwp/Microsoft.Build.Net.CoreRuntimeTask/ResourceHandlingTask.cs
@@ -402,7 +402,7 @@ namespace Microsoft.Build.Net.CoreRuntimeTask
                 {
                     foreach (DictionaryEntry dict in rr)
                     {
-                        rw.AddResource((string)dict.Key, (string)dict.Value);
+                        rw.AddResource((string)dict.Key, dict.Value);
                     }
                 }
             }


### PR DESCRIPTION
Remove unnecessary cast. Casting to a string in
`ResXResourceWriter.AddResource` prevents adding object / byte[]
resources. Copying any such resources will cause an
`InvalidCastException`. This technically allows binary data into the generated .resw and eventual PRI file, but it matches MSBuild's behavior. See https://github.com/Microsoft/msbuild/blob/4ceeb0936bd51eccc5fdf27105e1fb7e7de93249/src/Tasks/GenerateResource.cs#L3534