### PR TITLE
Change to current directory after calling VSDevCmd.bat

### DIFF
--- a/run.cmd
+++ b/run.cmd
@@ -19,5 +19,6 @@ call "%_VSCOMNTOOLS%\VsDevCmd.bat"
 :Run
 :: We do not want to run the first-time experience.
 set DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1
+pushd %~dp0
 powershell -NoProfile -ExecutionPolicy unrestricted -Command "%~dp0run.ps1 -- %*"
 exit /b %ERRORLEVEL%


### PR DESCRIPTION
VSDevCmd.bat switches to a user directory so we need to ensure
we are switched back to the root of the repo in order for the
commands that take relative paths to projects to work. This will
allow you to build the repo from a clean cmd prompt again (still
requires VS installed)

cc @eerhardt @steveharter 