### PR TITLE
[release/2.1] Configure auto-update from product builds

### DIFF
--- a/dependencies.props
+++ b/dependencies.props
@@ -60,7 +60,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <!--
     <RemoteDependencyBuildInfo Include="CoreFx">
       <BuildInfoPath>$(BaseDotNetBuildInfo)corefx/$(DependencyBranch)</BuildInfoPath>
       <CurrentRef>$(CoreFxCurrentRef)</CurrentRef>
@@ -73,6 +72,7 @@
       <BuildInfoPath>$(BaseDotNetBuildInfo)standard/release/2.0.0</BuildInfoPath>
       <CurrentRef>$(StandardCurrentRef)</CurrentRef>
     </RemoteDependencyBuildInfo>
+    <!--
     <RemoteDependencyBuildInfo Include="WCF">
       <BuildInfoPath>$(BaseDotNetBuildInfo)wcf/$(DependencyBranch)</BuildInfoPath>
       <CurrentRef>$(WCFCurrentRef)</CurrentRef>
@@ -87,7 +87,6 @@
       <RawVersionsBaseUrl>https://raw.githubusercontent.com/dotnet/versions</RawVersionsBaseUrl>
     </DependencyBuildInfo>
 
-    <!--
     <XmlUpdateStep Include="CoreFx">
       <Path>$(MSBuildThisFileFullPath)</Path>
       <ElementName>MicrosoftPrivateCoreFxNETCoreAppPackageVersion</ElementName>
@@ -113,6 +112,7 @@
       <ElementName>NETStandardLibraryPackageVersion</ElementName>
       <PackageId>NETStandard.Library</PackageId>
     </XmlUpdateStep>
+    <!--
     <XmlUpdateStep Include="WCF">
       <Path>$(MSBuildThisFileFullPath)</Path>
       <ElementName>SystemServiceModelDuplexPackageVersion</ElementName>

--- a/dependencies.props
+++ b/dependencies.props
@@ -9,18 +9,18 @@
        These ref versions are pulled from https://github.com/dotnet/versions.
   -->
   <PropertyGroup>
-    <CoreFxCurrentRef>f9f2dcffe189a681d43949ee3b02dd1fc9d9e636</CoreFxCurrentRef>
-    <CoreClrCurrentRef>f9f2dcffe189a681d43949ee3b02dd1fc9d9e636</CoreClrCurrentRef>
+    <CoreFxCurrentRef>d4af5af5ff2b80cbedd02bd1412b9faaeb0df7e6</CoreFxCurrentRef>
+    <CoreClrCurrentRef>d4af5af5ff2b80cbedd02bd1412b9faaeb0df7e6</CoreClrCurrentRef>
     <StandardCurrentRef>6298244e25cf84d91e3cda9627315f2425274624</StandardCurrentRef>
     <WCFCurrentRef>f9f2dcffe189a681d43949ee3b02dd1fc9d9e636</WCFCurrentRef>
     <BuildToolsCurrentRef>3198fbaed7e048fa6b096d9b8a9d83b731b41f8f</BuildToolsCurrentRef>
   </PropertyGroup>
 
   <PropertyGroup>
-    <MicrosoftNETCorePlatformsPackageVersion>2.1.0-preview1-26122-01</MicrosoftNETCorePlatformsPackageVersion>
-    <MicrosoftPrivateCoreFxNETCoreAppPackageVersion>4.5.0-preview1-26122-01</MicrosoftPrivateCoreFxNETCoreAppPackageVersion>
-    <MicrosoftPrivateCoreFxUAPPackageVersion>4.6.0-preview1-26122-01</MicrosoftPrivateCoreFxUAPPackageVersion>
-    <MicrosoftNETCoreRuntimeCoreCLRPackageVersion>2.1.0-preview1-26122-04</MicrosoftNETCoreRuntimeCoreCLRPackageVersion>
+    <MicrosoftNETCorePlatformsPackageVersion>2.1.0-preview1-26213-02</MicrosoftNETCorePlatformsPackageVersion>
+    <MicrosoftPrivateCoreFxNETCoreAppPackageVersion>4.5.0-preview1-26213-02</MicrosoftPrivateCoreFxNETCoreAppPackageVersion>
+    <MicrosoftPrivateCoreFxUAPPackageVersion>4.6.0-preview1-26213-02</MicrosoftPrivateCoreFxUAPPackageVersion>
+    <MicrosoftNETCoreRuntimeCoreCLRPackageVersion>2.1.0-preview1-26213-01</MicrosoftNETCoreRuntimeCoreCLRPackageVersion>
     <NETStandardLibraryPackageVersion>2.0.1</NETStandardLibraryPackageVersion>
     <MicrosoftNetNativeCompilerPackageVersion>2.0.0-preview-25429-00</MicrosoftNetNativeCompilerPackageVersion>
     <MicrosoftDiaSymReaderNativePackageVersion>1.4.1</MicrosoftDiaSymReaderNativePackageVersion>

--- a/dependencies.props
+++ b/dependencies.props
@@ -12,7 +12,6 @@
     <CoreFxCurrentRef>d4af5af5ff2b80cbedd02bd1412b9faaeb0df7e6</CoreFxCurrentRef>
     <CoreClrCurrentRef>d4af5af5ff2b80cbedd02bd1412b9faaeb0df7e6</CoreClrCurrentRef>
     <StandardCurrentRef>6298244e25cf84d91e3cda9627315f2425274624</StandardCurrentRef>
-    <WCFCurrentRef>f9f2dcffe189a681d43949ee3b02dd1fc9d9e636</WCFCurrentRef>
     <BuildToolsCurrentRef>3198fbaed7e048fa6b096d9b8a9d83b731b41f8f</BuildToolsCurrentRef>
   </PropertyGroup>
 
@@ -72,12 +71,6 @@
       <BuildInfoPath>$(BaseDotNetBuildInfo)standard/release/2.0.0</BuildInfoPath>
       <CurrentRef>$(StandardCurrentRef)</CurrentRef>
     </RemoteDependencyBuildInfo>
-    <!--
-    <RemoteDependencyBuildInfo Include="WCF">
-      <BuildInfoPath>$(BaseDotNetBuildInfo)wcf/$(DependencyBranch)</BuildInfoPath>
-      <CurrentRef>$(WCFCurrentRef)</CurrentRef>
-    </RemoteDependencyBuildInfo>
-    -->
     <RemoteDependencyBuildInfo Include="BuildTools">
       <BuildInfoPath>$(BaseDotNetBuildInfo)buildtools/$(DependencyBranch)</BuildInfoPath>
       <CurrentRef>$(BuildToolsCurrentRef)</CurrentRef>
@@ -112,13 +105,6 @@
       <ElementName>NETStandardLibraryPackageVersion</ElementName>
       <PackageId>NETStandard.Library</PackageId>
     </XmlUpdateStep>
-    <!--
-    <XmlUpdateStep Include="WCF">
-      <Path>$(MSBuildThisFileFullPath)</Path>
-      <ElementName>SystemServiceModelDuplexPackageVersion</ElementName>
-      <PackageId>System.ServiceModel.Duplex</PackageId>
-    </XmlUpdateStep>
-    -->
     <XmlUpdateStep Include="BuildTools">
        <Path>$(MSBuildThisFileFullPath)</Path>
        <ElementName>FeedTasksPackageVersion</ElementName>


### PR DESCRIPTION
I enabled standard release/2.0.0 here because it's also enabled in corefx: https://github.com/dotnet/corefx/pull/27180. Not sure if maybe disabling (for both repos?) might make more sense.