### PR TITLE
Add VS2015 support back to the uwp scripts

### DIFF
--- a/src/uwp/Windows/gen-buildsys-win.bat
+++ b/src/uwp/Windows/gen-buildsys-win.bat
@@ -16,7 +16,11 @@ echo %5
 
 setlocal
 set __sourceDir=%1
+
+set __VSString=14 2015
+if "%__VSVersion%" == "vs2017" (
 set __VSString=15 2017
+)
 
 :: Set the target architecture to a format cmake understands. ANYCPU defaults to x64
 set cm_BaseRid=win10-%2

--- a/src/uwp/build.cmd
+++ b/src/uwp/build.cmd
@@ -59,11 +59,25 @@ exit /b 1
 
 :VS2017
 :: Setup vars for VS2017
+set __VSVersion=vs2017
 set __PlatformToolset=v141
 if NOT "%__BuildArch%" == "arm64" (
     :: Set the environment for the native build
     call "%VS150COMNTOOLS%..\..\VC\Auxiliary\Build\vcvarsall.bat" %__VCBuildArch%
 )
+goto :SetupDirs
+
+:VS2015
+:: Setup vars for VS2015build
+set __VSVersion=vs2015
+set __PlatformToolset=v140
+if NOT "%__BuildArch%" == "arm64" (
+    :: Set the environment for the native build
+    call "%VS140COMNTOOLS%..\..\VC\vcvarsall.bat" %__VCBuildArch%
+)
+
+:SetupDirs
+
 :: Setup to cmake the native components
 echo Commencing build of native UWP components
 echo.


### PR DESCRIPTION
Official build machines don't yet have VS2017 so adding back VS2015
support until that is fixed

@sbomer @steveharter 

@dotnet/dnceng we need to get the official build machines setup with VS2017. 