### PR TITLE
Add xmlns to HostMachineInfo.props so the build passes on MSBuild 14.

### DIFF
--- a/build.proj
+++ b/build.proj
@@ -42,7 +42,7 @@
 
     <PropertyGroup>
       <HostMachineInfoPropsContent>
-&lt;Project&gt;
+&lt;Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003"&gt;
   &lt;PropertyGroup&gt;
     &lt;HostMachineRid&gt;$(HostMachineRid)&lt;/HostMachineRid&gt;
   &lt;/PropertyGroup&gt;


### PR DESCRIPTION
This should unblock the official build.

It's frustrating that our Jenkins CI runs use a different toolset than our official builds.