### PR TITLE
Build custom tasks for net45 on Windows, even when building in source-build.

### DIFF
--- a/tools-local/Microsoft.DotNet.Build.Tasks.Local/Microsoft.DotNet.Build.Tasks.Local.builds
+++ b/tools-local/Microsoft.DotNet.Build.Tasks.Local/Microsoft.DotNet.Build.Tasks.Local.builds
@@ -6,7 +6,7 @@
       <AdditionalProperties>TargetGroup=netstandard1.5</AdditionalProperties>
     </Project>
     <Project Include="$(MSBuildThisFileDirectory)$(MSBuildProjectName).csproj"
-             Condition="'$(DotNetBuildFromSource)' != 'true'">
+             Condition="'$(BuildCustomTasksForDesktop)' == 'true'">
       <AdditionalProperties>TargetGroup=net45</AdditionalProperties>
     </Project>
   </ItemGroup>

--- a/tools-local/dir.props
+++ b/tools-local/dir.props
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\dir.props" />
+
+  <PropertyGroup>
+    <BuildCustomTasksForDesktop Condition="'$(MSBuildRuntimeType)' != 'Core'">true</BuildCustomTasksForDesktop>
+  </PropertyGroup>
+
+</Project>

--- a/tools-local/tasks/core-setup.tasks.builds
+++ b/tools-local/tasks/core-setup.tasks.builds
@@ -6,7 +6,7 @@
       <AdditionalProperties>TargetGroup=netstandard1.5</AdditionalProperties>
     </Project>
     <Project Include="$(MSBuildThisFileDirectory)$(MSBuildProjectName).csproj"
-             Condition="'$(DotNetBuildFromSource)' != 'true'">
+             Condition="'$(BuildCustomTasksForDesktop)' == 'true'">
       <AdditionalProperties>TargetGroup=net45</AdditionalProperties>
     </Project>
   </ItemGroup>


### PR DESCRIPTION
Our custom tasks need to be build for net45 when running on Desktop MSBuild.

@weshaggard 

