### PR TITLE
add basic FreeBSD support

### DIFF
--- a/src/corehost/build.sh
+++ b/src/corehost/build.sh
@@ -41,14 +41,21 @@ init_rid_plat()
     if [ "$(uname -s)" == "Darwin" ]; then
         __rid_plat=osx.10.12
     fi
+    if [ "$(uname -s)" == "FreeBSD" ]; then
+        major_ver=`uname -U | cut -b1-2`
+        __rid_plat=freebsd.$major_ver
+    fi
 
     if [ $__linkPortable == 1 ]; then
         if [ "$(uname -s)" == "Darwin" ]; then
             __rid_plat="osx"
+        elif [ "$(uname -s)" == "FreeBSD" ]; then
+            __rid_plat="freebsd"
         else
             __rid_plat="linux"
         fi
     fi
+    echo __rid_plat=$__rid_plat
 }
 
 usage()

--- a/src/corehost/build.sh
+++ b/src/corehost/build.sh
@@ -55,7 +55,6 @@ init_rid_plat()
             __rid_plat="linux"
         fi
     fi
-    echo __rid_plat=$__rid_plat
 }
 
 usage()

--- a/src/corehost/common/pal.unix.cpp
+++ b/src/corehost/common/pal.unix.cpp
@@ -257,7 +257,8 @@ pal::string_t pal::get_current_os_rid_platform()
     if (ret == 0)
     {
         char *pos = strchr(str,'.');
-        if (pos) {
+        if (pos)
+        {
             *pos = '\0';
         }
         ridOS.append(_X("freebsd."));

--- a/src/corehost/common/pal.unix.cpp
+++ b/src/corehost/common/pal.unix.cpp
@@ -208,7 +208,7 @@ pal::string_t trim_quotes(pal::string_t stringToCleanup)
 pal::string_t pal::get_current_os_rid_platform()
 {
     pal::string_t ridOS;
-    
+
     char str[256];
 
     // There is no good way to get the visible version of OSX (i.e. something like 10.x.y) as
@@ -240,6 +240,28 @@ pal::string_t pal::get_current_os_rid_platform()
             ridOS.append(_X("osx.10."));
             ridOS.append(pal::to_string(minorVersion));
         }
+    }
+
+    return ridOS;
+}
+#elif defined(__FreeBSD__)
+// On FreeBSD get major verion. Minors should be compatible
+pal::string_t pal::get_current_os_rid_platform()
+{
+    pal::string_t ridOS;
+
+    char str[256];
+
+    size_t size = sizeof(str);
+    int ret = sysctlbyname("kern.osrelease", str, &size, NULL, 0);
+    if (ret == 0)
+    {
+        char *pos = strchr(str,'.');
+        if (pos) {
+            *pos = '\0';
+        }
+        ridOS.append(_X("freebsd."));
+        ridOS.append(str);
     }
 
     return ridOS;
@@ -436,17 +458,17 @@ bool pal::get_own_executable_path(pal::string_t* recv)
     if (error_code == ENOMEM)
     {
         size_t len = sysctl(mib, 4, NULL, NULL, NULL, 0);
-        std::unique_ptr<char[]> buffer = new (std::nothrow) char[len];
+        std::unique_ptr<char[]> buffer (new (std::nothrow) char[len]);
 
         if (buffer == NULL)
         {
             return false;
         }
 
-        error_code = sysctl(mib, 4, buffer, &len, NULL, 0);
+        error_code = sysctl(mib, 4, buffer.get(), &len, NULL, 0);
         if (error_code == 0)
         {
-            recv->assign(buffer);
+            recv->assign(buffer.get());
             return true;
         }
     }

--- a/src/managed/Microsoft.DotNet.PlatformAbstractions/Microsoft.DotNet.PlatformAbstractions.csproj
+++ b/src/managed/Microsoft.DotNet.PlatformAbstractions/Microsoft.DotNet.PlatformAbstractions.csproj
@@ -16,7 +16,10 @@
     <PackageReference Include="System.Reflection.TypeExtensions" Version="4.1.0" />
     <PackageReference Include="System.Runtime.Extensions" Version="4.1.0" />
     <PackageReference Include="System.Runtime.InteropServices" Version="4.1.0" />
+  </ItemGroup>
+  <ItemGroup>
     <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.0.0" />
   </ItemGroup>
+
 
 </Project>

--- a/src/managed/Microsoft.DotNet.PlatformAbstractions/Native/PlatformApis.cs
+++ b/src/managed/Microsoft.DotNet.PlatformAbstractions/Native/PlatformApis.cs
@@ -74,10 +74,14 @@ namespace Microsoft.DotNet.PlatformAbstractions.Native
 
         private static string GetFreeBSDVersion()
         {
-            String verson = RuntimeInformation.OSDescription;
+            // This is same as sysctl kern.version
+            // FreeBSD 11.0-RELEASE-p1 FreeBSD 11.0-RELEASE-p1 #0 r306420: Thu Sep 29 01:43:23 UTC 2016     root@releng2.nyi.freebsd.org:/usr/obj/usr/src/sys/GENERIC
+            // What we want is major release as minor releases should be compatible.
+            String version = RuntimeInformation.OSDescription;
             try
             {
-                return RuntimeInformation.OSDescription.Split()[1];
+                // second token up to first dot
+                return RuntimeInformation.OSDescription.Split()[1].Split('.')[0];
             }
             catch
             {
@@ -208,6 +212,10 @@ namespace Microsoft.DotNet.PlatformAbstractions.Native
                     if (string.Equals(uname, "Linux", StringComparison.OrdinalIgnoreCase))
                     {
                         return Platform.Linux;
+                    }
+                    if (string.Equals(uname, "FreeBSD", StringComparison.OrdinalIgnoreCase))
+                    {
+                        return Platform.FreeBSD;
                     }
                 }
                 catch

--- a/src/managed/Microsoft.DotNet.PlatformAbstractions/Native/PlatformApis.cs
+++ b/src/managed/Microsoft.DotNet.PlatformAbstractions/Native/PlatformApis.cs
@@ -28,6 +28,8 @@ namespace Microsoft.DotNet.PlatformAbstractions.Native
                     return GetDistroId() ?? "Linux";
                 case Platform.Darwin:
                     return "Mac OS X";
+                case Platform.FreeBSD:
+                    return "FreeBSD";
                 default:
                     return "Unknown";
             }
@@ -43,6 +45,8 @@ namespace Microsoft.DotNet.PlatformAbstractions.Native
                     return GetDistroVersionId() ?? string.Empty;
                 case Platform.Darwin:
                     return GetDarwinVersion() ?? string.Empty;
+                case Platform.FreeBSD:
+                    return GetFreeBSDVersion() ?? string.Empty;
                 default:
                     return string.Empty;
             }
@@ -66,6 +70,19 @@ namespace Microsoft.DotNet.PlatformAbstractions.Native
                 // https://en.wikipedia.org/wiki/Darwin_%28operating_system%29
                 return $"10.{version.Major - 4}";
             }
+        }
+
+        private static string GetFreeBSDVersion()
+        {
+            String verson = RuntimeInformation.OSDescription;
+            try
+            {
+                return RuntimeInformation.OSDescription.Split()[1];
+            }
+            catch
+            {
+            }
+            return string.Empty;
         }
 
         public static Platform GetOSPlatform()
@@ -214,6 +231,11 @@ namespace Microsoft.DotNet.PlatformAbstractions.Native
             {
                 return Platform.Darwin;
             }
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Create("FREEBSD")))
+            {
+                return Platform.FreeBSD;
+            }
+
             return Platform.Unknown;
         }
 #endif

--- a/src/managed/Microsoft.DotNet.PlatformAbstractions/Platform.cs
+++ b/src/managed/Microsoft.DotNet.PlatformAbstractions/Platform.cs
@@ -8,6 +8,7 @@ namespace Microsoft.DotNet.PlatformAbstractions
         Unknown = 0,
         Windows = 1,
         Linux = 2,
-        Darwin = 3
+        Darwin = 3,
+        FreeBSD = 4
     }
 }

--- a/src/managed/Microsoft.DotNet.PlatformAbstractions/RuntimeEnvironment.cs
+++ b/src/managed/Microsoft.DotNet.PlatformAbstractions/RuntimeEnvironment.cs
@@ -61,7 +61,7 @@ namespace Microsoft.DotNet.PlatformAbstractions
                 case Platform.Darwin:
                     return $".{OperatingSystemVersion}";
                 case Platform.FreeBSD:
-                    return $".{OperatingSystemVersion.Split('.')[0]}";
+                    return $".{OperatingSystemVersion}";
                 default:
                     return string.Empty; // Unknown Platform? Unknown Version!
             }

--- a/src/managed/Microsoft.DotNet.PlatformAbstractions/RuntimeEnvironment.cs
+++ b/src/managed/Microsoft.DotNet.PlatformAbstractions/RuntimeEnvironment.cs
@@ -60,6 +60,8 @@ namespace Microsoft.DotNet.PlatformAbstractions
                     return $".{OperatingSystemVersion}";
                 case Platform.Darwin:
                     return $".{OperatingSystemVersion}";
+                case Platform.FreeBSD:
+                    return $".{OperatingSystemVersion}";
                 default:
                     return string.Empty; // Unknown Platform? Unknown Version!
             }
@@ -101,6 +103,8 @@ namespace Microsoft.DotNet.PlatformAbstractions
                     return OperatingSystem.ToLowerInvariant();
                 case Platform.Darwin:
                     return "osx";
+                case Platform.FreeBSD:
+                    return "FreeBSD";
                 default:
                     return "unknown";
             }

--- a/src/managed/Microsoft.DotNet.PlatformAbstractions/RuntimeEnvironment.cs
+++ b/src/managed/Microsoft.DotNet.PlatformAbstractions/RuntimeEnvironment.cs
@@ -61,7 +61,7 @@ namespace Microsoft.DotNet.PlatformAbstractions
                 case Platform.Darwin:
                     return $".{OperatingSystemVersion}";
                 case Platform.FreeBSD:
-                    return $".{OperatingSystemVersion}";
+                    return $".{OperatingSystemVersion.Split('.')[0]}";
                 default:
                     return string.Empty; // Unknown Platform? Unknown Version!
             }
@@ -104,7 +104,7 @@ namespace Microsoft.DotNet.PlatformAbstractions
                 case Platform.Darwin:
                     return "osx";
                 case Platform.FreeBSD:
-                    return "FreeBSD";
+                    return "freebsd";
                 default:
                     return "unknown";
             }


### PR DESCRIPTION
This is part for https://github.com/dotnet/corefx/issues/1626

This change adds recognition for FreeBSD and implements function to get OS version. 
There should be no impact for other platforms. 
 
./dotnet --info
Runtime Environment:
 OS Name:     FreeBSD
 OS Version:  11.0-RELEASE-p1
 OS Platform: FreeBSD
 RID:         linux-x64
 Base Path:   /mnt/dotnetcli4/dotnetcli.OK/sdk/2.0.0-preview1-005977/

(RID fixup is not part of this change) 

