### PR TITLE
Only change platform to AnyCPU for csproj files

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -6,7 +6,7 @@
     We are currently on too old of an SDK to detect - it doesn't have https://github.com/dotnet/sdk/pull/1242.
     But once we move to a new version, we can remove this property setting, and everything else will work correctly.
     -->
-    <UsingMicrosoftNETSdk>true</UsingMicrosoftNETSdk>
+    <UsingMicrosoftNETSdk Condition="'$(MSBuildProjectExtension)' == '.csproj'">true</UsingMicrosoftNETSdk>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(UsingMicrosoftNETSdk)' == 'true'">


### PR DESCRIPTION
Fixes https://github.com/dotnet/core-setup/issues/3243

cc @eerhardt 
@steveharter this should fix the CMake issue, although I cannot build the UWP projects still locally. I think I just need some new install to support that I'm looking at that next. 

After @eerhardt added the Directory.Build.targets file it started setting Platform to AnyCPU which messed up the native builds so to fix this we should only apply these settings for csproj.