### PR TITLE
Integrate new symbol uploader build task.

### DIFF
--- a/buildpipeline/Core-Setup-Publish.json
+++ b/buildpipeline/Core-Setup-Publish.json
@@ -234,7 +234,7 @@
         "solution": "$(PB_SourcesDirectory)\\publish\\publish.proj",
         "platform": "$(PB_TargetArchitecture)",
         "configuration": "$(BuildConfiguration)",
-        "msbuildArguments": "/p:Configuration=$(BuildConfiguration) $(PB_CommonMSBuildArgs) /p:PublishType=$(PB_PublishType) /p:SignType=$(PB_SignType) /p:NuGetFeedUrl=$(NUGET_FEED_URL) /p:NuGetSymbolsFeedUrl=$(NUGET_SYMBOLS_FEED_URL) /p:NuGetApiKey=$(NUGET_API_KEY) /p:AzureAccountName=$(PB_AzureAccountName) /p:ContainerName=$(PB_ContainerName) /p:AzureAccessToken=$(PB_AzureAccessToken) /p:ChecksumAzureAccountName=$(PB_ChecksumAzureAccountName) /p:ChecksumContainerName=$(PB_ChecksumContainerName) /p:ChecksumAzureAccessToken=$(PB_ChecksumAzureAccessToken) /p:PackagesUrl=$(PB_PackagesUrl) /p:SymbolPackagesUrl=$(PB_SymbolPackagesUrl) /p:TransportFeedAccessToken=$(PB_TransportFeedAccessToken) /p:OfficialPublish=true /p:GitHubUser=$(PB_GitHubUser) /p:GitHubEmail=$(PB_GitHubEmail) /p:GitHubAuthToken=$(GITHUB_PASSWORD) /p:VersionsRepoOwner=$(PB_VersionsRepoOwner) /p:VersionsRepo=$(PB_VersionsRepo) /p:VersionsRepoPath=build-info/dotnet/$(PB_RepoName)/$(SourceBranch) /p:Finalize=true /p:DotNetToolDir=$(DotNetToolDir) /p:EmbedIndexToolDir=$(EmbedIndexToolDir) /flp:v=detailed;LogFile=$(PB_SourcesDirectory)\\publish.log",
+        "msbuildArguments": "/p:Configuration=$(BuildConfiguration) $(PB_CommonMSBuildArgs) /p:PublishType=$(PB_PublishType) /p:SignType=$(PB_SignType) /p:NuGetFeedUrl=$(NUGET_FEED_URL) /p:NuGetSymbolsFeedUrl=$(NUGET_SYMBOLS_FEED_URL) /p:NuGetApiKey=$(NUGET_API_KEY) /p:AzureAccountName=$(PB_AzureAccountName) /p:ContainerName=$(PB_ContainerName) /p:AzureAccessToken=$(PB_AzureAccessToken) /p:ChecksumAzureAccountName=$(PB_ChecksumAzureAccountName) /p:ChecksumContainerName=$(PB_ChecksumContainerName) /p:ChecksumAzureAccessToken=$(PB_ChecksumAzureAccessToken) /p:PackagesUrl=$(PB_PackagesUrl) /p:SymbolPackagesUrl=$(PB_SymbolPackagesUrl) /p:TransportFeedAccessToken=$(PB_TransportFeedAccessToken) /p:OfficialPublish=true /p:GitHubUser=$(PB_GitHubUser) /p:GitHubEmail=$(PB_GitHubEmail) /p:GitHubAuthToken=$(GITHUB_PASSWORD) /p:VersionsRepoOwner=$(PB_VersionsRepoOwner) /p:VersionsRepo=$(PB_VersionsRepo) /p:VersionsRepoPath=build-info/dotnet/$(PB_RepoName)/$(SourceBranch) /p:Finalize=true /p:DotNetToolDir=$(DotNetToolDir) /p:SymbolServerPath=$(PB_SymbolServerPath) /p:SymbolServerPAT=$(PB_SymbolServerPAT) /p:SymbolExpirationInDays=$(PB_SymbolExpirationInDays) /flp:v=detailed;LogFile=$(PB_SourcesDirectory)\\publish.log",
         "clean": "false",
         "maximumCpuCount": "false",
         "restoreNugetPackages": "false",
@@ -262,7 +262,7 @@
         "solution": "$(PB_SourcesDirectory)\\publish\\publish-type.proj",
         "platform": "$(PB_TargetArchitecture)",
         "configuration": "$(BuildConfiguration)",
-        "msbuildArguments": "/p:Configuration=$(BuildConfiguration) $(PB_CommonMSBuildArgs) /p:PublishType=$(PB_PublishType) /p:SignType=$(PB_SignType) /p:AzureAccountName=$(PB_AzureAccountName) /p:ContainerName=$(PB_ContainerName) /p:AzureAccessToken=$(PB_AzureAccessToken) /p:PublishBlobFeedUrl=$(PB_PublishBlobFeedUrl) /p:PublishBlobFeedKey=$(PB_PublishBlobFeedKey) /p:OfficialPublish=true /p:GitHubUser=$(PB_GitHubUser) /p:GitHubEmail=$(PB_GitHubEmail) /p:GitHubAuthToken=$(GITHUB_PASSWORD) /p:VersionsRepoOwner=$(PB_VersionsRepoOwner) /p:VersionsRepo=$(PB_VersionsRepo) /p:VersionsRepoPath=build-info/dotnet/$(PB_RepoName)/$(SourceBranch) /p:DotNetToolDir=$(DotNetToolDir) /p:EmbedIndexToolDir=$(EmbedIndexToolDir) /flp:v=detailed;LogFile=$(PB_SourcesDirectory)\\publish-blob.log",
+        "msbuildArguments": "/p:Configuration=$(BuildConfiguration) $(PB_CommonMSBuildArgs) /p:PublishType=$(PB_PublishType) /p:SignType=$(PB_SignType) /p:AzureAccountName=$(PB_AzureAccountName) /p:ContainerName=$(PB_ContainerName) /p:AzureAccessToken=$(PB_AzureAccessToken) /p:PublishBlobFeedUrl=$(PB_PublishBlobFeedUrl) /p:PublishBlobFeedKey=$(PB_PublishBlobFeedKey) /p:OfficialPublish=true /p:GitHubUser=$(PB_GitHubUser) /p:GitHubEmail=$(PB_GitHubEmail) /p:GitHubAuthToken=$(GITHUB_PASSWORD) /p:VersionsRepoOwner=$(PB_VersionsRepoOwner) /p:VersionsRepo=$(PB_VersionsRepo) /p:VersionsRepoPath=build-info/dotnet/$(PB_RepoName)/$(SourceBranch) /p:DotNetToolDir=$(DotNetToolDir) /flp:v=detailed;LogFile=$(PB_SourcesDirectory)\\publish-blob.log",
         "clean": "false",
         "maximumCpuCount": "false",
         "restoreNugetPackages": "false",
@@ -488,8 +488,15 @@
     "PB_ToolsRoot": {
       "value": "$(Build.SourcesDirectory)\\tools"
     },
-    "SymbolCatalogCertificateId": {
-      "value": "400"
+    "PB_SymbolServerPath": {
+      "value": "https://mikemvsts.artifacts.visualstudio.com/DefaultCollection"
+    },
+    "PB_SymbolServerPAT": {
+      "value": null,
+      "isSecret": true
+    }
+    "PB_SymbolExpirationInDays": {
+      "value": ""
     }
   },
   "demands": [

--- a/buildpipeline/Core-Setup-Publish.json
+++ b/buildpipeline/Core-Setup-Publish.json
@@ -494,7 +494,7 @@
     "PB_SymbolServerPAT": {
       "value": null,
       "isSecret": true
-    }
+    },
     "PB_SymbolExpirationInDays": {
       "value": ""
     }

--- a/dependencies.props
+++ b/dependencies.props
@@ -53,6 +53,12 @@
     <FeedTasksPackageVersion>2.1.0-prerelease-02228-01</FeedTasksPackageVersion>
   </PropertyGroup>
 
+  <!-- Publish symbol build task package -->
+  <PropertyGroup>
+    <PublishSymbolsPackage>Microsoft.SymbolUploader.Build.Task</PublishSymbolsPackage>
+    <PublishSymbolsPackageVersion>1.0.0-alpha-00001</PublishSymbolsPackageVersion>
+  </PropertyGroup>
+
   <ItemGroup>
     <RemoteDependencyBuildInfo Include="CoreFx">
       <BuildInfoPath>$(BaseDotNetBuildInfo)corefx/$(DependencyBranch)</BuildInfoPath>

--- a/init-tools.msbuild
+++ b/init-tools.msbuild
@@ -8,5 +8,6 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.DotNet.BuildTools" Version="$(BuildToolsPackageVersion)" />
     <PackageReference Include="$(FeedTasksPackage)" Version="$(FeedTasksPackageVersion)" />
+    <PackageReference Include="$(PublishSymbolsPackage)" Version="$(PublishSymbolsPackageVersion)" />
   </ItemGroup>
 </Project>

--- a/publish/publish-type.proj
+++ b/publish/publish-type.proj
@@ -90,4 +90,3 @@
   <Import Project="$(ToolsDir)VersionTools.targets" Condition="Exists('$(ToolsDir)VersionTools.targets')" />
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>
-

--- a/publish/publish-type.proj
+++ b/publish/publish-type.proj
@@ -8,8 +8,7 @@
   <PropertyGroup>
     <BuildDependsOn>
       ValidateProperties;
-      DownloadFilesFromContainer;
-      SignSymbolPackages
+      DownloadFilesFromContainer
     </BuildDependsOn>
 
     <BuildDependsOn Condition="$(PublishType.Contains('blob'))">
@@ -79,34 +78,6 @@
     </ItemGroup>
   </Target>
 
-  <Target Name="FindDownloadedPackagesForSigning">
-    <ItemGroup>
-      <!-- Find the downloaded symbol packages -->
-      <SymbolPackagesToEmbedIndex Include="$(DownloadDirectory)**\*.symbols.nupkg" />
-    </ItemGroup>
-
-    <PropertyGroup>
-      <UnsignedSymbolsDirectory Condition="'$(UnsignedSymbolsDirectory)' == ''">$(BinDir)UnsignedSymbolsDirectory/</UnsignedSymbolsDirectory>
-      <!-- Glob matching packages that we want to embed symbol signatures in. Used in BuildTools. -->
-      <SymbolPackagesToPublishGlob Condition="'$(SymbolPackagesToPublishGlob)' == ''">$(DownloadDirectory)**\*.symbols.nupkg</SymbolPackagesToPublishGlob>
-    </PropertyGroup>
-
-    <!-- Move all the symbol packages to an unsigned directory -->
-    <MakeDir Directories="$(UnsignedSymbolsDirectory)" />
-    <Move SourceFiles="@(SymbolPackagesToEmbedIndex)" DestinationFolder="$(UnsignedSymbolsDirectory)" />
-  </Target>
-
-  <Target Name="SignSymbolPackages"
-          DependsOnTargets="FindDownloadedPackagesForSigning;InjectSignedSymbolCatalogIntoSymbolPackages"
-          Condition="'$(WindowsSdkDir)' != '' AND '$(SignType)' == 'real'">
-    <ItemGroup>
-      <EmbedIndexArgPairs Include="@(SymbolPackagesToEmbedIndex -> '$(UnsignedSymbolsDirectory)%(Filename)%(Extension) %(Identity)')" />
-    </ItemGroup>
-
-    <!-- Inline the EmbedIndex.ps1 script used in CoreFX and CoreCLR: directly call EmbedIndex. -->
-    <Exec Command="$(DotNetToolDir)\dotnet $(EmbedIndexToolDir)\tools\EmbedIndex.dll %(EmbedIndexArgPairs.Identity)" />
-  </Target>
-
   <!--
     Target wrapping UpdatePublishedVersions: ensures that ShippedNuGetPackage items are created and
     disables versions repo update if no auth token is defined. Otherwise, not specifying an auth
@@ -119,3 +90,4 @@
   <Import Project="$(ToolsDir)VersionTools.targets" Condition="Exists('$(ToolsDir)VersionTools.targets')" />
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>
+

--- a/publish/publish.proj
+++ b/publish/publish.proj
@@ -8,6 +8,7 @@
   <UsingTask TaskName="UploadToAzure" AssemblyFile="$(BuildToolsTaskDir)Microsoft.DotNet.Build.CloudTestTasks.dll" />
 
   <Import Project="$(PackagesDir)/$(FeedTasksPackage.ToLower())/$(FeedTasksPackageVersion)/build/$(FeedTasksPackage).targets" />
+  <Import Project="$(PackagesDir)/$(PublishSymbolsPackage.ToLower())/$(PublishSymbolsPackageVersion)/build/PublishSymbols.targets" />
 
   <PropertyGroup>
     <!-- Always push the build assets to azure for final publish -->
@@ -32,7 +33,7 @@
 
   <Target Name="PublishFinalOutput"
           Condition="'$(Finalize)' == 'true'"
-          DependsOnTargets="PublishCoreHostPackages;FinalizeBuildInAzure;UpdateVersionsRepo" />
+          DependsOnTargets="PublishCoreHostPackages;SetupPublishSymbols;PublishSymbols;FinalizeBuildInAzure;UpdateVersionsRepo" />
 
   <!--
     Target wrapping UpdatePublishedVersions: ensures that ShippedNuGetPackage items are created and
@@ -176,7 +177,7 @@
   </Target>
 
   <Target Name="PublishCoreHostPackages"
-          DependsOnTargets="CheckIfAllBuildsHavePublished;DownloadCoreHostPackages;SignSymbolPackages;DoPushCoreHostPackagesToFeed;DoPushCoreHostPackagesToAzure"
+          DependsOnTargets="CheckIfAllBuildsHavePublished;DownloadCoreHostPackages;DoPushCoreHostPackagesToFeed;DoPushCoreHostPackagesToAzure"
           Condition="'@(_MissingBlobNames)' == '' AND '$(NuGetFeedUrl)' != ''">
     <Error Condition="'$(NuGetFeedUrl)' ==''" Text="Missing required property NuGetFeedUrl" />
     <Error Condition="'$(NuGetApiKey)' == ''" Text="Missing required property NuGetApiKey" />
@@ -221,32 +222,16 @@
     </ItemGroup>
   </Target>
 
-  <Target Name="FindDownloadedPackagesForSigning">
+  <Target Name="SetupPublishSymbols" Condition="'$(SymbolServerPath)'!=''" >
     <PropertyGroup>
-      <!-- Glob matching packages that we want to embed symbol signatures in. Used in BuildTools. -->
-      <SymbolPackagesToPublishGlob Condition="'$(SymbolPackagesToPublishGlob)' == ''">$(DownloadDirectory)**\*.symbols.nupkg</SymbolPackagesToPublishGlob>
+      <SymbolExpirationInDays Condition="'$(SymbolExpirationInDays)'=='' and '$(SymbolExpirationDate)'==''">1</SymbolExpirationInDays>
+      <ConvertPortablePdbsToWindowsPdbs>true</ConvertPortablePdbsToWindowsPdbs>
     </PropertyGroup>
-
     <ItemGroup>
-      <SymbolPackagesToEmbedIndex Include="$(SymbolPackagesToPublishGlob)" />
-      <NormalPackagesToNotEmbedIndex Include="$(DownloadDirectory)**\*.nupkg"
-                                     Exclude="@(SymbolPackagesToEmbedIndex)" />
+      <SymbolPackagesToPublish Include="$(DownloadDirectory)**\*.symbols.nupkg" />
     </ItemGroup>
-
-    <!-- Copy any nupkgs we skip running EmbedIndex on directly to the output folder. -->
-    <Copy SourceFiles="@(NormalPackagesToNotEmbedIndex)"
-          DestinationFolder="$(PublishDirectory)" />
-  </Target>
-
-  <Target Name="SignSymbolPackages"
-          DependsOnTargets="FindDownloadedPackagesForSigning;InjectSignedSymbolCatalogIntoSymbolPackages"
-          Condition="'$(WindowsSdkDir)' != '' AND '$(SignType)' == 'real'">
-    <ItemGroup>
-      <EmbedIndexArgPairs Include="@(SymbolPackagesToEmbedIndex -> '%(Identity) $(PublishDirectory)%(Filename)%(Extension)')" />
-    </ItemGroup>
-
-    <!-- Inline the EmbedIndex.ps1 script used in CoreFX and CoreCLR: directly call EmbedIndex. -->
-    <Exec Command="$(DotNetToolDir)\dotnet $(EmbedIndexToolDir)\tools\EmbedIndex.dll %(EmbedIndexArgPairs.Identity)" />
+    <Error Condition="'$(SymbolServerPAT)'==''" Text="Missing property SymbolServerPAT" />
+    <Message Importance="High" Text="Publishing @(SymbolPackagesToPublish) to $(SymbolServerPath)"/>
   </Target>
 
   <Target Name="DoPushCoreHostPackagesToFeed">


### PR DESCRIPTION
Symbol publishing will only happen for the pipeline builds if PB_SymbolServerPath and
PB_SymbolServerPAT are defined. PB_SymbolExpirationInDays is how long the symbol server
will keep. Default is 30 days. -1 means forever.

