### PR TITLE
Enable Alpine official RID

### DIFF
--- a/src/pkg/projects/netcoreappRIDs.props
+++ b/src/pkg/projects/netcoreappRIDs.props
@@ -8,6 +8,7 @@
   <ItemGroup>
     <OfficialBuildRID Include="linux-x64" />
     <OfficialBuildRID Include="rhel.6-x64" />
+    <OfficialBuildRID Include="alpine.3.6-x64" />
     <OfficialBuildRID Include="osx-x64" />
     <OfficialBuildRID Include="win-x86">
       <Platform>x86</Platform>


### PR DESCRIPTION
This is a leftover from the Alpine enabling changes that I've forgotten
to make after corefx and coreclr official builds were enabled.
