### PR TITLE
Enable building OpenSuse installers

### DIFF
--- a/buildpipeline/Core-Setup-Linux-BT.json
+++ b/buildpipeline/Core-Setup-Linux-BT.json
@@ -887,6 +887,46 @@
     {
       "environment": {},
       "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Package - OpenSuse",
+      "timeoutInMinutes": 0,
+      "refName": "Task38",
+      "task": {
+        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "filename": "docker",
+        "arguments": "run --rm $(DockerCommonRunArgs_Rhel7) $(PB_GitDirectory)/Tools/msbuild.sh $(PB_GitDirectory)/src/pkg/packaging/dir.proj $(AdditionalMSBuildProperties) $(DistroSpecificMSBuildArguments) /p:OutputRid=opensuse.42-$(PB_TargetArchitecture)",
+        "workingFolder": "",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "environment": {},
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Publish - OpenSuse",
+      "timeoutInMinutes": 0,
+      "refName": "Task39",
+      "task": {
+        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "filename": "docker",
+        "arguments": "run --rm $(DockerCommonRunArgs_Rhel7) $(PB_GitDirectory)/Tools/msbuild.sh $(PB_GitDirectory)/publish/publish.proj $(DistroSpecificMSBuildArguments) $(DistroSpecificMSBuildPublishArgs) /p:OutputRid=opensuse.42-$(PB_TargetArchitecture)",
+        "workingFolder": "",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "environment": {},
+      "enabled": true,
       "continueOnError": true,
       "alwaysRun": false,
       "displayName": "Cleanup Docker",

--- a/dir.props
+++ b/dir.props
@@ -343,6 +343,13 @@
         <TargetsUnix>true</TargetsUnix>
       </PropertyGroup>
     </When>
+    <When Condition="$(OutputRid.StartsWith('opensuse'))">
+      <PropertyGroup>
+        <TargetsOpensuse>true</TargetsOpensuse>
+        <TargetsLinux>true</TargetsLinux>
+        <TargetsUnix>true</TargetsUnix>
+      </PropertyGroup>
+    </When>
     <Otherwise>
       <PropertyGroup>
         <TargetsLinux>true</TargetsLinux>
@@ -357,7 +364,7 @@
     <InstallerExtension Condition="'$(OSGroup)' == 'Windows_NT'">.msi</InstallerExtension>
     <InstallerExtension Condition="'$(OSGroup)' == 'OSX'">.pkg</InstallerExtension>
     <InstallerExtension Condition="'$(TargetsDebian)' == 'true' or '$(TargetsUbuntu)' == 'true'">.deb</InstallerExtension>
-    <InstallerExtension Condition="'$(TargetsRhel)' == 'true' or '$(TargetsCentos)' == 'true'">.rpm</InstallerExtension>
+    <InstallerExtension Condition="'$(TargetsRhel)' == 'true' or '$(TargetsCentos)' == 'true' or '$(TargetsOpensuse)' == 'true'">.rpm</InstallerExtension>
     <CombinedInstallerExtension Condition="'$(OSGroup)' == 'Windows_NT'">.exe</CombinedInstallerExtension>
     <CombinedInstallerExtension Condition="'$(OSGroup)' != 'Windows_NT'">$(InstallerExtension)</CombinedInstallerExtension>
   </PropertyGroup>

--- a/publish/dir.props
+++ b/publish/dir.props
@@ -58,5 +58,6 @@
     <PublishRid Include="win-arm64" />
     <PublishRid Include="linux-arm" />
     <PublishRid Include="rhel.7-x64" />
+    <PublishRid Include="opensuse.42-x64" />
   </ItemGroup>
 </Project>

--- a/src/pkg/packaging/rpm/dotnet-sharedframework-opensuse-rpm_config.json
+++ b/src/pkg/packaging/rpm/dotnet-sharedframework-opensuse-rpm_config.json
@@ -1,0 +1,58 @@
+{
+    "maintainer_name": ".NET Core Team",
+    "maintainer_email": "dotnetpackages@dotnetfoundation.org",
+    "vendor": ".NET Foundation",
+
+    "package_name": "%SHARED_FRAMEWORK_RPM_PACKAGE_NAME%",
+    "install_root": "/usr/share/dotnet",
+    "install_doc": "/usr/share/doc/%SHARED_FRAMEWORK_RPM_PACKAGE_NAME%/",
+
+    "short_description": "%SHARED_FRAMEWORK_BRAND_NAME% %SHARED_FRAMEWORK_NUGET_NAME%",
+    "long_description": ".NET Core is a development platform that you can use to build command-line\napplications, microservices and modern websites. It is open source,\ncross-platform and is supported by Microsoft. We hope you enjoy using it!\nIf you do, please consider joining the active community of developers that are\ncontributing to the project on GitHub (https://github.com/dotnet/core).\nWe happily accept issues and PRs.",
+    "homepage": "https://github.com/dotnet/core",
+
+    "release":{
+        "package_version":"1.0.0.0",
+        "package_revision":"1",
+        "urgency" : "low",
+        "changelog_message" : "Initial shared framework."
+    },
+   
+    "control": {
+        "priority":"standard",
+        "section":"libs",
+        "architecture":"amd64"
+    },
+
+    "copyright": "2017 Microsoft",
+    "license": {
+        "type": "MIT",
+        "full_text": "Copyright (c) 2015 Microsoft\nPermission is hereby granted, free of charge, to any person obtaining a copy\nof this software and associated documentation files (the \"Software\"), to deal\nin the Software without restriction, including without limitation the rights\nto use, copy, modify, merge, publish, distribute, sublicense, and/or sell\ncopies of the Software, and to permit persons to whom the Software is\nfurnished to do so, subject to the following conditions:\nThe above copyright notice and this permission notice shall be included in all\ncopies or substantial portions of the Software.\nTHE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR\nIMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,\nFITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE\nAUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER\nLIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,\nOUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE\nSOFTWARE."
+    },
+    
+  "rpm_dependencies": [{
+      "package_name": "%HOSTFXR_RPM_PACKAGE_NAME%",
+      "package_version": ""
+    },
+    {
+      "package_name": "libopenssl1_0_0",
+      "package_version": ""
+    },
+    {
+      "package_name": "libicu52_1",
+      "package_version": ""
+    },
+    {
+      "package_name": "libunwind",
+      "package_version": ""
+    },
+    {
+      "package_name": "libcurl4",
+      "package_version": ""
+    }],
+   
+    "directories" : [
+        "/usr/share/dotnet/shared",
+        "/usr/share/doc/%SHARED_FRAMEWORK_RPM_PACKAGE_NAME%"
+    ]
+}

--- a/src/pkg/packaging/rpm/package.targets
+++ b/src/pkg/packaging/rpm/package.targets
@@ -6,9 +6,7 @@
   <UsingTask TaskName="BuildFPMToolPreReqs" AssemblyFile="$(LocalBuildToolsTaskDir)core-setup.tasks.dll"/>
 
   <PropertyGroup>
-    <IsRPMBasedDistro Condition="$(PackageTargetRid.StartsWith('rhel')) or
-                                 $(PackageTargetRid.StartsWith('centos')) or 
-                                 $(PackageTargetRid.StartsWith('opensuse'))">true</IsRPMBasedDistro>>true</IsRPMBasedDistro>
+    <IsRPMBasedDistro Condition="'$(InstallerExtension)' == '.rpm'">true</IsRPMBasedDistro>
     <BuildRpmPackage Condition="'$(IsRPMBasedDistro)' == true and '$(TargetArchitecture)' == 'x64'">true</BuildRpmPackage>
   </PropertyGroup>
 

--- a/src/pkg/packaging/rpm/package.targets
+++ b/src/pkg/packaging/rpm/package.targets
@@ -7,7 +7,8 @@
 
   <PropertyGroup>
     <IsRPMBasedDistro Condition="$(PackageTargetRid.StartsWith('rhel')) or
-                                    $(PackageTargetRid.StartsWith('centos'))">true</IsRPMBasedDistro>
+                                 $(PackageTargetRid.StartsWith('centos')) or 
+                                 $(PackageTargetRid.StartsWith('opensuse'))">true</IsRPMBasedDistro>>true</IsRPMBasedDistro>
     <BuildRpmPackage Condition="'$(IsRPMBasedDistro)' == true and '$(TargetArchitecture)' == 'x64'">true</BuildRpmPackage>
   </PropertyGroup>
 
@@ -192,6 +193,7 @@
       <InputRoot>$(SharedFrameworkPublishRoot)</InputRoot>
       <RpmFile>$(SharedFrameworkInstallerFile)</RpmFile>
       <ConfigJsonName>dotnet-sharedframework-rpm_config.json</ConfigJsonName>
+      <ConfigJsonName Condition="$(PackageTargetRid.StartsWith('opensuse'))">dotnet-sharedframework-opensuse-rpm_config.json</ConfigJsonName>
       <ConfigJsonFile>$(rpmPackagingConfigPath)$(ConfigJsonName)</ConfigJsonFile>
       <RpmIntermediatesDir>$(PackagesIntermediateDir)$(RpmPackageName)/$(RpmPackageVersion)</RpmIntermediatesDir>
     </PropertyGroup>


### PR DESCRIPTION
Enable building OpenSuse installers . OpenSuse is RPM based and has different set of system package requirement list as compared to rhel. However, we can use the Rhel image to build OpenSuse package using OutputRid msbuild parameter. This improves installer build time as well. 

fixes : https://github.com/dotnet/core-setup/issues/3107 and https://github.com/dotnet/core-setup/issues/3264