### PR TITLE
Port to 2.0.0: Add RHEL 6 and CentOS 6 distro detection

### DIFF
--- a/src/corehost/common/pal.unix.cpp
+++ b/src/corehost/common/pal.unix.cpp
@@ -274,6 +274,7 @@ pal::string_t pal::get_current_os_rid_platform()
 {
     pal::string_t ridOS;
     pal::string_t versionFile(_X("/etc/os-release"));
+    pal::string_t rhelVersionFile(_X("/etc/redhat-release"));
 
     if (pal::file_exists(versionFile))
     {
@@ -352,6 +353,35 @@ pal::string_t pal::get_current_os_rid_platform()
                 ridOS = trim_quotes(ridOS);
             }
         }
+    }
+    else if (pal::file_exists(rhelVersionFile))
+    {
+        // Read the file to check if the current OS is RHEL or CentOS 6.x
+        std::fstream fsVersionFile;
+        
+        fsVersionFile.open(rhelVersionFile, std::fstream::in);
+
+        // Proceed only if we were able to open the file
+        if (fsVersionFile.good())
+        {
+            pal::string_t line;
+            // Read the first line
+            std::getline(fsVersionFile, line);
+
+            if (!fsVersionFile.eof())
+            {
+                pal::string_t rhel6Prefix(_X("Red Hat Enterprise Linux Server release 6."));
+                pal::string_t centos6Prefix(_X("CentOS release 6."));
+
+                if ((line.find(rhel6Prefix) == 0) || (line.find(centos6Prefix) == 0))
+                {
+                    ridOS = _X("rhel.6");
+                }
+            }
+
+            // Close the file now that we are done with it.
+            fsVersionFile.close();
+        }        
     }
 
     return normalize_linux_rid(ridOS);

--- a/src/managed/CommonManaged.props
+++ b/src/managed/CommonManaged.props
@@ -5,7 +5,7 @@
 
   <PropertyGroup>
     <RepoRoot>$([System.IO.Path]::GetFullPath('$(MSBuildThisFileDirectory)../..'))/</RepoRoot>
-    <VersionPrefix>2.0.1</VersionPrefix>
+    <VersionPrefix>2.0.2</VersionPrefix>
     <AssemblyFileVersion>$(VersionPrefix)</AssemblyFileVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences>

--- a/src/managed/Microsoft.DotNet.PlatformAbstractions/Native/PlatformApis.cs
+++ b/src/managed/Microsoft.DotNet.PlatformAbstractions/Native/PlatformApis.cs
@@ -85,6 +85,8 @@ namespace Microsoft.DotNet.PlatformAbstractions.Native
 
         private static DistroInfo LoadDistroInfo()
         {
+            DistroInfo result = null;
+
             // Sample os-release file:
             //   NAME="Ubuntu"
             //   VERSION = "14.04.3 LTS, Trusty Tahr"
@@ -100,7 +102,7 @@ namespace Microsoft.DotNet.PlatformAbstractions.Native
             if (File.Exists("/etc/os-release"))
             {
                 var lines = File.ReadAllLines("/etc/os-release");
-                var result = new DistroInfo();
+                result = new DistroInfo();
                 foreach (var line in lines)
                 {
                     if (line.StartsWith("ID=", StringComparison.Ordinal))
@@ -112,10 +114,30 @@ namespace Microsoft.DotNet.PlatformAbstractions.Native
                         result.VersionId = line.Substring(11).Trim('"', '\'');
                     }
                 }
-
-                return NormalizeDistroInfo(result);
             }
-            return null;
+            else if (File.Exists("/etc/redhat-release"))
+            {
+                var lines = File.ReadAllLines("/etc/redhat-release");
+
+                if (lines.Length >= 1)
+                {
+                    string line = lines[0];
+                    if (line.StartsWith("Red Hat Enterprise Linux Server release 6.") ||
+                        line.StartsWith("CentOS release 6."))
+                    {
+                        result = new DistroInfo();
+                        result.Id = "rhel";
+                        result.VersionId = "6";
+                    }
+                }
+            }
+
+            if (result != null)
+            {
+                result = NormalizeDistroInfo(result);
+            }
+            
+            return result;
         }
 
         // For some distros, we don't want to use the full version from VERSION_ID. One example is

--- a/src/managed/Microsoft.Extensions.DependencyModel/Microsoft.Extensions.DependencyModel.csproj
+++ b/src/managed/Microsoft.Extensions.DependencyModel/Microsoft.Extensions.DependencyModel.csproj
@@ -8,9 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <!-- Since Microsoft.DotNet.PlatformAbstractions isn't being serviced, take a dependency on the shipped package. -->
-    <!--<ProjectReference Include="..\Microsoft.DotNet.PlatformAbstractions\Microsoft.DotNet.PlatformAbstractions.csproj" />-->
-    <PackageReference Include="Microsoft.DotNet.PlatformAbstractions" Version="2.0.0" />
+    <ProjectReference Include="..\Microsoft.DotNet.PlatformAbstractions\Microsoft.DotNet.PlatformAbstractions.csproj" />
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
   </ItemGroup>
 

--- a/src/pkg/packaging/dir.proj
+++ b/src/pkg/packaging/dir.proj
@@ -170,9 +170,14 @@
 
   <Target Name="GenerateNugetPackages" DependsOnTargets="InitPackage" Condition="'$(UsePrebuiltPortableBinariesForInstallers)' == 'false'">
 
-    <ItemGroup Condition="'$(BuildAllPackages)' == 'true'">
+    <ItemGroup>
+      <!-- The list of packages we are servicing -->
       <PackageProjects Include="$(ProjectDir)src\managed\Microsoft.DotNet.PlatformAbstractions\Microsoft.DotNet.PlatformAbstractions.csproj" />
       <PackageProjects Include="$(ProjectDir)src\managed\Microsoft.Extensions.DependencyModel\Microsoft.Extensions.DependencyModel.csproj" />
+    </ItemGroup>
+    
+    <ItemGroup Condition="'$(BuildAllPackages)' == 'true'">
+      <!-- The list of packages we are not servicing -->
     </ItemGroup>
 
     <PropertyGroup>


### PR DESCRIPTION
This change adds RHEL 6 and CentOS 6 distro detection. These distros
don't have the /etc/os-release file and so we use an alternative source
of the truth that is the /etc/redhat-release file.
