### PR TITLE
Fix dependency props files import order

### DIFF
--- a/dir.props
+++ b/dir.props
@@ -16,8 +16,6 @@
 
   <Import Project="$(MSBuildThisFileDirectory)RepoDirectories.props" />
 
-  <Import Project="dependencies.props" />
-
   <!-- Build as portable by default -->
   <PropertyGroup>
     <PortableBuild Condition="'$(PortableBuild)' == ''">true</PortableBuild>
@@ -38,6 +36,11 @@
     <OsEnvironment Condition="'$(OsEnvironment)'==''">$(OS)</OsEnvironment>
   </PropertyGroup>
 
+  <!-- Import Build tools common props file where repo-independent properties are found -->
+  <Import Condition="Exists('$(ToolsDir)Build.Common.props')" Project="$(ToolsDir)Build.Common.props" />
+  
+  <Import Project="dependencies.props" />
+
   <PropertyGroup Condition="'$(DotNetBuildOffline)' != 'true'">
     <!-- list of nuget package sources passed to NuGet -->
     <RestoreSources>
@@ -51,9 +54,6 @@
       https://dotnet.myget.org/F/dotnet-corefxlab/api/v3/index.json;
     </RestoreSources>
   </PropertyGroup>
-
-  <!-- Import Build tools common props file where repo-independent properties are found -->
-  <Import Condition="Exists('$(ToolsDir)Build.Common.props')" Project="$(ToolsDir)Build.Common.props" />
 
   <!-- Versioning -->
   <PropertyGroup>


### PR DESCRIPTION
This allows dependencies.props to pick up properties defined by BuildTools, such as `DotNetPackageVersionPropsPath` being assigned to the downloaded package version props path. Importing this early meant that dependency versions weren't being overridden in orchestrated builds.

Now the order is more like CoreFX's: https://github.com/dotnet/corefx/blob/33ec2994d85935b6c62df0792aef88b285d6c765/dir.props#L52-L82