### PR TITLE
Fix issue with not passing configProperties to CLR

### DIFF
--- a/src/corehost/cli/libhost.h
+++ b/src/corehost/cli/libhost.h
@@ -130,8 +130,6 @@ public:
         , m_host_interface()
         , m_tfm(get_app(fx_definitions).get_runtime_config().get_tfm())
     {
-        make_cstr_arr(m_clr_keys, &m_clr_keys_cstr);
-        make_cstr_arr(m_clr_values, &m_clr_values_cstr);
         make_cstr_arr(m_probe_paths, &m_probe_paths_cstr);
 
         int fx_count = fx_definitions.size();
@@ -161,6 +159,8 @@ public:
         make_cstr_arr(m_fx_dirs, &m_fx_dirs_cstr);
         make_cstr_arr(m_fx_requested_versions, &m_fx_requested_versions_cstr);
         make_cstr_arr(m_fx_found_versions, &m_fx_found_versions_cstr);
+        make_cstr_arr(m_clr_keys, &m_clr_keys_cstr);
+        make_cstr_arr(m_clr_values, &m_clr_values_cstr);
     }
 
     const pal::string_t& tfm() const

--- a/src/test/TestUtils/Assertions/CommandResultAssertions.cs
+++ b/src/test/TestUtils/Assertions/CommandResultAssertions.cs
@@ -21,114 +21,115 @@ namespace Microsoft.DotNet.CoreSetup.Test
         public AndConstraint<CommandResultAssertions> ExitWith(int expectedExitCode)
         {
             Execute.Assertion.ForCondition(_commandResult.ExitCode == expectedExitCode)
-                .FailWith(AppendDiagnosticsTo($"Expected command to exit with {expectedExitCode} but it did not."));
+                .FailWith("Expected command to exit with {0} but it did not.{1}", expectedExitCode, GetDiagnosticsInfo());
             return new AndConstraint<CommandResultAssertions>(this);
         }
 
         public AndConstraint<CommandResultAssertions> Pass()
         {
             Execute.Assertion.ForCondition(_commandResult.ExitCode == 0)
-                .FailWith(AppendDiagnosticsTo($"Expected command to pass but it did not."));
+                .FailWith("Expected command to pass but it did not.{0}", GetDiagnosticsInfo());
             return new AndConstraint<CommandResultAssertions>(this);
         }
 
         public AndConstraint<CommandResultAssertions> Fail()
         {
             Execute.Assertion.ForCondition(_commandResult.ExitCode != 0)
-                .FailWith(AppendDiagnosticsTo($"Expected command to fail but it did not."));
+                .FailWith("Expected command to fail but it did not.{0}", GetDiagnosticsInfo());
             return new AndConstraint<CommandResultAssertions>(this);
         }
 
         public AndConstraint<CommandResultAssertions> HaveStdOut()
         {
             Execute.Assertion.ForCondition(!string.IsNullOrEmpty(_commandResult.StdOut))
-                .FailWith(AppendDiagnosticsTo("Command did not output anything to stdout"));
+                .FailWith("Command did not output anything to stdout{0}", GetDiagnosticsInfo());
             return new AndConstraint<CommandResultAssertions>(this);
         }
 
         public AndConstraint<CommandResultAssertions> HaveStdOut(string expectedOutput)
         {
             Execute.Assertion.ForCondition(_commandResult.StdOut.Equals(expectedOutput, StringComparison.Ordinal))
-                .FailWith(AppendDiagnosticsTo($"Command did not output with Expected Output. Expected: {expectedOutput}"));
+                .FailWith("Command did not output with Expected Output. Expected: {0}{1}", expectedOutput, GetDiagnosticsInfo());
             return new AndConstraint<CommandResultAssertions>(this);
         }
 
         public AndConstraint<CommandResultAssertions> HaveStdOutContaining(string pattern)
         {
             Execute.Assertion.ForCondition(_commandResult.StdOut.Contains(pattern))
-                .FailWith(AppendDiagnosticsTo($"The command output did not contain expected result: {pattern}{Environment.NewLine}"));
+                .FailWith("The command output did not contain expected result: {0}{1}", pattern, GetDiagnosticsInfo());
             return new AndConstraint<CommandResultAssertions>(this);
         }
 
         public AndConstraint<CommandResultAssertions> HaveStdOutMatching(string pattern, RegexOptions options = RegexOptions.None)
         {
             Execute.Assertion.ForCondition(Regex.Match(_commandResult.StdOut, pattern, options).Success)
-                .FailWith(AppendDiagnosticsTo($"Matching the command output failed. Pattern: {pattern}{Environment.NewLine}"));
+                .FailWith("Matching the command output failed. Pattern: {0}{1}", pattern, GetDiagnosticsInfo());
             return new AndConstraint<CommandResultAssertions>(this);
         }
 
         public AndConstraint<CommandResultAssertions> HaveStdErr()
         {
             Execute.Assertion.ForCondition(!string.IsNullOrEmpty(_commandResult.StdErr))
-                .FailWith(AppendDiagnosticsTo("Command did not output anything to stderr."));
+                .FailWith("Command did not output anything to stderr.{0}", GetDiagnosticsInfo());
             return new AndConstraint<CommandResultAssertions>(this);
         }
 
         public AndConstraint<CommandResultAssertions> HaveStdErrContaining(string pattern)
         {
             Execute.Assertion.ForCondition(_commandResult.StdErr.Contains(pattern))
-                .FailWith(AppendDiagnosticsTo($"The command error output did not contain expected result: {pattern}{Environment.NewLine}"));
+                .FailWith("The command error output did not contain expected result: {0}{1}", pattern, GetDiagnosticsInfo());
             return new AndConstraint<CommandResultAssertions>(this);
         }
 
         public AndConstraint<CommandResultAssertions> NotHaveStdErrContaining(string pattern)
         {
             Execute.Assertion.ForCondition(!_commandResult.StdErr.Contains(pattern))
-                .FailWith(AppendDiagnosticsTo($"The command error output contained a result it should not have contained: {pattern}{Environment.NewLine}"));
+                .FailWith("The command error output contained a result it should not have contained: {0}{1}", pattern, GetDiagnosticsInfo());
             return new AndConstraint<CommandResultAssertions>(this);
         }
 
         public AndConstraint<CommandResultAssertions> HaveStdErrMatching(string pattern, RegexOptions options = RegexOptions.None)
         {
             Execute.Assertion.ForCondition(Regex.Match(_commandResult.StdErr, pattern, options).Success)
-                .FailWith(AppendDiagnosticsTo($"Matching the command error output failed. Pattern: {pattern}{Environment.NewLine}"));
+                .FailWith("Matching the command error output failed. Pattern: {0}{1}", pattern, GetDiagnosticsInfo());
             return new AndConstraint<CommandResultAssertions>(this);
         }
 
         public AndConstraint<CommandResultAssertions> NotHaveStdOut()
         {
             Execute.Assertion.ForCondition(string.IsNullOrEmpty(_commandResult.StdOut))
-                .FailWith(AppendDiagnosticsTo($"Expected command to not output to stdout but it was not:"));
+                .FailWith("Expected command to not output to stdout but it was not:{0}", GetDiagnosticsInfo());
             return new AndConstraint<CommandResultAssertions>(this);
         }
 
         public AndConstraint<CommandResultAssertions> NotHaveStdErr()
         {
             Execute.Assertion.ForCondition(string.IsNullOrEmpty(_commandResult.StdErr))
-                .FailWith(AppendDiagnosticsTo("Expected command to not output to stderr but it was not:"));
+                .FailWith("Expected command to not output to stderr but it was not:{0}", GetDiagnosticsInfo());
             return new AndConstraint<CommandResultAssertions>(this);
         }
 
-        private string AppendDiagnosticsTo(string s)
+
+        private string GetDiagnosticsInfo()
         {
-            return s + $"{Environment.NewLine}" +
-                       $"File Name: {_commandResult.StartInfo.FileName}{Environment.NewLine}" +
-                       $"Arguments: {_commandResult.StartInfo.Arguments}{Environment.NewLine}" +
-                       $"Exit Code: {_commandResult.ExitCode}{Environment.NewLine}" +
-                       $"StdOut:{Environment.NewLine}{_commandResult.StdOut}{Environment.NewLine}" +
-                       $"StdErr:{Environment.NewLine}{_commandResult.StdErr}{Environment.NewLine}"; ;
+            return $"{Environment.NewLine}" +
+                $"File Name: {_commandResult.StartInfo.FileName}{Environment.NewLine}" +
+                $"Arguments: {_commandResult.StartInfo.Arguments}{Environment.NewLine}" +
+                $"Exit Code: {_commandResult.ExitCode}{Environment.NewLine}" +
+                $"StdOut:{Environment.NewLine}{_commandResult.StdOut}{Environment.NewLine}" +
+                $"StdErr:{Environment.NewLine}{_commandResult.StdErr}{Environment.NewLine}"; ;
         }
-		
-		public AndConstraint<CommandResultAssertions> HaveSkippedProjectCompilation(string skippedProject, string frameworkFullName)
+
+        public AndConstraint<CommandResultAssertions> HaveSkippedProjectCompilation(string skippedProject, string frameworkFullName)
         {
-            _commandResult.StdOut.Should().Contain($"Project {skippedProject} ({frameworkFullName}) was previously compiled. Skipping compilation.");
+            _commandResult.StdOut.Should().Contain("Project {0} ({1}) was previously compiled. Skipping compilation.", skippedProject, frameworkFullName);
 
             return new AndConstraint<CommandResultAssertions>(this);
         }
 
         public AndConstraint<CommandResultAssertions> HaveCompiledProject(string compiledProject, string frameworkFullName)
         {
-            _commandResult.StdOut.Should().Contain($"Project {compiledProject} ({frameworkFullName}) will be compiled");
+            _commandResult.StdOut.Should().Contain($"Project {0} ({1}) will be compiled", compiledProject, frameworkFullName);
 
             return new AndConstraint<CommandResultAssertions>(this);
         }


### PR DESCRIPTION
The "configProperties" section of the runtimeconfig.json was not being passed to the CLR. This broke a couple weeks ago due to https://github.com/dotnet/core-setup/pull/3460

The fix is to move 2 LOC so that the keys and values are properly initialized.

A test was also modified to ensure the trace output lists an expected CLR variable, along with 'override' support for a higher-level runtimeconfig.json. However, the external fluentAssertions test dependency had an issue with a `=` being searched for in the new test (`"Property TestProperty = AppValue"`), so the core-setup test extensions (CommandResultAssertions.cs ) were modified to pass variables instead of literals to fluentAssertions which took care of the `=` issue.

Fixes https://github.com/dotnet/core-setup/issues/3510