### PR TITLE
Use new publish mechanism in core-setup

### DIFF
--- a/buildpipeline/Core-Setup-Publish.json
+++ b/buildpipeline/Core-Setup-Publish.json
@@ -232,7 +232,7 @@
         "solution": "$(PB_SourcesDirectory)\\publish\\publish.proj",
         "platform": "$(PB_TargetArchitecture)",
         "configuration": "$(BuildConfiguration)",
-        "msbuildArguments": "/p:Configuration=$(BuildConfiguration) $(PB_CommonMSBuildArgs) /p:SignType=$(PB_SignType) /p:NuGetFeedUrl=$(NUGET_FEED_URL) /p:NuGetSymbolsFeedUrl=$(NUGET_SYMBOLS_FEED_URL) /p:NuGetApiKey=$(NUGET_API_KEY) /p:AzureAccountName=$(PB_AzureAccountName) /p:ContainerName=$(PB_ContainerName) /p:AzureAccessToken=$(PB_AzureAccessToken) /p:ChecksumAzureAccountName=$(PB_ChecksumAzureAccountName) /p:ChecksumContainerName=$(PB_ChecksumContainerName) /p:ChecksumAzureAccessToken=$(PB_ChecksumAzureAccessToken) /p:GitHubUser=$(PB_GitHubUser) /p:GitHubEmail=$(PB_GitHubEmail) /p:GitHubAuthToken=$(GITHUB_PASSWORD) /p:VersionsRepoOwner=$(PB_VersionsRepoOwner) /p:VersionsRepo=$(PB_VersionsRepo) /p:VersionsRepoPath=build-info/dotnet/$(PB_RepoName)/$(SourceBranch) /p:Finalize=true /p:DotNetToolDir=$(DotNetToolDir) /p:EmbedIndexToolDir=$(EmbedIndexToolDir) /flp:v=detailed;LogFile=$(PB_SourcesDirectory)\\publish.log",
+        "msbuildArguments": "/p:Configuration=$(BuildConfiguration) $(PB_CommonMSBuildArgs) /p:SignType=$(PB_SignType) /p:NuGetFeedUrl=$(NUGET_FEED_URL) /p:NuGetSymbolsFeedUrl=$(NUGET_SYMBOLS_FEED_URL) /p:NuGetApiKey=$(NUGET_API_KEY) /p:AzureAccountName=$(PB_AzureAccountName) /p:ContainerName=$(PB_ContainerName) /p:AzureAccessToken=$(PB_AzureAccessToken) /p:ChecksumAzureAccountName=$(PB_ChecksumAzureAccountName) /p:ChecksumContainerName=$(PB_ChecksumContainerName) /p:ChecksumAzureAccessToken=$(PB_ChecksumAzureAccessToken) /p:PackagesUrl=$(PB_PackagesUrl) /p:SymbolPackagesUrl=$(PB_SymbolPackagesUrl) /p:TransportFeedAccessToken=$(PB_TransportFeedAccessToken) /p:GitHubUser=$(PB_GitHubUser) /p:GitHubEmail=$(PB_GitHubEmail) /p:GitHubAuthToken=$(GITHUB_PASSWORD) /p:VersionsRepoOwner=$(PB_VersionsRepoOwner) /p:VersionsRepo=$(PB_VersionsRepo) /p:VersionsRepoPath=build-info/dotnet/$(PB_RepoName)/$(SourceBranch) /p:Finalize=true /p:DotNetToolDir=$(DotNetToolDir) /p:EmbedIndexToolDir=$(EmbedIndexToolDir) /flp:v=detailed;LogFile=$(PB_SourcesDirectory)\\publish.log",
         "clean": "false",
         "maximumCpuCount": "false",
         "restoreNugetPackages": "false",
@@ -381,6 +381,22 @@
     "PB_AzureAccessToken": {
       "value": null,
       "isSecret": true
+    },
+    "PB_TransportFeedAccountName": {
+      "value": "dotnetfeed"
+    },
+    "PB_TransportFeedContainerName": {
+      "value": "dotnet-core"
+    },
+    "PB_TransportFeedAccessToken": {
+      "value": null,
+      "isSecret": true
+    },
+    "PB_PackagesUrl": {
+      "value": "https://$(PB_TransportFeedAccountName).blob.core.windows.net/$(PB_TransportFeedContainerName)/packages/index.json"
+    },
+    "PB_SymbolPackagesUrl": {
+      "value": "https://$(PB_TransportFeedAccountName).blob.core.windows.net/$(PB_TransportFeedContainerName)/symbols/index.json"
     },
     "PB_ChecksumAzureAccountName": {
       "value": "dotnetclichecksums"

--- a/dependencies.props
+++ b/dependencies.props
@@ -41,8 +41,13 @@
     <MicrosoftBuildFrameworkPackageVersion>$(MicrosoftBuildPackageVersion)</MicrosoftBuildFrameworkPackageVersion>
     <MicrosoftBuildTasksCorePackageVersion>$(MicrosoftBuildPackageVersion)</MicrosoftBuildTasksCorePackageVersion>
     <MicrosoftBuildUtilitiesCorePackageVersion>$(MicrosoftBuildPackageVersion)</MicrosoftBuildUtilitiesCorePackageVersion>
-
     <MicrosoftDotNetPlatformAbstractionsPackageVersion>1.1.1</MicrosoftDotNetPlatformAbstractionsPackageVersion>
+  </PropertyGroup>
+
+  <!-- Package versions used as toolsets -->
+  <PropertyGroup>
+    <FeedTasksPackage>Microsoft.DotNet.Build.Tasks.Feed</FeedTasksPackage>
+    <FeedTasksPackageVersion>1.0.0-prerelease-02121-01</FeedTasksPackageVersion>
   </PropertyGroup>
 
   <ItemGroup>
@@ -100,6 +105,11 @@
       <Path>$(MSBuildThisFileFullPath)</Path>
       <ElementName>WcfVersion</ElementName>
       <PackageId>System.ServiceModel.Duplex</PackageId>
+    </XmlUpdateStep>
+    <XmlUpdateStep Include="BuildTools">
+       <Path>$(MSBuildThisFileFullPath)</Path>
+       <ElementName>FeedTasksPackageVersion</ElementName>
+       <PackageId>$(FeedTasksPackage)</PackageId>
     </XmlUpdateStep>
     <UpdateStep Include="BuildTools">
       <UpdaterType>File</UpdaterType>

--- a/init-tools.msbuild
+++ b/init-tools.msbuild
@@ -3,9 +3,10 @@
     <TargetFramework>netcoreapp1.0</TargetFramework>
     <EnableDefaultItems>false</EnableDefaultItems>
     <DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences>
-    <BaseIntermediateOutputPath>$(MSBuildThisFileDirectory)Tools/$(BuildToolsPackageVersion)</BaseIntermediateOutputPath>
+    <BaseIntermediateOutputPath>$(ToolsDir)/$(BuildToolsPackageVersion)</BaseIntermediateOutputPath>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.DotNet.BuildTools" Version="$(BuildToolsPackageVersion)" />
+    <PackageReference Include="$(FeedTasksPackage)" Version="$(FeedTasksPackageVersion)" />
   </ItemGroup>
 </Project>

--- a/publish/publish.proj
+++ b/publish/publish.proj
@@ -7,6 +7,8 @@
   <UsingTask TaskName="ListAzureBlobs" AssemblyFile="$(BuildToolsTaskDir)Microsoft.DotNet.Build.CloudTestTasks.dll" />
   <UsingTask TaskName="UploadToAzure" AssemblyFile="$(BuildToolsTaskDir)Microsoft.DotNet.Build.CloudTestTasks.dll" />
 
+  <Import Project="$(PackagesDir)/$(FeedTasksPackage)/$(FeedTasksPackageVersion)/build/$(FeedTasksPackage).targets" />
+
   <Target Name="Build"
           DependsOnTargets="PublishToAzure;PublishDebFilesToDebianRepo;PublishDebToolPackageToFeed;PublishFinalOutput" />
   
@@ -149,8 +151,8 @@
                    ForcePublish="true" />
   </Target>
 
-  <Target Name="PublishCoreHostPackagesToFeed"
-          DependsOnTargets="CheckIfAllBuildsHavePublished;DownloadCoreHostPackages;SignSymbolPackages;DoPushCoreHostPackagesToFeed"
+  <Target Name="PublishCoreHostPackages"
+          DependsOnTargets="CheckIfAllBuildsHavePublished;DownloadCoreHostPackages;SignSymbolPackages;DoPushCoreHostPackagesToFeed;DoPushCoreHostPackagesToAzure"
           Condition="'@(_MissingBlobNames)' == '' AND '$(NuGetFeedUrl)' != ''">
     <Error Condition="'$(NuGetFeedUrl)' ==''" Text="Missing required property NuGetFeedUrl" />
     <Error Condition="'$(NuGetApiKey)' == ''" Text="Missing required property NuGetApiKey" />
@@ -239,6 +241,48 @@
     <ExecWithRetriesForNuGetPush Condition="'@(_DownloadedSymbolsPackages)' != ''"
                                  Command="$(NuGetPushSymbolsCommand) %(_DownloadedSymbolsPackages.Identity)"
                                  IgnoredErrorMessagesWithConditional="@(IgnorableErrorMessages)" />
+  </Target>
+
+  <Target Name="DoPushCoreHostPackagesToAzure"
+          DependsOnTargets="PublishToAzureBlobFeed;PublishSymbolsToAzureBlobFeed"
+          Condition="'$(OfficialPublish)' == 'true'"/>
+
+  <Target Name="PublishToAzureBlobFeed">
+    <Error Condition="'$(PackagesUrl)'==''" Text="Missing property PackagesUrl" />
+    <Error Condition="'$(TransportFeedAccessToken)'==''" Text="Missing property TransportFeedAccessToken" />
+    <PropertyGroup>
+      <ExpectedFeedUrl>$(PackagesUrl)</ExpectedFeedUrl>
+      <PublishFlatContainer Condition="'$(PublishFlatContainer)' == ''">false</PublishFlatContainer>
+    </PropertyGroup>
+    <ItemGroup>
+      <ItemsToPush Remove="*.nupkg" />
+      <ItemsToPush Include="@(_DownloadedStandardPackages)"/>
+    </ItemGroup>
+    <PushToBlobFeed ExpectedFeedUrl="$(ExpectedFeedUrl)"
+                    AccountKey="$(TransportFeedAccessToken)"
+                    ItemsToPush="@(ItemsToPush)"
+                    PublishFlatContainer="$(PublishFlatContainer)"
+                    Overwrite="$(OverwriteOnPublish)" 
+                    IndexDirectory="$(ObjDir)"/>
+  </Target>
+
+  <Target Name="PublishSymbolsToAzureBlobFeed">
+    <Error Condition="'$(SymbolPackagesUrl)'==''" Text="Missing property SymbolPackagesUrl" />
+    <Error Condition="'$(TransportFeedAccessToken)'==''" Text="Missing property TransportFeedAccessToken" />
+    <PropertyGroup>
+      <ExpectedFeedUrl>$(SymbolPackagesUrl)</ExpectedFeedUrl>
+      <PublishFlatContainer Condition="'$(PublishFlatContainer)' == ''">true</PublishFlatContainer>
+    </PropertyGroup>
+    <ItemGroup>
+      <ItemsToPush Remove="*.nupkg" />
+      <ItemsToPush Include="@(_DownloadedSymbolsPackages)"/>
+    </ItemGroup>
+    <PushToBlobFeed ExpectedFeedUrl="$(ExpectedFeedUrl)"
+                    AccountKey="$(TransportFeedAccessToken)"
+                    ItemsToPush="@(ItemsToPush)"
+                    PublishFlatContainer="$(PublishFlatContainer)"
+                    Overwrite="$(OverwriteOnPublish)" 
+                    IndexDirectory="$(ObjDir)"/>
   </Target>
 
   <Target Name="PublishDebToolPackageToFeed"


### PR DESCRIPTION
This should allow us to publish to the dotnetfeed transport feed in core-setup. Will also require adding:

`PB_TransportFeedAccessToken=[AzureKeyVault=EngKeyVault,SecretName=dotnetfeed-storage-access-key-1]`

Into the pipebuild definition. Will queue off a private test build after getting some feedback.

@karajas @markwilkie @chcosta @jcagme PTAL