### PR TITLE
Update uwp6.0 release to service 6.0.1

### DIFF
--- a/dependencies.props
+++ b/dependencies.props
@@ -21,7 +21,7 @@
     <PlatformPackageVersion>2.0.0</PlatformPackageVersion>
     <MicrosoftNETCoreRuntimeCoreCLRPackageVersion>2.1.0-b-uwp6-25707-02</MicrosoftNETCoreRuntimeCoreCLRPackageVersion>
     <MicrosoftNETCoreRuntimeJitPackageVersion>$(MicrosoftNETCoreRuntimeCoreCLRPackageVersion)</MicrosoftNETCoreRuntimeJitPackageVersion>
-    <MicrosoftNetNativeCompilerPackageVersion>2.0.0</MicrosoftNetNativeCompilerPackageVersion>
+    <MicrosoftNetNativeCompilerPackageVersion>2.0.1</MicrosoftNetNativeCompilerPackageVersion>
     <NETStandardVersion>2.0.1</NETStandardVersion>
     <DiaSymReaderNativeVersion>1.4.1</DiaSymReaderNativeVersion>
     <WcfVersion>4.5.0-preview1-25625-01</WcfVersion>

--- a/dir.props
+++ b/dir.props
@@ -46,7 +46,7 @@
 
     <SharedFrameworkNugetVersion>$(ProductVersion)</SharedFrameworkNugetVersion>
 
-    <UWPCoreRuntimeSdkVersion>6.0.1</UWPCoreRuntimeSdkVersion>
+    <UWPCoreRuntimeSdkVersion>6.0.2</UWPCoreRuntimeSdkVersion>
     <UWPCoreRuntimeSdkFullVersion>$(UWPCoreRuntimeSdkVersion)$(ProductVersionSuffix)</UWPCoreRuntimeSdkFullVersion>
 
     <NuGetVersion>$(SharedFrameworkNugetVersion)</NuGetVersion>
@@ -88,6 +88,15 @@
     <HostPolicyVersion Condition="'$(UseShippedHostPolicyPackage)' != 'true'">$(ProductVersion)</HostPolicyVersion>
     <HostPolicyVersion Condition="'$(UseShippedHostPolicyPackage)' == 'true'">2.0.0</HostPolicyVersion>
 
+    <!--
+         UWPCoreRuntimeSdk package version is only updated whenever there is a change in it.
+         If there is ever a need to use a shipped version of the package, then set the property
+         below to true.
+    -->
+    <UseShippedUwpCoreRuntimeSdkPackage>true</UseShippedUwpCoreRuntimeSdkPackage>
+    <RuntimeSdkPackageVersion>$(ProductVersion)</RuntimeSdkPackageVersion>
+    <RuntimeSdkPackageVersion>2.1.1</RuntimeSdkPackageVersion>
+    
     <BinariesRelativePath>Runtime/$(SharedFrameworkNugetVersion)</BinariesRelativePath>
     <InstallersRelativePath>Runtime/$(SharedFrameworkNugetVersion)</InstallersRelativePath>
   </PropertyGroup>

--- a/src/pkg/packages.builds
+++ b/src/pkg/packages.builds
@@ -20,7 +20,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(BuildAllpackages)' == 'false'">
-    <Project Include="$(ProjectsBasePath)Microsoft.Net.UWPCoreRuntimeSdk\Microsoft.Net.UWPCoreRuntimeSdk.builds" Condition="'$(_BuildUwpDependencies)' == 'true'" />
+    <Project Include="$(ProjectsBasePath)Microsoft.Net.UWPCoreRuntimeSdk\Microsoft.Net.UWPCoreRuntimeSdk.builds" Condition="'$(_BuildUwpDependencies)' == 'true' and $(UseShippedUwpCoreRuntimeSdkPackage) != 'true'" />
     <Project Include="$(ProjectsBasePath)Microsoft.NETCore.UniversalWindowsPlatform\Microsoft.NETCore.UniversalWindowsPlatform.builds" Condition="'$(_BuildUwpDependencies)' == 'true'" />
   </ItemGroup>
 

--- a/src/pkg/projects/Microsoft.NETCore.UniversalWindowsPlatform/Microsoft.NETCore.UniversalWindowsPlatform.pkgproj
+++ b/src/pkg/projects/Microsoft.NETCore.UniversalWindowsPlatform/Microsoft.NETCore.UniversalWindowsPlatform.pkgproj
@@ -30,9 +30,10 @@
       <TargetFramework>.NETCore50</TargetFramework>
     </Dependency>
 
-    <ProjectReference Include="..\Microsoft.Net.UWPCoreRuntimeSdk\Microsoft.Net.UWPCoreRuntimeSdk.pkgproj">
-      <TargetFramework>uap10.0.15138</TargetFramework>
-    </ProjectReference>
+    <Dependency Include="Microsoft.Net.UWPCoreRuntimeSdk">
+       <Version>$(RuntimeSdkPackageVersion)</Version>
+       <TargetFramework>uap10.0.15138</TargetFramework>
+    </Dependency>
 
     <!-- Add a placeholder to make sure NuGet understands we still support older versions,
          even though they don't have ref-assets -->

--- a/src/pkg/projects/Microsoft.Net.UWPCoreRuntimeSdk/Microsoft.Net.UWPCoreRuntimeSdk.pkgproj
+++ b/src/pkg/projects/Microsoft.Net.UWPCoreRuntimeSdk/Microsoft.Net.UWPCoreRuntimeSdk.pkgproj
@@ -3,7 +3,7 @@
   <Import Project="dir.props" />
 
   <PropertyGroup>
-    <Version>2.1.1</Version>
+    <Version>$(RuntimeSdkPackageVersion)</Version>
     <OmitDependencies>true</OmitDependencies>
 
   <!-- Reference runtime packages directly so that MSBuild .props / .targets get imported correctly in VS" -->


### PR DESCRIPTION
Update to 2.0.1 of .NET Native compiler
Update to 6.0.1 UWP meta-package
Retain 2.1.1 UWPCoreRuntimeSDK and skip building / publishing it due to Nuget immutability.
