### PR TITLE
Always use current executable's path when launching with filename

### DIFF
--- a/src/corehost/cli/args.cpp
+++ b/src/corehost/cli/args.cpp
@@ -66,10 +66,14 @@ bool parse_arguments(
     if (argc >= 1)
     {
         args.own_path = argv[0];
-        if (!args.own_path.empty() && (!pal::realpath(&args.own_path) || !pal::file_exists(args.own_path)))
+        if (!args.own_path.empty())
         {
-            trace::warning(_X("Failed to resolve argv[0] as path [%s]. Using location of current executable instead."), args.own_path.c_str());
-            args.own_path.clear();
+            trace::info(_X("Attempting to use argv[0] as path [%s]"), args.own_path.c_str());
+            if (!get_path_from_argv(&args.own_path))
+            {
+                trace::warning(_X("Failed to resolve argv[0] as path [%s]. Using location of current executable instead."), args.own_path.c_str());
+                args.own_path.clear();
+            }
         }
     }
 

--- a/src/corehost/cli/fxr/fx_muxer.cpp
+++ b/src/corehost/cli/fxr/fx_muxer.cpp
@@ -1396,10 +1396,14 @@ int fx_muxer_t::execute(const int argc, const pal::char_t* argv[])
     if (argc >= 1)
     {
         own_path = argv[0];
-        if (!own_path.empty() && (!pal::realpath(&own_path) || !pal::file_exists(own_path)))
+        if (!own_path.empty())
         {
-            trace::warning(_X("Failed to resolve argv[0] as path [%s]. Using location of current executable instead."), own_path.c_str());
-            own_path.clear();
+            trace::info(_X("Attempting to use argv[0] as path [%s]"), own_path.c_str());
+            if (!get_path_from_argv(&own_path))
+            {
+                trace::warning(_X("Failed to resolve argv[0] as path [%s]. Using location of current executable instead."), own_path.c_str());
+                own_path.clear();
+            }
         }
     }
 

--- a/src/corehost/common/utils.cpp
+++ b/src/corehost/common/utils.cpp
@@ -320,3 +320,17 @@ bool multilevel_lookup_enabled()
     }
     return multilevel_lookup;
 }
+
+// Determine if string is a valid path, and if so then fix up by using realpath()
+bool get_path_from_argv(pal::string_t *path)
+{
+    // Assume all paths will have at least one separator. We want to detect path vs. file before calling realpath
+    // because realpath will expand a filename into a full path containing the current directory which may be
+    // the wrong location when filename is ends up being found in %PATH% and not the current directory.
+    if (path->find(DIR_SEPARATOR) != pal::string_t::npos)
+    {
+        return (pal::realpath(path) && pal::file_exists(*path));
+    }
+
+    return false;
+}

--- a/src/corehost/common/utils.h
+++ b/src/corehost/common/utils.h
@@ -45,4 +45,5 @@ bool skip_utf8_bom(pal::ifstream_t* stream);
 bool get_env_shared_store_dirs(std::vector<pal::string_t>* dirs, const pal::string_t& arch, const pal::string_t& tfm);
 bool get_global_shared_store_dirs(std::vector<pal::string_t>* dirs, const pal::string_t& arch, const pal::string_t& tfm);
 bool multilevel_lookup_enabled();
+bool get_path_from_argv(pal::string_t *path);
 #endif


### PR DESCRIPTION
In Unix, launching dotnet with just a filename may attempt to use the current directory as the installed location instead of the current running executable's directory. 

The fix is to always use the current executable's directory when just a filename is passed. If a path to a file is used instead, then that path will continue to be used as the installed location to support the case of using an alternate host other than dotnet.exe.

Fixes https://github.com/dotnet/core-setup/issues/3580
  