### PR TITLE
Fix issue with deps resolver and duplicate assembly names

### DIFF
--- a/src/corehost/cli/deps_entry.h
+++ b/src/corehost/cli/deps_entry.h
@@ -12,13 +12,13 @@
 
 struct deps_asset_t
 {
-    deps_asset_t() : deps_asset_t(_X(""), version_t(), version_t()) { }
+    deps_asset_t() : deps_asset_t(_X(""), _X(""), version_t(), version_t()) { }
 
-    deps_asset_t(const pal::string_t& relative_path, const version_t& assembly_version, const version_t& file_version)
-        : relative_path(get_replaced_char(relative_path, _X('\\'), _X('/'))) // Deps file does not follow spec. It uses '\\', should use '/'
+    deps_asset_t(const pal::string_t& name, const pal::string_t& relative_path, const version_t& assembly_version, const version_t& file_version)
+        : name(name)
+        , relative_path(get_replaced_char(relative_path, _X('\\'), _X('/'))) // Deps file does not follow spec. It uses '\\', should use '/'
         , assembly_version(assembly_version)
-        , file_version(file_version)
-        , name(get_filename_without_ext(relative_path)) { }
+        , file_version(file_version) { }
 
     pal::string_t name;
     pal::string_t relative_path;

--- a/src/corehost/cli/deps_format.cpp
+++ b/src/corehost/cli/deps_format.cpp
@@ -89,7 +89,7 @@ void deps_json_t::reconcile_libraries_with_targets(
             for (const auto& asset : get_assets_fn(library.first, i, &rid_specific))
             {
                 bool ni_dll = false;
-                auto asset_name = get_filename_without_ext(asset.relative_path);
+                auto asset_name = asset.name;
                 if (ends_with(asset_name, _X(".ni"), false))
                 {
                     ni_dll = true;
@@ -110,6 +110,7 @@ void deps_json_t::reconcile_libraries_with_targets(
                 entry.is_rid_specific = rid_specific;
                 entry.deps_file = deps_file;
                 entry.asset = asset;
+                entry.asset.name = asset_name;
 
                 m_deps_entries[i].push_back(entry);
 
@@ -250,7 +251,7 @@ bool deps_json_t::process_runtime_targets(const json_value& json, const pal::str
                         version_t::parse(file_version_str, &file_version);
                     }
 
-                    deps_asset_t asset(file.first, assembly_version, file_version);
+                    deps_asset_t asset(get_filename_without_ext(file.first), file.first, assembly_version, file_version);
 
                     trace::info(_X("Adding runtimeTargets %s asset %s rid=%s assemblyVersion=%s fileVersion=%s from %s"),
                         deps_entry_t::s_known_asset_types[i],
@@ -302,7 +303,7 @@ bool deps_json_t::process_targets(const json_value& json, const pal::string_t& t
                         version_t::parse(file_version_str, &file_version);
                     }
 
-                    deps_asset_t asset(file.first, assembly_version, file_version);
+                    deps_asset_t asset(get_filename_without_ext(file.first), file.first, assembly_version, file_version);
 
                     trace::info(_X("Adding %s asset %s assemblyVersion=%s fileVersion=%s from %s"),
                         deps_entry_t::s_known_asset_types[i],

--- a/src/corehost/cli/deps_resolver.cpp
+++ b/src/corehost/cli/deps_resolver.cpp
@@ -163,7 +163,7 @@ void deps_resolver_t::get_dir_assemblies(
                 dir_name.c_str(),
                 file_path.c_str());
 
-            deps_asset_t asset(file_name, empty, empty);
+            deps_asset_t asset(file_name, file, empty, empty);
             deps_resolved_asset_t resolved_asset(asset, file_path);
             add_tpa_asset(resolved_asset, items);
         }
@@ -481,7 +481,7 @@ bool deps_resolver_t::resolve_tpa_list(
                             existing_entry = nullptr;
                             items.erase(existing);
 
-                            deps_asset_t asset(entry.asset.relative_path, entry.asset.assembly_version, entry.asset.file_version);
+                            deps_asset_t asset(entry.asset.name, entry.asset.relative_path, entry.asset.assembly_version, entry.asset.file_version);
                             deps_resolved_asset_t resolved_asset(asset, resolved_path);
                             add_tpa_asset(resolved_asset, &items);
                         }
@@ -500,8 +500,7 @@ bool deps_resolver_t::resolve_tpa_list(
     // First add managed assembly to the TPA.
     // TODO: Remove: the deps should contain the managed DLL.
     // Workaround for: csc.deps.json doesn't have the csc.dll
-    pal::string_t managed_app_asset = get_filename_without_ext(m_managed_app);
-    deps_asset_t asset(managed_app_asset, version_t(), version_t());
+    deps_asset_t asset(get_filename_without_ext(m_managed_app), get_filename(m_managed_app), version_t(), version_t());
     deps_resolved_asset_t resolved_asset(asset, m_managed_app);
     add_tpa_asset(resolved_asset, &items);
 


### PR DESCRIPTION
Fixes corefx test build break caused by https://github.com/dotnet/core-setup/pull/3704. See break detail at https://github.com/dotnet/corefx/pull/27443

The bug is an extra call to `get_filename_without_ext()` that stripped off the last part of an assembly name, causing the code to think that `X.Y.foo.dll` and `X.Y.dll` are the same in some cases.

The fix is to modify logic so that `get_filename_without_ext()` is called only once like it was before.

cc @jkotas @eerhardt @nguerrera