### PR TITLE
Add native API to hostpolicy that returns the native probe dirs for ASP.NET

### DIFF
--- a/src/corehost/cli/deps_resolver.cpp
+++ b/src/corehost/cli/deps_resolver.cpp
@@ -376,7 +376,7 @@ bool deps_resolver_t::resolve_tpa_list(
 
     auto process_entry = [&](const pal::string_t& deps_dir, const deps_entry_t& entry) -> bool
     {
-        if (entry.is_serviceable)
+        if (breadcrumb != nullptr && entry.is_serviceable)
         {
             breadcrumb->insert(entry.library_name + _X(",") + entry.library_version);
             breadcrumb->insert(entry.library_name);
@@ -629,7 +629,7 @@ bool deps_resolver_t::resolve_probe_dirs(
 
     auto add_package_cache_entry = [&](const deps_entry_t& entry, const pal::string_t& deps_dir) -> bool
     {
-        if (entry.is_serviceable)
+        if (breadcrumb != nullptr && entry.is_serviceable)
         {
             breadcrumb->insert(entry.library_name + _X(",") + entry.library_version);
             breadcrumb->insert(entry.library_name);

--- a/src/corehost/cli/fxr/fx_muxer.cpp
+++ b/src/corehost/cli/fxr/fx_muxer.cpp
@@ -1146,10 +1146,18 @@ std::vector<host_option> fx_muxer_t::get_known_opts(bool exec_mode, host_mode_t 
     return known_opts;
 }
 
-int fx_muxer_t::parse_args_and_execute(
+int fx_muxer_t::parse_args(
     const pal::string_t& own_dir,
     const pal::string_t& own_dll,
-    int argoff, int argc, const pal::char_t* argv[], bool exec_mode, host_mode_t mode, bool* is_an_app)
+    int argoff,
+    int argc,
+    const pal::char_t* argv[],
+    bool exec_mode,
+    host_mode_t mode,
+    bool* is_an_app,
+    int* new_argoff,
+    pal::string_t& app_candidate,
+    opt_map_t& opts)
 {
     *is_an_app = true;
 
@@ -1157,7 +1165,6 @@ int fx_muxer_t::parse_args_and_execute(
 
     // Parse the known arguments if any.
     int num_parsed = 0;
-    std::unordered_map<pal::string_t, std::vector<pal::string_t>> opts;
     if (!parse_known_args(argc - argoff, &argv[argoff], known_opts, &opts, &num_parsed))
     {
         trace::error(_X("Failed to parse supported options or their values:"));
@@ -1168,20 +1175,17 @@ int fx_muxer_t::parse_args_and_execute(
         return InvalidArgFailure;
     }
 
-    const pal::char_t** new_argv = argv;
-    int new_argc = argc;
-    std::vector<const pal::char_t*> vec_argv;
-    pal::string_t app_candidate = own_dll;
-    int cur_i = argoff + num_parsed;
+    app_candidate = own_dll;
+    *new_argoff = argoff + num_parsed;
     if (mode != host_mode_t::standalone)
     {
         trace::verbose(_X("Detected a non-standalone application, expecting app.dll to execute."));
-        if (cur_i >= argc)
+        if (*new_argoff >= argc)
         {
             return muxer_usage(!is_sdk_dir_present(own_dir));
         }
 
-        app_candidate = argv[cur_i];
+        app_candidate = argv[*new_argoff];
         bool is_app_managed = (ends_with(app_candidate, _X(".dll"), false) || ends_with(app_candidate, _X(".exe"), false)) && pal::realpath(&app_candidate);
 
         if (!is_app_managed)
@@ -1210,17 +1214,7 @@ int fx_muxer_t::parse_args_and_execute(
         return InvalidArgFailure;
     }
 
-    if (cur_i != 1)
-    {
-        vec_argv.reserve(argc - cur_i + 1); // +1 for dotnet
-        vec_argv.push_back(argv[0]);
-        vec_argv.insert(vec_argv.end(), argv + cur_i, argv + argc);
-        new_argv = vec_argv.data();
-        new_argc = vec_argv.size();
-    }
-
-    // Transform dotnet [exec] [--additionalprobingpath path] [--depsfile file] [dll] [args] -> dotnet [dll] [args]
-    return read_config_and_execute(own_dir, app_candidate, opts, new_argc, new_argv, mode);
+    return 1;
 }
 
 int read_config(
@@ -1259,10 +1253,16 @@ int read_config(
 }
 
 int fx_muxer_t::read_config_and_execute(
+    const pal::string_t& host_command,
     const pal::string_t& own_dir,
     const pal::string_t& app_candidate,
-    const std::unordered_map<pal::string_t, std::vector<pal::string_t>>& opts,
-    int new_argc, const pal::char_t** new_argv, host_mode_t mode)
+    const opt_map_t& opts,
+    int new_argc,
+    const pal::char_t** new_argv,
+    host_mode_t mode,
+    pal::char_t out_buffer[],
+    int32_t buffer_size,
+    int32_t* required_buffer_size)
 {
     pal::string_t opts_fx_version = _X("--fx-version");
     pal::string_t opts_roll_fwd_on_no_candidate_fx = _X("--roll-forward-on-no-candidate-fx");
@@ -1380,15 +1380,26 @@ int fx_muxer_t::read_config_and_execute(
         return CoreHostLibMissingFailure;
     }
 
-    corehost_init_t init(deps_file, additional_deps_serialized, probe_realpaths, mode, fx_definitions);
-    return execute_app(impl_dir, &init, new_argc, new_argv);
+    corehost_init_t init(host_command, deps_file, additional_deps_serialized, probe_realpaths, mode, fx_definitions);
+
+    if (host_command.size() == 0)
+    {
+        rc = execute_app(impl_dir, &init, new_argc, new_argv);
+    }
+    else
+    {
+        rc = execute_host_command(impl_dir, &init, new_argc, new_argv, out_buffer, buffer_size, required_buffer_size);
+    }
+
+    return rc;
 }
 
-/**
-*  Main entrypoint to detect operating mode and perform corehost, muxer,
-*  standalone application activation and the SDK activation.
-*/
-int fx_muxer_t::execute(const int argc, const pal::char_t* argv[])
+int fx_muxer_t::parse_path_args(
+    const int argc,
+    const pal::char_t* argv[],
+    pal::string_t& own_dir,
+    pal::string_t& own_dll,
+    pal::string_t& own_name)
 {
     pal::string_t own_path;
 
@@ -1414,63 +1425,141 @@ int fx_muxer_t::execute(const int argc, const pal::char_t* argv[])
         return StatusCode::LibHostCurExeFindFailure;
     }
 
-    pal::string_t own_name = get_filename(own_path);
-    pal::string_t own_dir = get_directory(own_path);
+    own_name = get_filename(own_path);
+    own_dir = get_directory(own_path);
     pal::string_t own_dll_filename = get_executable(own_name) + _X(".dll");
-    pal::string_t own_dll = own_dir;
+    own_dll = own_dir;
     append_path(&own_dll, own_dll_filename.c_str());
 
     trace::info(_X("Own dll path '%s'"), own_dll.c_str());
+    return 1;
+}
 
-    // Flag to indicate activation of an app instead of an invocation of the SDK.
-    bool is_an_app = true;
+/**
+*  Main entrypoint to detect operating mode and perform corehost, muxer,
+*  standalone application activation and the SDK activation.
+*/
+int fx_muxer_t::execute(
+    const pal::string_t host_command,
+    const int argc,
+    const pal::char_t* argv[],
+    pal::char_t result_buffer[],
+    int32_t buffer_size,
+    int32_t* required_buffer_size)
+{
+    pal::string_t own_dir;
+    pal::string_t own_dll;
+    pal::string_t own_name;
 
-    // Detect invocation mode
-    auto mode = detect_operating_mode(own_dir, own_dll, own_name);
-
-    //
-    // Invoked as corehost
-    //
-
-    if (mode == host_mode_t::split_fx)
-    {
-        trace::verbose(_X("--- Executing in split/FX mode..."));
-        return parse_args_and_execute(own_dir, own_dll, 1, argc, argv, false, host_mode_t::split_fx, &is_an_app);
-    }
-
-    //
-    // Invoked from the application base.
-    //
-
-    if (mode == host_mode_t::standalone)
-    {
-        trace::verbose(_X("--- Executing in standalone mode..."));
-        return parse_args_and_execute(own_dir, own_dll, 1, argc, argv, false, host_mode_t::standalone, &is_an_app);
-    }
-
-    //
-    // Invoked as the dotnet.exe muxer.
-    //
-
-    trace::verbose(_X("--- Executing in muxer mode..."));
-
-    if (argc <= 1)
-    {
-        return muxer_usage(!is_sdk_dir_present(own_dir));
-    }
-
-    if (pal::strcasecmp(_X("exec"), argv[1]) == 0)
-    {
-        return parse_args_and_execute(own_dir, own_dll, 2, argc, argv, true, host_mode_t::muxer, &is_an_app); // arg offset 2 for dotnet, exec
-    }
-
-    int result = parse_args_and_execute(own_dir, own_dll, 1, argc, argv, false, host_mode_t::muxer, &is_an_app); // arg offset 1 for dotnet
-
-    if (is_an_app)
+    int result = parse_path_args(argc, argv, own_dir, own_dll, own_name);
+    if (result != 1)
     {
         return result;
     }
 
+    // Detect invocation mode
+    host_mode_t mode = detect_operating_mode(own_dir, own_dll, own_name);
+
+    bool is_an_app = true; // Indicates activation of an app instead of an invocation of the SDK.
+    int new_argoff;
+    pal::string_t app_candidate;
+    opt_map_t opts;
+
+    if (mode == host_mode_t::split_fx)
+    {
+        // Invoked as corehost
+        trace::verbose(_X("--- Executing in split/FX mode..."));
+        result = parse_args(own_dir, own_dll, 1, argc, argv, false, mode, &is_an_app, &new_argoff, app_candidate, opts);
+    }
+    else if (mode == host_mode_t::standalone)
+    {
+        // Invoked from the application base.
+        trace::verbose(_X("--- Executing in standalone mode..."));
+        result = parse_args(own_dir, own_dll, 1, argc, argv, false, mode, &is_an_app, &new_argoff, app_candidate, opts);
+    }
+    else
+    {
+        // Invoked as the dotnet.exe muxer.
+        assert(mode == host_mode_t::muxer);
+        trace::verbose(_X("--- Executing in muxer mode..."));
+
+        if (argc <= 1)
+        {
+            return muxer_usage(!is_sdk_dir_present(own_dir));
+        }
+
+        if (pal::strcasecmp(_X("exec"), argv[1]) == 0)
+        {
+            result = parse_args(own_dir, own_dll, 2, argc, argv, true, mode, &is_an_app, &new_argoff, app_candidate, opts); // arg offset 2 for dotnet, exec
+        }
+        else
+        {
+            result = parse_args(own_dir, own_dll, 1, argc, argv, false, mode, &is_an_app, &new_argoff, app_candidate, opts); // arg offset 1 for dotnet
+
+            if (!is_an_app)
+            {
+                return handle_cli(own_dir, own_dll, argc, argv);
+            }
+        }
+    }
+
+    if (result == 1 && is_an_app)
+    {
+        // Transform dotnet [exec] [--additionalprobingpath path] [--depsfile file] [dll] [args] -> dotnet [dll] [args]
+        result = handle_exec_host_command(host_command, own_dir, app_candidate, opts, argc, argv, new_argoff, mode, result_buffer, buffer_size, required_buffer_size);
+    }
+
+    return result;
+}
+
+int fx_muxer_t::handle_exec(
+    const pal::string_t& own_dir,
+    const pal::string_t& app_candidate,
+    const opt_map_t& opts,
+    int argc,
+    const pal::char_t* argv[],
+    int argoff,
+    host_mode_t mode)
+{
+    return handle_exec_host_command(pal::string_t(), own_dir, app_candidate, opts, argc, argv, argoff, mode, nullptr, 0, nullptr);
+}
+
+int fx_muxer_t::handle_exec_host_command(
+    const pal::string_t& host_command,
+    const pal::string_t& own_dir,
+    const pal::string_t& app_candidate,
+    const opt_map_t& opts,
+    int argc,
+    const pal::char_t* argv[],
+    int argoff,
+    host_mode_t mode,
+    pal::char_t result_buffer[],
+    int32_t buffer_size,
+    int32_t* required_buffer_size)
+{
+    const pal::char_t** new_argv = argv;
+    int new_argc = argc;
+    std::vector<const pal::char_t*> vec_argv;
+
+    if (argoff != 1)
+    {
+        vec_argv.reserve(argc - argoff + 1); // +1 for dotnet
+        vec_argv.push_back(argv[0]);
+        vec_argv.insert(vec_argv.end(), argv + argoff, argv + argc);
+        new_argv = vec_argv.data();
+        new_argc = vec_argv.size();
+    }
+
+    // Transform dotnet [exec] [--additionalprobingpath path] [--depsfile file] [dll] [args] -> dotnet [dll] [args]
+    return read_config_and_execute(host_command, own_dir, app_candidate, opts, new_argc, new_argv, mode, result_buffer, buffer_size, required_buffer_size);
+}
+
+int fx_muxer_t::handle_cli(
+    const pal::string_t& own_dir,
+    const pal::string_t& own_dll,
+    int argc,
+    const pal::char_t* argv[])
+{
     // Check for commands that don't depend on the CLI SDK to be loaded
     if (pal::strcasecmp(_X("--list-sdks"), argv[1]) == 0)
     {
@@ -1502,6 +1591,7 @@ int fx_muxer_t::execute(const int argc, const pal::char_t* argv[])
         trace::error(_X("  %s"), DOTNET_CORE_URL);
         return StatusCode::LibHostSdkFindFailure;
     }
+
     append_path(&sdk_dotnet, _X("dotnet.dll"));
 
     if (!pal::file_exists(sdk_dotnet))
@@ -1519,7 +1609,18 @@ int fx_muxer_t::execute(const int argc, const pal::char_t* argv[])
     new_argv.insert(new_argv.end(), argv + 1, argv + argc);
 
     trace::verbose(_X("Using dotnet SDK dll=[%s]"), sdk_dotnet.c_str());
-    result = parse_args_and_execute(own_dir, own_dll, 1, new_argv.size(), new_argv.data(), false, host_mode_t::muxer, &is_an_app);
+
+    bool is_an_app;
+    int new_argoff;
+    pal::string_t app_candidate;
+    opt_map_t opts;
+    
+    int result = parse_args(own_dir, own_dll, 1, new_argv.size(), new_argv.data(), false, host_mode_t::muxer, &is_an_app, &new_argoff, app_candidate, opts); // arg offset 1 for dotnet
+    if (result == 1)
+    {
+        // Transform dotnet [exec] [--additionalprobingpath path] [--depsfile file] [dll] [args] -> dotnet [dll] [args]
+        result = handle_exec(own_dir, app_candidate, opts, new_argv.size(), new_argv.data(), new_argoff, host_mode_t::muxer);
+    }
 
     if (pal::strcasecmp(_X("--info"), argv[1]) == 0)
     {

--- a/src/corehost/cli/fxr/fx_muxer.cpp
+++ b/src/corehost/cli/fxr/fx_muxer.cpp
@@ -1214,7 +1214,7 @@ int fx_muxer_t::parse_args(
         return InvalidArgFailure;
     }
 
-    return 1;
+    return 0;
 }
 
 int read_config(
@@ -1432,7 +1432,7 @@ int fx_muxer_t::parse_path_args(
     append_path(&own_dll, own_dll_filename.c_str());
 
     trace::info(_X("Own dll path '%s'"), own_dll.c_str());
-    return 1;
+    return 0;
 }
 
 /**
@@ -1452,7 +1452,7 @@ int fx_muxer_t::execute(
     pal::string_t own_name;
 
     int result = parse_path_args(argc, argv, own_dir, own_dll, own_name);
-    if (result != 1)
+    if (result)
     {
         return result;
     }
@@ -1503,7 +1503,7 @@ int fx_muxer_t::execute(
         }
     }
 
-    if (result == 1 && is_an_app)
+    if (!result && is_an_app)
     {
         // Transform dotnet [exec] [--additionalprobingpath path] [--depsfile file] [dll] [args] -> dotnet [dll] [args]
         result = handle_exec_host_command(host_command, own_dir, app_candidate, opts, argc, argv, new_argoff, mode, result_buffer, buffer_size, required_buffer_size);
@@ -1616,7 +1616,7 @@ int fx_muxer_t::handle_cli(
     opt_map_t opts;
     
     int result = parse_args(own_dir, own_dll, 1, new_argv.size(), new_argv.data(), false, host_mode_t::muxer, &is_an_app, &new_argoff, app_candidate, opts); // arg offset 1 for dotnet
-    if (result == 1)
+    if (!result)
     {
         // Transform dotnet [exec] [--additionalprobingpath path] [--depsfile file] [dll] [args] -> dotnet [dll] [args]
         result = handle_exec(own_dir, app_candidate, opts, new_argv.size(), new_argv.data(), new_argoff, host_mode_t::muxer);

--- a/src/corehost/cli/fxr/fx_muxer.h
+++ b/src/corehost/cli/fxr/fx_muxer.h
@@ -14,19 +14,82 @@ int execute_app(
     const int argc,
     const pal::char_t* argv[]);
 
+int execute_host_command(
+    const pal::string_t& impl_dll_dir,
+    corehost_init_t* init,
+    const int argc,
+    const pal::char_t* argv[],
+    pal::char_t result_buffer[],
+    int32_t buffer_size,
+    int32_t* required_buffer_size);
+
 class fx_muxer_t
 {
 public:
-    static int execute(const int argc, const pal::char_t* argv[]);
+    static int execute(
+        const pal::string_t host_command,
+        const int argc,
+        const pal::char_t* argv[],
+        pal::char_t result_buffer[],
+        int32_t buffer_size,
+        int32_t* required_buffer_size);
+    static int parse_path_args(
+        const int argc,
+        const pal::char_t* argv[],
+        pal::string_t& own_dir,
+        pal::string_t& own_dll,
+        pal::string_t& own_name);
+    static int parse_args(
+        const pal::string_t& own_dir,
+        const pal::string_t& own_dll,
+        int argoff,
+        int argc,
+        const pal::char_t* argv[],
+        bool exec_mode,
+        host_mode_t mode,
+        bool* is_an_app,
+        int* new_argoff,
+        pal::string_t& app_candidate,
+        opt_map_t& opts);
+    static int handle_exec(
+        const pal::string_t& own_dir,
+        const pal::string_t& app_candidate,
+        const opt_map_t& opts,
+        int argc,
+        const pal::char_t* argv[],
+        int argoff,
+        host_mode_t mode);
+    static int handle_exec_host_command(
+        const pal::string_t& host_command,
+        const pal::string_t& own_dir,
+        const pal::string_t& app_candidate,
+        const opt_map_t& opts,
+        int argc,
+        const pal::char_t* argv[],
+        int argoff,
+        host_mode_t mode,
+        pal::char_t result_buffer[],
+        int32_t buffer_size,
+        int32_t* required_buffer_size);
+    static int handle_cli(
+        const pal::string_t& own_dir,
+        const pal::string_t& own_dll,
+        int argc,
+        const pal::char_t* argv[]);
     static std::vector<host_option> get_known_opts(bool exec_mode, host_mode_t mode, bool get_all_options = false);
     static bool resolve_sdk_dotnet_path(const pal::string_t& own_dir, const pal::string_t& cwd, pal::string_t* cli_sdk);
 private:
     static int read_config_and_execute(
+        const pal::string_t& host_command,
         const pal::string_t& own_dir,
         const pal::string_t& app_candidate,
-        const std::unordered_map<pal::string_t, std::vector<pal::string_t>>& opts,
-        int new_argc, const pal::char_t** new_argv, host_mode_t mode);
-    static int parse_args_and_execute(const pal::string_t& own_dir, const pal::string_t& own_dll, int argoff, int argc, const pal::char_t* argv[], bool exec_mode, host_mode_t mode, bool* can_execute);
+        const opt_map_t& opts,
+        int new_argc,
+        const pal::char_t** new_argv,
+        host_mode_t mode,
+        pal::char_t out_buffer[],
+        int32_t buffer_size,
+        int32_t* required_buffer_size);
     static bool resolve_hostpolicy_dir(
         host_mode_t mode,
         const pal::string_t& own_dir,

--- a/src/corehost/cli/fxr/hostfxr.cpp
+++ b/src/corehost/cli/fxr/hostfxr.cpp
@@ -283,13 +283,13 @@ SHARED_API int32_t hostfxr_resolve_sdk(
 //      The size of the buffer argument in pal::char_t units.
 //
 //    required_buffer_size
-//      If the apis fails because of insufficient buffer size,
-//      required_buffer_size is set to the minimium buffer size
-//      necessary to contain the result.
+//      If the return value is HostApiBufferTooSmall, then
+//      required_buffer_size is set to the minimium buffer
+//      size necessary to contain the result.
 //
 // Return value:
-//   1 on success, otherwise failure
-//   0x800080980  - Buffer is too small (HostApiBufferTooSmall)
+//   0 on success, otherwise failure
+//   0x800080980 - Buffer is too small (HostApiBufferTooSmall)
 //
 // String encoding:
 //   Windows     - UTF-16 (pal::char_t is 2 byte wchar_t)

--- a/src/corehost/cli/fxr/hostfxr.cpp
+++ b/src/corehost/cli/fxr/hostfxr.cpp
@@ -13,16 +13,16 @@
 
 typedef int(*corehost_load_fn) (const host_interface_t* init);
 typedef int(*corehost_main_fn) (const int argc, const pal::char_t* argv[]);
+typedef int(*corehost_main_with_output_buffer_fn) (const int argc, const pal::char_t* argv[], pal::char_t buffer[], int32_t buffer_size, int32_t* required_buffer_size);
 typedef int(*corehost_unload_fn) ();
 
-int load_host_library(
+int load_host_library_common(
     const pal::string_t& lib_dir,
+    pal::string_t& host_path,
     pal::dll_t* h_host,
     corehost_load_fn* load_fn,
-    corehost_main_fn* main_fn,
     corehost_unload_fn* unload_fn)
 {
-    pal::string_t host_path;
     if (!library_exists_in_dir(lib_dir, LIBHOSTPOLICY_NAME, &host_path))
     {
         return StatusCode::CoreHostLibMissingFailure;
@@ -37,10 +37,53 @@ int load_host_library(
 
     // Obtain entrypoint symbols
     *load_fn = (corehost_load_fn)pal::get_symbol(*h_host, "corehost_load");
-    *main_fn = (corehost_main_fn)pal::get_symbol(*h_host, "corehost_main");
     *unload_fn = (corehost_unload_fn)pal::get_symbol(*h_host, "corehost_unload");
 
-    return (*main_fn) && (*load_fn) && (*unload_fn)
+    return (*load_fn) && (*unload_fn)
+        ? StatusCode::Success
+        : StatusCode::CoreHostEntryPointFailure;
+}
+
+int load_host_library(
+    const pal::string_t& lib_dir,
+    pal::dll_t* h_host,
+    corehost_load_fn* load_fn,
+    corehost_main_fn* main_fn,
+    corehost_unload_fn* unload_fn)
+{
+    pal::string_t host_path;
+    int rc = load_host_library_common(lib_dir, host_path, h_host, load_fn, unload_fn);
+    if (rc != StatusCode::Success)
+    {
+        return rc;
+    }
+
+    // Obtain entrypoint symbol
+    *main_fn = (corehost_main_fn)pal::get_symbol(*h_host, "corehost_main");
+
+    return (*main_fn)
+        ? StatusCode::Success
+        : StatusCode::CoreHostEntryPointFailure;
+}
+
+int load_host_library_with_return(
+    const pal::string_t& lib_dir,
+    pal::dll_t* h_host,
+    corehost_load_fn* load_fn,
+    corehost_main_with_output_buffer_fn* main_fn,
+    corehost_unload_fn* unload_fn)
+{
+    pal::string_t host_path;
+    int rc = load_host_library_common(lib_dir, host_path, h_host, load_fn, unload_fn);
+    if (rc != StatusCode::Success)
+    {
+        return rc;
+    }
+
+    // Obtain entrypoint symbol
+    *main_fn = (corehost_main_with_output_buffer_fn)pal::get_symbol(*h_host, "corehost_main_with_output_buffer");
+
+    return (*main_fn)
         ? StatusCode::Success
         : StatusCode::CoreHostEntryPointFailure;
 }
@@ -57,7 +100,6 @@ int execute_app(
     corehost_unload_fn host_unload = nullptr;
 
     int code = load_host_library(impl_dll_dir, &corehost, &host_load, &host_main, &host_unload);
-
     if (code != StatusCode::Success)
     {
         trace::error(_X("An error occurred while loading required library %s from [%s]"), LIBHOSTPOLICY_NAME, impl_dll_dir.c_str());
@@ -79,14 +121,51 @@ int execute_app(
     return code;
 }
 
+int execute_host_command(
+    const pal::string_t& impl_dll_dir,
+    corehost_init_t* init,
+    const int argc,
+    const pal::char_t* argv[],
+    pal::char_t result_buffer[],
+    int32_t buffer_size,
+    int32_t* required_buffer_size)
+{
+    pal::dll_t corehost;
+    corehost_main_with_output_buffer_fn host_main = nullptr;
+    corehost_load_fn host_load = nullptr;
+    corehost_unload_fn host_unload = nullptr;
+
+    int code = load_host_library_with_return(impl_dll_dir, &corehost, &host_load, &host_main, &host_unload);
+
+    if (code != StatusCode::Success)
+    {
+        trace::error(_X("An error occurred while loading required library %s from [%s] for a host command"), LIBHOSTPOLICY_NAME, impl_dll_dir.c_str());
+        return code;
+    }
+
+    // Previous hostfxr trace messages must be printed before calling trace::setup in hostpolicy
+    trace::flush();
+
+    const host_interface_t& intf = init->get_host_init_data();
+    if ((code = host_load(&intf)) == 0)
+    {
+        code = host_main(argc, argv, result_buffer, buffer_size, required_buffer_size);
+        (void)host_unload();
+    }
+
+    pal::unload_library(corehost);
+
+    return code;
+}
+
 SHARED_API int hostfxr_main(const int argc, const pal::char_t* argv[])
 {
     trace::setup();
-    
+
     trace::info(_X("--- Invoked hostfxr [commit hash: %s] main"), _STRINGIFY(REPO_COMMIT_HASH));
 
     fx_muxer_t muxer;
-    return muxer.execute(argc, argv);
+    return muxer.execute(pal::string_t(), argc, argv, nullptr, 0, nullptr);
 }
 
 //
@@ -161,14 +240,14 @@ SHARED_API int32_t hostfxr_resolve_sdk(
     if (!fx_muxer_t::resolve_sdk_dotnet_path(exe_dir, working_dir, &cli_sdk))
     {
         // fx_muxer_t::resolve_sdk_dotnet_path handles tracing for this error case.
-        return 0; 
+        return 0;
     }
 
     if (cli_sdk.size() < buffer_size)
     {
         size_t length = cli_sdk.copy(buffer, buffer_size - 1);
         assert(length == cli_sdk.size());
-        assert(length < buffer_size); 
+        assert(length < buffer_size);
         buffer[length] = 0;
     }
     else
@@ -177,4 +256,58 @@ SHARED_API int32_t hostfxr_resolve_sdk(
     }
 
     return cli_sdk.size() + 1;
+}
+
+//
+// Returns the native directories of the runtime based upon
+// the specified app.
+//
+// Returned format is a list of paths separated by PATH_SEPARATOR
+// which is a semicolon (;) on Windows and a colon (:) otherwise,
+//
+// Invoked from ASP.NET in order to help load a native assembly
+// before the clr is initialized (through a custom host).
+//
+// Parameters:
+//    argc
+//      The number of argv arguments
+//
+//    argv
+//      The standard arguments normally passed to dotnet.exe
+//      for launching the application.
+//
+//    buffer
+//      The buffer where the native paths will be written.
+//
+//    buffer_size
+//      The size of the buffer argument in pal::char_t units.
+//
+//    required_buffer_size
+//      If the apis fails because of insufficient buffer size,
+//      required_buffer_size is set to the minimium buffer size
+//      necessary to contain the result.
+//
+// Return value:
+//   1 on success, otherwise failure
+//   0x800080980  - Buffer is too small (HostApiBufferTooSmall)
+//
+// String encoding:
+//   Windows     - UTF-16 (pal::char_t is 2 byte wchar_t)
+//   Unix        - UTF-8  (pal::char_t is 1 byte char)
+//
+SHARED_API int32_t hostfxr_get_native_search_directories(const int argc, const pal::char_t* argv[], pal::char_t buffer[], int32_t buffer_size, int32_t* required_buffer_size)
+{
+    trace::setup();
+
+    trace::info(_X("--- Invoked hostfxr_get_native_search_directories [commit hash: %s] main"), _STRINGIFY(REPO_COMMIT_HASH));
+
+    if (buffer_size < 0 || (buffer_size > 0 && buffer == nullptr) || required_buffer_size == nullptr)
+    {
+        trace::error(_X("hostfxr_get_native_search_directories received an invalid argument."));
+        return InvalidArgFailure;
+    }
+
+    fx_muxer_t muxer;
+    int rc = muxer.execute(_X("get-native-search-directories"), argc, argv, buffer, buffer_size, required_buffer_size);
+    return rc;
 }

--- a/src/corehost/cli/hostpolicy.cpp
+++ b/src/corehost/cli/hostpolicy.cpp
@@ -202,6 +202,7 @@ int run(const arguments_t& args, pal::string_t* out_host_command_result = nullpt
         {
             assert(out_host_command_result != nullptr);
             pal::clr_palstring(property_values[1], out_host_command_result);
+            exit_code = 0; // Success
         }
 
         return exit_code;
@@ -392,7 +393,7 @@ SHARED_API int corehost_main_with_output_buffer(const int argc, const pal::char_
         {
             pal::string_t output_string;
             rc = run(args, &output_string);
-            if (rc == 1)
+            if (!rc)
             {
                 // Get length in character count not including null terminator
                 int len = output_string.length();

--- a/src/corehost/cli/hostpolicy.cpp
+++ b/src/corehost/cli/hostpolicy.cpp
@@ -15,7 +15,7 @@
 
 hostpolicy_init_t g_init;
 
-int run(const arguments_t& args)
+int run(const arguments_t& args, pal::string_t* out_host_command_result = nullptr)
 {
     // Load the deps resolver
     deps_resolver_t resolver(g_init, args);
@@ -27,19 +27,31 @@ int run(const arguments_t& args)
         return StatusCode::ResolverInitFailure;
     }
 
-    // Setup breadcrumbs
-    pal::string_t policy_name = _STRINGIFY(HOST_POLICY_PKG_NAME);
-    pal::string_t policy_version = _STRINGIFY(HOST_POLICY_PKG_VER);
-
-    // Always insert the hostpolicy that the code is running on.
-    std::unordered_set<pal::string_t> breadcrumbs;
-    breadcrumbs.insert(policy_name);
-    breadcrumbs.insert(policy_name + _X(",") + policy_version);
-
+    // Setup breadcrumbs. Breadcrumbs are not enabled for API calls because they do not execute
+    // the app and may be re-entry
     probe_paths_t probe_paths;
-    if (!resolver.resolve_probe_paths(&probe_paths, &breadcrumbs))
+    std::unordered_set<pal::string_t> breadcrumbs;
+    bool breadcrumbs_enabled = (out_host_command_result == nullptr);
+    if (breadcrumbs_enabled)
     {
-        return StatusCode::ResolverResolveFailure;
+        pal::string_t policy_name = _STRINGIFY(HOST_POLICY_PKG_NAME);
+        pal::string_t policy_version = _STRINGIFY(HOST_POLICY_PKG_VER);
+
+        // Always insert the hostpolicy that the code is running on.
+        breadcrumbs.insert(policy_name);
+        breadcrumbs.insert(policy_name + _X(",") + policy_version);
+
+        if (!resolver.resolve_probe_paths(&probe_paths, &breadcrumbs))
+        {
+            return StatusCode::ResolverResolveFailure;
+        }
+    }
+    else
+    {
+        if (!resolver.resolve_probe_paths(&probe_paths, nullptr))
+        {
+            return StatusCode::ResolverResolveFailure;
+        }
     }
 
     pal::string_t clr_path = probe_paths.coreclr;
@@ -175,7 +187,27 @@ int run(const arguments_t& args)
     size_t property_size = property_keys.size();
     assert(property_keys.size() == property_values.size());
 
-    // Bind CoreCLR
+    unsigned int exit_code = 1;
+
+    // Check for host command(s)
+    if (pal::strcasecmp(g_init.host_command.c_str(), _X("get-native-search-directories")) == 0)
+    {
+        // Verify property_keys[1] contains the correct information
+        if (pal::cstrcasecmp(property_keys[1], "NATIVE_DLL_SEARCH_DIRECTORIES"))
+        {
+            trace::error(_X("get-native-search-directories failed to find NATIVE_DLL_SEARCH_DIRECTORIES property"));
+            exit_code = HostApiFailed;
+        }
+        else
+        {
+            assert(out_host_command_result != nullptr);
+            pal::clr_palstring(property_values[1], out_host_command_result);
+        }
+
+        return exit_code;
+    }
+
+   // Bind CoreCLR
     trace::verbose(_X("CoreCLR path = '%s', CoreCLR dir = '%s'"), clr_path.c_str(), clr_dir.c_str());
     if (!coreclr::bind(clr_dir))
     {
@@ -241,15 +273,17 @@ int run(const arguments_t& args)
     std::vector<char> managed_app;
     pal::pal_clrstring(args.managed_application, &managed_app);
 
-    // Leave breadcrumbs for servicing.
     breadcrumb_writer_t writer(&breadcrumbs);
-    writer.begin_write();
+    if (breadcrumbs_enabled)
+    {
+        // Leave breadcrumbs for servicing.
+        writer.begin_write();
+    }
 
     // Previous hostpolicy trace messages must be printed before executing assembly
     trace::flush();
 
     // Execute the application
-    unsigned int exit_code = 1;
     hr = coreclr::execute_assembly(
         host_handle,
         domain_id,
@@ -273,8 +307,11 @@ int run(const arguments_t& args)
 
     coreclr::unload();
 
-    // Finish breadcrumb writing
-    writer.end_write();
+    if (breadcrumbs_enabled)
+    {
+        // Finish breadcrumb writing
+        writer.end_write();
+    }
 
     return exit_code;
 }
@@ -282,7 +319,10 @@ int run(const arguments_t& args)
 SHARED_API int corehost_load(host_interface_t* init)
 {
     trace::setup();
-    
+
+    // Re-initialize global state in case of re-entry
+    g_init = hostpolicy_init_t();
+
     if (!hostpolicy_init_t::init(init, &g_init))
     {
         return StatusCode::LibHostInitFailure;
@@ -291,11 +331,12 @@ SHARED_API int corehost_load(host_interface_t* init)
     return 0;
 }
 
-SHARED_API int corehost_main(const int argc, const pal::char_t* argv[])
+int corehost_main_init(const int argc, const pal::char_t* argv[], const pal::string_t location, arguments_t& args)
 {
     if (trace::is_enabled())
     {
-        trace::info(_X("--- Invoked hostpolicy [commit hash: %s] [%s,%s,%s][%s] main = {"),
+        trace::info(_X("--- Invoked hostpolicy %s[commit hash: %s] [%s,%s,%s][%s] main = {"),
+            location.c_str(),
             _STRINGIFY(REPO_COMMIT_HASH),
             _STRINGIFY(HOST_POLICY_PKG_NAME),
             _STRINGIFY(HOST_POLICY_PKG_VER),
@@ -316,7 +357,6 @@ SHARED_API int corehost_main(const int argc, const pal::char_t* argv[])
     }
 
     // Take care of arguments
-    arguments_t args;
     if (!parse_arguments(g_init, argc, argv, &args))
     {
         return StatusCode::LibHostInvalidArgs;
@@ -326,7 +366,60 @@ SHARED_API int corehost_main(const int argc, const pal::char_t* argv[])
         args.print();
     }
 
-    return run(args);
+    return 0;
+}
+
+SHARED_API int corehost_main(const int argc, const pal::char_t* argv[])
+{
+    arguments_t args;
+    int rc = corehost_main_init(argc, argv, _X(""), args);
+    if (!rc)
+    {
+        rc = run(args);
+    }
+
+    return rc;
+}
+
+SHARED_API int corehost_main_with_output_buffer(const int argc, const pal::char_t* argv[], pal::char_t buffer[], int32_t buffer_size, int32_t* required_buffer_size)
+{
+    arguments_t args;
+
+    int rc = corehost_main_init(argc, argv, _X("corehost_main_with_output_buffer "), args);
+    if (!rc)
+    {
+        if (g_init.host_command == _X("get-native-search-directories"))
+        {
+            pal::string_t output_string;
+            rc = run(args, &output_string);
+            if (rc == 1)
+            {
+                // Get length in character count not including null terminator
+                int len = output_string.length();
+
+                if (len + 1 > buffer_size)
+                {
+                    rc = HostApiBufferTooSmall;
+                    *required_buffer_size = len + 1;
+                    trace::info(_X("get-native-search-directories failed with buffer too small"), output_string.c_str());
+                }
+                else
+                {
+                    output_string.copy(buffer, len);
+                    buffer[len] = '\0';
+                    *required_buffer_size = 0;
+                    trace::info(_X("get-native-search-directories success: %s"), output_string.c_str());
+                }
+            }
+        }
+        else
+        {
+            trace::error(_X("Unknown command: %s"), g_init.host_command.c_str());
+            rc = LibHostUnknownCommand;
+        }
+    }
+
+    return rc;
 }
 
 SHARED_API int corehost_unload()

--- a/src/corehost/cli/libhost.h
+++ b/src/corehost/cli/libhost.h
@@ -56,6 +56,7 @@ struct host_interface_t
     strarr_t fx_dirs;
     strarr_t fx_requested_versions;
     strarr_t fx_found_versions;
+    const pal::char_t* host_command;
     // !! WARNING / WARNING / WARNING / WARNING / WARNING / WARNING / WARNING / WARNING / WARNING
     // !! 1. Only append to this structure to maintain compat.
     // !! 2. Any nested structs should not use compiler specific padding (pack with _HOST_INTERFACE_PACK)
@@ -85,7 +86,8 @@ static_assert(offsetof(host_interface_t, fx_names) == 18 * sizeof(size_t), "Stru
 static_assert(offsetof(host_interface_t, fx_dirs) == 20 * sizeof(size_t), "Struct offset breaks backwards compatibility");
 static_assert(offsetof(host_interface_t, fx_requested_versions) == 22 * sizeof(size_t), "Struct offset breaks backwards compatibility");
 static_assert(offsetof(host_interface_t, fx_found_versions) == 24 * sizeof(size_t), "Struct offset breaks backwards compatibility");
-static_assert(sizeof(host_interface_t) == 26 * sizeof(size_t), "Did you add static asserts for the newly added fields?");
+static_assert(offsetof(host_interface_t, host_command) == 26 * sizeof(size_t), "Struct offset breaks backwards compatibility");
+static_assert(sizeof(host_interface_t) == 27 * sizeof(size_t), "Did you add static asserts for the newly added fields?");
 
 #define HOST_INTERFACE_LAYOUT_VERSION_HI 0x16041101 // YYMMDD:nn always increases when layout breaks compat.
 #define HOST_INTERFACE_LAYOUT_VERSION_LO sizeof(host_interface_t)
@@ -115,14 +117,17 @@ private:
     std::vector<const pal::char_t*> m_fx_requested_versions_cstr;
     std::vector<pal::string_t> m_fx_found_versions;
     std::vector<const pal::char_t*> m_fx_found_versions_cstr;
+    const pal::string_t m_host_command;
 public:
     corehost_init_t(
+        const pal::string_t& host_command,
         const pal::string_t& deps_file,
         const pal::string_t& additional_deps_serialized,
         const std::vector<pal::string_t>& probe_paths,
         const host_mode_t mode,
         const fx_definition_vector_t& fx_definitions)
-        : m_deps_file(deps_file)
+        : m_host_command(host_command)
+        , m_deps_file(deps_file)
         , m_additional_deps_serialized(additional_deps_serialized)
         , m_portable(get_app(fx_definitions).get_runtime_config().get_portable())
         , m_probe_paths(probe_paths)
@@ -220,6 +225,8 @@ public:
         hi.fx_found_versions.len = m_fx_found_versions_cstr.size();
         hi.fx_found_versions.arr = m_fx_found_versions_cstr.data();
 
+        hi.host_command = m_host_command.c_str();
+
         return hi;
     }
 
@@ -248,6 +255,7 @@ struct hostpolicy_init_t
     bool patch_roll_forward;
     bool prerelease_roll_forward;
     bool is_portable;
+    pal::string_t host_command;
 
     static bool init(host_interface_t* input, hostpolicy_init_t* init)
     {
@@ -260,7 +268,6 @@ struct hostpolicy_init_t
 
         trace::verbose(_X("Reading from host interface version: [0x%04x:%d] to initialize policy version: [0x%04x:%d]"), input->version_hi, input->version_lo, HOST_INTERFACE_LAYOUT_VERSION_HI, HOST_INTERFACE_LAYOUT_VERSION_LO);
 
-        
         //This check is to ensure is an old hostfxr can still load new hostpolicy.
         //We should not read garbage due to potentially shorter struct size
 
@@ -350,6 +357,11 @@ struct hostpolicy_init_t
                 fx = new fx_definition_t(fx_name, fx_dir, fx_requested_ver, fx_found_ver);
                 init->fx_definitions.push_back(std::unique_ptr<fx_definition_t>(fx));
             }
+        }
+
+        if (input->version_lo >= offsetof(host_interface_t, host_command) + sizeof(input->host_command))
+        {
+            init->host_command = input->host_command;
         }
 
         return true;

--- a/src/corehost/common/utils.cpp
+++ b/src/corehost/common/utils.cpp
@@ -183,7 +183,7 @@ const pal::char_t* get_arch()
 }
 
 pal::string_t get_last_known_arg(
-    const std::unordered_map<pal::string_t, std::vector<pal::string_t>>& opts,
+    const opt_map_t& opts,
     const pal::string_t& opt_key,
     const pal::string_t& de_fault)
 {
@@ -201,7 +201,7 @@ bool parse_known_args(
     const std::vector<host_option>& known_opts,
     // Although multimap would provide this functionality the order of kv, values are
     // not preserved in C++ < C++0x
-    std::unordered_map<pal::string_t, std::vector<pal::string_t>>* opts,
+    opt_map_t* opts,
     int* num_args)
 {
     int arg_i = *num_args;

--- a/src/corehost/common/utils.h
+++ b/src/corehost/common/utils.h
@@ -18,6 +18,8 @@ struct host_option
 
 #define RUNTIME_STORE_DIRECTORY_NAME _X("store")
 
+typedef std::unordered_map<pal::string_t, std::vector<pal::string_t>> opt_map_t;
+
 bool ends_with(const pal::string_t& value, const pal::string_t& suffix, bool match_case);
 bool starts_with(const pal::string_t& value, const pal::string_t& prefix, bool match_case);
 pal::string_t get_executable(const pal::string_t& filename);
@@ -32,14 +34,14 @@ void remove_trailing_dir_seperator(pal::string_t* dir);
 void replace_char(pal::string_t* path, pal::char_t match, pal::char_t repl);
 const pal::char_t* get_arch();
 pal::string_t get_last_known_arg(
-    const std::unordered_map<pal::string_t, std::vector<pal::string_t>>& opts,
+    const opt_map_t& opts,
     const pal::string_t& opt_key,
     const pal::string_t& de_fault);
 bool parse_known_args(
     const int argc,
     const pal::char_t* argv[],
     const std::vector<host_option>& known_opts,
-    std::unordered_map<pal::string_t, std::vector<pal::string_t>>* opts,
+    opt_map_t* opts,
     int* num_args);
 bool skip_utf8_bom(pal::ifstream_t* stream);
 bool get_env_shared_store_dirs(std::vector<pal::string_t>* dirs, const pal::string_t& arch, const pal::string_t& tfm);

--- a/src/corehost/error_codes.h
+++ b/src/corehost/error_codes.h
@@ -28,5 +28,8 @@ enum StatusCode
     AppArgNotRunnable           = 0x80008094,
     AppHostExeNotBoundFailure   = 0x80008095,
     FrameworkMissingFailure     = 0x80008096,
+    HostApiFailed               = 0x80008097,
+    HostApiBufferTooSmall       = 0x80008098,
+    LibHostUnknownCommand       = 0x80008099,
 };
 #endif // __ERROR_CODES_H__

--- a/src/test/Assets/TestProjects/HostApiInvokerApp/HostApiInvokerApp.csproj
+++ b/src/test/Assets/TestProjects/HostApiInvokerApp/HostApiInvokerApp.csproj
@@ -1,0 +1,13 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <OutputType>Exe</OutputType>
+    <RuntimeFrameworkVersion>$(MNAVersion)</RuntimeFrameworkVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
+  </ItemGroup>
+
+</Project>

--- a/src/test/Assets/TestProjects/HostApiInvokerApp/Program.cs
+++ b/src/test/Assets/TestProjects/HostApiInvokerApp/Program.cs
@@ -1,0 +1,93 @@
+using System;
+using System.Runtime.InteropServices;
+using System.Text;
+
+namespace StandaloneApp
+{
+    public static class Program
+    {
+        [DllImport("hostfxr", CharSet = CharSet.Unicode)]
+        static extern uint hostfxr_get_native_search_directories(int argc, IntPtr argv, StringBuilder buffer, int bufferSize, ref int required_buffer_size);
+
+        const uint HostApiBufferTooSmall = 0x80008098;
+
+        public static void Main(string[] args)
+        {
+            Console.WriteLine("Hello World!");
+            Console.WriteLine(string.Join(Environment.NewLine, args));
+
+            // A small operation involving NewtonSoft.Json to ensure the assembly is loaded properly
+            var t = typeof(Newtonsoft.Json.JsonReader);
+
+            if (args.Length == 0)
+            {
+                throw new Exception("Invalid number of arguments passed");
+            }
+
+            string apiToTest = args[0];
+            if (apiToTest == "hostfxr_get_native_search_directories")
+            {
+                Test_hostfxr_get_native_search_directories(args);
+            }
+            else
+            {
+                throw new Exception("Invalid args[0]");
+            }
+        }
+
+        /// <summary>
+        /// Test invoking the native hostfxr api hostfxr_get_native_search_directories
+        /// </summary>
+        /// <param name="args[0]">hostfxr_get_native_search_directories</param>
+        /// <param name="args[1]">Path to dotnet.exe</param>
+        /// <param name="args[2]">Path to application</param>
+        static void Test_hostfxr_get_native_search_directories(string[] args)
+        {
+            if (args.Length != 3)
+            {
+                throw new Exception("Invalid number of arguments passed");
+            }
+
+            string pathToDotnet = args[1];
+            string pathToApp = args[2];
+
+            IntPtr[] argv = new IntPtr[2];
+            argv[0] = Marshal.StringToHGlobalUni(pathToDotnet);
+            argv[1] = Marshal.StringToHGlobalUni(pathToApp);
+
+            GCHandle gch = GCHandle.Alloc(argv, GCHandleType.Pinned);
+
+            // Start with 0 bytes allocated to test re-entry and required_buffer_size
+            StringBuilder buffer = new StringBuilder(0);
+            int required_buffer_size = 0;
+
+            uint rc = 0;
+            for (int i = 0; i < 2; i++)
+            {
+                rc = hostfxr_get_native_search_directories(argv.Length, gch.AddrOfPinnedObject(), buffer, buffer.Capacity + 1, ref required_buffer_size);
+                if (rc != HostApiBufferTooSmall)
+                {
+                    break;
+                }
+
+                buffer = new StringBuilder(required_buffer_size);
+            }
+
+            gch.Free();
+            for (int i = 0; i < argv.Length; ++i)
+            {
+                Marshal.FreeHGlobal(argv[i]);
+            }
+
+            if (rc == 1)
+            {
+                Console.WriteLine("hostfxr_get_native_search_directories:Success");
+                Console.WriteLine($"hostfxr_get_native_search_directories buffer:[{buffer}]");
+            }
+            else
+            {
+                Console.WriteLine($"hostfxr_get_native_search_directories:Fail[{rc}]");
+            }
+        }
+    }
+}

--- a/src/test/Assets/TestProjects/HostApiInvokerApp/Program.cs
+++ b/src/test/Assets/TestProjects/HostApiInvokerApp/Program.cs
@@ -79,7 +79,7 @@ namespace StandaloneApp
                 Marshal.FreeHGlobal(argv[i]);
             }
 
-            if (rc == 1)
+            if (rc == 0)
             {
                 Console.WriteLine("hostfxr_get_native_search_directories:Success");
                 Console.WriteLine($"hostfxr_get_native_search_directories buffer:[{buffer}]");

--- a/src/test/HostActivationTests/GivenThatICareAboutNativeHostApis.cs
+++ b/src/test/HostActivationTests/GivenThatICareAboutNativeHostApis.cs
@@ -1,0 +1,65 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.IO;
+using System.Runtime.InteropServices;
+using Xunit;
+using FluentAssertions;
+using Microsoft.DotNet.CoreSetup.Test;
+
+namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.NativeHostApis
+{
+    public class GivenThatICareAboutNativeHostApis
+    {
+        private static TestProjectFixture PreviouslyBuiltAndRestoredPortableTestProjectFixture { get; set; }
+        private static TestProjectFixture PreviouslyPublishedAndRestoredPortableTestProjectFixture { get; set; }
+        private static RepoDirectoriesProvider RepoDirectories { get; set; }
+
+        static GivenThatICareAboutNativeHostApis()
+        {
+            RepoDirectories = new RepoDirectoriesProvider();
+
+            PreviouslyBuiltAndRestoredPortableTestProjectFixture = new TestProjectFixture("HostApiInvokerApp", RepoDirectories)
+                .EnsureRestored(RepoDirectories.CorehostPackages)
+                .BuildProject();
+
+            PreviouslyPublishedAndRestoredPortableTestProjectFixture = new TestProjectFixture("HostApiInvokerApp", RepoDirectories)
+                .EnsureRestored(RepoDirectories.CorehostPackages)
+                .PublishProject();
+        }
+
+        [Fact]
+        public void Muxer_activation_of_Publish_Output_Portable_DLL_hostfxr_get_native_search_directories_Succeeds()
+        {
+            // Currently the native API is used only on Windows, although it has been manually tested on Unix.
+            // Limit OS here to avoid issues with DllImport not being able to find the shared library.
+            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                return;
+            }
+
+            var fixture = PreviouslyPublishedAndRestoredPortableTestProjectFixture.Copy();
+            var dotnet = fixture.BuiltDotnet;
+            var appDll = fixture.TestProject.AppDll;
+
+            var dotnetLocation = Path.Combine(dotnet.BinPath, $"dotnet{fixture.ExeExtension}");
+            string[] args =
+            {
+                "hostfxr_get_native_search_directories",
+                dotnetLocation,
+                appDll
+            };
+
+            dotnet.Exec(appDll, args)
+                .CaptureStdOut()
+                .Execute()
+                .Should()
+                .Pass()
+                .And
+                .HaveStdOutContaining("hostfxr_get_native_search_directories:Success")
+                .And
+                .HaveStdOutContaining("hostfxr_get_native_search_directories buffer:[" + dotnet.GreatestVersionSharedFxPath);
+        }
+    }
+}


### PR DESCRIPTION
Adds a native API to hostfxr.dll that returns the native search paths for a given app. In order to obtain all valid directories (including servicing directories), it must call into the hostpolicy.dll for the current runtime and can't for example simply be implemented just in hostfxr.dll.

Fixes https://github.com/dotnet/core-setup/issues/3458

ASP.NET will call this to address scenarios where they need to pre-load a native dll. ASP.NET will cycle through these returned paths and attempt to load the given native dll manually.

Notes:
- Refactored the fx_muxer.cpp execute-related methods to separate exec, CLI and this new API mode.
- A new hostpolicy.dll entry point was added to address this API mode. It is designed to be used by future API calls in the future (if they just need to return a string).
- The name of the API \ 'command' is not passed to this new hostpolicy.dll entry point. Instead, the name is passed as part of the host_interface_t serialization to allow for future flexibility including adding additional arguments but while keeping the entry point the same.

cc @jkotalik