### PR TITLE
Support 'additionalFrameworks' section in app's runtimeconfig.json

### DIFF
--- a/src/corehost/cli/args.h
+++ b/src/corehost/cli/args.h
@@ -14,7 +14,6 @@ struct probe_config_t
 {
     pal::string_t probe_dir;
     bool patch_roll_fwd;
-    bool prerelease_roll_fwd;
     const deps_json_t* probe_deps_json;
     int fx_level;
 

--- a/src/corehost/cli/fx_definition.cpp
+++ b/src/corehost/cli/fx_definition.cpp
@@ -26,11 +26,11 @@ fx_definition_t::fx_definition_t(
 void fx_definition_t::parse_runtime_config(
     const pal::string_t& path,
     const pal::string_t& dev_path,
-    const runtime_config_t* previous_config,
+    const runtime_config_t* higher_layer_config,
     const runtime_config_t* app_config
 )
 {
-    m_runtime_config.parse(path, dev_path, previous_config, app_config);
+    m_runtime_config.parse(path, dev_path, higher_layer_config, app_config);
 }
 
 void fx_definition_t::parse_deps()

--- a/src/corehost/cli/fx_definition.cpp
+++ b/src/corehost/cli/fx_definition.cpp
@@ -26,10 +26,11 @@ fx_definition_t::fx_definition_t(
 void fx_definition_t::parse_runtime_config(
     const pal::string_t& path,
     const pal::string_t& dev_path,
-    const runtime_config_t* defaults
+    const runtime_config_t* previous_config,
+    const runtime_config_t* app_config
 )
 {
-    m_runtime_config.parse(path, dev_path, defaults);
+    m_runtime_config.parse(path, dev_path, previous_config, app_config);
 }
 
 void fx_definition_t::parse_deps()

--- a/src/corehost/cli/fx_definition.h
+++ b/src/corehost/cli/fx_definition.h
@@ -24,7 +24,7 @@ public:
     const pal::string_t& get_found_version() const { return m_found_version; }
     const pal::string_t& get_dir() const { return m_dir; }
     const runtime_config_t& get_runtime_config() const { return m_runtime_config; }
-    void parse_runtime_config(const pal::string_t& path, const pal::string_t& dev_path, const runtime_config_t* previous_config, const runtime_config_t* app_config);
+    void parse_runtime_config(const pal::string_t& path, const pal::string_t& dev_path, const runtime_config_t* higher_layer_config, const runtime_config_t* app_config);
 
     const pal::string_t& get_deps_file() const { return m_deps_file; }
     void set_deps_file(const pal::string_t value) { m_deps_file = value; }

--- a/src/corehost/cli/fx_definition.h
+++ b/src/corehost/cli/fx_definition.h
@@ -24,7 +24,7 @@ public:
     const pal::string_t& get_found_version() const { return m_found_version; }
     const pal::string_t& get_dir() const { return m_dir; }
     const runtime_config_t& get_runtime_config() const { return m_runtime_config; }
-    void parse_runtime_config(const pal::string_t& path, const pal::string_t& dev_path, const runtime_config_t* defaults);
+    void parse_runtime_config(const pal::string_t& path, const pal::string_t& dev_path, const runtime_config_t* previous_config, const runtime_config_t* app_config);
 
     const pal::string_t& get_deps_file() const { return m_deps_file; }
     void set_deps_file(const pal::string_t value) { m_deps_file = value; }

--- a/src/corehost/cli/fxr/fx_muxer.cpp
+++ b/src/corehost/cli/fxr/fx_muxer.cpp
@@ -1273,7 +1273,7 @@ int read_config(
         get_runtime_config_paths_from_arg(runtime_config, &config_file, &dev_config_file);
     }
 
-    app.parse_runtime_config(config_file, dev_config_file, nullptr);
+    app.parse_runtime_config(config_file, dev_config_file, nullptr, nullptr);
     if (!app.get_runtime_config().is_valid())
     {
         trace::error(_X("Invalid runtimeconfig.json [%s] [%s]"), app.get_runtime_config().get_path().c_str(), app.get_runtime_config().get_dev_path().c_str());
@@ -1326,18 +1326,21 @@ int fx_muxer_t::read_config_and_execute(
         return rc;
     }
 
-    auto config = app->get_runtime_config();
+    auto app_config = app->get_runtime_config();
 
     // 'Roll forward on no candidate fx' is set to 1 (roll_fwd_on_no_candidate_fx_option::minor) by default. It can be changed through:
-    // 1. Command line argument (--roll-forward-on-no-candidate-fx). Only defaults the app's config.
+    // 1. Command line argument (--roll-forward-on-no-candidate-fx).
     // 2. Runtimeconfig json file ('rollForwardOnNoCandidateFx' property), which is used as a default for lower level frameworks if they don't specify a value.
-    // 3. DOTNET_ROLL_FORWARD_ON_NO_CANDIDATE_FX env var. Only defaults the app's config.
-    // The conflicts will be resolved by following the priority rank described above (from 1 to 3).
+    // 3. Runtimeconfig json file ('rollForwardOnNoCandidateFx' property in "framework" section:).
+    // 4. DOTNET_ROLL_FORWARD_ON_NO_CANDIDATE_FX env var. Only defaults the app's config.
+    // The conflicts will be resolved by following the priority rank described above (from 1 to 4).
     // The env var condition is verified in the config file processing
     if (!roll_fwd_on_no_candidate_fx.empty())
     {
-        config.set_roll_fwd_on_no_candidate_fx(static_cast<roll_fwd_on_no_candidate_fx_option>(pal::xtoi(roll_fwd_on_no_candidate_fx.c_str())));
+        app_config.force_roll_fwd_on_no_candidate_fx(static_cast<roll_fwd_on_no_candidate_fx_option>(pal::xtoi(roll_fwd_on_no_candidate_fx.c_str())));
     }
+
+    auto config = app_config;
 
     // Determine additional deps
     pal::string_t additional_deps_serialized;
@@ -1368,7 +1371,7 @@ int fx_muxer_t::read_config_and_execute(
             pal::string_t config_file;
             pal::string_t dev_config_file;
             get_runtime_config_paths(fx->get_dir(), config.get_fx_name(), &config_file, &dev_config_file);
-            fx->parse_runtime_config(config_file, dev_config_file, &config);
+            fx->parse_runtime_config(config_file, dev_config_file, &config, &app_config);
 
             config = fx->get_runtime_config();
             if (!config.is_valid())

--- a/src/corehost/cli/fxr/fx_muxer.cpp
+++ b/src/corehost/cli/fxr/fx_muxer.cpp
@@ -1330,8 +1330,8 @@ int fx_muxer_t::read_config_and_execute(
 
     // 'Roll forward on no candidate fx' is set to 1 (roll_fwd_on_no_candidate_fx_option::minor) by default. It can be changed through:
     // 1. Command line argument (--roll-forward-on-no-candidate-fx).
-    // 2. Runtimeconfig json file ('rollForwardOnNoCandidateFx' property), which is used as a default for lower level frameworks if they don't specify a value.
-    // 3. Runtimeconfig json file ('rollForwardOnNoCandidateFx' property in "framework" section:).
+    // 2. Runtimeconfig json file ('rollForwardOnNoCandidateFx' property in "framework" section:).
+    // 3. Runtimeconfig json file ('rollForwardOnNoCandidateFx' property), which is used as a default for lower level frameworks if they don't specify a value.
     // 4. DOTNET_ROLL_FORWARD_ON_NO_CANDIDATE_FX env var. Only defaults the app's config.
     // The conflicts will be resolved by following the priority rank described above (from 1 to 4).
     // The env var condition is verified in the config file processing

--- a/src/corehost/cli/runtime_config.cpp
+++ b/src/corehost/cli/runtime_config.cpp
@@ -8,26 +8,36 @@
 #include "runtime_config.h"
 #include <cassert>
 
+
+// The semantics of applying the runtimeconfig.json values follows, in the following steps from
+// first to last, where last always wins.
+// 1a) If the app, use the default values from the environment; apply as defaults for current layer
+// 1b) If the framework, use the default values from the higher framework
+// 2) Use the global values in the current framework's runtimeconfig.json; apply as defaults for current layer
+// 3) Use the values in the app's "additionalFrameworks" section for the targeted framework
+// 4) Use the idempotent values which are the settings that can't be changed by lower layers
+
 runtime_config_t::runtime_config_t()
     : m_patch_roll_fwd(true)
-    , m_prerelease_roll_fwd(false)
     , m_roll_fwd_on_no_candidate_fx(roll_fwd_on_no_candidate_fx_option::minor)
     , m_portable(false)
     , m_valid(false)
 {
 }
 
-void runtime_config_t::parse(const pal::string_t& path, const pal::string_t& dev_path, const runtime_config_t* defaults)
+void runtime_config_t::parse(const pal::string_t& path, const pal::string_t& dev_path, const runtime_config_t* previous_config, const runtime_config_t* app_config)
 {
     m_path = path;
     m_dev_path = dev_path;
 
-    // Apply the defaults from previous config.
-    if (defaults)
+    // Step #1: apply the defaults from the environment (for the app) or previous layer (for a framework)
+    if (previous_config != nullptr)
     {
-        m_patch_roll_fwd = defaults->m_patch_roll_fwd;
-        m_prerelease_roll_fwd = defaults->m_prerelease_roll_fwd;
-        m_roll_fwd_on_no_candidate_fx = defaults->m_roll_fwd_on_no_candidate_fx;
+        // Copy the previous defaults so we can default the next framework; these may be changed by the current fx
+        copy_framework_settings_to(previous_config->m_fx_global, m_fx_global);
+
+        // Apply the defaults
+        set_effective_values(m_fx_global);
     }
     else
     {
@@ -37,15 +47,20 @@ void runtime_config_t::parse(const pal::string_t& path, const pal::string_t& dev
         if (pal::getenv(_X("DOTNET_ROLL_FORWARD_ON_NO_CANDIDATE_FX"), &env_no_candidate))
         {
             m_roll_fwd_on_no_candidate_fx = static_cast<roll_fwd_on_no_candidate_fx_option>(pal::xtoi(env_no_candidate.c_str()));
+            m_fx_global.set_roll_fwd_on_no_candidate_fx(m_roll_fwd_on_no_candidate_fx);
         }
     }
 
-    m_valid = ensure_parsed();
+    m_valid = ensure_parsed(app_config);
 
-    // Overwrite values that can't be changed from previous config.
-    if (defaults)
+    if (m_valid)
     {
-        m_tfm = defaults->m_tfm;
+        // Step #4: Use the readonly values
+        if (app_config != nullptr)
+        {
+            m_tfm = app_config->m_tfm;
+            set_effective_values(app_config->m_fx_readonly);
+        }
     }
 
     trace::verbose(_X("Runtime config [%s] is valid=[%d]"), path.c_str(), m_valid);
@@ -59,6 +74,8 @@ bool runtime_config_t::parse_opts(const json_value& opts)
     {
         return true;
     }
+
+    // Step #2: Use the global values
 
     const auto& opts_obj = opts.as_object();
 
@@ -95,18 +112,14 @@ bool runtime_config_t::parse_opts(const json_value& opts)
     if (patch_roll_fwd != opts_obj.end())
     {
         m_patch_roll_fwd = patch_roll_fwd->second.as_bool();
-    }
-
-    auto prerelease_roll_fwd = opts_obj.find(_X("preReleaseRollForward"));
-    if (prerelease_roll_fwd != opts_obj.end())
-    {
-        m_prerelease_roll_fwd = prerelease_roll_fwd->second.as_bool();
+        m_fx_global.set_patch_roll_fwd(m_patch_roll_fwd);
     }
 
     auto roll_fwd_on_no_candidate_fx = opts_obj.find(_X("rollForwardOnNoCandidateFx"));
     if (roll_fwd_on_no_candidate_fx != opts_obj.end())
     {
         m_roll_fwd_on_no_candidate_fx = static_cast<roll_fwd_on_no_candidate_fx_option>(roll_fwd_on_no_candidate_fx->second.as_integer());
+        m_fx_global.set_roll_fwd_on_no_candidate_fx(m_roll_fwd_on_no_candidate_fx);
     }
 
     auto tfm = opts_obj.find(_X("tfm"));
@@ -124,8 +137,74 @@ bool runtime_config_t::parse_opts(const json_value& opts)
     m_portable = true;
 
     const auto& fx_obj = framework->second.as_object();
+
     m_fx_name = fx_obj.at(_X("name")).as_string();
-    m_fx_ver = fx_obj.at(_X("version")).as_string();
+
+    // Step #3: Use the values in the app's "framework" section
+    bool rc = parse_framework(fx_obj);
+    if (rc)
+    {
+        set_effective_values(m_fx);
+    }
+
+    return rc;
+}
+
+void runtime_config_t::set_effective_values(const runtime_config_framework_t& overrides)
+{
+    if (overrides.get_fx_ver() != nullptr)
+    {
+        m_fx_ver = *overrides.get_fx_ver();
+    }
+
+    if (overrides.get_roll_fwd_on_no_candidate_fx() != nullptr)
+    {
+        m_roll_fwd_on_no_candidate_fx = *overrides.get_roll_fwd_on_no_candidate_fx();
+    }
+
+    if (overrides.get_patch_roll_fwd() != nullptr)
+    {
+        m_patch_roll_fwd = *overrides.get_patch_roll_fwd();
+    }
+}
+
+/*static*/ void runtime_config_t::copy_framework_settings_to(const runtime_config_framework_t& from, runtime_config_framework_t& to)
+{
+    if (from.get_fx_ver() != nullptr)
+    {
+        to.set_fx_ver(*from.get_fx_ver());
+    }
+
+    if (from.get_roll_fwd_on_no_candidate_fx() != nullptr)
+    {
+        to.set_roll_fwd_on_no_candidate_fx(*from.get_roll_fwd_on_no_candidate_fx());
+    }
+
+    if (from.get_patch_roll_fwd() != nullptr)
+    {
+        to.set_patch_roll_fwd(*from.get_patch_roll_fwd());
+    }
+}
+
+bool runtime_config_t::parse_framework(const json_object& fx_obj)
+{
+    auto fx_ver = fx_obj.find(_X("version"));
+    if (fx_ver != fx_obj.end())
+    {
+        m_fx.set_fx_ver(fx_ver->second.as_string());
+    }
+
+    auto patch_roll_fwd = fx_obj.find(_X("applyPatches"));
+    if (patch_roll_fwd != fx_obj.end())
+    {
+        m_fx.set_patch_roll_fwd(patch_roll_fwd->second.as_bool());
+    }
+
+    auto roll_fwd_on_no_candidate_fx = fx_obj.find(_X("rollForwardOnNoCandidateFx"));
+    if (roll_fwd_on_no_candidate_fx != fx_obj.end())
+    {
+        m_fx.set_roll_fwd_on_no_candidate_fx(static_cast<roll_fwd_on_no_candidate_fx_option>(roll_fwd_on_no_candidate_fx->second.as_integer()));
+    }
 
     return true;
 }
@@ -174,7 +253,7 @@ bool runtime_config_t::ensure_dev_config_parsed()
     return true;
 }
 
-bool runtime_config_t::ensure_parsed()
+bool runtime_config_t::ensure_parsed(const runtime_config_t* app_config)
 {
     trace::verbose(_X("Attempting to read runtime config: %s"), m_path.c_str());
     if (!ensure_dev_config_parsed())
@@ -201,6 +280,7 @@ bool runtime_config_t::ensure_parsed()
         trace::verbose(_X("UTF-8 BOM skipped while reading [%s]"), m_path.c_str());
     }
 
+    bool rc = true;
     try
     {
         const auto root = json_value::parse(file);
@@ -208,7 +288,52 @@ bool runtime_config_t::ensure_parsed()
         const auto iter = json.find(_X("runtimeOptions"));
         if (iter != json.end())
         {
-            parse_opts(iter->second);
+            rc = parse_opts(iter->second);
+
+            if (rc)
+            {
+                if (app_config == nullptr)
+                {
+                    // For the app, populate the additionalFrameworks section that is used to override framework values
+                    // and remember the settings so we can apply later while each framework's runtimeconfig is being read.
+                    const auto& opts_obj = iter->second.as_object();
+                    const auto iter = opts_obj.find(_X("additionalFrameworks"));
+                    if (iter != opts_obj.end())
+                    {
+                        const auto& additional_frameworks = iter->second.as_array();
+                        for (const auto& fx : additional_frameworks)
+                        {
+                            runtime_config_t fx_overrides;
+                            const auto& fx_obj = fx.as_object();
+                            fx_overrides.m_fx_name = fx_obj.at(_X("name")).as_string();
+                            if (fx_overrides.m_fx_name.length() == 0)
+                            {
+                                trace::verbose(_X("No framework name in additionalFrameworks section."));
+                                rc = false;
+                                break;
+                            }
+
+                            rc = fx_overrides.parse_framework(fx_obj);
+                            if (!rc)
+                            {
+                                break;
+                            }
+
+                            m_additional_frameworks[fx_overrides.m_fx_name] = fx_overrides.m_fx;
+                        }
+                    }
+
+                    // Use the framework specified if it exists in the additionalFramework
+                    app_config = this;
+                }
+
+                // For the framework, apply the overrides that the app specified
+                auto overrides = app_config->m_additional_frameworks.find(m_fx_name);
+                if (overrides != app_config->m_additional_frameworks.end())
+                {
+                    set_effective_values(overrides->second);
+                }
+            }
         }
     }
     catch (const std::exception& je)
@@ -218,7 +343,8 @@ bool runtime_config_t::ensure_parsed()
         trace::error(_X("A JSON parsing exception occurred in [%s]: %s"), m_path.c_str(), jes.c_str());
         return false;
     }
-    return true;
+
+    return rc;
 }
 
 const pal::string_t& runtime_config_t::get_tfm() const
@@ -245,22 +371,17 @@ bool runtime_config_t::get_patch_roll_fwd() const
     return m_patch_roll_fwd;
 }
 
-bool runtime_config_t::get_prerelease_roll_fwd() const
-{
-    assert(m_valid);
-    return m_prerelease_roll_fwd;
-}
-
 roll_fwd_on_no_candidate_fx_option runtime_config_t::get_roll_fwd_on_no_candidate_fx() const
 {
     assert(m_valid);
     return m_roll_fwd_on_no_candidate_fx;
 }
 
-void runtime_config_t::set_roll_fwd_on_no_candidate_fx(roll_fwd_on_no_candidate_fx_option value)
+void runtime_config_t::force_roll_fwd_on_no_candidate_fx(roll_fwd_on_no_candidate_fx_option value)
 {
     assert(m_valid);
     m_roll_fwd_on_no_candidate_fx = value;
+    m_fx_readonly.set_roll_fwd_on_no_candidate_fx(value);
 }
 
 bool runtime_config_t::get_portable() const

--- a/src/corehost/cli/runtime_config.cpp
+++ b/src/corehost/cli/runtime_config.cpp
@@ -25,16 +25,16 @@ runtime_config_t::runtime_config_t()
 {
 }
 
-void runtime_config_t::parse(const pal::string_t& path, const pal::string_t& dev_path, const runtime_config_t* previous_config, const runtime_config_t* app_config)
+void runtime_config_t::parse(const pal::string_t& path, const pal::string_t& dev_path, const runtime_config_t* higher_layer_config, const runtime_config_t* app_config)
 {
     m_path = path;
     m_dev_path = dev_path;
 
-    // Step #1: apply the defaults from the environment (for the app) or previous layer (for a framework)
-    if (previous_config != nullptr)
+    // Step #1: apply the defaults from the environment (for the app) or previous\higher layer (for a framework)
+    if (higher_layer_config != nullptr)
     {
         // Copy the previous defaults so we can default the next framework; these may be changed by the current fx
-        copy_framework_settings_to(previous_config->m_fx_global, m_fx_global);
+        copy_framework_settings_to(higher_layer_config->m_fx_global, m_fx_global);
 
         // Apply the defaults
         set_effective_values(m_fx_global);

--- a/src/corehost/cli/runtime_config.h
+++ b/src/corehost/cli/runtime_config.h
@@ -10,6 +10,7 @@
 #include "cpprest/json.h"
 
 typedef web::json::value json_value;
+typedef web::json::object json_object;
 
 enum class roll_fwd_on_no_candidate_fx_option
 {
@@ -18,45 +19,110 @@ enum class roll_fwd_on_no_candidate_fx_option
     major_or_minor
 };
 
+class runtime_config_framework_t
+{
+public:
+    // Uses a "nullable<T>" pattern until we add such a type
+
+    runtime_config_framework_t()
+        : has_fx_ver(false)
+        , has_roll_fwd_on_no_candidate_fx(false)
+        , has_patch_roll_fwd(false)
+        , fx_ver(_X(""))
+        , patch_roll_fwd(false)
+        , roll_fwd_on_no_candidate_fx((roll_fwd_on_no_candidate_fx_option)0)
+        { }
+
+    const pal::string_t* get_fx_ver() const
+    {
+        return (has_fx_ver ? &fx_ver : nullptr);
+    }
+    void set_fx_ver(pal::string_t value)
+    {
+        has_fx_ver = true;
+        fx_ver = value;
+    }
+
+    const bool* get_patch_roll_fwd() const
+    {
+        return (has_patch_roll_fwd ? &patch_roll_fwd : nullptr);
+    }
+    void set_patch_roll_fwd(bool value)
+    {
+        has_patch_roll_fwd = true;
+        patch_roll_fwd = value;
+    }
+
+    const roll_fwd_on_no_candidate_fx_option* get_roll_fwd_on_no_candidate_fx() const
+    {
+        return (has_roll_fwd_on_no_candidate_fx ? &roll_fwd_on_no_candidate_fx : nullptr);
+    }
+    void set_roll_fwd_on_no_candidate_fx(roll_fwd_on_no_candidate_fx_option value)
+    {
+        has_roll_fwd_on_no_candidate_fx = true;
+        roll_fwd_on_no_candidate_fx = value;
+    }
+
+private:
+    bool has_fx_ver;
+    bool has_patch_roll_fwd;
+    bool has_roll_fwd_on_no_candidate_fx;
+
+    pal::string_t fx_ver;
+    bool patch_roll_fwd;
+    roll_fwd_on_no_candidate_fx_option roll_fwd_on_no_candidate_fx;
+};
+
+class runtime_config_t;
 class runtime_config_t
 {
 public:
     runtime_config_t();
-    void parse(const pal::string_t& path, const pal::string_t& dev_path, const runtime_config_t* defaults);
+    void parse(const pal::string_t& path, const pal::string_t& dev_path, const runtime_config_t* previous_config, const runtime_config_t* app_config);
     bool is_valid() const { return m_valid; }
     const pal::string_t& get_path() const { return m_path; }
     const pal::string_t& get_dev_path() const { return m_dev_path; }
     const pal::string_t& get_fx_version() const;
-    void set_fx_version(const pal::string_t& value);
     const pal::string_t& get_fx_name() const;
     const pal::string_t& get_tfm() const;
     const std::list<pal::string_t>& get_probe_paths() const;
     bool get_patch_roll_fwd() const;
-    bool get_prerelease_roll_fwd() const;
     roll_fwd_on_no_candidate_fx_option get_roll_fwd_on_no_candidate_fx() const;
-    void set_roll_fwd_on_no_candidate_fx(roll_fwd_on_no_candidate_fx_option value);
+    void force_roll_fwd_on_no_candidate_fx(roll_fwd_on_no_candidate_fx_option value);
     bool get_portable() const;
     bool parse_opts(const json_value& opts);
     void combine_properties(std::unordered_map<pal::string_t, pal::string_t>& combined_properties) const;
 
 private:
-    bool ensure_parsed();
+    bool ensure_parsed(const runtime_config_t* defaults);
     bool ensure_dev_config_parsed();
 
     std::unordered_map<pal::string_t, pal::string_t> m_properties;
+    std::unordered_map<pal::string_t, runtime_config_framework_t> m_additional_frameworks;
+    runtime_config_framework_t m_fx_global;     // the defaults applied to the next lower layer (Step #2)
+    runtime_config_framework_t m_fx;            // the settings in the "framework" section (Step #3)
+    runtime_config_framework_t m_fx_readonly;   // the settings that can't be changed by lower layers (Step #4)
     std::vector<std::string> m_prop_keys;
     std::vector<std::string> m_prop_values;
     std::list<pal::string_t> m_probe_paths;
+
     pal::string_t m_tfm;
     pal::string_t m_fx_name;
+
+    // These are the effective settings
     pal::string_t m_fx_ver;
     bool m_patch_roll_fwd;
-    bool m_prerelease_roll_fwd;
     roll_fwd_on_no_candidate_fx_option m_roll_fwd_on_no_candidate_fx;
 
     pal::string_t m_dev_path;
     pal::string_t m_path;
     bool m_portable;
     bool m_valid;
+
+private:
+    bool parse_framework(const json_object& fx_obj);
+    void set_effective_values(const runtime_config_framework_t& overrides);
+    static void copy_framework_settings_to(const runtime_config_framework_t& from, runtime_config_framework_t& to);
+
 };
 #endif // __RUNTIME_CONFIG_H__

--- a/src/corehost/cli/runtime_config.h
+++ b/src/corehost/cli/runtime_config.h
@@ -73,7 +73,6 @@ private:
     roll_fwd_on_no_candidate_fx_option roll_fwd_on_no_candidate_fx;
 };
 
-class runtime_config_t;
 class runtime_config_t
 {
 public:
@@ -99,8 +98,8 @@ private:
 
     std::unordered_map<pal::string_t, pal::string_t> m_properties;
     std::unordered_map<pal::string_t, runtime_config_framework_t> m_additional_frameworks;
-    runtime_config_framework_t m_fx_global;     // the defaults applied to the next lower layer (Step #2)
-    runtime_config_framework_t m_fx;            // the settings in the "framework" section (Step #3)
+    runtime_config_framework_t m_fx_global;     // the settings that will be applied to the next lower layer; does not include version (Step #1)
+    runtime_config_framework_t m_fx;            // the settings in the current "framework" section (Step #3)
     runtime_config_framework_t m_fx_readonly;   // the settings that can't be changed by lower layers (Step #4)
     std::vector<std::string> m_prop_keys;
     std::vector<std::string> m_prop_values;

--- a/src/corehost/cli/runtime_config.h
+++ b/src/corehost/cli/runtime_config.h
@@ -78,7 +78,7 @@ class runtime_config_t
 {
 public:
     runtime_config_t();
-    void parse(const pal::string_t& path, const pal::string_t& dev_path, const runtime_config_t* previous_config, const runtime_config_t* app_config);
+    void parse(const pal::string_t& path, const pal::string_t& dev_path, const runtime_config_t* higher_layer_config, const runtime_config_t* app_config);
     bool is_valid() const { return m_valid; }
     const pal::string_t& get_path() const { return m_path; }
     const pal::string_t& get_dev_path() const { return m_dev_path; }


### PR DESCRIPTION
This adds support for the app to control and have last say for the following settings for each lower level framework:
1) "rollForwardOnNoCandidateFx"
2) "applyPatches"
3) "version" (the targeted framework version)

Fixes https://github.com/dotnet/core-setup/issues/3642

I will update the cli [doc ](https://github.com/dotnet/cli/blob/master/Documentation/specs/runtime-configuration-file.md)by EOW.

Sample addition in an app's runtimeconfig.json:
```
{
    "runtimeOptions": {
        "additionalFrameworks": [
            {
                "name": "Microsoft.AspNetCore.App",
                "version": "1.0.2",
                "rollForwardOnNoCandidateFx": "0",
            },
            {
                "name": "Microsoft.AspNetCore.All", 
                "version": "2.0.0",
                "applyPatches": true
            }
        ]
}
```