### PR TITLE
Sync run.sh script with what is in corefx

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -1,22 +1,16 @@
 #!/usr/bin/env bash
-#
-# Copyright (c) .NET Foundation and contributors. All rights reserved.
-# Licensed under the MIT license. See LICENSE file in the project root for full license information.
-#
 
-set -e
-
-# Use in the the functions: eval $invocation
-invocation='echo "Calling: ${FUNCNAME[0]}"'
 __scriptpath=$(cd "$(dirname "$0")"; pwd -P)
-__toolsLocalPath=$__scriptpath/Tools
 
 # We do not want to run the first-time experience.
 export DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1
 
-$__scriptpath/init-tools.sh
+# Source the init-tools.sh script rather than execute in order to preserve ulimit values in child-processes. https://github.com/dotnet/corefx/issues/19152
+. $__scriptpath/init-tools.sh
 
-__dotnet=$__toolsLocalPath/dotnetcli/dotnet
+__toolRuntime=$__scriptpath/Tools
+__dotnet=$__toolRuntime/dotnetcli/dotnet
 
-$__dotnet $__toolsLocalPath/run.exe $*
+cd $__scriptpath
+$__dotnet $__toolRuntime/run.exe $__scriptpath/config.json $*
 exit $?


### PR DESCRIPTION
Updating run.sh from master to fix problem with source-build:
In particular we need to 'source' (i.e. '.') the init-tools script
so that it can correctly exit when tools are already initialized.
