### PR TITLE
Disable including source files in nupkgs during source-build to work around the long path limitation.

### DIFF
--- a/src/pkg/projects/Microsoft.NETCore.App/src/Microsoft.NETCore.App.depproj
+++ b/src/pkg/projects/Microsoft.NETCore.App/src/Microsoft.NETCore.App.depproj
@@ -163,7 +163,7 @@
       </FilesToPackage>
     </ItemGroup>
 
-    <ItemGroup>
+    <ItemGroup Condition="'$(IncludeSourceFilesInPackage)' == 'true'">
       <!-- pick up any src our sources directory from packages contributing files -->
       <_sourcePathCandidate Include="@(FilesToPackage->'$(PackagesDir)\%(NuGetPackageId)\%(NuGetPackageVersion)\sources')" />
       <_sourcePathCandidate Include="@(FilesToPackage->'$(PackagesDir)\%(NuGetPackageId)\%(NuGetPackageVersion)\src')" />

--- a/src/pkg/projects/Microsoft.NETCore.UniversalWindowsPlatform/src/Microsoft.NETCore.UniversalWindowsPlatform.depproj
+++ b/src/pkg/projects/Microsoft.NETCore.UniversalWindowsPlatform/src/Microsoft.NETCore.UniversalWindowsPlatform.depproj
@@ -134,7 +134,7 @@
     </ItemGroup>
     <Error Text="Unexpected System package(s) @(_secondarySystemPackages)" Condition="'@(_secondarySystemPackages)' != ''" />
 
-    <ItemGroup>
+    <ItemGroup Condition="'$(IncludeSourceFilesInPackage)' == 'true'">
       <!-- pick up any src our sources directory from packages contributing files -->
       <_sourcePathCandidate Include="@(FilesToPackage->'$(PackagesDir)\%(NuGetPackageId)\%(NuGetPackageVersion)\sources')" />
       <_sourcePathCandidate Include="@(FilesToPackage->'$(PackagesDir)\%(NuGetPackageId)\%(NuGetPackageVersion)\src')" />

--- a/src/pkg/projects/dir.props
+++ b/src/pkg/projects/dir.props
@@ -13,6 +13,9 @@
     <PackageTargetRuntime Condition="'$(PackageTargetRuntime)' == '' AND '$(MSBuildProjectExtension)' == '.depproj'">$(NuGetRuntimeIdentifier)</PackageTargetRuntime>
 
     <IsLineupPackage Condition="'$(PackageTargetRuntime)' == ''">true</IsLineupPackage>
+
+    <IncludeSourceFilesInPackage Condition="'$(DotNetBuildFromSource)' == 'true'">false</IncludeSourceFilesInPackage>
+    <IncludeSourceFilesInPackage Condition="'$(IncludeSourceFilesInPackage)' == ''">true</IncludeSourceFilesInPackage>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(PackageTargetRuntime)' == ''">


### PR DESCRIPTION
/cc @weshaggard @ericstj @dagood 

I've logged https://github.com/dotnet/core-setup/issues/3269 to track turning this back on.