### PR TITLE
Don't check for UWP files while signing in arm64

### DIFF
--- a/signing/sign.proj
+++ b/signing/sign.proj
@@ -76,7 +76,7 @@
         <Authenticode>Appx</Authenticode>
       </FilesToSign>
     </ItemGroup>
-    <Error Condition="'@(FilesToSign)' == ''" Text="There are no files to sign. FilesToSign group is empty."/>
+    <Error Condition="'@(FilesToSign)' == '' AND '$(TargetRid)' != 'win-arm64'" Text="There are no files to sign. FilesToSign group is empty."/>
   </Target>
 
   <Target Name="SignMsiAndCab" DependsOnTargets="GetSignMsiAndCabFiles">

--- a/signing/sign.proj
+++ b/signing/sign.proj
@@ -76,7 +76,7 @@
         <Authenticode>Appx</Authenticode>
       </FilesToSign>
     </ItemGroup>
-    <Error Condition="'@(FilesToSign)' == '' AND '$(TargetRid)' != 'win-arm64'" Text="There are no files to sign. FilesToSign group is empty."/>
+    <Error Condition="'@(FilesToSign)' == '' AND '$(Platform)' != 'win-arm64'" Text="There are no files to sign. FilesToSign group is empty."/>
   </Target>
 
   <Target Name="SignMsiAndCab" DependsOnTargets="GetSignMsiAndCabFiles">


### PR DESCRIPTION
UWP is not supported in arm64, hence do not check for the existence of files to sign if the RID is win-arm64