### PR TITLE
Improve message when runtimeconfig.json is missing or has no framework

### DIFF
--- a/src/corehost/cli/fxr/fx_muxer.cpp
+++ b/src/corehost/cli/fxr/fx_muxer.cpp
@@ -482,6 +482,17 @@ bool fx_muxer_t::resolve_hostpolicy_dir(host_mode_t mode,
 
     // If it still couldn't be found, somebody upstack messed up. Flag an error for the "expected" location.
     trace::error(_X("A fatal error was encountered. The library '%s' required to execute the application was not found in '%s'."), LIBHOSTPOLICY_NAME, expected.c_str());
+    if (mode == host_mode_t::muxer && !config.get_portable())
+    {
+        if (!pal::file_exists(config.get_path()))
+        {
+            trace::error(_X("Running as a standalone app because there is no '%s' file. If this should be a portable app instead, add that file specifying the appropriate framework."), config.get_path().c_str());
+        }
+        else if (config.get_fx_name().empty())
+        {
+            trace::error(_X("Running as a standalone app because there is no framework specified in '%s'. If this should be a portable app instead, specify the appropriate framework in that file."), config.get_path().c_str());
+        }
+    }
     return false;
 }
 

--- a/src/corehost/cli/fxr/fx_muxer.cpp
+++ b/src/corehost/cli/fxr/fx_muxer.cpp
@@ -486,11 +486,11 @@ bool fx_muxer_t::resolve_hostpolicy_dir(host_mode_t mode,
     {
         if (!pal::file_exists(config.get_path()))
         {
-            trace::error(_X("Running as a standalone app because there is no '%s' file. If this should be a portable app instead, add that file specifying the appropriate framework."), config.get_path().c_str());
+            trace::error(_X("Failed to run as a standalone app because there is no '%s' file. If this should be a portable app instead, add that file specifying the appropriate framework."), config.get_path().c_str());
         }
         else if (config.get_fx_name().empty())
         {
-            trace::error(_X("Running as a standalone app because there is no framework specified in '%s'. If this should be a portable app instead, specify the appropriate framework in that file."), config.get_path().c_str());
+            trace::error(_X("Failed to run as a standalone app because there is no framework specified in '%s'. If this should be a portable app instead, specify the appropriate framework in that file."), config.get_path().c_str());
         }
     }
     return false;

--- a/src/corehost/cli/runtime_config.h
+++ b/src/corehost/cli/runtime_config.h
@@ -15,9 +15,9 @@ class runtime_config_t
 {
 public:
     runtime_config_t(const pal::string_t& path, const pal::string_t& dev_path);
-    bool is_valid() { return m_valid; }
-    const pal::string_t& get_path() { return m_path; }
-    const pal::string_t& get_dev_path() { return m_dev_path; }
+    bool is_valid() const { return m_valid; }
+    const pal::string_t& get_path() const { return m_path; }
+    const pal::string_t& get_dev_path() const { return m_dev_path; }
     const pal::string_t& get_gc_server() const;
     const pal::string_t& get_fx_version() const;
     const pal::string_t& get_fx_name() const;


### PR DESCRIPTION
Add an error message to help users identify the cause of not being able to find hostpolicy.dll when the runtimeconfig.json file is missing or has no framework specified.

When there is no runtimeconfig.json file or no framework specified in that file, the current code treats the app as a standalone app, so the new messages explain that.

Fixes https://github.com/dotnet/core-setup/issues/3193

The two messages are prefixed with this existing message:
```
A fatal error was encountered. The library 'hostpolicy.dll' required to execute the application was not found in 'C:\git\repros\console\bin\Debug\netcoreapp2.0\'.
```

The additional message when there is no runtimeconfig.json:
```
Failed to run as a standalone app because there is no 'C:\git\repros\console\bin\Debug\netcoreapp2.0\console.runtimeconfig.json' file. If this should be a portable app instead, add that file specifying the appropriate framework.
```

The additional message when there is no runtime section:
```
Failed to run as a standalone app because there is no framework specified in 'C:\git\repros\console\bin\Debug\netcoreapp2.0\console.runtimeconfig.json'. If this should be a portable app instead, specify the appropriate framework in that file.
```
