### PR TITLE
Increment patch version for release

### DIFF
--- a/BranchInfo.props
+++ b/BranchInfo.props
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <MajorVersion>2</MajorVersion>
     <MinorVersion>1</MinorVersion>
-    <PatchVersion>0</PatchVersion>
+    <PatchVersion>1</PatchVersion>
     <StabilizePackageVersion Condition="'$(StabilizePackageVersion)' == ''">true</StabilizePackageVersion>
     <PreReleaseLabel>servicingUWP</PreReleaseLabel>
     <ReleaseSuffix>$(PreReleaseLabel)</ReleaseSuffix>


### PR DESCRIPTION
The version is used to isolate binaries in the Azure storage blobs and
must be incremented each build when stabilized (ie, no internal build
numbers appended providing automatic blob isolation).
