### PR TITLE
Fix additional-deps feature with native and resource dlls

### DIFF
--- a/src/corehost/cli/deps_resolver.cpp
+++ b/src/corehost/cli/deps_resolver.cpp
@@ -691,7 +691,7 @@ bool deps_resolver_t::resolve_probe_dirs(
     // Handle any additional deps.json that were specified.
     for (const auto& additional_deps : m_additional_deps)
     {
-        const auto additional_deps_entries = additional_deps->get_entries(deps_entry_t::asset_types::runtime);
+        const auto additional_deps_entries = additional_deps->get_entries(asset_type);
         for (const auto entry : additional_deps_entries)
         {
             if (!add_package_cache_entry(entry, m_app_dir))


### PR DESCRIPTION
Fix issue with --additional-deps not processing native and resource dlls.

It appears this was a copy-paste bug from a similar area of code that processes managed assemblies.

Fixes https://github.com/dotnet/core-setup/issues/3634

After this is the main branch, this will be ported to the 2.1.0 branch and a new issue will be created for a 2.0.x port.
