### PR TITLE
When loading coreclr under Windows add PATH locations

### DIFF
--- a/src/corehost/common/pal.windows.cpp
+++ b/src/corehost/common/pal.windows.cpp
@@ -104,7 +104,8 @@ bool pal::load_library(const string_t* in_path, dll_t* dll)
     //Adding the assert to ensure relative paths which are not just filenames are not used for LoadLibrary Calls
     assert(!LongFile::IsPathNotFullyQualified(path) || !LongFile::ContainsDirectorySeparator(path));
 
-    *dll = ::LoadLibraryExW(path.c_str(), NULL, LOAD_LIBRARY_SEARCH_DLL_LOAD_DIR | LOAD_LIBRARY_SEARCH_DEFAULT_DIRS);
+    // LOAD_WITH_ALTERED_SEARCH_PATH looks in the directory specified by the first argument, and then the default locations.
+    *dll = ::LoadLibraryExW(path.c_str(), NULL, LOAD_WITH_ALTERED_SEARCH_PATH);
     if (*dll == nullptr)
     {
         trace::error(_X("Failed to load the dll from [%s], HRESULT: 0x%X"), path, HRESULT_FROM_WIN32(GetLastError()));

--- a/src/corehost/common/pal.windows.cpp
+++ b/src/corehost/common/pal.windows.cpp
@@ -88,10 +88,6 @@ bool pal::load_library(const string_t* in_path, dll_t* dll)
 {
     string_t path = *in_path;
 
-    // LOAD_LIBRARY_SEARCH_DLL_LOAD_DIR:
-    //   In portable apps, coreclr would come from another directory than the host,
-    //   so make sure coreclr dependencies can be resolved from coreclr.dll load dir.
-
     if (LongFile::IsPathNotFullyQualified(path))
     {
         if (!pal::realpath(&path))
@@ -101,10 +97,15 @@ bool pal::load_library(const string_t* in_path, dll_t* dll)
         }
     }
     
-    //Adding the assert to ensure relative paths which are not just filenames are not used for LoadLibrary Calls
+    // Adding the assert to ensure relative paths which are not just filenames are not used for LoadLibrary Calls
     assert(!LongFile::IsPathNotFullyQualified(path) || !LongFile::ContainsDirectorySeparator(path));
 
+    // Prevent LoadLibrary from looking in the current directory.
+    ::SetDllDirectoryW(_X(""));
+
     // LOAD_WITH_ALTERED_SEARCH_PATH looks in the directory specified by the first argument, and then the default locations.
+    // This is necessary when using the shared runtime because coreclr is in a different directory than the host,
+    // so make sure coreclr dependencies can be resolved in the directory coreclr.dll exists in.
     *dll = ::LoadLibraryExW(path.c_str(), NULL, LOAD_WITH_ALTERED_SEARCH_PATH);
     if (*dll == nullptr)
     {


### PR DESCRIPTION
Change the LoadLibrary options so that the PATH environment variable is also used when loading coreclr. This allows any static library references to be loaded that exist in %PATH% but not in the other 'standard' locations. This does not affect the behavior of other dlls loaded once the host->coreclr handoff occurs including loading of dlls specified in the deps file such as managed assemblies and pinvoke\native assemblies.

Fixes https://github.com/dotnet/core-setup/issues/3213. Note: if we don't fix this, then any dlls that need to be loaded must first be moved into one of the 'standard' locations.

The primary way we want to load the coreclr is to ensure the coreclr directory is searched first (the library we're loading), and then the 'standard' locations. This is usually done by one of two ways:
`LOAD_LIBRARY_SEARCH_DLL_LOAD_DIR | LOAD_LIBRARY_SEARCH_DEFAULT_DIRS` (current implementation)
or
`LOAD_WITH_ALTERED_SEARCH_PATH` (proposed change)

The `LOAD_WITH_ALTERED_SEARCH_PATH` will include the PATH while `LOAD_LIBRARY_SEARCH_DEFAULT_DIRS` will not.

Some links (note we do specify an absolute path in the _lpFileName_ argument)
https://msdn.microsoft.com/en-us/library/windows/desktop/ms682586(v=vs.85).aspx
https://msdn.microsoft.com/en-us/library/windows/desktop/ms684179(v=vs.85).aspx

Also, the intent is to affect the loading of coreclr, but the helper function is also used to load hostfxr.dll.