### PR TITLE
Fix output directories.

### DIFF
--- a/dir.props
+++ b/dir.props
@@ -215,6 +215,11 @@
     <TestTargetRid Condition="'$(TestTargetRid)' == ''">$(OutputRid)</TestTargetRid>
   </PropertyGroup>
 
+  <!-- Produce assets into the specified blob feed. -->
+  <PropertyGroup Condition="'$(DotNetOutputBlobFeedDir)' != ''">
+    <AssetOutputPath>$(DotNetOutputBlobFeedDir)assets/</AssetOutputPath>
+  </PropertyGroup>
+
   <!-- Set up the default output and intermediate paths -->
   <PropertyGroup>
     <OSPlatformConfig>$(OutputRid).$(ConfigurationGroup)</OSPlatformConfig>
@@ -230,8 +235,9 @@
     <CoreHostOutputDir>$(BaseOutputRootPath)corehost\</CoreHostOutputDir>
 
     <PackagesBasePath Condition="'$(PackagesBasePath)'==''">$(BinDir)$(OSPlatformConfig)/</PackagesBasePath>
-    <PackagesOutDir Condition="'$(PackagesOutDir)'==''">$(PackagesBasePath)packages/</PackagesOutDir>
-    <SymbolPackagesOutDir Condition="'$(SymbolPackagesOutDir)'==''">$(PackagesOutDir)</SymbolPackagesOutDir>
+    <PackageOutputPath Condition="'$(PackageOutputPath)'==''">$(PackagesBasePath)packages/</PackageOutputPath>
+    <AssetOutputPath Condition="'$(AssetOutputPath)'==''">$(PackageOutputPath)</AssetOutputPath>
+    <SymbolPackageOutputPath Condition="'$(SymbolPackageOutputPath)'==''">$(PackageOutputPath)</SymbolPackageOutputPath>
     <PackageSymbolsBinDir Condition="'$(PackageSymbolsBinDir)' == ''">$(PackagesBasePath)symbols/</PackageSymbolsBinDir>
 
     <SharedFrameworkPublishDir>$(IntermediateOutputRootPath)sharedFrameworkPublish\</SharedFrameworkPublishDir>
@@ -247,10 +253,10 @@
     <DotnetHostString>dotnet-host-</DotnetHostString>
     <DotnetHostFxrString>dotnet-hostfxr-</DotnetHostFxrString>
     <DotnetRuntimeString>dotnet-runtime-</DotnetRuntimeString>
-    <CombinedInstallerStart>$(PackagesOutDir)$(DotnetRuntimeString)</CombinedInstallerStart>
-    <SharedHostInstallerStart>$(PackagesOutDir)$(DotnetHostString)</SharedHostInstallerStart>
-    <HostFxrInstallerStart>$(PackagesOutDir)$(DotnetHostFxrString)</HostFxrInstallerStart>
-    <SharedFrameworkInstallerStart>$(PackagesOutDir)$(DotnetRuntimeString)</SharedFrameworkInstallerStart>
+    <CombinedInstallerStart>$(AssetOutputPath)$(DotnetRuntimeString)</CombinedInstallerStart>
+    <SharedHostInstallerStart>$(AssetOutputPath)$(DotnetHostString)</SharedHostInstallerStart>
+    <HostFxrInstallerStart>$(AssetOutputPath)$(DotnetHostFxrString)</HostFxrInstallerStart>
+    <SharedFrameworkInstallerStart>$(AssetOutputPath)$(DotnetRuntimeString)</SharedFrameworkInstallerStart>
 
     <!-- OSX specific intermediate package suffix -->
     <InstallerStartSuffix Condition="'$(OSGroup)' == 'OSX'">internal</InstallerStartSuffix>

--- a/src/pkg/dir.props
+++ b/src/pkg/dir.props
@@ -12,8 +12,6 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <PackageOutputPath>$(PackagesOutDir)</PackageOutputPath>
-    <SymbolPackageOutputPath>$(SymbolPackagesOutDir)</SymbolPackageOutputPath>
     <PackageLicenseFile>$(ProjectDir)LICENSE.TXT</PackageLicenseFile>
     <PackageThirdPartyNoticesFile>$(ProjectDir)THIRD-PARTY-NOTICES.TXT</PackageThirdPartyNoticesFile>
     <LicenseUrl>https://github.com/dotnet/core-setup/blob/master/LICENSE.TXT</LicenseUrl>

--- a/src/pkg/packaging/deb/package.props
+++ b/src/pkg/packaging/deb/package.props
@@ -2,7 +2,7 @@
 <Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <dotnetDebToolSource>$(ProjectDir)tools-local/setuptools/dotnet-deb-tool/</dotnetDebToolSource>
-    <dotnetDebToolPackageSource>$(PackagesOutDir)</dotnetDebToolPackageSource>
+    <dotnetDebToolPackageSource>$(PackageOutputPath)</dotnetDebToolPackageSource>
     <toolConsumerProjectName>dotnet-deb-tool-consumer.csproj</toolConsumerProjectName>
     <consumingProjectDirectory>$(IntermediateOutputRootPath)$(toolConsumerProjectName)</consumingProjectDirectory>
     <debPackaginfConfigPath>$(PackagingRoot)deb/</debPackaginfConfigPath>

--- a/src/pkg/packaging/deb/package.targets
+++ b/src/pkg/packaging/deb/package.targets
@@ -17,14 +17,7 @@
     </PropertyGroup>
 
     <Exec Command="$(DotnetRestoreCommand) $(dotnetDebToolSource)"/>
-    <Exec Command="$(DotnetToolCommand) pack $(dotnetDebToolSource) --output $(PackagesOutDir)intermediate/ $(VersionSuffixArg)"/>
-
-    <ItemGroup>
-      <pkFiles Include="$(PackagesOutDir)intermediate/dotnet-deb-tool.*.nupkg"
-               Exclude="$(PackagesOutDir)intermediate/*.symbols.nupkg" />
-    </ItemGroup>
-
-    <Copy SourceFiles="@(pkFiles)" DestinationFolder="$(PackagesOutDir)" />
+    <Exec Command="$(DotnetToolCommand) pack $(dotnetDebToolSource) --output $(PackageOutputPath) $(VersionSuffixArg)"/>
 
     <RemoveDir Condition="Exists('$(consumingProjectDirectory)')"
                Directories="$(consumingProjectDirectory)" />

--- a/src/pkg/packaging/dir.proj
+++ b/src/pkg/packaging/dir.proj
@@ -79,8 +79,8 @@
           DestinationFolder="$(CombinedPublishRoot)/%(CombinedFiles.RecursiveDir)" />
 
     <!-- create output dir -->
-    <MakeDir Condition="!Exists('$(PackagesOutDir)')"
-             Directories="$(PackagesOutDir)" />
+    <MakeDir Condition="!Exists('$(AssetOutputPath)')"
+             Directories="$(AssetOutputPath)" />
   </Target>
 
   <Target Name="GenerateVersionBadge">
@@ -105,22 +105,22 @@
 
     <ZipFileCreateFromDirectory
         SourceDirectory="$(CombinedPublishRoot)"
-        DestinationArchive="$(PackagesOutDir)$(CombinedCompressedFile)"
+        DestinationArchive="$(AssetOutputPath)$(CombinedCompressedFile)"
         OverwriteDestination="true" />
 
     <ZipFileCreateFromDirectory
         SourceDirectory="$(HostFxrPublishRoot)"
-        DestinationArchive="$(PackagesOutDir)$(HostFxrCompressedFile)"
+        DestinationArchive="$(AssetOutputPath)$(HostFxrCompressedFile)"
         OverwriteDestination="true" />
 
     <ZipFileCreateFromDirectory
         SourceDirectory="$(SharedFrameworkPublishRoot)"
-        DestinationArchive="$(PackagesOutDir)$(SharedFrameworkCompressedFile)"
+        DestinationArchive="$(AssetOutputPath)$(SharedFrameworkCompressedFile)"
         OverwriteDestination="true" />
 
     <ZipFileCreateFromDirectory
         SourceDirectory="$(SharedFrameworkPublishSymbolsDir)"
-        DestinationArchive="$(PackagesOutDir)$(SharedFrameworkSymbolsCompressedFile)"
+        DestinationArchive="$(AssetOutputPath)$(SharedFrameworkSymbolsCompressedFile)"
         OverwriteDestination="true" />
   </Target>
 
@@ -129,22 +129,22 @@
 
     <!-- tar command will throw 'file changed as we read it' on some distros.  ignore that error.
          we use -C so that we get a relative folder structure which is compressed rather than the full path -->
-    <Exec Command="tar -C $(CombinedPublishRoot) -czf $(PackagesOutDir)$(CombinedCompressedFile) ."
+    <Exec Command="tar -C $(CombinedPublishRoot) -czf $(AssetOutputPath)$(CombinedCompressedFile) ."
           IgnoreExitCode="true"
           IgnoreStandardErrorWarningFormat="true" />
-    <Exec Command="tar -C $(HostFxrPublishRoot) -czf $(PackagesOutDir)$(HostFxrCompressedFile) ."
+    <Exec Command="tar -C $(HostFxrPublishRoot) -czf $(AssetOutputPath)$(HostFxrCompressedFile) ."
           IgnoreExitCode="true"
           IgnoreStandardErrorWarningFormat="true" />
-    <Exec Command="tar -C $(SharedFrameworkPublishRoot) -czf $(PackagesOutDir)$(SharedFrameworkCompressedFile) ."
+    <Exec Command="tar -C $(SharedFrameworkPublishRoot) -czf $(AssetOutputPath)$(SharedFrameworkCompressedFile) ."
           IgnoreExitCode="true"
           IgnoreStandardErrorWarningFormat="true" />
-    <Exec Command="tar -C $(SharedFrameworkPublishSymbolsDir) -czf $(PackagesOutDir)$(SharedFrameworkSymbolsCompressedFile) ."
+    <Exec Command="tar -C $(SharedFrameworkPublishSymbolsDir) -czf $(AssetOutputPath)$(SharedFrameworkSymbolsCompressedFile) ."
           IgnoreExitCode="true"
           IgnoreStandardErrorWarningFormat="true" />
-    <Error Condition="!Exists('$(PackagesOutDir)$(CombinedCompressedFile)')" Message="Unable to create $(PackagesOutDir)$(CombinedCompressedFile)" />
-    <Error Condition="!Exists('$(PackagesOutDir)$(HostFxrCompressedFile)')" Message="Unable to create $(PackagesOutDir)$(HostFxrCompressedFile)" />
-    <Error Condition="!Exists('$(PackagesOutDir)$(SharedFrameworkCompressedFile)')" Message="Unable to create $(PackagesOutDir)$(SharedFrameworkCompressedFile)" />
-    <Error Condition="!Exists('$(PackagesOutDir)$(SharedFrameworkSymbolsCompressedFile)')" Message="Unable to create $(PackagesOutDir)$(SharedFrameworkSymbolsCompressedFile)" />
+    <Error Condition="!Exists('$(AssetOutputPath)$(CombinedCompressedFile)')" Message="Unable to create $(PackagesOutDir)$(CombinedCompressedFile)" />
+    <Error Condition="!Exists('$(AssetOutputPath)$(HostFxrCompressedFile)')" Message="Unable to create $(PackagesOutDir)$(HostFxrCompressedFile)" />
+    <Error Condition="!Exists('$(AssetOutputPath)$(SharedFrameworkCompressedFile)')" Message="Unable to create $(PackagesOutDir)$(SharedFrameworkCompressedFile)" />
+    <Error Condition="!Exists('$(AssetOutputPath)$(SharedFrameworkSymbolsCompressedFile)')" Message="Unable to create $(PackagesOutDir)$(SharedFrameworkSymbolsCompressedFile)" />
   </Target>
 
   <Import Project="windows\package.targets" />
@@ -181,7 +181,7 @@
     </ItemGroup>
 
     <PropertyGroup>
-      <PackArgs>--no-restore --no-build --output $(PackagesOutDir)</PackArgs>
+      <PackArgs>--no-restore --no-build --output $(PackageOutputPath)</PackArgs>
       <PackArgs>$(PackArgs) $(MSBuildPassThroughPropertyList) /p:BaseOutputPath=$(IntermediateOutputForPackaging)</PackArgs>
     </PropertyGroup>
 

--- a/src/sharedFramework/sharedFramework.proj
+++ b/src/sharedFramework/sharedFramework.proj
@@ -39,7 +39,7 @@
     <!-- Specify a separate 'packages' directory in case we are building an already built version of Microsoft.NETCore.App and the $(PackagesDir)
          already contains the same version as we are building.  (ex. building source-build for `2.0.0` when `2.0.0` has already shipped.
     -->
-    <Exec Command="$(DotnetRestoreCommandNoPackages) --source $(PackagesOutDir) --packages $(SharedFrameworkIntermediatePackagesDir) $(CommonSharedFrameworkArgs)"
+    <Exec Command="$(DotnetRestoreCommandNoPackages) --source $(PackageOutputPath) --packages $(SharedFrameworkIntermediatePackagesDir) $(CommonSharedFrameworkArgs)"
           WorkingDirectory="$(SharedFrameworkSourceRoot)" />
 
     <!-- We publish to a sub folder of the PublishRoot so tools like heat and zip can generate folder structures easier. -->
@@ -151,7 +151,7 @@
     <!-- Specify a separate 'packages' directory in case we are building an already built version of Microsoft.NETCore.DotNetHost and the $(PackagesDir)
          already contains the same version as we are building.  (ex. building source-build for `2.0.0` when `2.0.0` has already shipped.
     -->
-    <Exec Command="$(DotnetRestoreCommandNoPackages) --source $(PackagesOutDir) --packages $(SharedFrameworkIntermediatePackagesDir) $(CommonLockedHostArgs)"
+    <Exec Command="$(DotnetRestoreCommandNoPackages) --source $(PackageOutputPath) --packages $(SharedFrameworkIntermediatePackagesDir) $(CommonLockedHostArgs)"
           WorkingDirectory="$(LockedHostSourceRoot)" />
 
     <Exec Command="$(DotnetToolCommand) publish --no-restore --output $(CoreHostLockedDir) $(CommonLockedHostArgs)"


### PR DESCRIPTION
1. Use PackageOutputPath variable exclusively everywhere instead of our own name for the same path.
2. Split nuget packages and installer assets into separate paths - packages and assets.

This should fix the issues in https://github.com/dotnet/source-build/pull/249#issuecomment-337791094