### PR TITLE
Prepend to RestoreSources: BuildTools may set it

### DIFF
--- a/dir.props
+++ b/dir.props
@@ -52,6 +52,7 @@
       https://www.myget.org/F/nugetbuild/api/v3/index.json;
       https://api.nuget.org/v3/index.json;
       https://dotnet.myget.org/F/dotnet-corefxlab/api/v3/index.json;
+      $(RestoreSources);
     </RestoreSources>
   </PropertyGroup>
 


### PR DESCRIPTION
This property group used to be before the `Build.Common.props` import, and my change that moved it after (https://github.com/dotnet/core-setup/pull/3495/) broke this scenario. Instead of moving it back, change it to match what CoreFX is doing for maintainability.