### PR TITLE
Handle RIDs better during the build.

### DIFF
--- a/RepoDirectories.props
+++ b/RepoDirectories.props
@@ -26,4 +26,8 @@
     <PackagingTaskDir Condition="'$(BuildToolsTaskDir)' != ''">$(BuildToolsTaskDir)</PackagingTaskDir>
     <DotnetCliPath Condition="'$(DotnetCliPath)'==''">$(ToolsDir)dotnetcli/</DotnetCliPath>
   </PropertyGroup>
+
+  <PropertyGroup>
+    <HostMachineInfoProps>$(BaseIntermediateOutputPath)HostMachineInfo.props</HostMachineInfoProps>
+  </PropertyGroup>
 </Project>

--- a/build.proj
+++ b/build.proj
@@ -16,6 +16,7 @@
     <TraversalBuildDependencies>
       CreateOrUpdateCurrentVersionFile;
       CreateVersionInfoFile;
+      CreateHostMachineInfoFile;
       BatchRestorePackages;
       BuildCustomTasks;
     </TraversalBuildDependencies>
@@ -33,6 +34,26 @@
 
   <Target Name="BuildTraversalBuildDependencies"
           DependsOnTargets="$(TraversalBuildDependencies)" />
+
+  <Target Name="CreateHostMachineInfoFile">
+    <GetTargetMachineInfo>
+      <Output PropertyName="HostMachineRid" TaskParameter="RuntimeIdentifier" />
+    </GetTargetMachineInfo>
+
+    <PropertyGroup>
+      <HostMachineInfoPropsContent>
+&lt;Project&gt;
+  &lt;PropertyGroup&gt;
+    &lt;HostMachineRid&gt;$(HostMachineRid)&lt;/HostMachineRid&gt;
+  &lt;/PropertyGroup&gt;
+&lt;/Project&gt;
+      </HostMachineInfoPropsContent>
+    </PropertyGroup>
+
+    <WriteLinesToFile File="$(HostMachineInfoProps)"
+                      Lines="$(HostMachineInfoPropsContent)"
+                      Overwrite="True" />
+  </Target>
 
   <Target Name="BuildCustomTasks">
       <MSBuild Projects="tools-local/Microsoft.DotNet.Build.Tasks.Local/Microsoft.DotNet.Build.Tasks.Local.builds" />

--- a/buildpipeline/Core-Setup-Linux-Arm-BT.json
+++ b/buildpipeline/Core-Setup-Linux-Arm-BT.json
@@ -123,7 +123,7 @@
       },
       "inputs": {
         "filename": "docker",
-        "arguments": "run --rm $(PB_CrossBuildArgs)$(DockerCommonRunArgs) $(PB_GitDirectory)/build.sh -OfficialBuildId=$(OfficialBuildId) $(PB_BuildArguments)",
+        "arguments": "run --rm $(PB_CrossBuildArgs)$(DockerCommonRunArgs) $(PB_GitDirectory)/build.sh -OfficialBuildId=$(OfficialBuildId) $(PB_BuildArguments) -- $(PB_AdditionalMSBuildArguments)",
         "workingFolder": "$(PB_SourcesDirectory)",
         "failOnStandardError": "false"
       }
@@ -141,7 +141,7 @@
       },
       "inputs": {
         "filename": "docker",
-        "arguments": "run --privileged --rm $(DockerCommonRunArgs) $(PB_GitDirectory)/Tools/msbuild.sh $(PB_GitDirectory)/publish/publish.proj /p:AzureAccountName=$(PB_AzureAccountName) /p:ContainerName=$(PB_ContainerName) /p:AzureAccessToken=$(PB_AzureAccessToken) /p:ChecksumAzureAccountName=$(PB_ChecksumAzureAccountName) /p:ChecksumContainerName=$(PB_ChecksumContainerName) /p:ChecksumAzureAccessToken=$(PB_ChecksumAzureAccessToken) /p:DistroRid=$(PB_DistroRid) /p:TargetArchitecture=$(PB_TargetArchitecture) /p:ConfigurationGroup=$(BuildConfiguration) /p:PortableBuild=$(PB_PortableBuild) /p:OSGroup=Linux /p:DebRepoUser=$(PB_DebRepoUser) /p:DebRepoServer=$(PB_DebRepoServer) /p:DebRepoPass=$(DEB_REPO_PASSWORD) /p:DebianId_ubuntu1404-x64=$(PB_DebianId_ubuntu1404-x64) /p:DebianId_debian8-x64=$(PB_DebianId_debian8-x64) /p:DebianId_ubuntu1604-x64=$(PB_DebianId_ubuntu1604-x64) /p:DebianId_ubuntu1610-x64=$(PB_DebianId_ubuntu1610-x64)",
+        "arguments": "run --privileged --rm $(DockerCommonRunArgs) $(PB_GitDirectory)/Tools/msbuild.sh $(PB_GitDirectory)/publish/publish.proj /p:AzureAccountName=$(PB_AzureAccountName) /p:ContainerName=$(PB_ContainerName) /p:AzureAccessToken=$(PB_AzureAccessToken) /p:ChecksumAzureAccountName=$(PB_ChecksumAzureAccountName) /p:ChecksumContainerName=$(PB_ChecksumContainerName) /p:ChecksumAzureAccessToken=$(PB_ChecksumAzureAccessToken) /p:TargetArchitecture=$(PB_TargetArchitecture) /p:ConfigurationGroup=$(BuildConfiguration) /p:PortableBuild=$(PB_PortableBuild) /p:OSGroup=Linux /p:DebRepoUser=$(PB_DebRepoUser) /p:DebRepoServer=$(PB_DebRepoServer) /p:DebRepoPass=$(DEB_REPO_PASSWORD) /p:DebianId_ubuntu1404-x64=$(PB_DebianId_ubuntu1404-x64) /p:DebianId_debian8-x64=$(PB_DebianId_debian8-x64) /p:DebianId_ubuntu1604-x64=$(PB_DebianId_ubuntu1604-x64) /p:DebianId_ubuntu1610-x64=$(PB_DebianId_ubuntu1610-x64) $(PB_AdditionalMSBuildArguments)",
         "workingFolder": "$(PB_SourcesDirectory)",
         "failOnStandardError": "false"
       }
@@ -364,13 +364,13 @@
       "value": null,
       "isSecret": true
     },
-    "PB_DistroRid": {
-      "value": "ubuntu.14.04-arm"
-    },
     "PB_TargetArchitecture": {
       "value": "arm"
     },
     "PB_AdditionalBuildArguments": {
+      "value": ""
+    },
+    "PB_AdditionalMSBuildArguments": {
       "value": ""
     },
     "PB_PortableBuild": {

--- a/buildpipeline/Core-Setup-Linux-BT.json
+++ b/buildpipeline/Core-Setup-Linux-BT.json
@@ -141,7 +141,7 @@
       },
       "inputs": {
         "filename": "docker",
-        "arguments": "run --privileged --rm $(DockerCommonRunArgs) $(PB_GitDirectory)/Tools/msbuild.sh $(PB_GitDirectory)/publish/publish.proj /p:AzureAccountName=$(PB_AzureAccountName) /p:ContainerName=$(PB_ContainerName) /p:AzureAccessToken=$(PB_AzureAccessToken) /p:ChecksumAzureAccountName=$(PB_ChecksumAzureAccountName) /p:ChecksumContainerName=$(PB_ChecksumContainerName) /p:ChecksumAzureAccessToken=$(PB_ChecksumAzureAccessToken) /p:DistroRid=$(PB_DistroRid) /p:TargetArchitecture=$(PB_TargetArchitecture) /p:ConfigurationGroup=$(BuildConfiguration) /p:PortableBuild=$(PB_PortableBuild) /p:OSGroup=Linux /p:DebRepoUser=$(PB_DebRepoUser) /p:DebRepoServer=$(PB_DebRepoServer) /p:DebRepoPass=$(DEB_REPO_PASSWORD) /p:DebianId_ubuntu1404-x64=$(PB_DebianId_ubuntu1404-x64) /p:DebianId_debian8-x64=$(PB_DebianId_debian8-x64) /p:DebianId_ubuntu1604-x64=$(PB_DebianId_ubuntu1604-x64) /p:DebianId_ubuntu1610-x64=$(PB_DebianId_ubuntu1610-x64)",
+        "arguments": "run --privileged --rm $(DockerCommonRunArgs) $(PB_GitDirectory)/Tools/msbuild.sh $(PB_GitDirectory)/publish/publish.proj /p:AzureAccountName=$(PB_AzureAccountName) /p:ContainerName=$(PB_ContainerName) /p:AzureAccessToken=$(PB_AzureAccessToken) /p:ChecksumAzureAccountName=$(PB_ChecksumAzureAccountName) /p:ChecksumContainerName=$(PB_ChecksumContainerName) /p:ChecksumAzureAccessToken=$(PB_ChecksumAzureAccessToken) /p:TargetArchitecture=$(PB_TargetArchitecture) /p:ConfigurationGroup=$(BuildConfiguration) /p:PortableBuild=$(PB_PortableBuild) /p:OSGroup=Linux /p:DebRepoUser=$(PB_DebRepoUser) /p:DebRepoServer=$(PB_DebRepoServer) /p:DebRepoPass=$(DEB_REPO_PASSWORD) /p:DebianId_ubuntu1404-x64=$(PB_DebianId_ubuntu1404-x64) /p:DebianId_debian8-x64=$(PB_DebianId_debian8-x64) /p:DebianId_ubuntu1604-x64=$(PB_DebianId_ubuntu1604-x64) /p:DebianId_ubuntu1610-x64=$(PB_DebianId_ubuntu1610-x64)",
         "workingFolder": "$(PB_SourcesDirectory)",
         "failOnStandardError": "false"
       }
@@ -215,7 +215,7 @@
       },
       "inputs": {
         "filename": "docker",
-        "arguments": "run --rm $(DockerCommonRunArgs_Ubuntu1404) $(PB_GitDirectory)/Tools/msbuild.sh $(PB_GitDirectory)/build.proj /t:BuildTraversalBuildDependencies /p:DistroRid=$(DistroRid_Ubuntu1404) $(DistroSpecificMSBuildArguments)",
+        "arguments": "run --rm $(DockerCommonRunArgs_Ubuntu1404) $(PB_GitDirectory)/Tools/msbuild.sh $(PB_GitDirectory)/build.proj /t:BuildTraversalBuildDependencies $(DistroSpecificMSBuildArguments)",
         "workingFolder": "",
         "failOnStandardError": "false"
       }
@@ -233,7 +233,7 @@
       },
       "inputs": {
         "filename": "docker",
-        "arguments": "run --rm $(DockerCommonRunArgs_Ubuntu1404) $(PB_GitDirectory)/Tools/msbuild.sh $(PB_GitDirectory)/src/pkg/packaging/dir.proj $(AdditionalMSBuildProperties) /p:DistroRid=$(DistroRid_Ubuntu1404) $(DistroSpecificMSBuildArguments)",
+        "arguments": "run --rm $(DockerCommonRunArgs_Ubuntu1404) $(PB_GitDirectory)/Tools/msbuild.sh $(PB_GitDirectory)/src/pkg/packaging/dir.proj $(AdditionalMSBuildProperties) $(DistroSpecificMSBuildArguments)",
         "workingFolder": "",
         "failOnStandardError": "false"
       }
@@ -251,7 +251,7 @@
       },
       "inputs": {
         "filename": "docker",
-        "arguments": "run --rm $(DockerCommonRunArgs_Ubuntu1404) $(PB_GitDirectory)/Tools/msbuild.sh $(PB_GitDirectory)/publish/publish.proj /p:DistroRid=$(DistroRid_Ubuntu1404) /p:PublishDebToolToFeed=true /p:CliNuGetFeedUrl=$(CLI_NUGET_FEED_URL) /p:CliNuGetApiKey=$(CLI_NUGET_API_KEY) $(DistroSpecificMSBuildArguments) $(DistroSpecificMSBuildPublishArgs)",
+        "arguments": "run --rm $(DockerCommonRunArgs_Ubuntu1404) $(PB_GitDirectory)/Tools/msbuild.sh $(PB_GitDirectory)/publish/publish.proj /p:PublishDebToolToFeed=true /p:CliNuGetFeedUrl=$(CLI_NUGET_FEED_URL) /p:CliNuGetApiKey=$(CLI_NUGET_API_KEY) $(DistroSpecificMSBuildArguments) $(DistroSpecificMSBuildPublishArgs)",
         "workingFolder": "",
         "failOnStandardError": "false"
       }
@@ -305,7 +305,7 @@
       },
       "inputs": {
         "filename": "docker",
-        "arguments": "run --rm $(DockerCommonRunArgs_Ubuntu1604) $(PB_GitDirectory)/Tools/msbuild.sh $(PB_GitDirectory)/build.proj /t:BuildTraversalBuildDependencies /p:DistroRid=$(DistroRid_Ubuntu1604) $(DistroSpecificMSBuildArguments)",
+        "arguments": "run --rm $(DockerCommonRunArgs_Ubuntu1604) $(PB_GitDirectory)/Tools/msbuild.sh $(PB_GitDirectory)/build.proj /t:BuildTraversalBuildDependencies $(DistroSpecificMSBuildArguments)",
         "workingFolder": "",
         "failOnStandardError": "false"
       }
@@ -323,7 +323,7 @@
       },
       "inputs": {
         "filename": "docker",
-        "arguments": "run --rm $(DockerCommonRunArgs_Ubuntu1604) $(PB_GitDirectory)/Tools/msbuild.sh $(PB_GitDirectory)/src/pkg/packaging/dir.proj $(AdditionalMSBuildProperties) /p:DistroRid=$(DistroRid_Ubuntu1604) $(DistroSpecificMSBuildArguments)",
+        "arguments": "run --rm $(DockerCommonRunArgs_Ubuntu1604) $(PB_GitDirectory)/Tools/msbuild.sh $(PB_GitDirectory)/src/pkg/packaging/dir.proj $(AdditionalMSBuildProperties) $(DistroSpecificMSBuildArguments)",
         "workingFolder": "",
         "failOnStandardError": "false"
       }
@@ -341,7 +341,7 @@
       },
       "inputs": {
         "filename": "docker",
-        "arguments": "run --rm $(DockerCommonRunArgs_Ubuntu1604) $(PB_GitDirectory)/Tools/msbuild.sh $(PB_GitDirectory)/publish/publish.proj /p:DistroRid=$(DistroRid_Ubuntu1604) $(DistroSpecificMSBuildArguments) $(DistroSpecificMSBuildPublishArgs)",
+        "arguments": "run --rm $(DockerCommonRunArgs_Ubuntu1604) $(PB_GitDirectory)/Tools/msbuild.sh $(PB_GitDirectory)/publish/publish.proj $(DistroSpecificMSBuildArguments) $(DistroSpecificMSBuildPublishArgs)",
         "workingFolder": "",
         "failOnStandardError": "false"
       }
@@ -395,7 +395,7 @@
       },
       "inputs": {
         "filename": "docker",
-        "arguments": "run --rm $(DockerCommonRunArgs_Ubuntu1610) $(PB_GitDirectory)/Tools/msbuild.sh $(PB_GitDirectory)/build.proj /t:BuildTraversalBuildDependencies /p:DistroRid=$(DistroRid_Ubuntu1610) $(DistroSpecificMSBuildArguments)",
+        "arguments": "run --rm $(DockerCommonRunArgs_Ubuntu1610) $(PB_GitDirectory)/Tools/msbuild.sh $(PB_GitDirectory)/build.proj /t:BuildTraversalBuildDependencies $(DistroSpecificMSBuildArguments)",
         "workingFolder": "",
         "failOnStandardError": "false"
       }
@@ -413,7 +413,7 @@
       },
       "inputs": {
         "filename": "docker",
-        "arguments": "run --rm $(DockerCommonRunArgs_Ubuntu1610) $(PB_GitDirectory)/Tools/msbuild.sh $(PB_GitDirectory)/src/pkg/packaging/dir.proj $(AdditionalMSBuildProperties) /p:DistroRid=$(DistroRid_Ubuntu1610) $(DistroSpecificMSBuildArguments)",
+        "arguments": "run --rm $(DockerCommonRunArgs_Ubuntu1610) $(PB_GitDirectory)/Tools/msbuild.sh $(PB_GitDirectory)/src/pkg/packaging/dir.proj $(AdditionalMSBuildProperties) $(DistroSpecificMSBuildArguments)",
         "workingFolder": "",
         "failOnStandardError": "false"
       }
@@ -431,7 +431,7 @@
       },
       "inputs": {
         "filename": "docker",
-        "arguments": "run --rm $(DockerCommonRunArgs_Ubuntu1610) $(PB_GitDirectory)/Tools/msbuild.sh $(PB_GitDirectory)/publish/publish.proj /p:DistroRid=$(DistroRid_Ubuntu1610) $(DistroSpecificMSBuildArguments) $(DistroSpecificMSBuildPublishArgs)",
+        "arguments": "run --rm $(DockerCommonRunArgs_Ubuntu1610) $(PB_GitDirectory)/Tools/msbuild.sh $(PB_GitDirectory)/publish/publish.proj $(DistroSpecificMSBuildArguments) $(DistroSpecificMSBuildPublishArgs)",
         "workingFolder": "",
         "failOnStandardError": "false"
       }
@@ -485,7 +485,7 @@
       },
       "inputs": {
         "filename": "docker",
-        "arguments": "run --rm $(DockerCommonRunArgs_Debian8) $(PB_GitDirectory)/Tools/msbuild.sh $(PB_GitDirectory)/build.proj /t:BuildTraversalBuildDependencies /p:DistroRid=$(DistroRid_Debian8) $(DistroSpecificMSBuildArguments)",
+        "arguments": "run --rm $(DockerCommonRunArgs_Debian8) $(PB_GitDirectory)/Tools/msbuild.sh $(PB_GitDirectory)/build.proj /t:BuildTraversalBuildDependencies $(DistroSpecificMSBuildArguments)",
         "workingFolder": "",
         "failOnStandardError": "false"
       }
@@ -503,7 +503,7 @@
       },
       "inputs": {
         "filename": "docker",
-        "arguments": "run --rm $(DockerCommonRunArgs_Debian8) $(PB_GitDirectory)/Tools/msbuild.sh $(PB_GitDirectory)/src/pkg/packaging/dir.proj $(AdditionalMSBuildProperties) /p:DistroRid=$(DistroRid_Debian8) $(DistroSpecificMSBuildArguments)",
+        "arguments": "run --rm $(DockerCommonRunArgs_Debian8) $(PB_GitDirectory)/Tools/msbuild.sh $(PB_GitDirectory)/src/pkg/packaging/dir.proj $(AdditionalMSBuildProperties) $(DistroSpecificMSBuildArguments)",
         "workingFolder": "",
         "failOnStandardError": "false"
       }
@@ -521,7 +521,7 @@
       },
       "inputs": {
         "filename": "docker",
-        "arguments": "run --rm $(DockerCommonRunArgs_Debian8) $(PB_GitDirectory)/Tools/msbuild.sh $(PB_GitDirectory)/publish/publish.proj /p:DistroRid=$(DistroRid_Debian8) $(DistroSpecificMSBuildArguments) $(DistroSpecificMSBuildPublishArgs)",
+        "arguments": "run --rm $(DockerCommonRunArgs_Debian8) $(PB_GitDirectory)/Tools/msbuild.sh $(PB_GitDirectory)/publish/publish.proj $(DistroSpecificMSBuildArguments) $(DistroSpecificMSBuildPublishArgs)",
         "workingFolder": "",
         "failOnStandardError": "false"
       }
@@ -575,7 +575,7 @@
       },
       "inputs": {
         "filename": "docker",
-        "arguments": "run --rm $(DockerCommonRunArgs_Rhel7) $(PB_GitDirectory)/Tools/msbuild.sh $(PB_GitDirectory)/build.proj /t:BuildTraversalBuildDependencies /p:DistroRid=$(DistroRid_Rhel7) $(DistroSpecificMSBuildArguments)",
+        "arguments": "run --rm $(DockerCommonRunArgs_Rhel7) $(PB_GitDirectory)/Tools/msbuild.sh $(PB_GitDirectory)/build.proj /t:BuildTraversalBuildDependencies $(DistroSpecificMSBuildArguments)",
         "workingFolder": "",
         "failOnStandardError": "false"
       }
@@ -593,7 +593,7 @@
       },
       "inputs": {
         "filename": "docker",
-        "arguments": "run --rm $(DockerCommonRunArgs_Rhel7) $(PB_GitDirectory)/Tools/msbuild.sh $(PB_GitDirectory)/src/pkg/packaging/dir.proj $(AdditionalMSBuildProperties) /p:DistroRid=$(DistroRid_Rhel7) $(DistroSpecificMSBuildArguments)",
+        "arguments": "run --rm $(DockerCommonRunArgs_Rhel7) $(PB_GitDirectory)/Tools/msbuild.sh $(PB_GitDirectory)/src/pkg/packaging/dir.proj $(AdditionalMSBuildProperties) $(DistroSpecificMSBuildArguments)",
         "workingFolder": "",
         "failOnStandardError": "false"
       }
@@ -611,7 +611,7 @@
       },
       "inputs": {
         "filename": "docker",
-        "arguments": "run --rm $(DockerCommonRunArgs_Rhel7) $(PB_GitDirectory)/Tools/msbuild.sh $(PB_GitDirectory)/publish/publish.proj /p:DistroRid=$(DistroRid_Rhel7) $(DistroSpecificMSBuildArguments) $(DistroSpecificMSBuildPublishArgs)",
+        "arguments": "run --rm $(DockerCommonRunArgs_Rhel7) $(PB_GitDirectory)/Tools/msbuild.sh $(PB_GitDirectory)/publish/publish.proj $(DistroSpecificMSBuildArguments) $(DistroSpecificMSBuildPublishArgs)",
         "workingFolder": "",
         "failOnStandardError": "false"
       }
@@ -844,9 +844,6 @@
       "value": null,
       "isSecret": true
     },
-    "PB_DistroRid": {
-      "value": "ubuntu.14.04-$(PB_TargetArchitecture)"
-    },
     "PB_TargetArchitecture": {
       "value": "x64"
     },
@@ -877,9 +874,6 @@
     "DockerTag_Ubuntu1404": {
       "value": "ubuntu-14.04-debpkg-e5cf912-20175003025046"
     },
-    "DistroRid_Ubuntu1404": {
-      "value": "ubuntu.14.04-x64"
-    },
     "DockerImageName_Ubuntu1404": {
       "value": "$(PB_DockerRepository):$(DockerTag_Ubuntu1404)"
     },
@@ -888,9 +882,6 @@
     },
     "DockerTag_Ubuntu1604": {
       "value": "ubuntu-16.04-debpkg-e5cf912-20174703024721"
-    },
-    "DistroRid_Ubuntu1604": {
-      "value": "ubuntu.16.04-$(PB_TargetArchitecture)"
     },
     "DockerImageName_Ubuntu1604": {
       "value": "$(PB_DockerRepository):$(DockerTag_Ubuntu1604)"
@@ -901,9 +892,6 @@
     "DockerTag_Ubuntu1610": {
       "value": "ubuntu-16.10-debpkg-ec863bb-20170003030028"
     },
-    "DistroRid_Ubuntu1610": {
-      "value": "ubuntu.16.10-$(PB_TargetArchitecture)"
-    },
     "DockerImageName_Ubuntu1610": {
       "value": "$(PB_DockerRepository):$(DockerTag_Ubuntu1610)"
     },
@@ -913,9 +901,6 @@
     "DockerTag_Debian8": {
       "value": "debian-8.2-debpkg-9f87c3c-20173003023006"
     },
-    "DistroRid_Debian8": {
-      "value": "debian.8-$(PB_TargetArchitecture)"
-    },
     "DockerImageName_Debian8": {
       "value": "$(PB_DockerRepository):$(DockerTag_Debian8)"
     },
@@ -924,9 +909,6 @@
     },
     "DockerTag_Rhel7": {
       "value": "rhel-7-rpmpkg-c982313-20174116044113"
-    },
-    "DistroRid_Rhel7": {
-      "value": "rhel.7-$(PB_TargetArchitecture)"
     },
     "DockerImageName_Rhel7": {
       "value": "$(PB_DockerRepository):$(DockerTag_Rhel7)"

--- a/buildpipeline/Core-Setup-Publish.json
+++ b/buildpipeline/Core-Setup-Publish.json
@@ -248,9 +248,6 @@
       "value": null,
       "isSecret": true
     },
-    "PB_DistroRid": {
-      "value": "win7-x64"
-    },
     "NUGET_SYMBOLS_FEED_URL": {
       "value": "https:%2F%2Fdotnet.myget.org/F/dotnet-core/symbols/api/v2/package"
     },
@@ -291,7 +288,7 @@
       "value": "HEAD"
     },
     "PB_CommonMSBuildArgs": {
-      "value": "/p:DistroRid=$(PB_DistroRid) /p:ConfigurationGroup=$(BuildConfiguration) /p:TargetArchitecture=$(PB_TargetArchitecture)"
+      "value": "/p:ConfigurationGroup=$(BuildConfiguration) /p:TargetArchitecture=$(PB_TargetArchitecture)"
     },
     "OfficialBuildId": {
       "value": "$(Build.BuildNumber)"

--- a/buildpipeline/Core-Setup-Windows-Arm-BT.json
+++ b/buildpipeline/Core-Setup-Windows-Arm-BT.json
@@ -391,10 +391,6 @@
     "CertificateId": {
       "value": "400"
     },
-    "PB_DistroRid": {
-      "value": "win-$(PB_TargetArchitecture)",
-      "allowOverride": true
-    },
     "MsbuildSigningArguments": {
       "value": "/p:CertificateId=$(CertificateId) /v:detailed"
     },
@@ -451,7 +447,7 @@
       "value": "real"
     },
     "PB_CommonMSBuildArgs": {
-      "value": "/p:DistroRid=$(PB_DistroRid) /p:ConfigurationGroup=$(BuildConfiguration) /p:TargetArchitecture=$(PB_TargetArchitecture) /p:PortableBuild=$(PB_PortableBuild) /p:DisableCrossgen=true $(PB_AdditionalBuildArguments)"
+      "value": "/p:ConfigurationGroup=$(BuildConfiguration) /p:TargetArchitecture=$(PB_TargetArchitecture) /p:PortableBuild=$(PB_PortableBuild) /p:DisableCrossgen=true $(PB_AdditionalBuildArguments)"
     },
     "PB_AdditionalBuildArguments": {
       "value": ""

--- a/buildpipeline/Core-Setup-Windows-BT.json
+++ b/buildpipeline/Core-Setup-Windows-BT.json
@@ -586,10 +586,6 @@
     "CertificateId": {
       "value": "400"
     },
-    "PB_DistroRid": {
-      "value": "win-$(PB_TargetArchitecture)",
-      "allowOverride": true
-    },
     "MsbuildSigningArguments": {
       "value": "/p:CertificateId=$(CertificateId) /v:detailed"
     },
@@ -649,7 +645,7 @@
       "value": "real"
     },
     "PB_CommonMSBuildArgs": {
-      "value": "/p:DistroRid=$(PB_DistroRid) /p:ConfigurationGroup=$(BuildConfiguration) /p:TargetArchitecture=$(PB_TargetArchitecture) /p:PortableBuild=$(PB_PortableBuild)"
+      "value": "/p:ConfigurationGroup=$(BuildConfiguration) /p:TargetArchitecture=$(PB_TargetArchitecture) /p:PortableBuild=$(PB_PortableBuild)"
     },
     "OfficialBuildId": {
       "value": "$(Build.BuildNumber)"

--- a/buildpipeline/pipeline.json
+++ b/buildpipeline/pipeline.json
@@ -18,7 +18,6 @@
         {
           "Name": "Core-Setup-Linux-BT",
           "Parameters": {
-            "PB_DistroRid": "rhel.7.2-x64",
             "PB_DockerTag": "rhel7_prereqs_2",
             "PB_AdditionalBuildArguments":"-PortableBuild=true -strip-symbols",
             "PB_PortableBuild": "true"
@@ -33,10 +32,10 @@
         {
           "Name": "Core-Setup-Linux-Arm-BT",
           "Parameters": {
-            "PB_DistroRid": "rhel.6-x64",
             "PB_DockerTag": "centos-6-c8c9b08-20174310104313",
             "PB_TargetArchitecture": "x64",
-            "PB_AdditionalBuildArguments":"-TargetArchitecture=x64 -DistroRid=rhel.6-x64 -PortableBuild=false -strip-symbols",
+            "PB_AdditionalBuildArguments":"-TargetArchitecture=x64 -PortableBuild=false -strip-symbols",
+            "PB_AdditionalMSBuildArguments":"/p:OutputRid=rhel.6-x64",
             "PB_PortableBuild": "false"
           },
           "ReportingParameters": {
@@ -48,10 +47,9 @@
         {
           "Name": "Core-Setup-Linux-Arm-BT",
           "Parameters": {
-            "PB_DistroRid": "ubuntu.14.04-arm",
             "PB_DockerTag": "ubuntu-14.04-cross-0cd4667-20172211042239",
             "PB_TargetArchitecture": "arm",
-            "PB_AdditionalBuildArguments":"-TargetArchitecture=arm -DistroRid=linux-arm -DisableCrossgen=true -PortableBuild=true -SkipTests=true -CrossBuild=true -strip-symbols",
+            "PB_AdditionalBuildArguments":"-TargetArchitecture=arm -DisableCrossgen=true -PortableBuild=true -SkipTests=true -CrossBuild=true -strip-symbols",
             "PB_CrossBuildArgs": "-e ROOTFS_DIR ",
             "PB_PortableBuild": "true"
           },
@@ -80,7 +78,6 @@
           "Parameters": {
             "PB_AdditionalBuildArguments": "/p:SkipTests=true",
             "PB_TargetArchitecture": "arm",
-            "PB_DistroRid": "win-arm",
             "PB_PortableBuild": "true"
           },
           "ReportingParameters": {
@@ -95,7 +92,6 @@
           "Parameters": {
             "PB_AdditionalBuildArguments": "/p:SkipTests=true /p:NativeToolSetDir=C:\\tools\\clr",
             "PB_TargetArchitecture": "arm64",
-            "PB_DistroRid": "win-arm64",
             "PB_PortableBuild": "true"
           },
           "ReportingParameters": {
@@ -108,7 +104,6 @@
         {
           "Name": "Core-Setup-Windows-BT",
           "Parameters": {
-            "PB_DistroRid": "win7-x64",
             "PB_TargetArchitecture": "x64",
             "PB_PortableBuild": "true",
             "PB_PublishRidAgnosticPackages": "true",
@@ -124,7 +119,6 @@
         {
           "Name": "Core-Setup-Windows-BT",
           "Parameters": {
-            "PB_DistroRid": "win7-x86",
             "PB_TargetArchitecture": "x86",
             "PB_PortableBuild": "true"
           },

--- a/config.json
+++ b/config.json
@@ -30,12 +30,6 @@
       "values": [ "True", "False"],
       "defaultValue": "False"
     },
-    "DistroRid": {
-      "description": "Specifies the distro rid for Unix OS.",
-      "valueType": "property",
-      "values": [],
-      "defaultValue": "${OSRid}-${CPUArch}"
-    },
     "TargetArchitecture":{
       "description": "Build for the specified architecture (x64, x86 (supported only on Windows), arm, or arm64, default: x64)",
       "valueType": "property",
@@ -264,7 +258,6 @@
            "TargetArchitecture": "default",
            "OSGroup": "default",
            "MsBuildLogging":"default",
-           "DistroRid":"default",
            "Project":"build.proj"
         }
       }

--- a/dir.props
+++ b/dir.props
@@ -197,33 +197,27 @@
     <Framework>netcoreapp2.0</Framework>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(TargetRid)' == '' and '$(OSGroup)' == 'Windows_NT'">
-    <TargetRid Condition="'$(TargetArchitecture)' == 'x86'">win7-x86</TargetRid>
-    <TargetRid Condition="'$(TargetArchitecture)' == 'x64'">win7-x64</TargetRid>
-    <TargetRid Condition="'$(TargetArchitecture)' == 'arm'">win8-arm</TargetRid>
-    <TargetRid Condition="'$(TargetArchitecture)' == 'arm64'">win10-arm64</TargetRid>
+  <Import Project="$(HostMachineInfoProps)"
+          Condition="Exists('$(HostMachineInfoProps)')" />
+
+  <PropertyGroup Condition="'$(OutputRid)' == '' and '$(HostMachineRid)' != ''">
+    <OutputRid>$(HostMachineRid.Remove($(HostMachineRid.LastIndexOf('-'))))-$(TargetArchitecture)</OutputRid>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(TargetRid)' == '' and '$(OSGroup)' == 'OSX'">
-    <TargetRid>osx.10.12-x64</TargetRid>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(TargetRid)' == '' and '$(DistroRid)' != ''">
-    <TargetRid>$(DistroRid)</TargetRid>
-  </PropertyGroup>
+
   <!-- Portable -->
   <PropertyGroup Condition="'$(PortableBuild)' == 'true'">
-    <TargetRid Condition="'$(OSGroup)' == 'Windows_NT'">win-$(TargetArchitecture)</TargetRid>
-    <TargetRid Condition="'$(OSGroup)' == 'OSX'">osx-$(TargetArchitecture)</TargetRid>
-    <TargetRid Condition="'$(OSGroup)' == 'Linux'">linux-$(TargetArchitecture)</TargetRid>
+    <OutputRid Condition="'$(OSGroup)' == 'Windows_NT'">win-$(TargetArchitecture)</OutputRid>
+    <OutputRid Condition="'$(OSGroup)' == 'OSX'">osx-$(TargetArchitecture)</OutputRid>
+    <OutputRid Condition="'$(OSGroup)' == 'Linux'">linux-$(TargetArchitecture)</OutputRid>
   </PropertyGroup>
 
   <PropertyGroup>
-    <TestTargetRid Condition="'$(TestTargetRid)' == '' and '$(PortableBuild)' != 'true' and '$(OSGroup)' == 'Windows_NT'">win10-$(TargetArchitecture)</TestTargetRid>
-    <TestTargetRid Condition="'$(TestTargetRid)' == ''">$(TargetRid)</TestTargetRid>
+    <TestTargetRid Condition="'$(TestTargetRid)' == ''">$(OutputRid)</TestTargetRid>
   </PropertyGroup>
 
   <!-- Set up the default output and intermediate paths -->
   <PropertyGroup>
-    <OSPlatformConfig>$(TargetRid).$(ConfigurationGroup)</OSPlatformConfig>
+    <OSPlatformConfig>$(OutputRid).$(ConfigurationGroup)</OSPlatformConfig>
 
     <BaseOutputPath Condition="'$(BaseOutputPath)'==''">$(BinDir)</BaseOutputPath>
     <BaseOutputRootPath>$(BaseOutputPath)$(OSPlatformConfig)\</BaseOutputRootPath>
@@ -246,7 +240,7 @@
 
   <PropertyGroup>
     <DisableCrossgen>false</DisableCrossgen>
-    <OutputVersionBadge>$(BaseOutputRootPath)sharedfx_$(TargetRid)_$(ConfigurationGroup)_version_badge.svg</OutputVersionBadge>
+    <OutputVersionBadge>$(BaseOutputRootPath)sharedfx_$(OutputRid)_$(ConfigurationGroup)_version_badge.svg</OutputVersionBadge>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -283,39 +277,39 @@
     <TargetsCentos>false</TargetsCentos>
   </PropertyGroup>
   <Choose>
-    <When Condition="$(TargetRid.StartsWith('win'))">
+    <When Condition="$(OutputRid.StartsWith('win'))">
       <PropertyGroup>
         <TargetsWindows>true</TargetsWindows>
       </PropertyGroup>
     </When>
-    <When Condition="$(TargetRid.StartsWith('osx'))">
+    <When Condition="$(OutputRid.StartsWith('osx'))">
       <PropertyGroup>
         <TargetsOSX>true</TargetsOSX>
         <TargetsUnix>true</TargetsUnix>
       </PropertyGroup>
     </When>
-    <When Condition="$(TargetRid.StartsWith('debian'))">
+    <When Condition="$(OutputRid.StartsWith('debian'))">
       <PropertyGroup>
         <TargetsDebian>true</TargetsDebian>
         <TargetsLinux>true</TargetsLinux>
         <TargetsUnix>true</TargetsUnix>
       </PropertyGroup>
     </When>
-    <When Condition="$(TargetRid.StartsWith('ubuntu'))">
+    <When Condition="$(OutputRid.StartsWith('ubuntu'))">
       <PropertyGroup>
         <TargetsUbuntu>true</TargetsUbuntu>
         <TargetsLinux>true</TargetsLinux>
         <TargetsUnix>true</TargetsUnix>
       </PropertyGroup>
     </When>
-    <When Condition="$(TargetRid.StartsWith('rhel'))">
+    <When Condition="$(OutputRid.StartsWith('rhel'))">
       <PropertyGroup>
         <TargetsRhel>true</TargetsRhel>
         <TargetsLinux>true</TargetsLinux>
         <TargetsUnix>true</TargetsUnix>
       </PropertyGroup>
     </When>
-        <When Condition="$(TargetRid.StartsWith('centos'))">
+    <When Condition="$(OutputRid.StartsWith('centos'))">
       <PropertyGroup>
         <TargetsCentos>true</TargetsCentos>
         <TargetsLinux>true</TargetsLinux>
@@ -342,14 +336,14 @@
   </PropertyGroup>
 
   <!-- Use actual publishable (non-dummy) package name produced by the build system for this RID -->
-  <PropertyGroup Condition="'$(TargetRid)' != ''">
-    <PackageTargetRid>$(TargetRid)</PackageTargetRid>
-    <PackageTargetRid Condition="'$(TargetRid)' == 'osx.10.11-x64'">osx.10.10-x64</PackageTargetRid>
-    <PackageTargetRid Condition="'$(TargetRid)' == 'rhel.7.0-x64'">rhel.7-x64</PackageTargetRid>
-    <PackageTargetRid Condition="'$(TargetRid)' == 'rhel.7.1-x64'">rhel.7-x64</PackageTargetRid>
-    <PackageTargetRid Condition="'$(TargetRid)' == 'rhel.7.2-x64'">rhel.7-x64</PackageTargetRid>
-    <PackageTargetRid Condition="'$(TargetRid)' == 'rhel.7.3-x64'">rhel.7-x64</PackageTargetRid>
-    <PackageTargetRid Condition="'$(TargetRid)' == 'rhel.7.4-x64'">rhel.7-x64</PackageTargetRid>
+  <PropertyGroup Condition="'$(OutputRid)' != ''">
+    <PackageTargetRid>$(OutputRid)</PackageTargetRid>
+    <PackageTargetRid Condition="'$(OutputRid)' == 'osx.10.11-x64'">osx.10.10-x64</PackageTargetRid>
+    <PackageTargetRid Condition="'$(OutputRid)' == 'rhel.7.0-x64'">rhel.7-x64</PackageTargetRid>
+    <PackageTargetRid Condition="'$(OutputRid)' == 'rhel.7.1-x64'">rhel.7-x64</PackageTargetRid>
+    <PackageTargetRid Condition="'$(OutputRid)' == 'rhel.7.2-x64'">rhel.7-x64</PackageTargetRid>
+    <PackageTargetRid Condition="'$(OutputRid)' == 'rhel.7.3-x64'">rhel.7-x64</PackageTargetRid>
+    <PackageTargetRid Condition="'$(OutputRid)' == 'rhel.7.4-x64'">rhel.7-x64</PackageTargetRid>
     <ProductMoniker>$(SharedFrameworkNugetVersion)-$(PackageTargetRid)</ProductMoniker>
     <HostResolverVersionMoniker>$(HostResolverVersion)-$(PackageTargetRid)</HostResolverVersionMoniker>
   </PropertyGroup>

--- a/netci.groovy
+++ b/netci.groovy
@@ -48,7 +48,7 @@ platformList.each { platform ->
         dockerContainer = "ubuntu1404_cross_prereqs_v4-tizen_rootfs"
 
         dockerCommand = "docker run -e ROOTFS_DIR=/crossrootfs/${architecture}.tizen.build --name ${dockerContainer} --rm -v \${WORKSPACE}:${dockerWorkingDirectory} -w=${dockerWorkingDirectory} ${dockerRepository}:${dockerContainer}"
-        buildArgs += " -DistroRid=tizen.4.0.0-${architecture} -SkipTests=true -DisableCrossgen=true -PortableBuild=false -CrossBuild=true -- /p:OverridePackageSource=https:%2F%2Ftizen.myget.org/F/dotnet-core/api/v3/index.json"
+        buildArgs += " -SkipTests=true -DisableCrossgen=true -PortableBuild=false -CrossBuild=true -- /p:OverridePackageSource=https:%2F%2Ftizen.myget.org/F/dotnet-core/api/v3/index.json /p:OutputRid=tizen.4.0.0-${architecture}"
         buildCommand = "${dockerCommand} ./build.sh ${buildArgs}"
     }
     else if (os == "Linux") {
@@ -57,7 +57,7 @@ platformList.each { platform ->
         if (architecture == 'arm' || architecture == 'armel') {
             dockerContainer = "ubuntu-14.04-cross-0cd4667-20172211042239"
             dockerCommand = "docker run -e ROOTFS_DIR=/crossrootfs/${architecture} --name ${dockerContainer} --rm -v \${WORKSPACE}:${dockerWorkingDirectory} -w=${dockerWorkingDirectory} ${dockerRepository}:${dockerContainer}"
-            buildArgs += " -DistroRid=linux-${architecture} -SkipTests=true -DisableCrossgen=true -CrossBuild=true"
+            buildArgs += " -SkipTests=true -DisableCrossgen=true -CrossBuild=true"
             buildCommand = "${dockerCommand} ./build.sh ${buildArgs}"
 
             osForGHTrigger = "Linux"

--- a/publish/dir.props
+++ b/publish/dir.props
@@ -12,12 +12,7 @@
     <ChecksumsRelativePath>Runtime/$(ProductVersion)</ChecksumsRelativePath>
     <ChecksumExtension>.sha512</ChecksumExtension>
   </PropertyGroup>
-  
-  <PropertyGroup>
-    <ProductMoniker>$(DistroRid).$(SharedFrameworkNugetVersion)</ProductMoniker>
-    <HostResolverVersionMoniker>$(DistroRid).$(HostResolverVersion)</HostResolverVersionMoniker>
-  </PropertyGroup>
-  
+
   <ItemGroup>
     <CompressedFile Include="$(PackagesOutDir)**/*$(CompressedFileExtension)">
       <RelativeBlobPath>$(BinariesRelativePath)</RelativeBlobPath>

--- a/publish/dir.targets
+++ b/publish/dir.targets
@@ -63,7 +63,7 @@
       </RepoIds>
     </ItemGroup>
     <PropertyGroup>
-      <RidWithoutDots>$([System.String]::Copy($(DistroRid)).Replace('.', ''))</RidWithoutDots>
+      <RidWithoutDots>$([System.String]::Copy($(OutputRid)).Replace('.', ''))</RidWithoutDots>
       <DebRepoId Condition="$([System.String]::Copy(%(RepoIds.Identity)).EndsWith('$(RidWithoutDots)'))">%(RepoIds.Key)</DebRepoId>
     </PropertyGroup>
     <Error Condition="'$(DebRepoId)'=='' OR '$(DebRepoUser)'=='' OR '$(DebRepoPass)'=='' OR '$(DebRepoServer)'==''"

--- a/sign.proj
+++ b/sign.proj
@@ -11,7 +11,7 @@
   <Import Project="Tools/MicroBuild.Core.targets" />
 
   <Target Name="SetSigningProperties">
-    <Error Condition="'$(TargetRid)' == ''" Text="Missing required property 'TargetRid'." />
+    <Error Condition="'$(OutputRid)' == ''" Text="Missing required property 'OutputRid'." />
     <Error Condition="'$(CertificateId)' == ''" Text="Missing required property 'CertificateId'." />
     <PropertyGroup>
       <!-- The OutDir and IntermediateOutputPath properties are required by MicroBuild. MicroBuild only

--- a/src/corehost/build.proj
+++ b/src/corehost/build.proj
@@ -57,7 +57,7 @@
              Properties="GenerateNativeVersionInfo=true;AssemblyName=%(HostFiles.Identity);NativeVersionFileDir=$(IntermediateOutputRootPath)hostResourceFiles\%(HostFiles.Identity);NativeVersionHeaderFile=$(IntermediateOutputRootPath)hostResourceFiles\%(HostFiles.Identity)\version_info.h"
              Targets="GenerateVersionHeader" />
     <PropertyGroup>
-      <BuildArgs>$(ConfigurationGroup) $(TargetArchitecture) apphostver $(AppHostVersion) hostver $(HostVersion) fxrver $(HostResolverVersion) policyver $(HostPolicyVersion) commit $(LatestCommit) rid $(TargetRid)</BuildArgs>
+      <BuildArgs>$(ConfigurationGroup) $(TargetArchitecture) apphostver $(AppHostVersion) hostver $(HostVersion) fxrver $(HostResolverVersion) policyver $(HostPolicyVersion) commit $(LatestCommit) rid $(OutputRid)</BuildArgs>
       <BuildArgs Condition="'$(PortableBuild)' == 'true'">$(BuildArgs) portable</BuildArgs>  
       <CustomNativeToolsetDir Condition="'$(TargetArchitecture)' == 'arm64'"> toolsetdir $(NativeToolsetDir)</CustomNativeToolsetDir>      
     </PropertyGroup>

--- a/src/pkg/projects/netcoreappRIDs.props
+++ b/src/pkg/projects/netcoreappRIDs.props
@@ -1,18 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  
-  <PropertyGroup Condition="'$(PortableBuild)' != 'true' and '$(PackageRID)' == ''">
-    <PackageRID>$(DistroRid)</PackageRID>
-    <PackageRID Condition="'$(OSGroup)' == 'OSX'">osx.10.12-$(Platform)</PackageRID>
-    <PackageRID Condition="'$(OSGroup)' == 'Windows_NT'">win7-$(Platform)</PackageRID>
-    <PackageRID Condition="'$(OSGroup)' == 'Windows_NT' AND '$(Platform)' =='arm'">win8-$(Platform)</PackageRID>
-    <PackageRID Condition="'$(OSGroup)' == 'Windows_NT' AND '$(Platform)' =='arm64'">win10-$(Platform)</PackageRID>
-  </PropertyGroup>
 
-  <PropertyGroup Condition="'$(PortableBuild)' == 'true'">
-    <PackageRID>win-$(Platform)</PackageRID>
-    <PackageRID Condition="'$(OSGroup)' == 'OSX'">osx-$(Platform)</PackageRID>
-    <PackageRID Condition="'$(OSGroup)' == 'Linux'">linux-$(Platform)</PackageRID>
+  <PropertyGroup>
+    <PackageRID Condition="'$(PackageRID)' == ''">$(OutputRid)</PackageRID>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/test/dir.proj
+++ b/src/test/dir.proj
@@ -90,7 +90,7 @@
     </PropertyGroup>
     <Exec Command="$(DotnetToolCommand) test $(TestArgs) --logger &quot;trx;LogFileName=$(TestResultsXml)&quot;"
           WorkingDirectory="$(TestWorkingDirectory)"
-          EnvironmentVariables="NUGET_PACKAGES=$(PackagesDir);TEST_ARTIFACTS=$(SystemPathTestsOutputDir);TEST_TARGETRID=$(TestTargetRid);BUILDRID=$(TargetRid);BUILD_ARCHITECTURE=$(TargetArchitecture);BUILD_CONFIGURATION=$(ConfigurationGroup);MNA_VERSION=$(ProductVersion);DOTNET_SDK_PATH=$(DotnetCliPath)"
+          EnvironmentVariables="NUGET_PACKAGES=$(PackagesDir);TEST_ARTIFACTS=$(SystemPathTestsOutputDir);TEST_TARGETRID=$(TestTargetRid);BUILDRID=$(OutputRid);BUILD_ARCHITECTURE=$(TargetArchitecture);BUILD_CONFIGURATION=$(ConfigurationGroup);MNA_VERSION=$(ProductVersion);DOTNET_SDK_PATH=$(DotnetCliPath)"
           Condition="'$(TestProjectFilename)' != 'HostActivationTests' or '$(IsCrossArch)' != 'true'"
           ContinueOnError="true"
           IgnoreStandardErrorWarningFormat="true"

--- a/tools-local/scripts/arm32_ci_script.sh
+++ b/tools-local/scripts/arm32_ci_script.sh
@@ -213,7 +213,7 @@ function cross_build_core_setup_with_docker {
     fi
 
     # Cross building core-setup with rootfs in Docker
-    __buildCmd="./build.sh --configuration $__buildConfig --env-vars DISABLE_CROSSGEN=1,TARGETPLATFORM=$__buildArch,TARGETRID=$__runtimeOS-$__buildArch,CROSS=1,ROOTFS_DIR=$__rootfsDir"
+    __buildCmd="./build.sh --configuration $__buildConfig --env-vars DISABLE_CROSSGEN=1,TARGETPLATFORM=$__buildArch,OUTPUTRID=$__runtimeOS-$__buildArch,CROSS=1,ROOTFS_DIR=$__rootfsDir"
     $__dockerCmd $__buildCmd
 }
 


### PR DESCRIPTION
Currently, when building non-portable on a win10 machine, core-setup restores and produces `win7` RID assets.  This causes problems in source-build since corefx produces `win10` assets on the same machine. Thus, core-setup can't use the corefx assets because win10 is not compatible with win7.

In fixing this, I refactored the way RIDs are handled during the build.  We have 3 main RID usages:
* What is the RID of the current machine?  $(HostMachineRid)
* What is the RID of the toolset we are using to build?  core-setup doesn't have this scenario yet, but corefx calls this $(ToolRuntimeRID)
* What is the RID that the current build is producing outputs for?  $(OutputRid)

## Notes

I expect the ARM CIs to fail since I needed to modify the netci.groovy file.