### PR TITLE
Make 'invalid app dll' error messages consistent across platforms

### DIFF
--- a/src/corehost/cli/fxr/fx_muxer.h
+++ b/src/corehost/cli/fxr/fx_muxer.h
@@ -47,7 +47,6 @@ public:
         const pal::char_t* argv[],
         bool exec_mode,
         host_mode_t mode,
-        bool* is_an_app,
         int* new_argoff,
         pal::string_t& app_candidate,
         opt_map_t& opts);

--- a/src/corehost/common/utils.cpp
+++ b/src/corehost/common/utils.cpp
@@ -329,7 +329,7 @@ bool get_path_from_argv(pal::string_t *path)
     // the wrong location when filename is ends up being found in %PATH% and not the current directory.
     if (path->find(DIR_SEPARATOR) != pal::string_t::npos)
     {
-        return (pal::realpath(path) && pal::file_exists(*path));
+        return pal::realpath(path);
     }
 
     return false;

--- a/src/test/HostActivationTests/GivenThatICareAboutDotnetArgValidationScenarios.cs
+++ b/src/test/HostActivationTests/GivenThatICareAboutDotnetArgValidationScenarios.cs
@@ -1,0 +1,98 @@
+﻿using FluentAssertions;
+using Microsoft.DotNet.CoreSetup.Test;
+using Microsoft.DotNet.Cli.Build.Framework;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using System.IO;
+using System.Runtime.InteropServices;
+using Xunit;
+
+namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.ArgValidation
+{
+    public class GivenThatICareAboutDotnetArgValidationScenarios
+    {
+        private RepoDirectoriesProvider RepoDirectories { get; set; }
+        private TestProjectFixture PreviouslyBuiltAndRestoredPortableTestProjectFixture { get; set; }
+
+        public GivenThatICareAboutDotnetArgValidationScenarios()
+        {
+            RepoDirectories = new RepoDirectoriesProvider();
+
+            PreviouslyBuiltAndRestoredPortableTestProjectFixture = new TestProjectFixture("PortableApp", RepoDirectories)
+                .EnsureRestored(RepoDirectories.CorehostPackages)
+                .BuildProject();
+        }
+
+        [Fact]
+        public void Muxer_Exec_With_Missing_App_Assembly_Fails()
+        {
+            var fixture = PreviouslyBuiltAndRestoredPortableTestProjectFixture
+                .Copy();
+
+            var dotnet = fixture.BuiltDotnet;
+
+            string assemblyName = Path.Combine(GetNonexistentAndUnnormalizedPath(), "foo.dll");
+
+            dotnet.Exec("exec", assemblyName)
+                .CaptureStdOut()
+                .CaptureStdErr()
+                .Execute()
+                .Should()
+                .Fail()
+                .And
+                .HaveStdErrContaining($"The application to execute does not exist: '{assemblyName}'");
+        }
+
+        [Fact]
+        public void Muxer_Exec_With_Missing_App_Assembly_And_Bad_Extension_Fails()
+        {
+            var fixture = PreviouslyBuiltAndRestoredPortableTestProjectFixture
+                .Copy();
+
+            var dotnet = fixture.BuiltDotnet;
+
+            string assemblyName = Path.Combine(GetNonexistentAndUnnormalizedPath(), "foo.xzy");
+
+            dotnet.Exec("exec", assemblyName)
+                .CaptureStdOut()
+                .CaptureStdErr()
+                .Execute()
+                .Should()
+                .Fail()
+                .And
+                .HaveStdErrContaining($"The application to execute does not exist: '{assemblyName}'");
+        }
+
+        [Fact]
+        public void Muxer_Exec_With_Bad_Extension_Fails()
+        {
+            var fixture = PreviouslyBuiltAndRestoredPortableTestProjectFixture
+                .Copy();
+
+            var dotnet = fixture.BuiltDotnet;
+
+            // Get a valid file name, but not exe or dll
+            string fxDir = Path.Combine(fixture.SdkDotnet.BinPath, "shared", "Microsoft.NETCore.App");
+            fxDir = new DirectoryInfo(fxDir).GetDirectories()[0].FullName;
+            string assemblyName = Path.Combine(fxDir, "Microsoft.NETCore.App.deps.json");
+
+            dotnet.Exec("exec", assemblyName)
+                .CaptureStdOut()
+                .CaptureStdErr()
+                .Execute()
+                .Should()
+                .Fail()
+                .And
+                .HaveStdErrContaining($"dotnet exec needs a managed .dll or .exe extension. The application specified was '{assemblyName}'");
+        }
+
+
+        // Return a non-exisitent path that contains a mix of / and \
+        private string GetNonexistentAndUnnormalizedPath()
+        {
+            return Path.Combine(PreviouslyBuiltAndRestoredPortableTestProjectFixture.SdkDotnet.BinPath, @"x\y/");
+        }
+    }
+}


### PR DESCRIPTION
Fixes issue with Unix and Windows returning different error messages.

The root of the problem was realpath() was checking for file exists on Unix, but not on Windows. This was changed to always check for file exists, and redundant code was removed.

Fixes https://github.com/dotnet/core-setup/issues/2828
