### PR TITLE
Fix PlatformManifest generation

### DIFF
--- a/tools-local/tasks/GenerateFileVersionProps.cs
+++ b/tools-local/tasks/GenerateFileVersionProps.cs
@@ -58,15 +58,21 @@ namespace Microsoft.DotNet.Build.Tasks
 
                 if (fileVersions.TryGetValue(fileName, out existing))
                 {
-                    if (current.AssemblyVersion != null &&
-                        existing.AssemblyVersion != null &&
-                        current.AssemblyVersion != existing.AssemblyVersion)
+                    if (current.AssemblyVersion != null)
                     {
-                        if (current.AssemblyVersion > existing.AssemblyVersion)
+                        if (existing.AssemblyVersion == null)
                         {
                             fileVersions[fileName] = current;
+                            continue;
                         }
-                        continue;
+                        else if (current.AssemblyVersion != existing.AssemblyVersion)
+                        {
+                            if (current.AssemblyVersion > existing.AssemblyVersion)
+                            {
+                                fileVersions[fileName] = current;
+                            }
+                            continue;
+                        }
                     }
 
                     if (current.FileVersion != null && 


### PR DESCRIPTION
When we generate the PlatformManifest.txt, and an assembly doesn't have a valid FileVersion, we are never updating the first entry that gets put into the fileVersions collection.  This is because the check for AssemblyVersion only updates the entry if both current and existing AssemblyVersions are non-null.

Fixing it check for current != null and existing == null, to update the entry.

Fix https://github.com/dotnet/corefx/issues/23988

/cc @rynowak 

## Note

I compared the PlatformManifest.txt from https://dotnet.myget.org/feed/dotnet-core/package/nuget/Microsoft.NETCore.App/2.1.0-preview2-25708-01 and my locally built file, and only 2 differences show up:

![image](https://user-images.githubusercontent.com/8291187/30401956-acdf0780-98a1-11e7-97fd-f9d5a55d3716.png)

![image](https://user-images.githubusercontent.com/8291187/30401962-b324361a-98a1-11e7-9466-6f690d91d990.png)
