### PR TITLE
Handle all RHEL 7.x releases as RHEL 7 in dir.props

### DIFF
--- a/dir.props
+++ b/dir.props
@@ -373,11 +373,7 @@
   <PropertyGroup Condition="'$(OutputRid)' != ''">
     <PackageTargetRid>$(OutputRid)</PackageTargetRid>
     <PackageTargetRid Condition="'$(OutputRid)' == 'osx.10.11-x64'">osx.10.10-x64</PackageTargetRid>
-    <PackageTargetRid Condition="'$(OutputRid)' == 'rhel.7.0-x64'">rhel.7-x64</PackageTargetRid>
-    <PackageTargetRid Condition="'$(OutputRid)' == 'rhel.7.1-x64'">rhel.7-x64</PackageTargetRid>
-    <PackageTargetRid Condition="'$(OutputRid)' == 'rhel.7.2-x64'">rhel.7-x64</PackageTargetRid>
-    <PackageTargetRid Condition="'$(OutputRid)' == 'rhel.7.3-x64'">rhel.7-x64</PackageTargetRid>
-    <PackageTargetRid Condition="'$(OutputRid)' == 'rhel.7.4-x64'">rhel.7-x64</PackageTargetRid>
+    <PackageTargetRid Condition="$(OutputRid.StartsWith('rhel.7.')) and $(OutputRid.EndsWith('-x64'))">rhel.7-x64</PackageTargetRid>
     <ProductMoniker>$(SharedFrameworkNugetVersion)-$(PackageTargetRid)</ProductMoniker>
     <HostResolverVersionMoniker>$(HostResolverVersion)-$(PackageTargetRid)</HostResolverVersionMoniker>
   </PropertyGroup>


### PR DESCRIPTION
Instead of hardcoding the specific RHEL 7.x versions, just handle all RHEL 7 releases. This makes this code more future-proof for future RHEL releases.

This is similar to what is being done in src/managed/Microsoft.DotNet.PlatformAbstractions/Native/PlatformApis.cs.
