### PR TITLE
Use the DotNetCore-Test pool which has WS2016 agents

### DIFF
--- a/buildpipeline/Core-Setup-Signing-Windows-x64.json
+++ b/buildpipeline/Core-Setup-Signing-Windows-x64.json
@@ -515,11 +515,11 @@
   "quality": "definition",
   "queue": {
     "pool": {
-      "id": 39,
-      "name": "DotNet-Build"
+      "id": 83,
+      "name": "DotNetCore-Test"
     },
-    "id": 36,
-    "name": "DotNet-Build"
+    "id": 159,
+    "name": "DotNetCore-Test"
   },
   "path": "\\",
   "type": "build",

--- a/buildpipeline/Core-Setup-Signing-Windows-x86.json
+++ b/buildpipeline/Core-Setup-Signing-Windows-x86.json
@@ -488,11 +488,11 @@
   "quality": "definition",
   "queue": {
     "pool": {
-      "id": 39,
-      "name": "DotNet-Build"
+      "id": 83,
+      "name": "DotNetCore-Test"
     },
-    "id": 36,
-    "name": "DotNet-Build"
+    "id": 159,
+    "name": "DotNetCore-Test"
   },
   "path": "\\",
   "type": "build",


### PR DESCRIPTION
Use the DotNetCore-Test pool for sign task since it contains WS2016 agents