### PR TITLE
Remove cli-deps feed and publishing of deb-tool

### DIFF
--- a/buildpipeline/Core-Setup-Linux-BT.json
+++ b/buildpipeline/Core-Setup-Linux-BT.json
@@ -279,7 +279,7 @@
       },
       "inputs": {
         "filename": "docker",
-        "arguments": "run --rm $(DockerCommonRunArgs_Ubuntu1404) $(PB_GitDirectory)/Tools/msbuild.sh $(PB_GitDirectory)/publish/publish.proj /p:PublishType=$(PB_PublishType) /p:PublishDebToolToFeed=true /p:CliNuGetFeedUrl=$(CLI_NUGET_FEED_URL) /p:CliNuGetApiKey=$(CLI_NUGET_API_KEY) $(DistroSpecificMSBuildArguments) $(DistroSpecificMSBuildPublishArgs)",
+        "arguments": "run --rm $(DockerCommonRunArgs_Ubuntu1404) $(PB_GitDirectory)/Tools/msbuild.sh $(PB_GitDirectory)/publish/publish.proj /p:PublishType=$(PB_PublishType) $(DistroSpecificMSBuildArguments) $(DistroSpecificMSBuildPublishArgs)",
         "workingFolder": "",
         "failOnStandardError": "false"
       }
@@ -1135,16 +1135,6 @@
     },
     "PB_AdditionalMSBuildArguments": {
       "value": ""
-    },
-    "CLI_NUGET_FEED_URL": {
-      "value": "https:%2F%2Fdotnet.myget.org/F/cli-deps/api/v2/package"
-    },
-    "CLI_NUGET_SYMBOLS_FEED_URL": {
-      "value": "https:%2F%2Fdotnet.myget.org/F/cli-deps/symbols/api/v2/package"
-    },
-    "CliNuGetApiKey": {
-      "value": null,
-      "isSecret": true
     },
     "DistroSpecificMSBuildArguments": {
       "value": "/flp:v=diag /clp:v=detailed /p:TargetArchitecture=$(PB_TargetArchitecture) /p:PortableBuild=false /p:ConfigurationGroup=$(BuildConfiguration) /p:OSGroup=Linux /p:OfficialBuildId=$(OfficialBuildId)"

--- a/dir.props
+++ b/dir.props
@@ -46,7 +46,7 @@
 
   <!-- Import Build tools common props file where repo-independent properties are found -->
   <Import Condition="Exists('$(ToolsDir)Build.Common.props')" Project="$(ToolsDir)Build.Common.props" />
-  
+
   <Import Project="dependencies.props" />
 
   <PropertyGroup Condition="'$(DotNetBuildOffline)' != 'true'">
@@ -55,7 +55,6 @@
       $(OverridePackageSource);
       https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json;
       https://dotnet.myget.org/F/dotnet-core/api/v3/index.json;
-      https://dotnet.myget.org/F/cli-deps/api/v3/index.json;
       https://dotnet.myget.org/F/dotnet-buildtools/api/v3/index.json;
       https://www.myget.org/F/nugetbuild/api/v3/index.json;
       https://api.nuget.org/v3/index.json;
@@ -416,11 +415,11 @@
     <SharedHostInstallerFile>$(SharedHostInstallerStart)$(ProductMoniker)$(InstallerExtension)</SharedHostInstallerFile>
     <HostFxrInstallerFile>$(HostFxrInstallerStart)$(HostResolverVersionMoniker)$(InstallerExtension)</HostFxrInstallerFile>
     <SharedFrameworkInstallerFile>$(SharedFrameworkInstallerStart)$(ProductMoniker)$(InstallerExtension)</SharedFrameworkInstallerFile>
-    <!-- Runtime Deb and Rpm packages are distro version agnostic --> 
+    <!-- Runtime Deb and Rpm packages are distro version agnostic -->
     <SharedHostInstallerFile Condition="'$(InstallerExtension)' == '.deb' or '$(InstallerExtension)' == '.rpm' ">$(SharedHostInstallerStart)$(SharedFrameworkNugetVersion)-$(TargetArchitecture)$(InstallerExtension)</SharedHostInstallerFile>
     <HostFxrInstallerFile Condition="'$(InstallerExtension)' == '.deb' or '$(InstallerExtension)' == '.rpm'">$(HostFxrInstallerStart)$(HostResolverVersion)-$(TargetArchitecture)$(InstallerExtension)</HostFxrInstallerFile>
     <SharedFrameworkInstallerFile Condition="'$(InstallerExtension)' == '.deb' or '$(InstallerExtension)' == '.rpm'">$(SharedFrameworkInstallerStart)$(SharedFrameworkNugetVersion)-$(TargetArchitecture)$(InstallerExtension)</SharedFrameworkInstallerFile>
-    
+
     <DotnetRuntimeDependenciesPackageInstallerFile>$(DotnetRuntimeDependenciesPackageInstallerStart)$(ProductMoniker)$(InstallerExtension)</DotnetRuntimeDependenciesPackageInstallerFile>
   </PropertyGroup>
 

--- a/publish/publish.proj
+++ b/publish/publish.proj
@@ -24,7 +24,6 @@
     <BuildDependsOn Condition="$(PublishType.Contains('nopublishtype'))">
       $(BuildDependsOn);
       PublishDebFilesToDebianRepo;
-      PublishDebToolPackageToFeed;
       PublishFinalOutput;
     </BuildDependsOn>
   </PropertyGroup>
@@ -280,19 +279,6 @@
                     AccountKey="$(TransportFeedAccessToken)"
                     ItemsToPush="@(ItemsToPush)"
                     Overwrite="$(OverwriteOnPublish)"/>
-  </Target>
-
-  <Target Name="PublishDebToolPackageToFeed"
-          Condition="'$(PublishDebToolToFeed)' == 'true' AND '$(CliNuGetFeedUrl)' != ''">
-    <Error Condition="'$(CliNuGetApiKey)' == ''" Text="Missing required property CliNuGetApiKey" />
-    <ItemGroup>
-      <DebToolPackages Include="$(PackageOutputPath)/dotnet-deb-tool.*.nupkg" />
-    </ItemGroup>
-    <PropertyGroup>
-      <NuGetPushCommand>$(DotnetToolCommand) nuget push --source $(CliNuGetFeedUrl) --api-key $(CliNuGetApiKey) --timeout $(NuGetPushTimeoutSeconds)</NuGetPushCommand>
-    </PropertyGroup>
-    <ExecWithRetriesForNuGetPush Command="$(NuGetPushCommand) %(DebToolPackages.Identity)"
-                                 IgnoredErrorMessagesWithConditional="@(IgnorableErrorMessages)" />
   </Target>
 
   <Import Project="$(ToolsDir)VersionTools.targets" Condition="Exists('$(ToolsDir)VersionTools.targets')" />

--- a/tools-local/scripts/dockerrun.sh
+++ b/tools-local/scripts/dockerrun.sh
@@ -113,9 +113,6 @@ docker run $INTERACTIVE -t --rm --sig-proxy=true \
     -e NUGET_SYMBOLS_FEED_URL \
     -e NUGET_API_KEY \
     -e GITHUB_PASSWORD \
-    -e CLI_NUGET_FEED_URL \
-    -e CLI_NUGET_SYMBOLS_FEED_URL \
-    -e CLI_NUGET_API_KEY \
     $DOTNET_BUILD_CONTAINER_TAG \
     $BUILD_COMMAND "$@"
 


### PR DESCRIPTION
cli-deps feed has been removed so cleaning up that feed as
well as removing the publishing of the deb-tool that published
to it.

cc @rakeshsinghranchi @eerhardt 