### PR TITLE
Fixing Redhat 7 official builds by copying the tasks dependencies to …

### DIFF
--- a/dir.targets
+++ b/dir.targets
@@ -22,6 +22,7 @@
     </PropertyGroup>
 
       <ItemGroup>
+        <CustomTaskDependencies Include="$(BuildToolsTaskDir)Microsoft.DotNet.Build.CloudTestTasks.dll" />
         <CustomTaskDependencies Include="$(BuildToolsTaskDir)Newtonsoft.Json.dll" />
         <CustomTaskDependencies Include="$(BuildToolsTaskDir)Microsoft.DotNet.PlatformAbstractions.dll" />
         <CustomTaskDependencies Include="$(PackagesDir)microsoft.extensions.dependencymodel\1.1.1\lib\$(DependencyModelTFM)\Microsoft.Extensions.DependencyModel.dll" />

--- a/src/pkg/packaging/deb/package.targets
+++ b/src/pkg/packaging/deb/package.targets
@@ -103,12 +103,6 @@
       </SharedHostTokenValue>
     </ItemGroup>
 
-    <!-- Copying dependencies of ReplaceFileContents task to local folder -->
-    <ItemGroup>
-      <__ReplaceFileContentsDependencies Include="$(ToolsDir)/Microsoft.DotNet.Build.CloudTestTasks*" />
-    </ItemGroup>
-    <Copy SourceFiles="@(__ReplaceFileContentsDependencies)" DestinationFolder="$(LocalBuildToolsTaskDir)" />
-
     <ReplaceFileContents InputFile="$(ConfigJsonFile)"
                          DestinationFile="$(debLayoutDirectory)$(DebianConfigJsonName)"
                          ReplacementItems="@(SharedHostTokenValue)" />

--- a/src/pkg/packaging/deb/package.targets
+++ b/src/pkg/packaging/deb/package.targets
@@ -103,6 +103,12 @@
       </SharedHostTokenValue>
     </ItemGroup>
 
+    <!-- Copying dependencies of ReplaceFileContents task to local folder -->
+    <ItemGroup>
+      <__ReplaceFileContentsDependencies Include="$(ToolsDir)/Microsoft.DotNet.Build.CloudTestTasks*" />
+    </ItemGroup>
+    <Copy SourceFiles="@(__ReplaceFileContentsDependencies)" DestinationFolder="$(LocalBuildToolsTaskDir)" />
+
     <ReplaceFileContents InputFile="$(ConfigJsonFile)"
                          DestinationFile="$(debLayoutDirectory)$(DebianConfigJsonName)"
                          ReplacementItems="@(SharedHostTokenValue)" />


### PR DESCRIPTION
cc: @weshaggard @ericstj @eerhardt 

Fixing Redhat 7 bulids by copying the local tasks dependencies to the local dir. Now that MSBuild is no longer on the Tools directory, the Tools directory was not part of the probing path any longer for loading assemblies. That means that for this other tasks we now require to copy the right dependencies to the local tools dir.