### PR TITLE
Fix issue with standalone exe name length >64

### DIFF
--- a/src/corehost/corehost.cpp
+++ b/src/corehost/corehost.cpp
@@ -39,12 +39,15 @@ bool is_exe_enabled_for_execution(const pal::string_t& own_path)
 {
     constexpr int EMBED_SZ = sizeof(EMBED_HASH_FULL_UTF8) / sizeof(EMBED_HASH_FULL_UTF8[0]);
     constexpr int EMBED_MAX = (EMBED_SZ > 1025 ? EMBED_SZ : 1025); // 1024 DLL name length, 1 NUL
-    static const char embed[EMBED_MAX] = EMBED_HASH_FULL_UTF8;     // series of NULs followed by embed hash string
+
+    // Contains the embed hash value at compile time or the managed DLL name replaced by "dotnet build".
+    // Must not be 'const' because std::string(&embed[0]) below would bind to a const string ctor plus length
+    // where length is determined at compile time (=64) instead of the actual length of the string at runtime.
+    static char embed[EMBED_MAX] = EMBED_HASH_FULL_UTF8;     // series of NULs followed by embed hash string
+
     static const char hi_part[] = EMBED_HASH_HI_PART_UTF8;
     static const char lo_part[] = EMBED_HASH_LO_PART_UTF8;
 
-    // At this point the "embed" variable may contain the embed hash value specified above at compile time
-    // or the managed DLL name replaced by "dotnet build".
     std::string binding(&embed[0]);
     pal::string_t pal_binding;
     if (!pal::utf8_palstring(binding, &pal_binding))


### PR DESCRIPTION
When a standalone exe has a length >64 characters it is truncated due to a compiler optimization regarding 'const' arrays.

This issue only occurs on release builds where the optimization is present.

No unit test was added due to the cost of another complete build\publish cycle.

Fixes https://github.com/dotnet/core-setup/issues/3150