### PR TITLE
Fix upgrade issue where symbolic link for dotnet-host rpm package gets removed

### DIFF
--- a/src/pkg/packaging/rpm/scripts/after_remove_host.sh
+++ b/src/pkg/packaging/rpm/scripts/after_remove_host.sh
@@ -3,5 +3,8 @@
 # Copyright (c) .NET Foundation and contributors. All rights reserved.
 # Licensed under the MIT license. See LICENSE file in the project root for full license information.
 #
-echo "Removing dotnet host symbolic link"
-unlink /usr/bin/dotnet
+# Run the script only when newer version is not installed. Skip during package upgrade 
+if [ $1 = 0 ]; then
+   echo "Removing dotnet host symbolic link"
+   unlink /usr/bin/dotnet
+fi


### PR DESCRIPTION
Fixes : https://github.com/dotnet/core-setup/issues/3455

More details : http://meinit.nl/rpm-spec-prepostpreunpostun-argument-values 