### PR TITLE
Move Version attribute to child element to allow MSBuild 14 to continue building core-setup.tasks.csproj.

### DIFF
--- a/tools-local/tasks/core-setup.tasks.csproj
+++ b/tools-local/tasks/core-setup.tasks.csproj
@@ -36,11 +36,19 @@
     <Compile Include="netstandard/FileUtilities.netstandard.cs" />
 
     <Reference Include="$(BuildToolsTaskCoreDir)Microsoft.DotNet.Build.CloudTestTasks.dll" />
-    
-    <PackageReference Include="Microsoft.Build" Version="$(MicrosoftBuildPackageVersion)" />
-    <PackageReference Include="Microsoft.Build.Framework" Version="$(MicrosoftBuildFrameworkPackageVersion)" />
-    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="$(MicrosoftBuildTasksCorePackageVersion)" />
-    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="$(MicrosoftBuildUtilitiesCorePackageVersion)" />
+
+    <PackageReference Include="Microsoft.Build">
+      <Version>$(MicrosoftBuildPackageVersion)</Version>
+    </PackageReference>
+    <PackageReference Include="Microsoft.Build.Framework">
+      <Version>$(MicrosoftBuildFrameworkPackageVersion)</Version>
+    </PackageReference>
+    <PackageReference Include="Microsoft.Build.Tasks.Core">
+      <Version>$(MicrosoftBuildTasksCorePackageVersion)</Version>
+    </PackageReference>
+    <PackageReference Include="Microsoft.Build.Utilities.Core">
+      <Version>$(MicrosoftBuildUtilitiesCorePackageVersion)</Version>
+    </PackageReference>
     <PackageReference Include="Microsoft.Tpl.Dataflow">
       <Version>4.5.24</Version>
       <IncludeAssets>None</IncludeAssets>


### PR DESCRIPTION
Trying to fix the official build again.