### PR TITLE
Add condition on BuildCustomTasks to not build in offline build

### DIFF
--- a/build.proj
+++ b/build.proj
@@ -55,7 +55,7 @@
                       Overwrite="True" />
   </Target>
 
-  <Target Name="BuildCustomTasks">
+  <Target Name="BuildCustomTasks" Condition="'$(DotNetBuildOffline)' != 'true'" >
       <MSBuild Projects="tools-local/Microsoft.DotNet.Build.Tasks.Local/Microsoft.DotNet.Build.Tasks.Local.builds" />
       <MSBuild Projects="tools-local/tasks/core-setup.tasks.builds" />
 


### PR DESCRIPTION
With the OfflineBuild, tasks are already present in the tarball, so they don't need to be built again.  Adding a condition on BuildCustomTasks to only build when OfflineBuild isn't set.