### PR TITLE
Pass manifest details to PushToBlobFeed

### DIFF
--- a/buildpipeline/Core-Setup-Publish.json
+++ b/buildpipeline/Core-Setup-Publish.json
@@ -262,7 +262,7 @@
         "solution": "$(PB_SourcesDirectory)\\publish\\publish-type.proj",
         "platform": "$(PB_TargetArchitecture)",
         "configuration": "$(BuildConfiguration)",
-        "msbuildArguments": "/p:Configuration=$(BuildConfiguration) $(PB_CommonMSBuildArgs) /p:PublishType=$(PB_PublishType) /p:SignType=$(PB_SignType) /p:AzureAccountName=$(PB_AzureAccountName) /p:ContainerName=$(PB_ContainerName) /p:AzureAccessToken=$(PB_AzureAccessToken) /p:PublishBlobFeedUrl=$(PB_PublishBlobFeedUrl) /p:PublishBlobFeedKey=$(PB_PublishBlobFeedKey) /p:OfficialPublish=true /p:GitHubUser=$(PB_GitHubUser) /p:GitHubEmail=$(PB_GitHubEmail) /p:GitHubAuthToken=$(GITHUB_PASSWORD) /p:VersionsRepoOwner=$(PB_VersionsRepoOwner) /p:VersionsRepo=$(PB_VersionsRepo) /p:VersionsRepoPath=build-info/dotnet/$(PB_RepoName)/$(SourceBranch) /p:DotNetToolDir=$(DotNetToolDir) /flp:v=detailed;LogFile=$(PB_SourcesDirectory)\\publish-blob.log",
+        "msbuildArguments": "/p:Configuration=$(BuildConfiguration) $(PB_CommonMSBuildArgs) $(PB_BuildOutputManifestArguments) /p:PublishType=$(PB_PublishType) /p:SignType=$(PB_SignType) /p:AzureAccountName=$(PB_AzureAccountName) /p:ContainerName=$(PB_ContainerName) /p:AzureAccessToken=$(PB_AzureAccessToken) /p:PublishBlobFeedUrl=$(PB_PublishBlobFeedUrl) /p:PublishBlobFeedKey=$(PB_PublishBlobFeedKey) /p:OfficialPublish=true /p:GitHubUser=$(PB_GitHubUser) /p:GitHubEmail=$(PB_GitHubEmail) /p:GitHubAuthToken=$(GITHUB_PASSWORD) /p:VersionsRepoOwner=$(PB_VersionsRepoOwner) /p:VersionsRepo=$(PB_VersionsRepo) /p:VersionsRepoPath=build-info/dotnet/$(PB_RepoName)/$(SourceBranch) /p:DotNetToolDir=$(DotNetToolDir) /flp:v=detailed;LogFile=$(PB_SourcesDirectory)\\publish-blob.log",
         "clean": "false",
         "maximumCpuCount": "false",
         "restoreNugetPackages": "false",
@@ -497,6 +497,9 @@
     },
     "PB_SymbolExpirationInDays": {
       "value": ""
+    },
+    "PB_BuildOutputManifestArguments": {
+      "value": "/p:ManifestBuildId=$(OfficialBuildId) /p:ManifestBranch=$(SourceBranch) /p:ManifestCommit=$(SourceVersion)"
     }
   },
   "demands": [

--- a/dir.props
+++ b/dir.props
@@ -16,6 +16,14 @@
 
   <Import Project="$(MSBuildThisFileDirectory)RepoDirectories.props" />
 
+  <PropertyGroup>
+    <!--
+      This name is used to create a GIT repository URL https://github.com/dotnet/$(GitHubRepositoryName) used to find source code for debugging
+      It is also used to name the build output manifest for orchestrated builds.
+    -->
+    <GitHubRepositoryName Condition="'$(GitHubRepositoryName)' == ''">core-setup</GitHubRepositoryName>
+  </PropertyGroup>
+
   <!-- Build as portable by default -->
   <PropertyGroup>
     <PortableBuild Condition="'$(PortableBuild)' == ''">true</PortableBuild>


### PR DESCRIPTION
Passes in manifest info so that `core-setup.xml` will be created with useful manifest information instead of the default `anonymous.xml`. See https://github.com/dotnet/corefx/pull/26192

CoreCLR and CoreFX already had `GitHubRepositoryName` defined, so I added it here, too. The initial reason for the property was to create GitHub raw URLs for SourceLink--if this turns out to be destabilizing in Core-Setup I can use `PB_RepoName` instead.

This change also needs https://github.com/dotnet/buildtools/pull/1852 to fully work, but merge order doesn't matter.

https://github.com/dotnet/core-eng/issues/2335