### PR TITLE
Generate test packages with version 1.0.0 instead of %VERSION%

### DIFF
--- a/src/test/TestUtils/TestProjectFixture.cs
+++ b/src/test/TestUtils/TestProjectFixture.cs
@@ -240,6 +240,7 @@ namespace Microsoft.DotNet.CoreSetup.Test
             dotnet.Build(buildArgs.ToArray())
                 .WorkingDirectory(_testProject.ProjectDirectory)
                 .Environment("NUGET_PACKAGES", _repoDirectoriesProvider.NugetPackages)
+                .Environment("VERSION", "") // Generate with package version 1.0.0, not %VERSION%
                 .CaptureStdErr()
                 .CaptureStdOut()
                 .Execute()


### PR DESCRIPTION
This clears out %VERSION% when generating test projects, so that the package version of 1.0.0 will be used for test projects.

This prevents test failures when %VERSION% is set to a value other than 1.0.0. The test that compares package version is: Microsoft.DotNet.CoreSetup.Test.HostActivation.LightupApp.GivenThatICareAboutLightupAppActivation.Muxer_activation_of_LightupApp_NoLightupLib_Fails

Fixes https://github.com/dotnet/core-setup/issues/3593