### PR TITLE
Don't look in global store when DOTNET_MULTILEVEL_LOOKUP is disabled

### DIFF
--- a/src/corehost/cli/args.cpp
+++ b/src/corehost/cli/args.cpp
@@ -49,7 +49,11 @@ void setup_shared_store_paths(const hostpolicy_init_t& init, const pal::string_t
     }
 
     // Global shared store dir
-    get_global_shared_store_dirs(&args->global_shared_stores, get_arch(), init.tfm);
+    bool multilevel_lookup = multilevel_lookup_enabled();
+    if (multilevel_lookup)
+    {
+        get_global_shared_store_dirs(&args->global_shared_stores, get_arch(), init.tfm);
+    }
 }
 
 bool parse_arguments(

--- a/src/corehost/cli/fxr/fx_muxer.cpp
+++ b/src/corehost/cli/fxr/fx_muxer.cpp
@@ -14,23 +14,6 @@
 #include "error_codes.h"
 #include "deps_format.h"
 
-/**
- * Multilevel Lookup is enabled by default
- *  It can be disabled by setting DOTNET_MULTILEVEL_LOOKUP env var to a value that is not 1
- */
-bool multilevel_lookup_enabled()
-{
-    pal::string_t env_lookup;
-    bool multilevel_lookup = true;
-
-    if (pal::getenv(_X("DOTNET_MULTILEVEL_LOOKUP"), &env_lookup))
-    {
-        auto env_val = pal::xtoi(env_lookup.c_str());
-        multilevel_lookup = (env_val == 1);
-    }
-    return multilevel_lookup;
-}
-
 void get_all_fx_versions(
     host_mode_t mode,
     const pal::string_t& own_dir,

--- a/src/corehost/common/utils.cpp
+++ b/src/corehost/common/utils.cpp
@@ -303,3 +303,20 @@ bool get_global_shared_store_dirs(std::vector<pal::string_t>*  dirs, const pal::
     }
     return true;
 }
+
+/**
+* Multilevel Lookup is enabled by default
+*  It can be disabled by setting DOTNET_MULTILEVEL_LOOKUP env var to a value that is not 1
+*/
+bool multilevel_lookup_enabled()
+{
+    pal::string_t env_lookup;
+    bool multilevel_lookup = true;
+
+    if (pal::getenv(_X("DOTNET_MULTILEVEL_LOOKUP"), &env_lookup))
+    {
+        auto env_val = pal::xtoi(env_lookup.c_str());
+        multilevel_lookup = (env_val == 1);
+    }
+    return multilevel_lookup;
+}

--- a/src/corehost/common/utils.h
+++ b/src/corehost/common/utils.h
@@ -44,4 +44,5 @@ bool parse_known_args(
 bool skip_utf8_bom(pal::ifstream_t* stream);
 bool get_env_shared_store_dirs(std::vector<pal::string_t>* dirs, const pal::string_t& arch, const pal::string_t& tfm);
 bool get_global_shared_store_dirs(std::vector<pal::string_t>* dirs, const pal::string_t& arch, const pal::string_t& tfm);
+bool multilevel_lookup_enabled();
 #endif

--- a/src/test/HostActivationTests/GivenThatICareAboutPortableAppActivation.cs
+++ b/src/test/HostActivationTests/GivenThatICareAboutPortableAppActivation.cs
@@ -147,6 +147,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.PortableApp
                     "--additionalprobingpath", additionalProbingPath,
                     appDll)
                 .EnvironmentVariable("COREHOST_TRACE", "1")
+                .EnvironmentVariable("DOTNET_MULTILEVEL_LOOKUP", "0")
                 .CaptureStdErr()
                 .CaptureStdOut()
                 .Execute()


### PR DESCRIPTION
Currently the global store location is being searched when the DOTNET_MULTILEVEL_LOOKUP environment variable is zero. DOTNET_MULTILEVEL_LOOKUP controls whether the global locations are used when looking for the shared framework (on Windows, `C:\Program Files\dotnet\shared`), and the fix here is to also control whether the store global location (`C:\Program Files\dotnet\store`) are used.

This was found because a test had its own store and instead of finding an assembly there, it was finding the assembly in the global store location (environment specific). However, the test was not setting DOTNET_MULTILEVEL_LOOKUP either, so the test also needed to be changed.

Fixes https://github.com/dotnet/core-setup/issues/3315
