### PR TITLE
*fx_muxer: Include the argument in the "failed to parse options" error.

### DIFF
--- a/src/corehost/cli/fxr/fx_muxer.cpp
+++ b/src/corehost/cli/fxr/fx_muxer.cpp
@@ -1116,7 +1116,7 @@ int fx_muxer_t::parse_args_and_execute(
         trace::error(_X("Failed to parse supported options or their values:"));
         for (const auto& arg : known_opts)
         {
-            trace::error(_X("  %s"), arg.option.c_str());
+            trace::error(_X("  %s"), (arg.option + _X(" ") + arg.argument).c_str());
         }
         return InvalidArgFailure;
     }


### PR DESCRIPTION
Currently the error message says:
```
Failed to parse supported options or their values:
  --additionalprobingpath
  --fx-version
  --roll-forward-on-no-candidate-fx
  --additional-deps
```
This changes it to:
```
Failed to parse supported options or their values:
  --additionalprobingpath <path>
  --fx-version <version>
  --roll-forward-on-no-candidate-fx
  --additional-deps <path>
```