### PR TITLE
Fix Alpine and RHEL official builds

### DIFF
--- a/buildpipeline/pipeline.json
+++ b/buildpipeline/pipeline.json
@@ -30,7 +30,7 @@
           }
         },
         {
-          "Name": "Core-Setup-Linux-BT",
+          "Name": "Core-Setup-Linux-Arm-BT",
           "Parameters": {
             "PB_DockerTag": "centos-6-376e1a3-20174311014331",
             "PB_TargetArchitecture": "x64",
@@ -45,12 +45,13 @@
           }
         },
         {
-          "Name": "Core-Setup-Linux-BT",
+          "Name": "Core-Setup-Linux-Arm-BT",
           "Parameters": {
             "PB_DistroRid": "alpine.3.6-x64",
             "PB_DockerTag": "alpine-3.6-3148f11-20171119021156",
             "PB_TargetArchitecture": "x64",
-            "PB_AdditionalBuildArguments":"-TargetArchitecture=x64 -DistroRid=alpine.3.6-x64 -PortableBuild=false -strip-symbols",
+            "PB_AdditionalBuildArguments":"-TargetArchitecture=x64 -PortableBuild=false -strip-symbols",
+            "PB_AdditionalMSBuildArguments":"/p:OutputRid=alpine.3.6-x64",
             "PB_PortableBuild": "false"
           },
           "ReportingParameters": {

--- a/buildpipeline/pipeline.json
+++ b/buildpipeline/pipeline.json
@@ -47,7 +47,6 @@
         {
           "Name": "Core-Setup-Linux-Arm-BT",
           "Parameters": {
-            "PB_DistroRid": "alpine.3.6-x64",
             "PB_DockerTag": "alpine-3.6-3148f11-20171119021156",
             "PB_TargetArchitecture": "x64",
             "PB_AdditionalBuildArguments":"-TargetArchitecture=x64 -PortableBuild=false -strip-symbols",


### PR DESCRIPTION
I have broken the RHEL build by my recent change that was supposed to
enable Alpine official builds. The Alpine build didn't work either since
there was a recent change that modified the way we specify the distro
RID and I have missed that.

The RHEL 6 should work with the Core-Setup-Linux-BT name, but for some 
reason it tries to use crossgen from a linux-x64 coreclr package instead of 
the rhel.6-x64 one and obviously fails. I've created issue #3377 to investigate 
and fix that.
The Core-Setup-Linux-Arm-BT that was there before disables the crossgen, so 
that's why it works.

skip ci please
