### PR TITLE
Port VersionSuffix changes from release/2.0.0 to master.

### DIFF
--- a/dir.props
+++ b/dir.props
@@ -45,6 +45,7 @@
   <PropertyGroup>
     <VersionSuffix Condition="'$(PreReleaseLabel)' != ''">$(PreReleaseLabel)-</VersionSuffix>
     <VersionSuffix>$(VersionSuffix)$(BuildNumberMajor)-$(BuildNumberMinor)</VersionSuffix>
+    <VersionSuffix Condition="'$(StabilizePackageVersion)' =='true'"></VersionSuffix>
     <ProductVersionSuffix Condition="'$(StabilizePackageVersion)' !='true'">-$(VersionSuffix)</ProductVersionSuffix>
     <ProductVersion>$(MajorVersion).$(MinorVersion).$(PatchVersion)$(ProductVersionSuffix)</ProductVersion>
     <ProductionVersion>$(MajorVersion).$(MinorVersion).$(PatchVersion)</ProductionVersion>

--- a/src/managed/CommonManaged.props
+++ b/src/managed/CommonManaged.props
@@ -15,15 +15,6 @@
     <PackageThirdPartyNoticesFile>$(RepoRoot)THIRD-PARTY-NOTICES.TXT</PackageThirdPartyNoticesFile>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(StabilizePackageVersion)' != 'true'">
-    <!-- 
-    Ensure VersionSuffix is set (especially during 'dotnet restore')
-    to work around https://github.com/NuGet/Home/issues/4337
-     -->
-    <VersionSuffix Condition="'$(PreReleaseLabel)' != ''">$(PreReleaseLabel)-</VersionSuffix>
-    <VersionSuffix>$(VersionSuffix)$(BuildNumberMajor)-$(BuildNumberMinor)</VersionSuffix>
-  </PropertyGroup>
-
   <PropertyGroup>
     <AssemblyOriginatorKeyFile>$(RepoRoot)tools-local/setuptools/Key.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>


### PR DESCRIPTION
This change brings https://github.com/dotnet/core-setup/commit/d85d263924c2ee7b7109d4ee209275ad1dbcb2b4 into master, along with removing an unnecessary VersionSuffix setting in CommonManaged.props.