### PR TITLE
Update NuGet.ProjectModel reference to respect RepoAPI package version.

### DIFF
--- a/dependencies.props
+++ b/dependencies.props
@@ -28,6 +28,8 @@
     <SystemServiceModelNetTcpPackageVersion>$(SystemServiceModelDuplexPackageVersion)</SystemServiceModelNetTcpPackageVersion>
     <SystemServiceModelPrimitivesPackageVersion>$(SystemServiceModelDuplexPackageVersion)</SystemServiceModelPrimitivesPackageVersion>
     <SystemServiceModelSecurityPackageVersion>$(SystemServiceModelDuplexPackageVersion)</SystemServiceModelSecurityPackageVersion>
+
+    <NuGetProjectModelPackageVersion>4.3.0-preview2-4095</NuGetProjectModelPackageVersion>
   </PropertyGroup>
 
   <!-- Package dependency verification/auto-upgrade configuration. -->

--- a/tools-local/tasks/core-setup.tasks.csproj
+++ b/tools-local/tasks/core-setup.tasks.csproj
@@ -25,9 +25,7 @@
     <Compile Include="*.cs" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="NuGet.ProjectModel">
-      <Version>4.3.0-preview2-4095</Version>
-    </PackageReference>
+    <PackageReference Include="NuGet.ProjectModel" Version="$(NuGetProjectModelPackageVersion)" />
     <PackageReference Include="Microsoft.Extensions.DependencyModel">
       <Version>1.1.1</Version>
     </PackageReference>

--- a/tools-local/tasks/core-setup.tasks.csproj
+++ b/tools-local/tasks/core-setup.tasks.csproj
@@ -25,7 +25,9 @@
     <Compile Include="*.cs" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="NuGet.ProjectModel" Version="$(NuGetProjectModelPackageVersion)" />
+    <PackageReference Include="NuGet.ProjectModel">
+      <Version>$(NuGetProjectModelPackageVersion)</Version>
+    </PackageReference>
     <PackageReference Include="Microsoft.Extensions.DependencyModel">
       <Version>1.1.1</Version>
     </PackageReference>


### PR DESCRIPTION
Updated reference to NuGet.ProjectModel to use version from RepoAPI and moved default value to dependencies.props.