### PR TITLE
Improve the error message when hostpolicy can't be found

### DIFF
--- a/src/corehost/cli/fxr/fx_muxer.cpp
+++ b/src/corehost/cli/fxr/fx_muxer.cpp
@@ -485,12 +485,12 @@ bool fx_muxer_t::resolve_hostpolicy_dir(
     {
         if (!pal::file_exists(get_app(fx_definitions).get_runtime_config().get_path()))
         {
-            trace::error(_X("Failed to run as a standalone app because there is no '%s' file. If this should be a portable app instead, add that file specifying the appropriate framework."),
+            trace::error(_X("Failed to run as a standalone app. If this should be a portable app, add the %s file specifying the appropriate framework."),
                 get_app(fx_definitions).get_runtime_config().get_path().c_str());
         }
         else if (get_app(fx_definitions).get_runtime_config().get_fx_name().empty())
         {
-            trace::error(_X("Failed to run as a standalone app because there is no framework specified in '%s'. If this should be a portable app instead, specify the appropriate framework in that file."),
+            trace::error(_X("Failed to run as a standalone app. If this should be a portable app, specify the appropriate framework in %s."),
                 get_app(fx_definitions).get_runtime_config().get_path().c_str());
         }
     }


### PR DESCRIPTION
When there is no hostpolicy.dll in a standalone app, the existing error messages are confusing because they imply the runtimeconfig.json file must exist and have a framework section which is not true in standalone.