### PR TITLE
Update CentOS 6 docker image

### DIFF
--- a/buildpipeline/pipeline.json
+++ b/buildpipeline/pipeline.json
@@ -34,7 +34,7 @@
           "Name": "Core-Setup-Linux-Arm-BT",
           "Parameters": {
             "PB_DistroRid": "rhel.6-x64",
-            "PB_DockerTag": "centos-6-d485f41-20173404063424",
+            "PB_DockerTag": "centos-6-376e1a3-20174311014331",
             "PB_TargetArchitecture": "x64",
             "PB_AdditionalBuildArguments":"-TargetArchitecture=x64 -DistroRid=rhel.6-x64 -PortableBuild=false -strip-symbols",
             "PB_PortableBuild": "false"


### PR DESCRIPTION
This update fixes problem with git not supporting https protocol
