### PR TITLE
Fix alpine linux RID graph generation

### DIFF
--- a/src/sharedFramework/sharedFramework.proj
+++ b/src/sharedFramework/sharedFramework.proj
@@ -123,6 +123,7 @@
       <SharedFrameworkDepsFile>$(SharedFrameworkNameAndVersionRoot)\$(SharedFrameworkName).deps.json</SharedFrameworkDepsFile>
       <RuntimeGraphGeneratorRuntime Condition="'$(OSGroup)'=='Windows_NT'">win</RuntimeGraphGeneratorRuntime>
       <RuntimeGraphGeneratorRuntime Condition="'$(OSGroup)'=='OSX'">osx</RuntimeGraphGeneratorRuntime>
+      <RuntimeGraphGeneratorRuntime Condition="$(OutputRID.StartsWith('alpine'))">alpine</RuntimeGraphGeneratorRuntime>
       <RuntimeGraphGeneratorRuntime Condition="'$(RuntimeGraphGeneratorRuntime)'==''">linux</RuntimeGraphGeneratorRuntime>      
     </PropertyGroup>
 


### PR DESCRIPTION
Alpine Linux doesn't have 'linux' in its hierarchy, so the
GenerateRuntimeGraph target doesn't output alpine node to the runtimes
section of the Microsoft.NETCore.App.deps.json.

This change is a quick fix to that issue to unblock my work on enabling building of CLI for Alpine. 
In longer term, we should create a new osgroup named `alpine` or maybe better `linuxmusl` or something
along these lines and make it a fully supported OS group everywhere.
