### PR TITLE
Support shared hosts other than dotnet.exe

### DIFF
--- a/src/corehost/cli/args.cpp
+++ b/src/corehost/cli/args.cpp
@@ -66,7 +66,7 @@ bool parse_arguments(
     if (argc >= 1)
     {
         args.own_path = argv[0];
-        if (!pal::realpath(&args.own_path) || !pal::file_exists(args.own_path))
+        if (!args.own_path.empty() && (!pal::realpath(&args.own_path) || !pal::file_exists(args.own_path)))
         {
             trace::warning(_X("Failed to resolve argv[0] as path [%s]. Using location of current executable instead."), args.own_path.c_str());
             args.own_path.clear();

--- a/src/corehost/cli/args.cpp
+++ b/src/corehost/cli/args.cpp
@@ -66,8 +66,9 @@ bool parse_arguments(
     if (argc >= 1)
     {
         args.own_path = argv[0];
-        if (!pal::realpath(&args.own_path))
+        if (!pal::realpath(&args.own_path) || !pal::file_exists(args.own_path))
         {
+            trace::warning(_X("Failed to resolve argv[0] as path [%s]. Using location of current executable instead."), args.own_path.c_str());
             args.own_path.clear();
         }
     }

--- a/src/corehost/cli/args.cpp
+++ b/src/corehost/cli/args.cpp
@@ -61,8 +61,19 @@ bool parse_arguments(
     const int argc, const pal::char_t* argv[], arguments_t* arg_out)
 {
     arguments_t& args = *arg_out;
+
+    // Try to use argv[0] as own_path to allow for hosts located elsewhere
+    if (argc >= 1)
+    {
+        args.own_path = argv[0];
+        if (!pal::realpath(&args.own_path))
+        {
+            args.own_path.clear();
+        }
+    }
+
     // Get the full name of the application
-    if (!pal::get_own_executable_path(&args.own_path) || !pal::realpath(&args.own_path))
+    if (args.own_path.empty() && (!pal::get_own_executable_path(&args.own_path) || !pal::realpath(&args.own_path)))
     {
         trace::error(_X("Failed to resolve full path of the current executable [%s]"), args.own_path.c_str());
         return false;

--- a/src/corehost/cli/fxr/fx_muxer.cpp
+++ b/src/corehost/cli/fxr/fx_muxer.cpp
@@ -1268,8 +1268,18 @@ int fx_muxer_t::execute(const int argc, const pal::char_t* argv[])
 {
     pal::string_t own_path;
 
+    // Try to use argv[0] as own_path to allow for hosts located elsewhere
+    if (argc >= 1)
+    {
+        own_path = argv[0];
+        if (!pal::realpath(&own_path))
+        {
+            own_path.clear();
+        }
+    }
+
     // Get the full name of the application
-    if (!pal::get_own_executable_path(&own_path) || !pal::realpath(&own_path))
+    if (own_path.empty() && (!pal::get_own_executable_path(&own_path) || !pal::realpath(&own_path)))
     {
         trace::error(_X("Failed to resolve full path of the current executable [%s]"), own_path.c_str());
         return StatusCode::LibHostCurExeFindFailure;

--- a/src/corehost/cli/fxr/fx_muxer.cpp
+++ b/src/corehost/cli/fxr/fx_muxer.cpp
@@ -1272,8 +1272,9 @@ int fx_muxer_t::execute(const int argc, const pal::char_t* argv[])
     if (argc >= 1)
     {
         own_path = argv[0];
-        if (!pal::realpath(&own_path))
+        if (!pal::realpath(&own_path) || !pal::file_exists(own_path))
         {
+            trace::warning(_X("Failed to resolve argv[0] as path [%s]. Using location of current executable instead."), own_path.c_str());
             own_path.clear();
         }
     }

--- a/src/corehost/cli/fxr/fx_muxer.cpp
+++ b/src/corehost/cli/fxr/fx_muxer.cpp
@@ -1272,7 +1272,7 @@ int fx_muxer_t::execute(const int argc, const pal::char_t* argv[])
     if (argc >= 1)
     {
         own_path = argv[0];
-        if (!pal::realpath(&own_path) || !pal::file_exists(own_path))
+        if (!own_path.empty() && (!pal::realpath(&own_path) || !pal::file_exists(own_path)))
         {
             trace::warning(_X("Failed to resolve argv[0] as path [%s]. Using location of current executable instead."), own_path.c_str());
             own_path.clear();


### PR DESCRIPTION
The current code in hostfxr sets own_dir to be the location of the currently running executable, which in turn is used to determine the location to search for the runtime. This prevents other hosts such as IIS (w3wp.exe) from using CoreClr when it does its own implementation of dotnet.exe and calls hostfxr.dll itself.

The fix is to use argv[0] as the path to the dotnet.exe which from which own_dir will be obtained. Normally argv[0] will be the current path to the executable. Also similar changes were made to hostpolicy to use argv[0] since it uses own_dir to set up global store paths.

Fixes https://github.com/dotnet/core-setup/issues/2983

Tested by creating a simple Windows console test compiled for x64, and renaming of the `C:\program files\dotnet` directory to `C:\program files\dotnet2` so that the global lookup doesn't occur and cause a false positive on the test. Code:
```C
#include "stdafx.h"
#include "windows.h"

typedef int(*hostfxr_main_fn) (const int argc, const WCHAR* argv[]);

int main()
{
    HMODULE fxrDll = ::LoadLibraryExW(L"C:\\Program Files\\dotnet2\\host\\fxr\\2.0.0\\hostfxr.dll", NULL, LOAD_LIBRARY_SEARCH_DLL_LOAD_DIR | LOAD_LIBRARY_SEARCH_DEFAULT_DIRS);
    if (!fxrDll)
    {
        printf("LoadLibraryExW failed with error %d.\n", GetLastError());
        return 0;
    }

    puts("Loaded hostfxr...");

    hostfxr_main_fn main_fn = (hostfxr_main_fn)GetProcAddress(fxrDll, "hostfxr_main");
    if (!main_fn)
    {
        printf("GetProcAddress failed with error %d.\n", GetLastError());
        return 0;
    }

    WCHAR **new_argv = new WCHAR*[3];
    new_argv[0] = L"C:\\Program Files\\dotnet2\\dotnet.exe";
    // relative paths also work since they are converted to absolute:
    // new_argv[0] = L"..\\..\\..\\..\\..\\..\\Program Files\\dotnet2\\dotnet.exe";
    new_argv[1] = L"exec";
    new_argv[2] = L"C:\\git\\repros\\console\\bin\\Debug\\netcoreapp2.0\\console.dll";

    puts("Invoking...");
    int rc = main_fn(3, (const WCHAR**)new_argv);

    ::FreeLibrary(fxrDll);

    puts("Success!");

    return rc;
}
```


