### PR TITLE
Add support for stable build parameters

### DIFF
--- a/BranchInfo.props
+++ b/BranchInfo.props
@@ -4,7 +4,8 @@
     <MinorVersion>1</MinorVersion>
     <PatchVersion>0</PatchVersion>
     <StabilizePackageVersion Condition="'$(StabilizePackageVersion)' == ''">false</StabilizePackageVersion>
-    <PreReleaseLabel>preview2</PreReleaseLabel>
+    <PreReleaseLabel Condition="'$(PackageVersionStamp)' != ''">$(PackageVersionStamp)</PreReleaseLabel>
+    <PreReleaseLabel Condition="'$(PreReleaseLabel)' == ''">preview2</PreReleaseLabel>
     <ReleaseSuffix>$(PreReleaseLabel)</ReleaseSuffix>
     <ReleaseBrandSuffix>Preview 2</ReleaseBrandSuffix>
     <Channel>master</Channel>

--- a/BranchInfo.props
+++ b/BranchInfo.props
@@ -3,9 +3,14 @@
     <MajorVersion>2</MajorVersion>
     <MinorVersion>1</MinorVersion>
     <PatchVersion>0</PatchVersion>
+
     <StabilizePackageVersion Condition="'$(StabilizePackageVersion)' == ''">false</StabilizePackageVersion>
+
     <PreReleaseLabel Condition="'$(PackageVersionStamp)' != ''">$(PackageVersionStamp)</PreReleaseLabel>
     <PreReleaseLabel Condition="'$(PreReleaseLabel)' == ''">preview2</PreReleaseLabel>
+    <IncludePreReleaseLabelInPackageVersion Condition="'$(StabilizePackageVersion)' != 'true' or '$(PackageVersionStamp)' != ''">true</IncludePreReleaseLabelInPackageVersion>
+    <IncludeBuildNumberInPackageVersion Condition="'$(StabilizePackageVersion)' != 'true'">true</IncludeBuildNumberInPackageVersion>
+
     <ReleaseSuffix>$(PreReleaseLabel)</ReleaseSuffix>
     <ReleaseBrandSuffix>Preview 2</ReleaseBrandSuffix>
     <Channel>master</Channel>

--- a/buildpipeline/pipeline.json
+++ b/buildpipeline/pipeline.json
@@ -20,7 +20,7 @@
           "Parameters": {
             "PB_DockerTag": "centos-7-d485f41-20173404063424",
             "PB_AdditionalBuildArguments":"-PortableBuild=true -strip-symbols -SkipTests=$(PB_SkipTests)",
-            "PB_AdditionalMSBuildArguments":"/p:DotNetRestoreSources=$(PB_RestoreSource)",
+            "PB_AdditionalMSBuildArguments":"/p:DotNetRestoreSources=$(PB_RestoreSource) /p:StabilizePackageVersion=$(PB_IsStable) /p:PackageVersionStamp=$(PB_VersionStamp)",
             "PB_PortableBuild": "true"
           },
           "ReportingParameters": {
@@ -36,7 +36,7 @@
             "PB_DockerTag": "centos-6-376e1a3-20174311014331",
             "PB_TargetArchitecture": "x64",
             "PB_AdditionalBuildArguments":"-TargetArchitecture=x64 -PortableBuild=false -strip-symbols -SkipTests=$(PB_SkipTests)",
-            "PB_AdditionalMSBuildArguments":"/p:OutputRid=rhel.6-x64 /p:DotNetRestoreSources=$(PB_RestoreSource)",
+            "PB_AdditionalMSBuildArguments":"/p:OutputRid=rhel.6-x64 /p:DotNetRestoreSources=$(PB_RestoreSource) /p:StabilizePackageVersion=$(PB_IsStable) /p:PackageVersionStamp=$(PB_VersionStamp)",
             "PB_PortableBuild": "false"
           },
           "ReportingParameters": {
@@ -51,7 +51,7 @@
             "PB_DockerTag": "alpine-3.6-3148f11-20171119021156",
             "PB_TargetArchitecture": "x64",
             "PB_AdditionalBuildArguments":"-TargetArchitecture=x64 -PortableBuild=false -strip-symbols -SkipTests=$(PB_SkipTests)",
-            "PB_AdditionalMSBuildArguments":"/p:OutputRid=alpine.3.6-x64 /p:DotNetRestoreSources=$(PB_RestoreSource)",
+            "PB_AdditionalMSBuildArguments":"/p:OutputRid=alpine.3.6-x64 /p:DotNetRestoreSources=$(PB_RestoreSource) /p:StabilizePackageVersion=$(PB_IsStable) /p:PackageVersionStamp=$(PB_VersionStamp)",
             "PB_PortableBuild": "false"
           },
           "ReportingParameters": {
@@ -66,7 +66,7 @@
             "PB_DockerTag": "ubuntu-14.04-cross-0cd4667-20170319080304",
             "PB_TargetArchitecture": "arm",
             "PB_AdditionalBuildArguments":"-TargetArchitecture=arm -DisableCrossgen=true -PortableBuild=true -SkipTests=true -CrossBuild=true -strip-symbols",
-            "PB_AdditionalMSBuildArguments": "/p:DotNetRestoreSources=$(PB_RestoreSource)",
+            "PB_AdditionalMSBuildArguments": "/p:DotNetRestoreSources=$(PB_RestoreSource) /p:StabilizePackageVersion=$(PB_IsStable) /p:PackageVersionStamp=$(PB_VersionStamp)",
             "PB_CrossBuildArgs": "-e ROOTFS_DIR ",
             "PB_PortableBuild": "true"
           },
@@ -81,7 +81,7 @@
           "Name": "Core-Setup-OSX-BT",
           "Parameters": {
             "PB_AdditionalBuildArguments": "-PortableBuild=true -strip-symbols -SkipTests=$(PB_SkipTests)",
-            "PB_AdditionalMSBuildArguments": "/p:DotNetRestoreSources=$(PB_RestoreSource)",
+            "PB_AdditionalMSBuildArguments": "/p:DotNetRestoreSources=$(PB_RestoreSource) /p:StabilizePackageVersion=$(PB_IsStable) /p:PackageVersionStamp=$(PB_VersionStamp)",
             "PB_PortableBuild": "true"
           },
           "ReportingParameters": {
@@ -94,7 +94,7 @@
         {
           "Name": "Core-Setup-Windows-Arm-BT",
           "Parameters": {
-            "PB_AdditionalMSBuildArguments": "/p:SkipTests=true /p:DotNetRestoreSources=$(PB_RestoreSource)",
+            "PB_AdditionalMSBuildArguments": "/p:SkipTests=true /p:DotNetRestoreSources=$(PB_RestoreSource) /p:StabilizePackageVersion=$(PB_IsStable) /p:PackageVersionStamp=$(PB_VersionStamp)",
             "PB_TargetArchitecture": "arm",
             "PB_PortableBuild": "true"
           },
@@ -108,7 +108,7 @@
         {
           "Name": "Core-Setup-Windows-Arm-BT",
           "Parameters": {
-            "PB_AdditionalMSBuildArguments": "/p:SkipTests=true /p:NativeToolSetDir=C:\\tools\\clr /p:DotNetRestoreSources=$(PB_RestoreSource)",
+            "PB_AdditionalMSBuildArguments": "/p:SkipTests=true /p:NativeToolSetDir=C:\\tools\\clr /p:DotNetRestoreSources=$(PB_RestoreSource) /p:StabilizePackageVersion=$(PB_IsStable) /p:PackageVersionStamp=$(PB_VersionStamp)",
             "PB_TargetArchitecture": "arm64",
             "PB_PortableBuild": "true"
           },
@@ -124,7 +124,7 @@
           "Parameters": {
             "PB_TargetArchitecture": "x64",
             "PB_PortableBuild": "true",
-            "PB_AdditionalMSBuildArguments": "/p:SkipTests=$(PB_SkipTests) /p:DotNetRestoreSources=$(PB_RestoreSource)",
+            "PB_AdditionalMSBuildArguments": "/p:SkipTests=$(PB_SkipTests) /p:DotNetRestoreSources=$(PB_RestoreSource) /p:StabilizePackageVersion=$(PB_IsStable) /p:PackageVersionStamp=$(PB_VersionStamp)",
             "PB_PublishRidAgnosticPackages": "true",
             "PB_BuildFullPlatformManifest": "true"
           },
@@ -140,7 +140,7 @@
           "Parameters": {
             "PB_TargetArchitecture": "x86",
             "PB_PortableBuild": "true",
-            "PB_AdditionalMSBuildArguments": "/p:SkipTests=$(PB_SkipTests) /p:DotNetRestoreSources=$(PB_RestoreSource)"
+            "PB_AdditionalMSBuildArguments": "/p:SkipTests=$(PB_SkipTests) /p:DotNetRestoreSources=$(PB_RestoreSource) /p:StabilizePackageVersion=$(PB_IsStable) /p:PackageVersionStamp=$(PB_VersionStamp)"
           },
           "ReportingParameters": {
             "OperatingSystem": "Windows",

--- a/dir.props
+++ b/dir.props
@@ -472,7 +472,7 @@
     <!-- These properties should be passed through to new msbuild instances (like 'dotnet build')
          in order to get the correct output directories in the child project.
     -->
-    <MSBuildPassThroughPropertyList>/p:OSGroup=$(OSGroup) /p:PortableBuild=$(PortableBuild) /p:TargetArchitecture=$(TargetArchitecture) /p:ConfigurationGroup=$(ConfigurationGroup)</MSBuildPassThroughPropertyList>
+    <MSBuildPassThroughPropertyList>/p:OSGroup=$(OSGroup) /p:PortableBuild=$(PortableBuild) /p:TargetArchitecture=$(TargetArchitecture) /p:ConfigurationGroup=$(ConfigurationGroup) /p:VersionSuffix=$(VersionSuffix)</MSBuildPassThroughPropertyList>
     <MSBuildPassThroughPropertyList Condition="'$(OutputRid)' != ''">$(MSBuildPassThroughPropertyList) /p:OutputRid=$(OutputRid)</MSBuildPassThroughPropertyList>
   </PropertyGroup>
 

--- a/dir.props
+++ b/dir.props
@@ -65,10 +65,11 @@
 
   <!-- Versioning -->
   <PropertyGroup>
-    <VersionSuffix Condition="'$(PreReleaseLabel)' != ''">$(PreReleaseLabel)-</VersionSuffix>
-    <VersionSuffix>$(VersionSuffix)$(BuildNumberMajor)-$(BuildNumberMinor)</VersionSuffix>
-    <VersionSuffix Condition="'$(StabilizePackageVersion)' =='true'"></VersionSuffix>
-    <ProductVersionSuffix Condition="'$(StabilizePackageVersion)' !='true'">-$(VersionSuffix)</ProductVersionSuffix>
+    <VersionSuffix></VersionSuffix>
+    <VersionSuffix Condition="'$(IncludePreReleaseLabelInPackageVersion)' == 'true'">$(PreReleaseLabel)</VersionSuffix>
+    <VersionSuffix Condition="'$(IncludeBuildNumberInPackageVersion)' == 'true'">$(VersionSuffix)-$(BuildNumberMajor)-$(BuildNumberMinor)</VersionSuffix>
+
+    <ProductVersionSuffix Condition="'$(IncludePreReleaseLabelInPackageVersion)' == 'true'">-$(VersionSuffix)</ProductVersionSuffix>
     <ProductVersion>$(MajorVersion).$(MinorVersion).$(PatchVersion)$(ProductVersionSuffix)</ProductVersion>
     <ProductionVersion>$(MajorVersion).$(MinorVersion).$(PatchVersion)</ProductionVersion>
 

--- a/src/pkg/projects/dir.targets
+++ b/src/pkg/projects/dir.targets
@@ -11,7 +11,7 @@
       If we are stabilizing set the StableVersion property for the packages.
       Needs to happen in dir.targets to allow all the pkgproj's to set Version property first.
     -->
-    <StableVersion Condition="'$(StabilizePackageVersion)' =='true'">$(Version)</StableVersion>
+    <StableVersion Condition="'$(IncludePreReleaseLabelInPackageVersion)' != 'true'">$(Version)</StableVersion>
   </PropertyGroup>
 
   <!--


### PR DESCRIPTION
Adds support for PB_IsSTable and PB_VersionStamp which will allow
for stable builds to be produced without commits to the repo.

PTAL @mmitche this should add support for final stable builds but not for preview stable builds (i.e. 2.1.0-preview1). I'm doing some testing and hope I can provide support for those as well. 

cc @jashook I expect this will be implemented in a similar fashion in coreclr repo. 