### PR TITLE
Compare assembly and file versions on minor roll forward

### DIFF
--- a/src/corehost/cli/args.h
+++ b/src/corehost/cli/args.h
@@ -16,6 +16,7 @@ struct probe_config_t
     bool patch_roll_fwd;
     bool prerelease_roll_fwd;
     const deps_json_t* probe_deps_json;
+    int fx_level;
 
     bool only_runtime_assets;
     bool only_serviceable_assets;
@@ -24,18 +25,20 @@ struct probe_config_t
 
     void print() const
     {
-        trace::verbose(_X("probe_config_t: probe=[%s]  deps-json=[%p] deps-dir-probe=[%d]"),
-            probe_dir.c_str(), probe_deps_json, probe_publish_dir);
+        trace::verbose(_X("probe_config_t: probe=[%s] deps-dir-probe=[%d]"),
+            probe_dir.c_str(), probe_publish_dir);
     }
 
     probe_config_t(
         const pal::string_t& probe_dir,
         const deps_json_t* probe_deps_json,
+        int fx_level,
         bool only_serviceable_assets,
         bool only_runtime_assets,
         bool probe_publish_dir)
         : probe_dir(probe_dir)
         , probe_deps_json(probe_deps_json)
+        , fx_level(fx_level)
         , only_serviceable_assets(only_serviceable_assets)
         , only_runtime_assets(only_runtime_assets)
         , probe_publish_dir(probe_publish_dir)
@@ -50,29 +53,39 @@ struct probe_config_t
             !probe_publish_dir;
     }
 
+    bool is_fx() const
+    {
+        return (probe_deps_json != nullptr);
+    }
+
+    bool is_app() const
+    {
+        return probe_publish_dir;
+    }
+
     static probe_config_t svc_ni(const pal::string_t& dir)
     {
-        return probe_config_t(dir, nullptr, true, true, false);
+        return probe_config_t(dir, nullptr, -1, true, true, false);
     }
 
     static probe_config_t svc(const pal::string_t& dir)
     {
-        return probe_config_t(dir, nullptr, true, false, false);
+        return probe_config_t(dir, nullptr, -1, true, false, false);
     }
 
-    static probe_config_t fx(const pal::string_t& dir, const deps_json_t* deps)
+    static probe_config_t fx(const pal::string_t& dir, const deps_json_t* deps, int fx_level)
     {
-        return probe_config_t(dir, deps, false, false, false);
+        return probe_config_t(dir, deps, fx_level, false, false, false);
     }
 
     static probe_config_t lookup(const pal::string_t& dir)
     {
-        return probe_config_t(dir, nullptr, false, false, false);
+        return probe_config_t(dir, nullptr, -1, false, false, false);
     }
 
     static probe_config_t published_deps_dir()
     {
-        return probe_config_t(_X(""), nullptr, false, false, true);
+        return probe_config_t(_X(""), nullptr, 0, false, false, true);
     }
 };
 

--- a/src/corehost/cli/deps_entry.cpp
+++ b/src/corehost/cli/deps_entry.cpp
@@ -21,7 +21,7 @@ bool deps_entry_t::to_path(const pal::string_t& base, bool look_in_base, pal::st
 
     // Entry relative path contains '/' separator, sanitize it to use
     // platform separator. Perf: avoid extra copy if it matters.
-    pal::string_t pal_relative_path = relative_path;
+    pal::string_t pal_relative_path = asset.relative_path;
     if (_X('/') != DIR_SEPARATOR)
     {
         replace_char(&pal_relative_path, _X('/'), DIR_SEPARATOR);
@@ -64,7 +64,7 @@ bool deps_entry_t::to_dir_path(const pal::string_t& base, pal::string_t* str) co
 {
     if (asset_type == asset_types::resources)
     {
-        pal::string_t pal_relative_path = relative_path;
+        pal::string_t pal_relative_path = asset.relative_path;
         if (_X('/') != DIR_SEPARATOR)
         {
             replace_char(&pal_relative_path, _X('/'), DIR_SEPARATOR);
@@ -83,7 +83,7 @@ bool deps_entry_t::to_dir_path(const pal::string_t& base, pal::string_t* str) co
         
         pal::string_t base_ietf_dir = base;
         append_path(&base_ietf_dir, ietf.c_str());
-        trace::verbose(_X("Detected a resource asset, will query dir/ietf-tag/resource base: %s asset: %s"), base_ietf_dir.c_str(), asset_name.c_str());
+        trace::verbose(_X("Detected a resource asset, will query dir/ietf-tag/resource base: %s asset: %s"), base_ietf_dir.c_str(), asset.name.c_str());
         return to_path(base_ietf_dir, true, str);
     }
     return to_path(base, true, str);

--- a/src/corehost/cli/deps_entry.h
+++ b/src/corehost/cli/deps_entry.h
@@ -8,6 +8,23 @@
 #include <array>
 #include <vector>
 #include "pal.h"
+#include "version.h"
+
+struct deps_asset_t
+{
+    deps_asset_t() : deps_asset_t(_X(""), version_t(), version_t()) { }
+
+    deps_asset_t(const pal::string_t& relative_path, const version_t& assembly_version, const version_t& file_version)
+        : relative_path(get_replaced_char(relative_path, _X('\\'), _X('/'))) // Deps file does not follow spec. It uses '\\', should use '/'
+        , assembly_version(assembly_version)
+        , file_version(file_version)
+        , name(get_filename_without_ext(relative_path)) { }
+
+    pal::string_t name;
+    pal::string_t relative_path;
+    version_t assembly_version;
+    version_t file_version;
+};
 
 struct deps_entry_t
 {
@@ -30,11 +47,9 @@ struct deps_entry_t
     pal::string_t library_hash_path;
     pal::string_t runtime_store_manifest_list;
     asset_types asset_type;
-    pal::string_t asset_name;
-    pal::string_t relative_path;
+    deps_asset_t asset;
     bool is_serviceable;
     bool is_rid_specific;
-
 
     // Given a "base" dir, yield the filepath within this directory or relative to this directory based on "look_in_base"
     bool to_path(const pal::string_t& base, bool look_in_base, pal::string_t* str) const;
@@ -47,7 +62,6 @@ struct deps_entry_t
 
     // Given a "base" dir, yield the relative path with package name, version in the package layout.
     bool to_full_path(const pal::string_t& root, pal::string_t* str) const;
-
 };
 
 #endif // __DEPS_ENTRY_H_

--- a/src/corehost/cli/deps_format.cpp
+++ b/src/corehost/cli/deps_format.cpp
@@ -29,16 +29,16 @@ pal::string_t deps_json_t::get_optional_property(
     const json_object& properties,
     const pal::string_t& key) const
 {
-    pal::string_t path;
+    pal::string_t value;
 
     const auto& iter = properties.find(key);
 
     if (iter != properties.end())
     {
-        path = iter->second.as_string();
+        value = iter->second.as_string();
     }
 
-    return path;
+    return value;
 }
 
 pal::string_t deps_json_t::get_optional_path(

--- a/src/corehost/cli/deps_format.cpp
+++ b/src/corehost/cli/deps_format.cpp
@@ -17,9 +17,9 @@ const std::array<const pal::char_t*, deps_entry_t::asset_types::count> deps_entr
 
 const deps_entry_t& deps_json_t::try_ni(const deps_entry_t& entry) const
 {
-    if (m_ni_entries.count(entry.asset_name))
+    if (m_ni_entries.count(entry.asset.name))
     {
-        int index = m_ni_entries.at(entry.asset_name);
+        int index = m_ni_entries.at(entry.asset.name);
         return m_deps_entries[deps_entry_t::asset_types::runtime][index];
     }
     return entry;
@@ -50,7 +50,7 @@ void deps_json_t::reconcile_libraries_with_targets(
     const pal::string_t& deps_path,
     const json_value& json,
     const std::function<bool(const pal::string_t&)>& library_exists_fn,
-    const std::function<const std::vector<pal::string_t>&(const pal::string_t&, int, bool*)>& get_rel_paths_by_asset_type_fn)
+    const std::function<const vec_asset_t&(const pal::string_t&, int, bool*)>& get_assets_fn)
 {
     pal::string_t deps_file = get_filename(deps_path);
 
@@ -77,10 +77,10 @@ void deps_json_t::reconcile_libraries_with_targets(
         for (int i = 0; i < deps_entry_t::s_known_asset_types.size(); ++i)
         {
             bool rid_specific = false;
-            for (const auto& rel_path : get_rel_paths_by_asset_type_fn(library.first, i, &rid_specific))
+            for (const auto& asset : get_assets_fn(library.first, i, &rid_specific))
             {
                 bool ni_dll = false;
-                auto asset_name = get_filename_without_ext(rel_path);
+                auto asset_name = get_filename_without_ext(asset.relative_path);
                 if (ends_with(asset_name, _X(".ni"), false))
                 {
                     ni_dll = true;
@@ -96,33 +96,30 @@ void deps_json_t::reconcile_libraries_with_targets(
                 entry.library_path = library_path;
                 entry.library_hash_path = library_hash_path;
                 entry.runtime_store_manifest_list = runtime_store_manifest_list;
-                entry.asset_name = asset_name;
                 entry.asset_type = (deps_entry_t::asset_types) i;
-                entry.relative_path = rel_path;
                 entry.is_serviceable = serviceable;
                 entry.is_rid_specific = rid_specific;
                 entry.deps_file = deps_file;
-
-                // TODO: Deps file does not follow spec. It uses '\\', should use '/'
-                replace_char(&entry.relative_path, _X('\\'), _X('/'));
+                entry.asset = asset;
 
                 m_deps_entries[i].push_back(entry);
 
                 if (ni_dll)
                 {
-                    m_ni_entries[entry.asset_name] = m_deps_entries
+                    m_ni_entries[entry.asset.name] = m_deps_entries
                         [deps_entry_t::asset_types::runtime].size() - 1;
                 }
 
-                trace::info(_X("Parsed %s deps entry %d for asset name: %s from %s: %s, version: %s, relpath: %s"),
+                trace::info(_X("Parsed %s deps entry %d for asset name: %s from %s: %s, library version: %s, relpath: %s, assemblyVersion %s, fileVersion %s"),
                     deps_entry_t::s_known_asset_types[i],
                     m_deps_entries[i].size() - 1,
-                    entry.asset_name.c_str(),
+                    entry.asset.name.c_str(),
                     entry.library_type.c_str(),
                     entry.library_name.c_str(),
                     entry.library_version.c_str(),
-                    entry.relative_path.c_str());
-                
+                    entry.asset.relative_path.c_str(),
+                    entry.asset.assembly_version.as_str().c_str(),
+                    entry.asset.file_version.as_str().c_str());
             }
         }
     }
@@ -209,6 +206,7 @@ bool deps_json_t::perform_rid_fallback(rid_specific_assets_t* portable_assets, c
 
 bool deps_json_t::process_runtime_targets(const json_value& json, const pal::string_t& target_name, const rid_fallback_graph_t& rid_fallback_graph, rid_specific_assets_t* p_assets)
 {
+    version_t empty;
     rid_specific_assets_t& assets = *p_assets;
     for (const auto& package : json.at(_X("targets")).at(target_name).as_object())
     {
@@ -228,7 +226,8 @@ bool deps_json_t::process_runtime_targets(const json_value& json, const pal::str
                 if (pal::strcasecmp(type.c_str(), deps_entry_t::s_known_asset_types[i]) == 0)
                 {
                     const auto& rid = file.second.at(_X("rid")).as_string();
-                    assets.libs[package.first].rid_assets[rid].by_type[i].vec.push_back(file.first);
+                    deps_asset_t asset(file.first, empty, empty);
+                    assets.libs[package.first].rid_assets[rid][i].push_back(asset);
                 }
             }
         }
@@ -255,8 +254,31 @@ bool deps_json_t::process_targets(const json_value& json, const pal::string_t& t
             {
                 for (const auto& file : iter->second.as_object())
                 {
-                    trace::info(_X("Adding %s asset %s from %s"), deps_entry_t::s_known_asset_types[i], file.first.c_str(), package.first.c_str());
-                    assets.libs[package.first].by_type[i].vec.push_back(file.first);
+                    const auto& properties = file.second.as_object();
+                    version_t assembly_version, file_version;
+
+                    pal::string_t assembly_version_str = get_optional_path(properties, _X("assemblyVersion"));
+                    if (assembly_version_str.length() > 0)
+                    {
+                        version_t::parse(assembly_version_str, &assembly_version);
+                    }
+
+                    pal::string_t file_version_str = get_optional_path(properties, _X("fileVersion"));
+                    if (file_version_str.length() > 0)
+                    {
+                        version_t::parse(file_version_str, &file_version);
+                    }
+
+                    deps_asset_t asset(file.first, assembly_version, file_version);
+
+                    trace::info(_X("Adding %s asset %s assemblyVersion=%s fileVersion=%s from %s"),
+                        deps_entry_t::s_known_asset_types[i],
+                        asset.relative_path.c_str(),
+                        asset.assembly_version.as_str().c_str(),
+                        asset.file_version.as_str().c_str(),
+                        package.first.c_str());
+
+                    assets.libs[package.first][i].push_back(asset);
                 }
             }
         }
@@ -280,15 +302,15 @@ bool deps_json_t::load_portable(const pal::string_t& deps_path, const json_value
         return m_rid_assets.libs.count(package) || m_assets.libs.count(package);
     };
 
-    const std::vector<pal::string_t> empty;
-    auto get_relpaths = [&](const pal::string_t& package, int type_index, bool* rid_specific) -> const std::vector<pal::string_t>& {
+    const vec_asset_t empty;
+    auto get_relpaths = [&](const pal::string_t& package, int type_index, bool* rid_specific) -> const vec_asset_t& {
 
         *rid_specific = false;
 
         // Is there any rid specific assets for this type ("native" or "runtime" or "resources")
         if (m_rid_assets.libs.count(package) && !m_rid_assets.libs[package].rid_assets.empty())
         {
-            const auto& assets_by_type = m_rid_assets.libs[package].rid_assets.begin()->second.by_type[type_index].vec;
+            const auto& assets_by_type = m_rid_assets.libs[package].rid_assets.begin()->second[type_index];
             if (!assets_by_type.empty())
             {
                 *rid_specific = true;
@@ -300,7 +322,7 @@ bool deps_json_t::load_portable(const pal::string_t& deps_path, const json_value
 
         if (m_assets.libs.count(package))
         {
-            return m_assets.libs[package].by_type[type_index].vec;
+            return m_assets.libs[package][type_index];
         }
 
         return empty;
@@ -322,9 +344,9 @@ bool deps_json_t::load_standalone(const pal::string_t& deps_path, const json_val
         return m_assets.libs.count(package);
     };
 
-    auto get_relpaths = [&](const pal::string_t& package, int type_index, bool* rid_specific) -> const std::vector<pal::string_t>& {
+    auto get_relpaths = [&](const pal::string_t& package, int type_index, bool* rid_specific) -> const vec_asset_t& {
         *rid_specific = false;
-        return m_assets.libs[package].by_type[type_index].vec;
+        return m_assets.libs[package][type_index];
     };
 
     reconcile_libraries_with_targets(deps_path, json, package_exists, get_relpaths);

--- a/src/corehost/cli/deps_format.h
+++ b/src/corehost/cli/deps_format.h
@@ -16,8 +16,8 @@ class deps_json_t
 {
     typedef web::json::value json_value;
     typedef web::json::object json_object;
-    struct vec_t { std::vector<pal::string_t> vec; };
-    struct assets_t { std::array<vec_t, deps_entry_t::asset_types::count> by_type; };
+    typedef std::vector<deps_asset_t> vec_asset_t;
+    typedef std::array<vec_asset_t, deps_entry_t::asset_types::count> assets_t;
     struct deps_assets_t { std::unordered_map<pal::string_t, assets_t> libs; };
     struct rid_assets_t { std::unordered_map<pal::string_t, assets_t> rid_assets; };
     struct rid_specific_assets_t { std::unordered_map<pal::string_t, rid_assets_t> libs; };
@@ -90,7 +90,7 @@ private:
         const pal::string_t& deps_path,
         const json_value& json,
         const std::function<bool(const pal::string_t&)>& library_exists_fn,
-        const std::function<const std::vector<pal::string_t>&(const pal::string_t&, int, bool*)>& get_rel_paths_by_asset_type_fn);
+        const std::function<const vec_asset_t&(const pal::string_t&, int, bool*)>& get_assets_fn);
 
     pal::string_t get_optional_path(const json_object& properties, const pal::string_t& key) const;
 
@@ -102,7 +102,7 @@ private:
     deps_assets_t m_assets;
     rid_specific_assets_t m_rid_assets;
 
-	std::unordered_map<pal::string_t, int> m_ni_entries;
+    std::unordered_map<pal::string_t, int> m_ni_entries;
     rid_fallback_graph_t m_rid_fallback_graph;
     bool m_file_exists;
     bool m_valid;

--- a/src/corehost/cli/deps_format.h
+++ b/src/corehost/cli/deps_format.h
@@ -92,6 +92,7 @@ private:
         const std::function<bool(const pal::string_t&)>& library_exists_fn,
         const std::function<const vec_asset_t&(const pal::string_t&, int, bool*)>& get_assets_fn);
 
+    pal::string_t get_optional_property(const json_object& properties, const pal::string_t& key) const;
     pal::string_t get_optional_path(const json_object& properties, const pal::string_t& key) const;
 
     pal::string_t get_current_rid(const rid_fallback_graph_t& rid_fallback_graph);

--- a/src/corehost/cli/deps_resolver.h
+++ b/src/corehost/cli/deps_resolver.h
@@ -24,6 +24,18 @@ struct probe_paths_t
     pal::string_t clrjit;
 };
 
+struct deps_resolved_asset_t
+{
+    deps_resolved_asset_t(const deps_asset_t& asset, const pal::string_t& resolved_path)
+        : asset(asset)
+        , resolved_path(resolved_path) { }
+
+    deps_asset_t asset;
+    pal::string_t resolved_path;
+};
+
+typedef std::unordered_map<pal::string_t, deps_resolved_asset_t> name_to_resolved_asset_map_t;
+
 class deps_resolver_t
 {
 public:
@@ -156,25 +168,22 @@ private:
     void get_dir_assemblies(
         const pal::string_t& dir,
         const pal::string_t& dir_name,
-        std::unordered_map<pal::string_t, pal::string_t>* dir_assemblies);
+        name_to_resolved_asset_map_t* items);
 
     // Probe entry in probe configurations and deps dir.
     bool probe_deps_entry(
         const deps_entry_t& entry,
         const pal::string_t& deps_dir,
+        int fx_level,
         pal::string_t* candidate);
 
     fx_definition_vector_t& m_fx_definitions;
 
     pal::string_t m_app_dir;
 
-    // Map of simple name -> full path of local/fx assemblies
-    typedef std::unordered_map<pal::string_t, pal::string_t> dir_assemblies_t;
-
     void add_tpa_asset(
-        const pal::string_t& asset_name,
-        const pal::string_t& asset_path,
-        dir_assemblies_t* items);
+        const deps_resolved_asset_t& asset,
+        name_to_resolved_asset_map_t* items);
 
     // The managed application the dependencies are being resolved for.
     pal::string_t m_managed_app;

--- a/src/corehost/cli/dll/CMakeLists.txt
+++ b/src/corehost/cli/dll/CMakeLists.txt
@@ -43,6 +43,7 @@ set(SOURCES
     ../deps_format.cpp
     ../deps_entry.cpp
     ../fx_definition.cpp
+    ../version.cpp
 )
 
 

--- a/src/corehost/cli/fx_definition.cpp
+++ b/src/corehost/cli/fx_definition.cpp
@@ -2,9 +2,10 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 #include "deps_format.h"
+#include "fx_definition.h"
+#include "fx_ver.h"
 #include "pal.h"
 #include "runtime_config.h"
-#include "fx_definition.h"
 
 fx_definition_t::fx_definition_t()
 {
@@ -39,4 +40,42 @@ void fx_definition_t::parse_deps()
 void fx_definition_t::parse_deps(const deps_json_t::rid_fallback_graph_t& graph)
 {
     m_deps.parse(true, m_deps_file, graph);
+}
+
+bool fx_definition_t::did_minor_or_major_roll_forward_occur() const
+{
+    fx_ver_t requested_ver(-1, -1, -1);
+    if (!fx_ver_t::parse(m_requested_version, &requested_ver, false))
+    {
+        assert(false);
+        return false;
+    }
+
+    fx_ver_t found_ver(-1, -1, -1);
+    if (!fx_ver_t::parse(m_found_version, &found_ver, false))
+    {
+        assert(false);
+        return false;
+    }
+
+    if (requested_ver >= found_ver)
+    {
+        assert(requested_ver == found_ver); // We shouldn't have a > case here
+        return false;
+    }
+
+    if (requested_ver.get_major() != found_ver.get_major())
+    {
+        assert(requested_ver.get_major() < found_ver.get_major());
+        return true;
+    }
+
+    if (requested_ver.get_minor() != found_ver.get_minor())
+    {
+        assert(requested_ver.get_minor() < found_ver.get_minor());
+        return true;
+    }
+
+    // Differs in patch version only
+    return false;
 }

--- a/src/corehost/cli/fx_definition.h
+++ b/src/corehost/cli/fx_definition.h
@@ -32,6 +32,8 @@ public:
     void parse_deps();
     void parse_deps(const deps_json_t::rid_fallback_graph_t& graph);
 
+    bool did_minor_or_major_roll_forward_occur() const;
+
 private:
     pal::string_t m_name;
     pal::string_t m_dir;

--- a/src/corehost/cli/fxr/CMakeLists.txt
+++ b/src/corehost/cli/fxr/CMakeLists.txt
@@ -37,6 +37,7 @@ set(SOURCES
     ../json/casablanca/src/json/json_serialization.cpp
     ../json/casablanca/src/utilities/asyncrt_utils.cpp
     ../fx_definition.cpp
+    ../version.cpp
     ./hostfxr.cpp
     ./fx_ver.cpp
     ./fx_muxer.cpp

--- a/src/corehost/cli/fxr/fx_ver.cpp
+++ b/src/corehost/cli/fxr/fx_ver.cpp
@@ -3,6 +3,7 @@
 
 #include <cassert>
 #include "pal.h"
+#include "utils.h"
 #include "fx_ver.h"
 
 fx_ver_t::fx_ver_t(int major, int minor, int patch, const pal::string_t& pre, const pal::string_t& build)
@@ -118,20 +119,6 @@ int fx_ver_t::compare(const fx_ver_t&a, const fx_ver_t& b)
     return a.m_build.compare(b.m_build);
 }
 
-bool try_stou(const pal::string_t& str, unsigned* num)
-{
-    if (str.empty())
-    {
-        return false;
-    }
-    if (str.find_first_not_of(_X("0123456789")) != pal::string_t::npos)
-    {
-        return false;
-    }
-    *num = (unsigned) std::stoul(str);
-    return true;
-}
-
 bool parse_internal(const pal::string_t& ver, fx_ver_t* fx_ver, bool parse_only_production)
 {
     size_t maj_start = 0;
@@ -161,7 +148,7 @@ bool parse_internal(const pal::string_t& ver, fx_ver_t* fx_ver, bool parse_only_
 
     unsigned patch = 0;
     size_t pat_start = min_sep + 1;
-    size_t pat_sep = ver.find_first_not_of(_X("0123456789"), pat_start);
+    size_t pat_sep = index_of_non_numeric(ver, pat_start);
     if (pat_sep == pal::string_t::npos)
     {
         if (!try_stou(ver.substr(pat_start), &patch))

--- a/src/corehost/cli/version.cpp
+++ b/src/corehost/cli/version.cpp
@@ -1,0 +1,163 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#include <cassert>
+#include "pal.h"
+#include "version.h"
+
+version_t::version_t() : version_t(-1, -1, -1, -1) { }
+
+version_t::version_t(int major, int minor, int build, int revision)
+    : m_major(major)
+    , m_minor(minor)
+    , m_build(build)
+    , m_revision(revision) { }
+
+bool version_t::operator ==(const version_t& b) const
+{
+    return compare(*this, b) == 0;
+}
+
+bool version_t::operator !=(const version_t& b) const
+{
+    return !operator ==(b);
+}
+
+bool version_t::operator <(const version_t& b) const
+{
+    return compare(*this, b) < 0;
+}
+
+bool version_t::operator >(const version_t& b) const
+{
+    return compare(*this, b) > 0;
+}
+
+bool version_t::operator <=(const version_t& b) const
+{
+    return compare(*this, b) <= 0;
+}
+
+bool version_t::operator >=(const version_t& b) const
+{
+    return compare(*this, b) >= 0;
+}
+
+pal::string_t version_t::as_str() const
+{
+    pal::stringstream_t stream;
+
+    if (m_major >= 0)
+    {
+        stream << m_major;
+
+        if (m_minor >= 0)
+        {
+            stream << _X(".") << m_minor;
+
+            if (m_build >= 0)
+            {
+                stream << _X(".") << m_build;
+
+                if (m_revision >= 0)
+                {
+                    stream << _X(".") << m_revision;
+                }
+            }
+        }
+    }
+
+    return stream.str();
+}
+
+/*static*/ int version_t::compare(const version_t&a, const version_t& b)
+{
+    if (a.m_major != b.m_major)
+    {
+        return (a.m_major > b.m_major) ? 1 : -1;
+    }
+
+    if (a.m_minor != b.m_minor)
+    {
+        return (a.m_minor > b.m_minor) ? 1 : -1;
+    }
+
+    if (a.m_build != b.m_build)
+    {
+        return (a.m_build > b.m_build) ? 1 : -1;
+    }
+
+    if (a.m_revision != b.m_revision)
+    {
+        return (a.m_revision > b.m_revision) ? 1 : -1;
+    }
+
+    return 0;
+}
+
+bool parse_internal(const pal::string_t& ver, version_t* ver_out)
+{
+    unsigned major = -1;
+    size_t maj_start = 0;
+    size_t maj_sep = ver.find(_X('.'));
+    if (maj_sep == pal::string_t::npos)
+    {
+        return false; // minor required
+    }
+    if (!try_stou(ver.substr(maj_start, maj_sep), &major))
+    {
+        return false;
+    }
+
+    unsigned minor = -1;
+    size_t min_start = maj_sep + 1;
+    size_t min_sep = ver.find(_X('.'), min_start);
+    if (min_sep == pal::string_t::npos)
+    {
+        if (!try_stou(ver.substr(min_start), &minor))
+        {
+            return false;
+        }
+        *ver_out = version_t(major, minor, -1, -1);
+        return true; // build and revision not required
+    }
+    if (!try_stou(ver.substr(min_start, min_sep - min_start), &minor))
+    {
+        return false;
+    }
+
+    unsigned build = -1;
+    size_t build_start = min_sep + 1;
+    size_t build_sep = ver.find(_X('.'), build_start);
+    if (build_sep == pal::string_t::npos)
+    {
+        if (!try_stou(ver.substr(build_start), &build))
+        {
+            return false;
+        }
+        *ver_out = version_t(major, minor, build, -1);
+        return true; // revision not required
+    }
+    if (!try_stou(ver.substr(build_start, build_sep - build_start), &build))
+    {
+        return false;
+    }
+
+    unsigned revision = -1;
+    size_t revision_start = build_sep + 1;
+    if (!try_stou(ver.substr(revision_start), &revision))
+    {
+        return false;
+    }
+    *ver_out = version_t(major, minor, build, revision);
+
+    return true;
+}
+
+/* static */
+bool version_t::parse(const pal::string_t& ver, version_t* ver_out)
+{
+    bool valid = parse_internal(ver, ver_out);
+    assert(!valid || ver_out->as_str() == ver);
+    return valid;
+}

--- a/src/corehost/cli/version.cpp
+++ b/src/corehost/cli/version.cpp
@@ -5,9 +5,10 @@
 #include "pal.h"
 #include "version.h"
 
-// This type is made to match semantics of System.Version used by tooling and differs from ver_t:
+// This type matches semantics of System.Version used by tooling and differs from fx_ver_t:
 // -- version_t does not require the third segment
 // -- version_t does not support the "pre" label behavior
+// -- if version_t is an empty value (-1 for all segments) then as_str() returns an empty string
 // -- Different terminology; fx_ver_t(major, minor, patch, build) vs version_t(major, minor, build, revision)
 
 version_t::version_t() : version_t(-1, -1, -1, -1) { }

--- a/src/corehost/cli/version.cpp
+++ b/src/corehost/cli/version.cpp
@@ -5,6 +5,11 @@
 #include "pal.h"
 #include "version.h"
 
+// This type is made to match semantics of System.Version used by tooling and differs from ver_t:
+// -- version_t does not require the third segment
+// -- version_t does not support the "pre" label behavior
+// -- Different terminology; fx_ver_t(major, minor, patch, build) vs version_t(major, minor, build, revision)
+
 version_t::version_t() : version_t(-1, -1, -1, -1) { }
 
 version_t::version_t(int major, int minor, int build, int revision)

--- a/src/corehost/cli/version.h
+++ b/src/corehost/cli/version.h
@@ -1,0 +1,45 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#ifndef __VERSION_H__
+#define __VERSION_H__
+
+#include "pal.h"
+#include "utils.h"
+
+struct version_t
+{
+    version_t();
+    version_t(int major, int minor, int build, int revision);
+
+    int get_major() const { return m_major; }
+    int get_minor() const { return m_minor; }
+    int get_build() const { return m_build; }
+    int get_revision() const { return m_revision; }
+
+    void set_major(int m) { m_major = m; }
+    void set_minor(int m) { m_minor = m; }
+    void set_build(int m) { m_build = m; }
+    void set_revision(int m) { m_revision = m; }
+
+    pal::string_t as_str() const;
+
+    bool operator ==(const version_t& b) const;
+    bool operator !=(const version_t& b) const;
+    bool operator <(const version_t& b) const;
+    bool operator >(const version_t& b) const;
+    bool operator <=(const version_t& b) const;
+    bool operator >=(const version_t& b) const;
+
+    static bool parse(const pal::string_t& ver, version_t* ver_out);
+
+private:
+    int m_major;
+    int m_minor;
+    int m_build;
+    int m_revision;
+
+    static int compare(const version_t&a, const version_t& b);
+};
+
+#endif // __VERSION_H__

--- a/src/corehost/common/utils.cpp
+++ b/src/corehost/common/utils.cpp
@@ -167,6 +167,23 @@ void replace_char(pal::string_t* path, pal::char_t match, pal::char_t repl)
     }
 }
 
+pal::string_t get_replaced_char(const pal::string_t& path, pal::char_t match, pal::char_t repl)
+{
+    int pos = path.find(match);
+    if (pos == pal::string_t::npos)
+    {
+        return path;
+    }
+
+    pal::string_t out = path;
+    do
+    {
+        out[pos] = repl;
+    } while ((pos = out.find(match, pos)) != pal::string_t::npos);
+
+    return out;
+}
+
 const pal::char_t* get_arch()
 {
 #if _TARGET_AMD64_
@@ -333,4 +350,23 @@ bool get_path_from_argv(pal::string_t *path)
     }
 
     return false;
+}
+
+size_t index_of_non_numeric(const pal::string_t& str, unsigned i)
+{
+    return str.find_first_not_of(_X("0123456789"), i);
+}
+
+bool try_stou(const pal::string_t& str, unsigned* num)
+{
+    if (str.empty())
+    {
+        return false;
+    }
+    if (index_of_non_numeric(str, 0) != pal::string_t::npos)
+    {
+        return false;
+    }
+    *num = (unsigned)std::stoul(str);
+    return true;
 }

--- a/src/corehost/common/utils.h
+++ b/src/corehost/common/utils.h
@@ -32,6 +32,7 @@ bool library_exists_in_dir(const pal::string_t& lib_dir, const pal::string_t& li
 bool coreclr_exists_in_dir(const pal::string_t& candidate);
 void remove_trailing_dir_seperator(pal::string_t* dir);
 void replace_char(pal::string_t* path, pal::char_t match, pal::char_t repl);
+pal::string_t get_replaced_char(const pal::string_t& path, pal::char_t match, pal::char_t repl);
 const pal::char_t* get_arch();
 pal::string_t get_last_known_arg(
     const opt_map_t& opts,
@@ -48,4 +49,6 @@ bool get_env_shared_store_dirs(std::vector<pal::string_t>* dirs, const pal::stri
 bool get_global_shared_store_dirs(std::vector<pal::string_t>* dirs, const pal::string_t& arch, const pal::string_t& tfm);
 bool multilevel_lookup_enabled();
 bool get_path_from_argv(pal::string_t *path);
+size_t index_of_non_numeric(const pal::string_t& str, unsigned i);
+bool try_stou(const pal::string_t& str, unsigned* num);
 #endif

--- a/src/managed/Microsoft.Extensions.DependencyModel/CollectionExtensions.cs
+++ b/src/managed/Microsoft.Extensions.DependencyModel/CollectionExtensions.cs
@@ -37,7 +37,7 @@ namespace System.Collections.Generic
                 .SelectMany(a => a.AssetPaths);
         }
 
-        public static IEnumerable<RuntimeFile> GetDefaultRuntimeFiles(this IEnumerable<RuntimeAssetGroup> self) => GetRuntimeFiles(self, string.Empty);
+        public static IEnumerable<RuntimeFile> GetDefaultRuntimeFileAssets(this IEnumerable<RuntimeAssetGroup> self) => GetRuntimeFiles(self, string.Empty);
         public static IEnumerable<RuntimeFile> GetRuntimeFileAssets(this IEnumerable<RuntimeAssetGroup> self, string runtime)
         {
             if (string.IsNullOrEmpty(runtime))

--- a/src/managed/Microsoft.Extensions.DependencyModel/CollectionExtensions.cs
+++ b/src/managed/Microsoft.Extensions.DependencyModel/CollectionExtensions.cs
@@ -36,5 +36,22 @@ namespace System.Collections.Generic
                 .Where(a => string.Equals(a.Runtime, runtime, StringComparison.Ordinal))
                 .SelectMany(a => a.AssetPaths);
         }
+
+        public static IEnumerable<RuntimeFile> GetDefaultRuntimeFiles(this IEnumerable<RuntimeAssetGroup> self) => GetRuntimeFiles(self, string.Empty);
+        public static IEnumerable<RuntimeFile> GetRuntimeFileAssets(this IEnumerable<RuntimeAssetGroup> self, string runtime)
+        {
+            if (string.IsNullOrEmpty(runtime))
+            {
+                throw new ArgumentNullException(nameof(runtime));
+            }
+            return GetRuntimeFiles(self, runtime);
+        }
+
+        private static IEnumerable<RuntimeFile> GetRuntimeFiles(IEnumerable<RuntimeAssetGroup> groups, string runtime)
+        {
+            return groups
+                .Where(a => string.Equals(a.Runtime, runtime, StringComparison.Ordinal))
+                .SelectMany(a => a.RuntimeFiles);
+        }
     }
 }

--- a/src/managed/Microsoft.Extensions.DependencyModel/DependencyContextExtensions.cs
+++ b/src/managed/Microsoft.Extensions.DependencyModel/DependencyContextExtensions.cs
@@ -19,13 +19,13 @@ namespace Microsoft.Extensions.DependencyModel
             return self.RuntimeLibraries.SelectMany(library => library.GetDefaultNativeAssets(self));
         }
 
-        public static IEnumerable<RuntimeFile> GetDefaultNativeRuntimeFiles(this DependencyContext self)
+        public static IEnumerable<RuntimeFile> GetDefaultNativeRuntimeFileAssets(this DependencyContext self)
         {
             if (self == null)
             {
                 throw new ArgumentNullException(nameof(self));
             }
-            return self.RuntimeLibraries.SelectMany(library => library.GetDefaultNativeRuntimeFiles(self));
+            return self.RuntimeLibraries.SelectMany(library => library.GetDefaultNativeRuntimeFileAssets(self));
         }
 
         public static IEnumerable<string> GetRuntimeNativeAssets(this DependencyContext self, string runtimeIdentifier)
@@ -41,7 +41,7 @@ namespace Microsoft.Extensions.DependencyModel
             return self.RuntimeLibraries.SelectMany(library => library.GetRuntimeNativeAssets(self, runtimeIdentifier));
         }
 
-        public static IEnumerable<RuntimeFile> GetRuntimeNativeRuntimeFiles(this DependencyContext self, string runtimeIdentifier)
+        public static IEnumerable<RuntimeFile> GetRuntimeNativeRuntimeFileAssets(this DependencyContext self, string runtimeIdentifier)
         {
             if (self == null)
             {
@@ -51,7 +51,7 @@ namespace Microsoft.Extensions.DependencyModel
             {
                 throw new ArgumentNullException(nameof(runtimeIdentifier));
             }
-            return self.RuntimeLibraries.SelectMany(library => library.GetRuntimeNativeRuntimeFiles(self, runtimeIdentifier));
+            return self.RuntimeLibraries.SelectMany(library => library.GetRuntimeNativeRuntimeFileAssets(self, runtimeIdentifier));
         }
 
         public static IEnumerable<string> GetDefaultNativeAssets(this RuntimeLibrary self, DependencyContext context)
@@ -63,7 +63,7 @@ namespace Microsoft.Extensions.DependencyModel
             return ResolveAssets(context, string.Empty, self.NativeLibraryGroups);
         }
 
-        public static IEnumerable<RuntimeFile> GetDefaultNativeRuntimeFiles(this RuntimeLibrary self, DependencyContext context)
+        public static IEnumerable<RuntimeFile> GetDefaultNativeRuntimeFileAssets(this RuntimeLibrary self, DependencyContext context)
         {
             if (self == null)
             {
@@ -89,7 +89,7 @@ namespace Microsoft.Extensions.DependencyModel
             return ResolveAssets(context, runtimeIdentifier, self.NativeLibraryGroups);
         }
 
-        public static IEnumerable<RuntimeFile> GetRuntimeNativeRuntimeFiles(this RuntimeLibrary self, DependencyContext context, string runtimeIdentifier)
+        public static IEnumerable<RuntimeFile> GetRuntimeNativeRuntimeFileAssets(this RuntimeLibrary self, DependencyContext context, string runtimeIdentifier)
         {
             if (self == null)
             {
@@ -221,7 +221,7 @@ namespace Microsoft.Extensions.DependencyModel
             }
 
             // Return the RID-agnostic group
-            return groups.GetDefaultRuntimeFiles();
+            return groups.GetDefaultRuntimeFileAssets();
         }
     }
 }

--- a/src/managed/Microsoft.Extensions.DependencyModel/DependencyContextExtensions.cs
+++ b/src/managed/Microsoft.Extensions.DependencyModel/DependencyContextExtensions.cs
@@ -19,6 +19,15 @@ namespace Microsoft.Extensions.DependencyModel
             return self.RuntimeLibraries.SelectMany(library => library.GetDefaultNativeAssets(self));
         }
 
+        public static IEnumerable<RuntimeFile> GetDefaultNativeRuntimeFiles(this DependencyContext self)
+        {
+            if (self == null)
+            {
+                throw new ArgumentNullException(nameof(self));
+            }
+            return self.RuntimeLibraries.SelectMany(library => library.GetDefaultNativeRuntimeFiles(self));
+        }
+
         public static IEnumerable<string> GetRuntimeNativeAssets(this DependencyContext self, string runtimeIdentifier)
         {
             if (self == null)
@@ -32,6 +41,19 @@ namespace Microsoft.Extensions.DependencyModel
             return self.RuntimeLibraries.SelectMany(library => library.GetRuntimeNativeAssets(self, runtimeIdentifier));
         }
 
+        public static IEnumerable<RuntimeFile> GetRuntimeNativeRuntimeFiles(this DependencyContext self, string runtimeIdentifier)
+        {
+            if (self == null)
+            {
+                throw new ArgumentNullException(nameof(self));
+            }
+            if (runtimeIdentifier == null)
+            {
+                throw new ArgumentNullException(nameof(runtimeIdentifier));
+            }
+            return self.RuntimeLibraries.SelectMany(library => library.GetRuntimeNativeRuntimeFiles(self, runtimeIdentifier));
+        }
+
         public static IEnumerable<string> GetDefaultNativeAssets(this RuntimeLibrary self, DependencyContext context)
         {
             if (self == null)
@@ -39,6 +61,15 @@ namespace Microsoft.Extensions.DependencyModel
                 throw new ArgumentNullException(nameof(self));
             }
             return ResolveAssets(context, string.Empty, self.NativeLibraryGroups);
+        }
+
+        public static IEnumerable<RuntimeFile> GetDefaultNativeRuntimeFiles(this RuntimeLibrary self, DependencyContext context)
+        {
+            if (self == null)
+            {
+                throw new ArgumentNullException(nameof(self));
+            }
+            return ResolveRuntimeFiles(context, string.Empty, self.NativeLibraryGroups);
         }
 
         public static IEnumerable<string> GetRuntimeNativeAssets(this RuntimeLibrary self, DependencyContext context, string runtimeIdentifier)
@@ -56,6 +87,23 @@ namespace Microsoft.Extensions.DependencyModel
                 throw new ArgumentNullException(nameof(runtimeIdentifier));
             }
             return ResolveAssets(context, runtimeIdentifier, self.NativeLibraryGroups);
+        }
+
+        public static IEnumerable<RuntimeFile> GetRuntimeNativeRuntimeFiles(this RuntimeLibrary self, DependencyContext context, string runtimeIdentifier)
+        {
+            if (self == null)
+            {
+                throw new ArgumentNullException(nameof(self));
+            }
+            if (context == null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+            if (runtimeIdentifier == null)
+            {
+                throw new ArgumentNullException(nameof(runtimeIdentifier));
+            }
+            return ResolveRuntimeFiles(context, runtimeIdentifier, self.NativeLibraryGroups);
         }
 
         public static IEnumerable<AssemblyName> GetDefaultAssemblyNames(this DependencyContext self)
@@ -136,6 +184,16 @@ namespace Microsoft.Extensions.DependencyModel
             return SelectAssets(rids, assets);
         }
 
+        private static IEnumerable<RuntimeFile> ResolveRuntimeFiles(
+            DependencyContext context,
+            string runtimeIdentifier,
+            IEnumerable<RuntimeAssetGroup> assets)
+        {
+            var fallbacks = context.RuntimeGraph.FirstOrDefault(f => f.Runtime == runtimeIdentifier);
+            var rids = Enumerable.Concat(new[] { runtimeIdentifier }, fallbacks?.Fallbacks ?? Enumerable.Empty<string>());
+            return SelectRuntimeFiles(rids, assets);
+        }
+
         private static IEnumerable<string> SelectAssets(IEnumerable<string> rids, IEnumerable<RuntimeAssetGroup> groups)
         {
             foreach (var rid in rids)
@@ -151,5 +209,19 @@ namespace Microsoft.Extensions.DependencyModel
             return groups.GetDefaultAssets();
         }
 
+        private static IEnumerable<RuntimeFile> SelectRuntimeFiles(IEnumerable<string> rids, IEnumerable<RuntimeAssetGroup> groups)
+        {
+            foreach (var rid in rids)
+            {
+                var group = groups.FirstOrDefault(g => g.Runtime == rid);
+                if (group != null)
+                {
+                    return group.RuntimeFiles;
+                }
+            }
+
+            // Return the RID-agnostic group
+            return groups.GetDefaultRuntimeFiles();
+        }
     }
 }

--- a/src/managed/Microsoft.Extensions.DependencyModel/DependencyContextJsonReader.cs
+++ b/src/managed/Microsoft.Extensions.DependencyModel/DependencyContextJsonReader.cs
@@ -415,16 +415,16 @@ namespace Microsoft.Extensions.DependencyModel
 
                 string propertyName;
                 string propertyValue;
-
                 while (reader.TryReadStringProperty(out propertyName, out propertyValue))
                 {
-                    if (propertyName == DependencyContextStrings.AssemblyVersionPropertyName)
+                    switch (propertyName)
                     {
-                        assemblyVersion = propertyValue;
-                    }
-                    else if (propertyName == DependencyContextStrings.FileVersionPropertyName)
-                    {
-                        fileVersion = propertyValue;
+                        case DependencyContextStrings.AssemblyVersionPropertyName:
+                            assemblyVersion = propertyValue;
+                            break;
+                        case DependencyContextStrings.FileVersionPropertyName:
+                            fileVersion = propertyValue;
+                            break;
                     }
                 }
 
@@ -462,6 +462,12 @@ namespace Microsoft.Extensions.DependencyModel
                             break;
                         case DependencyContextStrings.AssetTypePropertyName:
                             runtimeTarget.Type = Pool(propertyValue);
+                            break;
+                        case DependencyContextStrings.AssemblyVersionPropertyName:
+                            runtimeTarget.AssemblyVersion = propertyValue;
+                            break;
+                        case DependencyContextStrings.FileVersionPropertyName:
+                            runtimeTarget.FileVersion = propertyValue;
                             break;
                     }
                 }
@@ -645,26 +651,26 @@ namespace Microsoft.Extensions.DependencyModel
                     {
                         var groupRuntimeAssemblies = ridGroup
                             .Where(e => e.Type == DependencyContextStrings.RuntimeAssetType)
-                            .Select(e => e.Path)
+                            .Select(e => new RuntimeFile(e.Path, e.AssemblyVersion, e.FileVersion))
                             .ToArray();
 
                         if (groupRuntimeAssemblies.Any())
                         {
                             runtimeAssemblyGroups.Add(new RuntimeAssetGroup(
                                 ridGroup.Key,
-                                groupRuntimeAssemblies.Where(a => Path.GetFileName(a) != "_._")));
+                                groupRuntimeAssemblies.Where(a => Path.GetFileName(a.Path) != "_._")));
                         }
 
                         var groupNativeLibraries = ridGroup
                             .Where(e => e.Type == DependencyContextStrings.NativeAssetType)
-                            .Select(e => e.Path)
+                            .Select(e => new RuntimeFile(e.Path, e.AssemblyVersion, e.FileVersion))
                             .ToArray();
 
                         if (groupNativeLibraries.Any())
                         {
                             nativeLibraryGroups.Add(new RuntimeAssetGroup(
                                 ridGroup.Key,
-                                groupNativeLibraries.Where(a => Path.GetFileName(a) != "_._")));
+                                groupNativeLibraries.Where(a => Path.GetFileName(a.Path) != "_._")));
                         }
                     }
                 }
@@ -758,6 +764,10 @@ namespace Microsoft.Extensions.DependencyModel
             public string Path;
 
             public string Rid;
+
+            public string AssemblyVersion;
+
+            public string FileVersion;
         }
 
         private struct LibraryStub

--- a/src/managed/Microsoft.Extensions.DependencyModel/DependencyContextStrings.cs
+++ b/src/managed/Microsoft.Extensions.DependencyModel/DependencyContextStrings.cs
@@ -82,5 +82,9 @@ namespace Microsoft.Extensions.DependencyModel
         internal const string LocalePropertyName = "locale";
 
         internal const string CompilationOnlyPropertyName = "compileOnly";
+
+        internal const string AssemblyVersionPropertyName = "assemblyVersion";
+
+        internal const string FileVersionPropertyName = "fileVersion";
     }
 }

--- a/src/managed/Microsoft.Extensions.DependencyModel/DependencyContextWriter.cs
+++ b/src/managed/Microsoft.Extensions.DependencyModel/DependencyContextWriter.cs
@@ -298,12 +298,22 @@ namespace Microsoft.Extensions.DependencyModel
         {
             foreach (var asset in assets)
             {
-                target.Add(new JProperty(NormalizePath(asset.Path),
-                    new JObject(
+                var asset_props = new JObject(
                         new JProperty(DependencyContextStrings.RidPropertyName, runtime),
                         new JProperty(DependencyContextStrings.AssetTypePropertyName, assetType)
-                        )
-                    ));
+                        );
+
+                if (asset.AssemblyVersion != null)
+                {
+                    asset_props.Add(DependencyContextStrings.AssemblyVersionPropertyName, asset.AssemblyVersion);
+                }
+
+                if (asset.FileVersion != null)
+                {
+                    asset_props.Add(DependencyContextStrings.FileVersionPropertyName, asset.FileVersion);
+                }
+
+                target.Add(new JProperty(NormalizePath(asset.Path), asset_props));
             }
         }
 

--- a/src/managed/Microsoft.Extensions.DependencyModel/RuntimeAssetGroup.cs
+++ b/src/managed/Microsoft.Extensions.DependencyModel/RuntimeAssetGroup.cs
@@ -8,12 +8,21 @@ namespace Microsoft.Extensions.DependencyModel
 {
     public class RuntimeAssetGroup
     {
+        private IReadOnlyList<string> _assetPaths;
+        private IReadOnlyList<RuntimeFile> _runtimeFiles;
+
         public RuntimeAssetGroup(string runtime, params string[] assetPaths) : this(runtime, (IEnumerable<string>)assetPaths) { }
 
         public RuntimeAssetGroup(string runtime, IEnumerable<string> assetPaths)
         {
             Runtime = runtime;
-            AssetPaths = assetPaths.ToArray();
+            _assetPaths = assetPaths.ToArray();
+        }
+
+        public RuntimeAssetGroup(string runtime, IEnumerable<RuntimeFile> runtimeFiles)
+        {
+            Runtime = runtime;
+            _runtimeFiles = runtimeFiles.ToArray();
         }
 
         /// <summary>
@@ -22,8 +31,35 @@ namespace Microsoft.Extensions.DependencyModel
         public string Runtime { get; }
 
         /// <summary>
-        /// Gets a list of assets provided in this runtime group
+        /// Gets a list of asset paths provided in this runtime group
         /// </summary>
-        public IReadOnlyList<string> AssetPaths { get; }
+        public IReadOnlyList<string> AssetPaths
+        {
+            get
+            {
+                if (_assetPaths != null)
+                {
+                    return _assetPaths;
+                }
+
+                return _runtimeFiles.Select(file => file.Path).ToArray();
+            }
+        }
+
+        /// <summary>
+        /// Gets a list of RuntimeFiles provided in this runtime group
+        /// </summary>
+        public IReadOnlyList<RuntimeFile> RuntimeFiles
+        {
+            get
+            {
+                if (_runtimeFiles != null)
+                {
+                    return _runtimeFiles;
+                }
+
+                return _assetPaths.Select(path => new RuntimeFile(path, null, null)).ToArray();
+            }
+        }
     }
 }

--- a/src/managed/Microsoft.Extensions.DependencyModel/RuntimeFile.cs
+++ b/src/managed/Microsoft.Extensions.DependencyModel/RuntimeFile.cs
@@ -1,0 +1,28 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+
+namespace Microsoft.Extensions.DependencyModel
+{
+    public class RuntimeFile
+    {
+        public RuntimeFile(string path, string assemblyVersion, string fileVersion)
+        {
+            if (string.IsNullOrEmpty(path))
+            {
+                throw new ArgumentException(nameof(path));
+            }
+
+            Path = path;
+            AssemblyVersion = assemblyVersion;
+            FileVersion = fileVersion;
+        }
+
+        public string Path { get; }
+
+        public string AssemblyVersion { get; }
+
+        public string FileVersion { get; }
+    }
+}

--- a/src/test/Microsoft.Extensions.DependencyModel.Tests/DependencyContextJsonWriterTests.cs
+++ b/src/test/Microsoft.Extensions.DependencyModel.Tests/DependencyContextJsonWriterTests.cs
@@ -192,6 +192,23 @@ namespace Microsoft.Extensions.DependencyModel.Tests
         [Fact]
         public void WritesRuntimeLibrariesToRuntimeTarget()
         {
+            var group = new RuntimeAssetGroup("win7-x64", "Banana.Win7-x64.dll");
+            WritesRuntimeLibrariesToRuntimeTarget(group);
+        }
+
+        [Fact]
+        public void WritesRuntimeLibrariesToRuntimeTargetWithAssemblyVersions()
+        {
+            RuntimeFile[] runtimeFile = { new RuntimeFile("Banana.Win7-x64.dll", "1.2.3", "7.8.9") };
+            var group = new RuntimeAssetGroup("win7-x64", runtimeFile);
+
+            var runtimeAssembly = WritesRuntimeLibrariesToRuntimeTarget(group);
+            runtimeAssembly.Should().HavePropertyValue("assemblyVersion", "1.2.3");
+            runtimeAssembly.Should().HavePropertyValue("fileVersion", "7.8.9");
+        }
+
+        private JObject WritesRuntimeLibrariesToRuntimeTarget(RuntimeAssetGroup group)
+        {
             var result = Save(Create(
                             "Target",
                             "runtime",
@@ -205,7 +222,7 @@ namespace Microsoft.Extensions.DependencyModel.Tests
                                         "HASH",
                                         new [] {
                                             new RuntimeAssetGroup(string.Empty, "Banana.dll"),
-                                            new RuntimeAssetGroup("win7-x64", "Banana.Win7-x64.dll")
+                                            group
                                         },
                                         new [] {
                                             new RuntimeAssetGroup(string.Empty, "runtimes\\linux\\native\\native.so"),
@@ -257,6 +274,8 @@ namespace Microsoft.Extensions.DependencyModel.Tests
             library.Should().HavePropertyValue("path", "PackagePath");
             library.Should().HavePropertyValue("hashPath", "PackageHashPath");
             library.Should().HavePropertyValue("runtimeStoreManifestName", "placeHolderManifest.xml");
+
+            return runtimeAssembly;
         }
 
         [Fact]

--- a/src/test/Microsoft.Extensions.DependencyModel.Tests/DependencyContextJsonWriterTests.cs
+++ b/src/test/Microsoft.Extensions.DependencyModel.Tests/DependencyContextJsonWriterTests.cs
@@ -345,7 +345,29 @@ namespace Microsoft.Extensions.DependencyModel.Tests
         }
 
         [Fact]
+        public void WritesRuntimeTargetForNonPortableLegacy()
+        {
+            var group = new RuntimeAssetGroup(string.Empty, "Banana.dll");
+            var assetGroup = WritesRuntimeTarget(group);
+
+            var files = assetGroup.Should().HavePropertyAsObject("runtime").Subject;
+            files.Should().HaveProperty("Banana.dll");
+        }
+
+        [Fact]
         public void WritesRuntimeTargetForNonPortable()
+        {
+            RuntimeFile[] runtimeFiles = { new RuntimeFile("Banana.dll", "1.2.3", "7.8.9") };
+            var group = new RuntimeAssetGroup(string.Empty, runtimeFiles);
+            var assetGroup = WritesRuntimeTarget(group);
+
+            var files = assetGroup.Should().HavePropertyAsObject("runtime").Subject;
+            var file = files.Should().HavePropertyAsObject("Banana.dll").Subject;
+            file.Should().HavePropertyValue("assemblyVersion", "1.2.3");
+            file.Should().HavePropertyValue("fileVersion", "7.8.9");
+        }
+
+        private JObject WritesRuntimeTarget(RuntimeAssetGroup group)
         {
             var result = Save(Create(
                             "Target",
@@ -359,7 +381,7 @@ namespace Microsoft.Extensions.DependencyModel.Tests
                                         "1.2.3",
                                         "HASH",
                                         new [] {
-                                            new RuntimeAssetGroup(string.Empty, "Banana.dll")
+                                            group
                                         },
                                         new [] {
                                             new RuntimeAssetGroup(string.Empty, "runtimes\\osx\\native\\native.dylib")
@@ -377,22 +399,22 @@ namespace Microsoft.Extensions.DependencyModel.Tests
             // targets
             var targets = result.Should().HavePropertyAsObject("targets").Subject;
             var target = targets.Should().HavePropertyAsObject("Target/runtime").Subject;
-            var library = target.Should().HavePropertyAsObject("PackageName/1.2.3").Subject;
-            var dependencies = library.Should().HavePropertyAsObject("dependencies").Subject;
+            var assetGroup = target.Should().HavePropertyAsObject("PackageName/1.2.3").Subject;
+            var dependencies = assetGroup.Should().HavePropertyAsObject("dependencies").Subject;
             dependencies.Should().HavePropertyValue("Fruits.Abstract.dll", "2.0.0");
-            library.Should().HavePropertyAsObject("runtime")
-                .Subject.Should().HaveProperty("Banana.dll");
-            library.Should().HavePropertyAsObject("native")
+            assetGroup.Should().HavePropertyAsObject("native")
                 .Subject.Should().HaveProperty("runtimes/osx/native/native.dylib");
 
             //libraries
             var libraries = result.Should().HavePropertyAsObject("libraries").Subject;
-            library = libraries.Should().HavePropertyAsObject("PackageName/1.2.3").Subject;
+            var library = libraries.Should().HavePropertyAsObject("PackageName/1.2.3").Subject;
             library.Should().HavePropertyValue("sha512", "HASH");
             library.Should().HavePropertyValue("type", "package");
             library.Should().HavePropertyValue("serviceable", true);
             library.Should().HavePropertyValue("path", "PackagePath");
             library.Should().HavePropertyValue("hashPath", "PackageHashPath");
+
+            return assetGroup;
         }
 
         [Fact]

--- a/src/test/Microsoft.Extensions.DependencyModel.Tests/JsonAssetions.cs
+++ b/src/test/Microsoft.Extensions.DependencyModel.Tests/JsonAssetions.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Extensions.DependencyModel.Tests
             var token = Subject[expected];
             Execute.Assertion
                 .ForCondition(token != null)
-                .FailWith($"Expected {Subject} to have property '" + expected + "'");
+                .FailWith("Expected {0} to have property '{1}'", Subject, expected);
 
             return new AndWhichConstraint<JsonAssetions, JToken>(this, token);
         }
@@ -41,7 +41,7 @@ namespace Microsoft.Extensions.DependencyModel.Tests
             var token = Subject[expected];
             Execute.Assertion
                 .ForCondition(token == null)
-                .FailWith($"Expected {Subject} not to have property '" + expected + "'");
+                .FailWith("Expected {0} to have property '{1}'", Subject, expected);
 
             return new AndConstraint<JsonAssetions>(this);
         }


### PR DESCRIPTION
This makes DependencyModel changes so that assemblyVersion and fileVersion can be written to the deps.json file for each runtime asset and adds conflict resolution to hostpolicy.dll that uses that metadata during roll-forward cases.

Fixes https://github.com/dotnet/core-setup/issues/3546

The actual metadata is not added to the .deps.json files yet. That will be done once this PR is in and https://github.com/dotnet/sdk/issues/1847 is resolved.

Changes to conflict resolution are documented at https://github.com/dotnet/core-setup/blob/master/Documentation/design-docs/assembly-conflict-resolution.md.

One conflict test has been commented out until the SDK changes are made (the functionality was verified manually) . Additional tests may be added at that time as well.