### PR TITLE
Removing NetStandard.Library reference from the UWP metapackage

### DIFF
--- a/src/pkg/projects/Microsoft.NETCore.UniversalWindowsPlatform/src/Microsoft.NETCore.UniversalWindowsPlatform.depproj
+++ b/src/pkg/projects/Microsoft.NETCore.UniversalWindowsPlatform/src/Microsoft.NETCore.UniversalWindowsPlatform.depproj
@@ -53,7 +53,6 @@
     <!-- Bring in Platforms for RID graph, NETStandard.Library for build-tools, 
          Targets for an empty runtime.json to reduce conflicts from 1.x packages,
          and toolset. -->
-    <DependenciesToPackage Include="NETStandard.Library" />
     <DependenciesToPackage Include="Microsoft.NETCore.Platforms" />
     <DependenciesToPackage Include="Microsoft.NETCore.Targets" />
     <DependenciesToPackage Include="Microsoft.Net.Native.Compiler" />


### PR DESCRIPTION
cc: @joshfree @weshaggard @nattress @Petermarcu 

In case we decide to remove netsandard dependency from the UWP metapackage, this is the PR that would take care of that. I'm adding a no-merge label until we decide in our meeting what we will want to do, but I wanted to get the PR ready and CI running in case we decide to take it.