### PR TITLE
Revert RTM stable package change

### DIFF
--- a/BranchInfo.props
+++ b/BranchInfo.props
@@ -3,10 +3,10 @@
     <MajorVersion>2</MajorVersion>
     <MinorVersion>1</MinorVersion>
     <PatchVersion>0</PatchVersion>
-    <StabilizePackageVersion Condition="'$(StabilizePackageVersion)' == ''">true</StabilizePackageVersion>
-    <PreReleaseLabel>servicingUWP</PreReleaseLabel>
+    <StabilizePackageVersion Condition="'$(StabilizePackageVersion)' == ''">false</StabilizePackageVersion>
+    <PreReleaseLabel>preview1</PreReleaseLabel>
     <ReleaseSuffix>$(PreReleaseLabel)</ReleaseSuffix>
-    <ReleaseBrandSuffix></ReleaseBrandSuffix>
+    <ReleaseBrandSuffix>Preview 1</ReleaseBrandSuffix>
     <Channel>release/uwp6.0</Channel>
     <BranchName>release/uwp6.0</BranchName>
     <ContainerName>dotnet</ContainerName>

--- a/build.proj
+++ b/build.proj
@@ -10,7 +10,6 @@
   <PropertyGroup>
     <!-- To disable the restoration of packages, set RestoreDuringBuild=false or pass /p:RestoreDuringBuild=false.-->
     <RestoreDuringBuild Condition="'$(RestoreDuringBuild)'==''">true</RestoreDuringBuild>
-    <BuildPackagingProject>false</BuildPackagingProject>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -28,7 +27,7 @@
 
   <ItemGroup>
     <Project Include="src/dir.proj" />
-    <Project Include="src/pkg/packaging/dir.proj" Condition="'$(BuildPackagingProject)' != 'false'" />
+    <Project Include="src/pkg/packaging/dir.proj"/>
     <Project Include="$(MSBuildThisFileDirectory)src/test/dir.proj" Condition="'$(SkipTests)' != 'true'"/>
   </ItemGroup>
 

--- a/dependencies.props
+++ b/dependencies.props
@@ -18,11 +18,11 @@
   <PropertyGroup>
     <MicrosoftPrivateCoreFxNETCoreAppPackageVersion>4.5.0-preview1-25531-01</MicrosoftPrivateCoreFxNETCoreAppPackageVersion>
     <MicrosoftPrivateCoreFxUAPPackageVersion>4.5.0-preview1-25708-01</MicrosoftPrivateCoreFxUAPPackageVersion>
-    <PlatformPackageVersion>2.0.0</PlatformPackageVersion>
+    <PlatformPackageVersion>2.1.0-preview1-25631-01</PlatformPackageVersion>
     <MicrosoftNETCoreRuntimeCoreCLRPackageVersion>2.1.0-b-uwp6-25707-02</MicrosoftNETCoreRuntimeCoreCLRPackageVersion>
     <MicrosoftNETCoreRuntimeJitPackageVersion>$(MicrosoftNETCoreRuntimeCoreCLRPackageVersion)</MicrosoftNETCoreRuntimeJitPackageVersion>
-    <MicrosoftNetNativeCompilerPackageVersion>2.0.0</MicrosoftNetNativeCompilerPackageVersion>
-    <NETStandardVersion>2.0.0</NETStandardVersion>
+    <MicrosoftNetNativeCompilerPackageVersion>2.0.0-preview-25630-00</MicrosoftNetNativeCompilerPackageVersion>
+    <NETStandardVersion>2.1.0-preview1-25624-01</NETStandardVersion>
     <DiaSymReaderNativeVersion>1.4.1</DiaSymReaderNativeVersion>
     <WcfVersion>4.5.0-preview1-25625-01</WcfVersion>
   </PropertyGroup>
@@ -30,7 +30,7 @@
   <!-- Package dependency verification/auto-upgrade configuration. -->
   <PropertyGroup>
     <BaseDotNetBuildInfo>build-info/dotnet/</BaseDotNetBuildInfo>
-    <DependencyBranch>release/2.0.0</DependencyBranch>
+    <DependencyBranch>master</DependencyBranch>
     <Uwp6ReleaseDependencyBranch>release/uwp6.0</Uwp6ReleaseDependencyBranch>
     <CurrentRefXmlPath>$(MSBuildThisFileFullPath)</CurrentRefXmlPath>
   </PropertyGroup>

--- a/src/dir.proj
+++ b/src/dir.proj
@@ -5,13 +5,12 @@
   <!-- required to build the projects in their specified order -->
   <PropertyGroup>
     <SerializeProjects>true</SerializeProjects>
-    <BuildSharedFrameworkProject>false</BuildSharedFrameworkProject>
   </PropertyGroup>
 
   <ItemGroup>
     <Project Include="$(MSBuildThisFileDirectory)src.builds" />
     <Project Include="$(MSBuildThisFileDirectory)pkg/dir.proj" />
-    <Project Include="$(MSBuildThisFileDirectory)sharedFramework/sharedFramework.proj" Condition="'$(BuildSharedFrameworkProject)' != 'false'"/>
+    <Project Include="$(MSBuildThisFileDirectory)sharedFramework/sharedFramework.proj" />
   </ItemGroup>
 
   <!-- Tasks from buildtools for easy project.json dependency updates -->

--- a/src/pkg/projects/dir.targets
+++ b/src/pkg/projects/dir.targets
@@ -6,14 +6,6 @@
     <PrereleaseResolveNuGetPackages>true</PrereleaseResolveNuGetPackages>
   </PropertyGroup>
 
-  <PropertyGroup>
-    <!--
-      If we are stabilizing set the StableVersion property for the packages.
-      Needs to happen in dir.targets to allow all the pkgproj's to set Version property first.
-    -->
-    <StableVersion Condition="'$(StabilizePackageVersion)' =='true'">$(Version)</StableVersion>
-  </PropertyGroup>
-
   <!--
     Finds symbol files and injects them into the package build.
   -->

--- a/src/test/dir.proj
+++ b/src/test/dir.proj
@@ -27,15 +27,7 @@
 
   <Target Name="RestoreTests">
     <ItemGroup>
-      <RestoreProjectExclusions Include="$(TestDir)/**/LightupClient.csproj" />
-      <RestoreProjectExclusions Include="$(TestDir)/**/LightupLib.csproj" />
-      <RestoreProjectExclusions Include="$(TestDir)/**/PortableApp.csproj" />
-      <RestoreProjectExclusions Include="$(TestDir)/**/PortableTestApp.csproj" />
-      <RestoreProjectExclusions Include="$(TestDir)/**/ResourceLookup.csproj" />
-      <RestoreProjectExclusions Include="$(TestDir)/**/SharedFxLookupPortableApp.csproj" />
-      <RestoreProjectExclusions Include="$(TestDir)/**/StandaloneApp.csproj" />
-      <RestoreProjectExclusions Include="$(TestDir)/**/StandaloneTestApp.csproj" />
-      <RestoreTest Include="$(TestDir)/**/*.csproj" Exclude="@(RestoreProjectExclusions)" />
+      <RestoreTest Include="$(TestDir)/**/*.csproj" />
     </ItemGroup>
 
     <PropertyGroup>


### PR DESCRIPTION
This reverts commit 3d45f4b9a00ced8aae2f1e5a971d5235d5f8f69d, reversing
changes made to f35a8c2bd5f825543bc37f98002fbeb6eef8d165.

The Linux / OSX VSO builds were broken with this commit.