### PR TITLE
Fix issue with --additionalprobingpath parsing

### DIFF
--- a/src/corehost/cli/fxr/fx_muxer.cpp
+++ b/src/corehost/cli/fxr/fx_muxer.cpp
@@ -1102,14 +1102,14 @@ void append_probe_realpath(const pal::string_t& path, std::vector<pal::string_t>
         pal::string_t placeholder = _X("|arch|");
         placeholder.push_back(DIR_SEPARATOR);
         placeholder.append(_X("|tfm|"));
-        auto pos_placeholder = probe_path.find_last_of(placeholder);
+        auto pos_placeholder = probe_path.find(placeholder);
 
         if (pos_placeholder != pal::string_t::npos)
         {
             pal::string_t segment = get_arch();
             segment.push_back(DIR_SEPARATOR);
             segment.append(tfm);
-            probe_path.replace(pos_placeholder - placeholder.length() + 1, placeholder.length(), segment);
+            probe_path.replace(pos_placeholder, placeholder.length(), segment);
 
             if (pal::directory_exists(probe_path))
             {


### PR DESCRIPTION
The code to parse `|arch|/|tfm|` from the additional probing paths was using string::find_last_of("|arch|/|tfm|") which returns the last occurrence of ***any*** character (so the last occurrence of `|`, `a`, etc). This was not the intent as the whole string was to be compared, not any character. This can cause incorrect string substitutions and an access violation in some cases when a negative position was calculated.

Note there is a test to cover the positive result (GivenThatICareAboutPortableAppActivation.Muxer_Activation_With_Templated_AdditionalProbingPath_Succeeds) but there is no test for this negative scenario, and no new test added.

Note: I'm not sure why the original code wanted the *last* occurrence; I changed it to just the first occurrence.

Fixes https://github.com/dotnet/core-setup/issues/3511