### PR TITLE
Reference Microsoft.NETCore.Targets

### DIFF
--- a/dependencies.props
+++ b/dependencies.props
@@ -18,6 +18,7 @@
 
   <PropertyGroup>
     <MicrosoftNETCorePlatformsPackageVersion>2.1.0-preview2-26127-04</MicrosoftNETCorePlatformsPackageVersion>
+    <MicrosoftNETCoreTargetsPackageVersion>2.0.0</MicrosoftNETCoreTargetsPackageVersion>
     <MicrosoftPrivateCoreFxNETCoreAppPackageVersion>4.5.0-preview2-26127-04</MicrosoftPrivateCoreFxNETCoreAppPackageVersion>
     <MicrosoftPrivateCoreFxUAPPackageVersion>4.6.0-preview2-26127-04</MicrosoftPrivateCoreFxUAPPackageVersion>
     <MicrosoftNETCoreRuntimeCoreCLRPackageVersion>2.1.0-preview2-26129-01</MicrosoftNETCoreRuntimeCoreCLRPackageVersion>

--- a/src/pkg/projects/Microsoft.NETCore.App/src/Microsoft.NETCore.App.depproj
+++ b/src/pkg/projects/Microsoft.NETCore.App/src/Microsoft.NETCore.App.depproj
@@ -35,7 +35,7 @@
       <Version>$(MicrosoftNETCorePlatformsPackageVersion)</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.NETCore.Targets">
-      <Version>2.0.0</Version>
+      <Version>$(MicrosoftNETCoreTargetsPackageVersion)</Version>
     </PackageReference>
     <PackageReference Include="NETStandard.Library">
       <Version>$(NETStandardLibraryPackageVersion)</Version>

--- a/src/pkg/projects/Microsoft.NETCore.App/src/Microsoft.NETCore.App.depproj
+++ b/src/pkg/projects/Microsoft.NETCore.App/src/Microsoft.NETCore.App.depproj
@@ -34,6 +34,9 @@
     <PackageReference Include="Microsoft.NETCore.Platforms">
       <Version>$(MicrosoftNETCorePlatformsPackageVersion)</Version>
     </PackageReference>
+    <PackageReference Include="Microsoft.NETCore.Targets">
+      <Version>2.0.0</Version>
+    </PackageReference>
     <PackageReference Include="NETStandard.Library">
       <Version>$(NETStandardLibraryPackageVersion)</Version>
     </PackageReference>


### PR DESCRIPTION
We want to make sure that Microsoft.NETCore.App has a reference to Microsoft.NETCore.Targets
so that the latest version is used and none of the old pre-2.0 runtime-specific packages get
brought into the package graph.

We were trying to do this before but it was failing because we weren't directly referencing the package.

In the future we could change this target to use the SDK assets file raising task then read the version
that was actually restored instead of forcing us to keep a direct reference to it.

Fixes  #2716