### PR TITLE
Bump package versions for CoreClr dependencies for 1.1.0

### DIFF
--- a/build_projects/shared-build-targets-utils/DependencyVersions.cs
+++ b/build_projects/shared-build-targets-utils/DependencyVersions.cs
@@ -7,7 +7,7 @@ namespace Microsoft.DotNet.Cli.Build
 {
     public class DependencyVersions
     {
-        public static readonly string CoreCLRVersion = "1.1.6";
-        public static readonly string JitVersion = "1.1.6";
+        public static readonly string CoreCLRVersion = "1.1.7-servicing-26117-01";
+        public static readonly string JitVersion = "1.1.7-servicing-26117-01";
     }
 }

--- a/pkg/projects/Microsoft.NETCore.App/Microsoft.NETCore.App.pkgproj
+++ b/pkg/projects/Microsoft.NETCore.App/Microsoft.NETCore.App.pkgproj
@@ -76,7 +76,7 @@
       <Version>1.0.2</Version>
     </NETCoreApp10Dependency>
     <NETCoreApp10Dependency Include="Microsoft.NETCore.Runtime.CoreCLR">
-      <Version>1.0.11</Version>
+      <Version>1.0.12-servicing-26117-01</Version>
     </NETCoreApp10Dependency>
     <NETCoreApp10Dependency Include="Microsoft.VisualBasic">
       <Version>10.0.1</Version>

--- a/pkg/projects/Microsoft.NETCore.App/project.json
+++ b/pkg/projects/Microsoft.NETCore.App/project.json
@@ -5,7 +5,7 @@
     "Microsoft.CodeAnalysis.VisualBasic": "1.3.0",
     "Microsoft.CSharp": "4.3.0",
     "Microsoft.DiaSymReader.Native": "1.4.1",
-    "Microsoft.NETCore.Runtime.CoreCLR": "1.1.6",
+    "Microsoft.NETCore.Runtime.CoreCLR": "1.1.7-servicing-26117-01",
     "Microsoft.NETCore.Targets": "1.1.2",
     "Microsoft.VisualBasic": "10.1.0",
     "NETStandard.Library": "1.6.1",


### PR DESCRIPTION
Bump versions for CoreClr packages in 1.1.0

CC @weshaggard @safern