### PR TITLE
Enable symbol publishing

### DIFF
--- a/buildpipeline/Core-Setup-Publish.json
+++ b/buildpipeline/Core-Setup-Publish.json
@@ -489,7 +489,7 @@
       "value": "$(Build.SourcesDirectory)\\tools"
     },
     "PB_SymbolServerPath": {
-      "value": "https://mikemvsts.artifacts.visualstudio.com/DefaultCollection"
+      "value": "https://microsoftpublicsymbolsppe.artifacts.visualstudio.com/DefaultCollection"
     },
     "PB_SymbolServerPAT": {
       "value": null,

--- a/dependencies.props
+++ b/dependencies.props
@@ -56,7 +56,7 @@
   <!-- Publish symbol build task package -->
   <PropertyGroup>
     <PublishSymbolsPackage>Microsoft.SymbolUploader.Build.Task</PublishSymbolsPackage>
-    <PublishSymbolsPackageVersion>1.0.0-alpha-00001</PublishSymbolsPackageVersion>
+    <PublishSymbolsPackageVersion>1.0.0-alpha-00014</PublishSymbolsPackageVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/publish/publish.proj
+++ b/publish/publish.proj
@@ -34,6 +34,7 @@
   <Target Name="PublishFinalOutput"
           Condition="'$(Finalize)' == 'true'"
           DependsOnTargets="PublishCoreHostPackages;SetupPublishSymbols;PublishSymbols;FinalizeBuildInAzure;UpdateVersionsRepo" />
+
   <!--
     Target wrapping UpdatePublishedVersions: ensures that ShippedNuGetPackage items are created and
     disables versions repo update if no auth token is defined. Otherwise, not specifying an auth

--- a/publish/publish.proj
+++ b/publish/publish.proj
@@ -33,8 +33,7 @@
 
   <Target Name="PublishFinalOutput"
           Condition="'$(Finalize)' == 'true'"
-          DependsOnTargets="PublishCoreHostPackages;FinalizeBuildInAzure;UpdateVersionsRepo" />
-
+          DependsOnTargets="PublishCoreHostPackages;SetupPublishSymbols;PublishSymbols;FinalizeBuildInAzure;UpdateVersionsRepo" />
   <!--
     Target wrapping UpdatePublishedVersions: ensures that ShippedNuGetPackage items are created and
     disables versions repo update if no auth token is defined. Otherwise, not specifying an auth
@@ -219,8 +218,9 @@
 
   <Target Name="SetupPublishSymbols" Condition="'$(SymbolServerPath)'!=''" >
     <PropertyGroup>
-      <SymbolExpirationInDays Condition="'$(SymbolExpirationInDays)'=='' and '$(SymbolExpirationDate)'==''">1</SymbolExpirationInDays>
-      <ConvertPortablePdbsToWindowsPdbs>true</ConvertPortablePdbsToWindowsPdbs>
+      <SymbolExpirationInDays Condition="'$(SymbolExpirationInDays)'=='' and '$(SymbolExpirationDate)'==''">5</SymbolExpirationInDays>
+      <SymbolVerboseLogging>true</SymbolVerboseLogging>
+      <ConvertPortablePdbsToWindowsPdbs>false</ConvertPortablePdbsToWindowsPdbs>
     </PropertyGroup>
     <ItemGroup>
       <SymbolPackagesToPublish Include="$(DownloadDirectory)**\*.symbols.nupkg" />


### PR DESCRIPTION
Using version 1.0.0-alpha-00014 of the Microsoft.SymbolUploader.Build.Task package.

Switch to ppe test server.
