### PR TITLE
Use BuildTools PackageVersionPropsUrl tooling

### DIFF
--- a/buildpipeline/Core-Setup-Linux-Arm-BT.json
+++ b/buildpipeline/Core-Setup-Linux-Arm-BT.json
@@ -356,7 +356,7 @@
       "allowOverride": true
     },
     "DockerCommonRunArgs": {
-      "value": "--name $(PB_DockerContainerName) -v \"$(PB_SourcesDirectory):$(PB_GitDirectory)\" -w=\"$(PB_GitDirectory)\" $(PB_DockerImageName)"
+      "value": "--name $(PB_DockerContainerName) -v \"$(PB_SourcesDirectory):$(PB_GitDirectory)\" -w=\"$(PB_GitDirectory)\" -e \"PACKAGEVERSIONPROPSURL=$(PB_PackageVersionPropsUrl)\" $(PB_DockerImageName)"
     },
     "PB_VsoRepoUrl": {
       "value": "--branch $(PB_Branch) https://$(PB_VsoAccountName):$(PB_VsoPassword)@devdiv.visualstudio.com/DevDiv/_git/DotNet-Core-Setup-Trusted"
@@ -414,6 +414,9 @@
     "PB_ChecksumAzureAccessToken": {
       "value": null,
       "isSecret": true
+    },
+    "PB_PackageVersionPropsUrl": {
+      "value": ""
     }
   },
   "demands": [

--- a/buildpipeline/Core-Setup-Linux-BT.json
+++ b/buildpipeline/Core-Setup-Linux-BT.json
@@ -1128,7 +1128,7 @@
       "allowOverride": true
     },
     "DockerCommonRunArgs": {
-      "value": "--name $(PB_DockerContainerName) -v \"$(PB_SourcesDirectory):$(PB_GitDirectory)\" -w=\"$(PB_GitDirectory)\" $(PB_DockerImageName)"
+      "value": "--name $(PB_DockerContainerName) -v \"$(PB_SourcesDirectory):$(PB_GitDirectory)\" -w=\"$(PB_GitDirectory)\" -e \"PACKAGEVERSIONPROPSURL=$(PB_PackageVersionPropsUrl)\" $(PB_DockerImageName)"
     },
     "PB_VsoRepoUrl": {
       "value": "--branch $(PB_Branch) https://$(PB_VsoAccountName):$(PB_VsoPassword)@devdiv.visualstudio.com/DevDiv/_git/DotNet-Core-Setup-Trusted"
@@ -1266,6 +1266,9 @@
     "PB_DebianId_ubuntu1710-x64": {
       "value": null,
       "isSecret": true
+    },
+    "PB_PackageVersionPropsUrl": {
+      "value": ""
     }
   },
   "demands": [

--- a/buildpipeline/Core-Setup-OSX-BT.json
+++ b/buildpipeline/Core-Setup-OSX-BT.json
@@ -237,6 +237,12 @@
     },
     "PB_PortableBuild": {
       "value": "true"
+    },
+    "PB_PackageVersionPropsUrl": {
+      "value": ""
+    },
+    "PACKAGEVERSIONPROPSURL": {
+      "value": "$(PB_PackageVersionPropsUrl)"
     }
   },
   "demands": [

--- a/buildpipeline/Core-Setup-Windows-Arm-BT.json
+++ b/buildpipeline/Core-Setup-Windows-Arm-BT.json
@@ -544,6 +544,12 @@
     },
     "PB_BuildFullPlatformManifest": {
       "value": "false"
+    },
+    "PB_PackageVersionPropsUrl": {
+      "value": ""
+    },
+    "PACKAGEVERSIONPROPSURL": {
+      "value": "$(PB_PackageVersionPropsUrl)"
     }
   },
   "demands": [

--- a/buildpipeline/Core-Setup-Windows-BT.json
+++ b/buildpipeline/Core-Setup-Windows-BT.json
@@ -746,6 +746,12 @@
     },
     "TeamName": {
       "value": "DotNetCore"
+    },
+    "PB_PackageVersionPropsUrl": {
+      "value": ""
+    },
+    "PACKAGEVERSIONPROPSURL": {
+      "value": "$(PB_PackageVersionPropsUrl)"
     }
   },
   "demands": [


### PR DESCRIPTION
https://github.com/dotnet/core-eng/issues/2037
BuildTools PR this is using: https://github.com/dotnet/buildtools/pull/1787

These changes are the same as https://github.com/dotnet/corefx/pull/25319

---

All definitions need PB_PackageVersionPropsUrl to default to empty string, not undefined. If it were undefined, VSTS could leave in $(PB_PackageVersionPropsUrl) which would make the build fail when it fails to download it.

For Docker, map the environment variable on each run command.

For OSX/Windows, have VSTS set the environment variable by creating a definition variable.