### PR TITLE
Disable PAX mprotect for native executables

### DIFF
--- a/src/corehost/cli/exe/exe.cmake
+++ b/src/corehost/cli/exe/exe.cmake
@@ -43,6 +43,11 @@ if(WIN32 AND NOT SKIP_VERSIONING)
 endif()
 
 add_executable(${DOTNET_HOST_EXE_NAME} ${SOURCES} ${RESOURCES})
+
+if(NOT WIN32)
+    disable_pax_mprotect(${DOTNET_HOST_EXE_NAME})
+endif()
+
 install(TARGETS ${DOTNET_HOST_EXE_NAME} DESTINATION bin)
 
 # Specify the import library to link against for Arm32 build since the default set is minimal


### PR DESCRIPTION
This change adds marking native executables that core-setup build produces
(dotnet, apphost) using the paxctl tool to allow them running on systems
with PAX configured so that creating executable memory mappings by applications
is prohibited.
Alpine is one of systems that needs this.