### PR TITLE
Update CentOS 6 docker image

### DIFF
--- a/buildpipeline/pipeline.json
+++ b/buildpipeline/pipeline.json
@@ -18,8 +18,8 @@
         {
           "Name": "Core-Setup-Linux-BT",
           "Parameters": {
-            "PB_DistroRid": "rhel.7.2-x64",
-            "PB_DockerTag": "rhel7_prereqs_2",
+            "PB_DistroRid": "rhel.7-x64",
+            "PB_DockerTag": "centos-7-d485f41-20173404063424",
             "PB_AdditionalBuildArguments":"-PortableBuild=true -strip-symbols",
             "PB_PortableBuild": "true"
           },
@@ -34,7 +34,7 @@
           "Name": "Core-Setup-Linux-Arm-BT",
           "Parameters": {
             "PB_DistroRid": "rhel.6-x64",
-            "PB_DockerTag": "centos-6-c8c9b08-20174310104313",
+            "PB_DockerTag": "centos-6-d485f41-20173404063424",
             "PB_TargetArchitecture": "x64",
             "PB_AdditionalBuildArguments":"-TargetArchitecture=x64 -DistroRid=rhel.6-x64 -PortableBuild=false -strip-symbols",
             "PB_PortableBuild": "false"
@@ -49,7 +49,7 @@
           "Name": "Core-Setup-Linux-Arm-BT",
           "Parameters": {
             "PB_DistroRid": "ubuntu.14.04-arm",
-            "PB_DockerTag": "ubuntu-14.04-cross-0cd4667-20172211042239",
+            "PB_DockerTag": "ubuntu-14.04-cross-0cd4667-20170319080304",
             "PB_TargetArchitecture": "arm",
             "PB_AdditionalBuildArguments":"-TargetArchitecture=arm -DistroRid=linux-arm -DisableCrossgen=true -PortableBuild=true -SkipTests=true -CrossBuild=true -strip-symbols",
             "PB_CrossBuildArgs": "-e ROOTFS_DIR ",


### PR DESCRIPTION
The image now contains clang 3.9 with PGO support
