### PR TITLE
Fail when additional deps files are not valid

### DIFF
--- a/src/corehost/cli/deps_format.cpp
+++ b/src/corehost/cli/deps_format.cpp
@@ -439,6 +439,7 @@ bool deps_json_t::has_package(const pal::string_t& name, const pal::string_t& ve
 //
 bool deps_json_t::load(bool portable, const pal::string_t& deps_path, const rid_fallback_graph_t& rid_fallback_graph)
 {
+    m_deps_file = deps_path;
     m_file_exists = pal::file_exists(deps_path);
 
     // If file doesn't exist, then assume parsed.

--- a/src/corehost/cli/deps_format.h
+++ b/src/corehost/cli/deps_format.h
@@ -79,6 +79,11 @@ public:
 
     const deps_entry_t& try_ni(const deps_entry_t& entry) const;
 
+    pal::string_t get_deps_file() const
+    {
+        return m_deps_file;
+    }
+
 private:
     bool load_standalone(const pal::string_t& deps_path, const json_value& json, const pal::string_t& target_name);
     bool load_portable(const pal::string_t& deps_path, const json_value& json, const pal::string_t& target_name, const rid_fallback_graph_t& rid_fallback_graph);
@@ -107,6 +112,8 @@ private:
     rid_fallback_graph_t m_rid_fallback_graph;
     bool m_file_exists;
     bool m_valid;
+
+    pal::string_t m_deps_file;
 };
 
 #endif // __DEPS_FORMAT_H_

--- a/src/corehost/cli/deps_resolver.cpp
+++ b/src/corehost/cli/deps_resolver.cpp
@@ -633,11 +633,11 @@ void deps_resolver_t::resolve_additional_deps(const hostpolicy_init_t& init)
         {
             for (int i = 1; i < m_fx_definitions.size(); ++i)
             {
-                // We'll search deps files in 'base_dir'/shared/fx_name/fx_ver
+                // We'll search deps files in 'base_dir'/shared/fx_name/fx_requested_ver
                 pal::string_t additional_deps_path_fx = additional_deps_path;
                 append_path(&additional_deps_path_fx, _X("shared"));
                 append_path(&additional_deps_path_fx, m_fx_definitions[i]->get_name().c_str());
-                append_path(&additional_deps_path_fx, m_fx_definitions[i]->get_found_version().c_str());
+                append_path(&additional_deps_path_fx, m_fx_definitions[i]->get_requested_version().c_str()); // Use requested version as that is what the app deployed with
 
                 // The resulting list will be empty if 'additional_deps_path_fx' is not a valid directory path
                 std::vector<pal::string_t> list;

--- a/src/corehost/cli/deps_resolver.h
+++ b/src/corehost/cli/deps_resolver.h
@@ -100,6 +100,15 @@ public:
             }
         }
 
+        for (const auto& additional_deps : m_additional_deps)
+        {
+            if (!additional_deps->is_valid())
+            {
+                errors->assign(_X("An error occurred while parsing: ") + additional_deps->get_deps_file());
+                return false;
+            }
+        }
+
         errors->clear();
         return true;
     }

--- a/src/corehost/cli/libhost.h
+++ b/src/corehost/cli/libhost.h
@@ -191,7 +191,7 @@ public:
         {
             hi.fx_name = m_fx_names_cstr[1];
             hi.fx_dir = m_fx_dirs_cstr[1];
-            hi.fx_ver = m_fx_found_versions_cstr[1];
+            hi.fx_ver = m_fx_requested_versions_cstr[1];
         }
         else
         {

--- a/src/test/HostActivationTests/GivenThatICareAboutLightupAppActivation.cs
+++ b/src/test/HostActivationTests/GivenThatICareAboutLightupAppActivation.cs
@@ -128,6 +128,61 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.LightupApp
                 .HaveStdOutContaining("Hello LightupClient");
         }
 
+        // Attempt to run the app with a bad lightup deps.json specified.
+        [Fact]
+        public void Muxer_activation_of_LightupApp_With_Bad_JsonFile_Fails()
+        {
+            var fixtureLib = PreviouslyBuiltAndRestoredLightupLibTestProjectFixture
+                .Copy();
+
+            var fixtureApp = PreviouslyBuiltAndRestoredLightupAppTestProjectFixture
+                .Copy();
+
+            var dotnet = fixtureApp.BuiltDotnet;
+            var appDll = fixtureApp.TestProject.AppDll;
+            var libDll = fixtureLib.TestProject.AppDll;
+
+            // Get the version number of the SharedFX we just built since that is the version
+            // going to be specified in the test's runtimeconfig.json.
+            var builtSharedFXVersion = Path.GetFileName(dotnet.GreatestVersionSharedFxPath);
+
+            // Create the M.N.App specific folder where lightup.deps.json can be found.
+            var baseDir = fixtureApp.TestProject.ProjectDirectory;
+            var customLightupPath = Path.Combine(baseDir, "shared");
+
+            // Delete any existing artifacts
+            if (Directory.Exists(customLightupPath))
+            {
+                Directory.Delete(customLightupPath, true);
+            }
+
+            customLightupPath = Path.Combine(customLightupPath, "Microsoft.NETCore.App");
+            customLightupPath = Path.Combine(customLightupPath, builtSharedFXVersion);
+
+            // Create the folder to which lightup.deps.json will be copied to.
+            Directory.CreateDirectory(customLightupPath);
+
+            // Copy the lightup.deps.json
+            var libDepsJson = fixtureLib.TestProject.DepsJson;
+            string path = Path.Combine(customLightupPath, Path.GetFileName(libDepsJson));
+
+            File.WriteAllText(path, "THIS IS A BAD JSON FILE");
+
+            // Copy the library to the location of the lightup app (app-local)
+            var destLibPath = Path.Combine(Path.GetDirectoryName(appDll), Path.GetFileName(libDll));
+            File.Copy(libDll, destLibPath);
+
+            // Execute the test using the custom lightup path where lightup.deps.json can be found.
+            dotnet.Exec("exec", "--additional-deps", baseDir, appDll)
+                .CaptureStdErr()
+                .CaptureStdOut()
+                .Execute()
+                .Should()
+                .Fail()
+                .And
+                .HaveStdErrContaining("An error occurred while parsing: " + path);
+        }
+
         // Attempt to run the app without lightup deps.json specified but lightup library present in the expected 
         // probe location (of being app-local).
         [Fact]

--- a/src/test/HostActivationTests/GivenThatICareAboutMultilevelSharedFxLookup.cs
+++ b/src/test/HostActivationTests/GivenThatICareAboutMultilevelSharedFxLookup.cs
@@ -932,6 +932,49 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.MultilevelSharedFxLooku
             DeleteAvailableSharedFxVersions(_exeSharedUberFxBaseDir, "7777.0.0");
         }
 
+        [Fact]
+        public void Additional_Deps_Lightup_Folder_With_Roll_Forward_And_Bad_JsonFile()
+        {
+            var fixture = PreviouslyBuiltAndRestoredPortableTestProjectFixture
+                .Copy();
+
+            var dotnet = fixture.BuiltDotnet;
+            var appDll = fixture.TestProject.AppDll;
+
+            // Add version in the exe folder
+            AddAvailableSharedFxVersions(_exeSharedFxBaseDir, "9999.0.1");
+
+            // Set desired version = 9999.0.0
+            string runtimeConfig = Path.Combine(fixture.TestProject.OutputDirectory, "SharedFxLookupPortableApp.runtimeconfig.json");
+            SetRuntimeConfigJson(runtimeConfig, "9999.0.0");
+
+            // Create a deps.json file in the folder "additionalDeps\shared\Microsoft.NETCore.App\9999.0.0"
+            string additionalDepsRootPath = Path.Combine(_exeSharedFxBaseDir, "additionalDeps");
+            string additionalDepsPath = Path.Combine(additionalDepsRootPath, "shared", "Microsoft.NETCore.App", "9999.0.0", "myAddtionalDeps.deps.json");
+            FileInfo additionalDepsFile = new FileInfo(additionalDepsPath);
+            additionalDepsFile.Directory.Create();
+            File.WriteAllText(additionalDepsFile.FullName, "THIS IS A BAD JSON FILE");
+
+            // Version: NetCoreApp 9999.0.0
+            // Exe: NetCoreApp 9999.0.1
+            // Expected: 9999.0.1
+            // Expected: the "specified" location (9999.0.0) is used to find the lightup folder, not the "found" location (9999.0.1)
+            dotnet.Exec("exec", "--additional-deps", additionalDepsRootPath, appDll)
+                .WorkingDirectory(_currentWorkingDir)
+                .EnvironmentVariable("COREHOST_TRACE", "1")
+                .CaptureStdOut()
+                .CaptureStdErr()
+                .Execute()
+                .Should()
+                .Fail()
+                .And
+                .HaveStdErrContaining(Path.Combine(_exeSelectedMessage, "9999.0.1"))
+                .And
+                .HaveStdErrContaining($"Error initializing the dependency resolver: An error occurred while parsing: {additionalDepsPath}");
+
+            DeleteAvailableSharedFxVersions(_exeSharedFxBaseDir, "9999.0.1", "additionalDeps");
+        }
+
         // This method adds a list of new framework version folders in the specified
         // sharedFxBaseDir. The files are copied from the _buildSharedFxDir.
         // Remarks:


### PR DESCRIPTION
Previously a bad deps.json file that was included via the "additional deps files" feature was treated as a silent failure, and the app was allowed to run (or try to run). This PR changes that so the app fails to launch with an error such as:
```
A JSON parsing exception occurred in [d:\git\repros\ValidateAdditionalDeps\shared\Microsoft.NETCore.App\2.0.0\foo.deps.json]: * Line 1, Column 2 Syntax error: Malformed token
Error initializing the dependency resolver: An error occurred while parsing: d:\git\repros\ValidateAdditionalDeps\shared\Microsoft.NETCore.App\2.0.0\foo.deps.json
```
Fixes https://github.com/dotnet/core-setup/issues/3476

Also fixed was to use the "requested" version of the framework when looking up the additional deps, when using the mode where additional deps specifies a directory following framework naming convention such as `c:\foo\shared\Microsoft.NETCoreApp\2.1.0`. Previously, it was using the "found" version of the framework. Originally the code was using "requested", was changed to "found" in 2.1preview a few weeks ago, and now this PR changes it back to "requested". The "requested" version should be used as that is what the app targets, and deployed the additional deps folders using that version in the path.