### PR TITLE
Disable non-Windows platforms in CI

### DIFF
--- a/netci.groovy
+++ b/netci.groovy
@@ -10,7 +10,7 @@ def project = GithubProject
 def branch = GithubBranchName
 def isPR = true
 
-def platformList = ['Linux:x64:Release', 'Linux:arm:Release', 'OSX:x64:Release', 'Windows_NT:x64:Release', 'Windows_NT:x86:Debug', 'Windows_NT:arm:Debug', 'Tizen:armel:Release']
+def platformList = ['Windows_NT:x64:Release', 'Windows_NT:x86:Debug', 'Windows_NT:arm:Debug']
 
 def static getBuildJobName(def configuration, def os, def architecture) {
     return configuration.toLowerCase() + '_' + os.toLowerCase() + '_' + architecture.toLowerCase()


### PR DESCRIPTION
We've chopped out enough packages and tests that the CI fails publishing
artifacts (because there are now none and that's fatal) and running
tests (if no tests run there's no test results file - which is fatal
too).
