### PR TITLE
Fix build error with glibc 2.26: missing xlocale.h

### DIFF
--- a/src/corehost/cli/json/casablanca/include/cpprest/asyncrt_utils.h
+++ b/src/corehost/cli/json/casablanca/include/cpprest/asyncrt_utils.h
@@ -40,9 +40,6 @@
 
 #ifndef _WIN32
 #include <sys/time.h>
-#ifdef __GLIBC__
-#include <xlocale.h>
-#endif
 #endif
 
 /// Various utilities for string conversions and date and time manipulation.


### PR DESCRIPTION
glibc 2.26 removed xlocale.h. They suggest locale.h is a complete
superset and should be enough. locale.h is already included.

See: https://sourceware.org/git/?p=glibc.git;a=commit;h=f0be25b
See: https://sourceware.org/glibc/wiki/Release/2.26#Removal_of_.27xlocale.h.27

Port of https://github.com/Microsoft/cpprestsdk/pull/502

This is a cherry-pick of commit 23510ddc07acb714c1dace14322ef047f9f1c888 from master. Please let me know if there is some other process for backporting a fix to the 2.0 servicing branch.