### PR TITLE
Sort output from --list-sdks and --list-runtimes

### DIFF
--- a/src/corehost/cli/fxr/CMakeLists.txt
+++ b/src/corehost/cli/fxr/CMakeLists.txt
@@ -41,6 +41,8 @@ set(SOURCES
     ./hostfxr.cpp
     ./fx_ver.cpp
     ./fx_muxer.cpp
+    ./framework_info.cpp
+    ./sdk_info.cpp
 )
 
 if(WIN32)

--- a/src/corehost/cli/fxr/framework_info.cpp
+++ b/src/corehost/cli/fxr/framework_info.cpp
@@ -1,0 +1,126 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#include <cassert>
+#include "framework_info.h"
+#include "pal.h"
+#include "trace.h"
+#include "utils.h"
+
+bool compare_by_name_and_version(const framework_info &a, const framework_info &b)
+{
+    if (a.name < b.name)
+    {
+        return true;
+    }
+
+    if (a.name > b.name)
+    {
+        return false;
+    }
+
+    return a.version < b.version;
+}
+
+/*static*/ void framework_info::get_all_framework_infos(
+    host_mode_t mode,
+    const pal::string_t& own_dir,
+    const pal::string_t& fx_name,
+    std::vector<framework_info>* framework_infos)
+{
+    // No FX resolution for standalone apps
+    if (mode == host_mode_t::standalone)
+    {
+        trace::verbose(_X("Standalone mode detected. Not gathering shared FX locations"));
+        return;
+    }
+
+    // No FX resolution for mixed apps
+    if (mode == host_mode_t::split_fx)
+    {
+        trace::verbose(_X("Split/FX mode detected. Not gathering shared FX locations"));
+        return;
+    }
+
+    std::vector<pal::string_t> global_dirs;
+    bool multilevel_lookup = multilevel_lookup_enabled();
+
+    // own_dir contains DIR_SEPARATOR appended that we need to remove.
+    pal::string_t own_dir_temp = own_dir;
+    remove_trailing_dir_seperator(&own_dir_temp);
+
+    std::vector<pal::string_t> hive_dir;
+    hive_dir.push_back(own_dir_temp);
+
+    if (multilevel_lookup && pal::get_global_dotnet_dirs(&global_dirs))
+    {
+        for (pal::string_t dir : global_dirs)
+        {
+            if (dir != own_dir_temp)
+            {
+                hive_dir.push_back(dir);
+            }
+        }
+    }
+
+    for (pal::string_t dir : hive_dir)
+    {
+        auto fx_shared_dir = dir;
+        append_path(&fx_shared_dir, _X("shared"));
+
+        if (pal::directory_exists(fx_shared_dir))
+        {
+            std::vector<pal::string_t> fx_names;
+            if (fx_name.length())
+            {
+                // Use the provided framework name
+                fx_names.push_back(fx_name);
+            }
+            else
+            {
+                // Read all frameworks, including "Microsoft.NETCore.App"
+                pal::readdir_onlydirectories(fx_shared_dir, &fx_names);
+            }
+
+            for (pal::string_t fx_name : fx_names)
+            {
+                auto fx_dir = fx_shared_dir;
+                append_path(&fx_dir, fx_name.c_str());
+
+                if (pal::directory_exists(fx_dir))
+                {
+                    trace::verbose(_X("Gathering FX locations in [%s]"), fx_dir.c_str());
+
+                    std::vector<pal::string_t> versions;
+                    pal::readdir_onlydirectories(fx_dir, &versions);
+                    for (const auto& ver : versions)
+                    {
+                        // Make sure we filter out any non-version folders.
+                        fx_ver_t parsed(-1, -1, -1);
+                        if (fx_ver_t::parse(ver, &parsed, false))
+                        {
+                            trace::verbose(_X("Found FX version [%s]"), ver.c_str());
+
+                            framework_info info(fx_name, fx_dir, parsed);
+                            framework_infos->push_back(info);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    std::sort(framework_infos->begin(), framework_infos->end(), compare_by_name_and_version);
+}
+
+/*static*/ bool framework_info::print_all_frameworks(const pal::string_t& own_dir, const pal::string_t& leading_whitespace)
+{
+    std::vector<framework_info> framework_infos;
+    get_all_framework_infos(host_mode_t::muxer, own_dir, _X(""), &framework_infos);
+    for (framework_info info : framework_infos)
+    {
+        trace::println(_X("%s%s %s [%s]"), leading_whitespace.c_str(), info.name.c_str(), info.version.as_str().c_str(), info.path.c_str());
+    }
+
+    return framework_infos.size() > 0;
+}

--- a/src/corehost/cli/fxr/framework_info.h
+++ b/src/corehost/cli/fxr/framework_info.h
@@ -1,0 +1,29 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#ifndef __FRAMEWORK_INFO_H_
+#define __FRAMEWORK_INFO_H_
+
+#include "libhost.h"
+
+struct framework_info
+{
+    framework_info(pal::string_t name, pal::string_t path, fx_ver_t version)
+        : name(name)
+        , path(path)
+        , version(version) { }
+
+    static void get_all_framework_infos(
+        host_mode_t mode,
+        const pal::string_t& own_dir,
+        const pal::string_t& fx_name,
+        std::vector<framework_info>* framework_infos);
+
+    static bool print_all_frameworks(const pal::string_t& own_dir, const pal::string_t& leading_whitespace);
+
+    pal::string_t name;
+    pal::string_t path;
+    fx_ver_t version;
+};
+
+#endif // __FRAMEWORK_INFO_H_

--- a/src/corehost/cli/fxr/sdk_info.cpp
+++ b/src/corehost/cli/fxr/sdk_info.cpp
@@ -1,0 +1,80 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#include <cassert>
+#include "pal.h"
+#include "sdk_info.h"
+#include "trace.h"
+#include "utils.h"
+
+bool compare_by_version(const sdk_info &a, const sdk_info &b)
+{
+    return a.version < b.version;
+}
+
+void sdk_info::get_all_sdk_infos(
+    const pal::string_t& own_dir,
+    std::vector<sdk_info>* sdk_infos)
+{
+    std::vector<pal::string_t> global_dirs;
+    bool multilevel_lookup = multilevel_lookup_enabled();
+
+    // own_dir contains DIR_SEPARATOR appended that we need to remove.
+    pal::string_t own_dir_temp = own_dir;
+    remove_trailing_dir_seperator(&own_dir_temp);
+
+    std::vector<pal::string_t> hive_dir;
+    hive_dir.push_back(own_dir_temp);
+
+    if (multilevel_lookup && pal::get_global_dotnet_dirs(&global_dirs))
+    {
+        for (pal::string_t dir : global_dirs)
+        {
+            if (dir != own_dir_temp)
+            {
+                hive_dir.push_back(dir);
+            }
+        }
+    }
+
+    for (pal::string_t dir : hive_dir)
+    {
+        auto sdk_dir = dir;
+        trace::verbose(_X("Gathering SDK locations in [%s]"), sdk_dir.c_str());
+
+        append_path(&sdk_dir, _X("sdk"));
+
+        if (pal::directory_exists(sdk_dir))
+        {
+            std::vector<pal::string_t> versions;
+            pal::readdir_onlydirectories(sdk_dir, &versions);
+            for (const auto& ver : versions)
+            {
+                // Make sure we filter out any non-version folders.
+                fx_ver_t parsed(-1, -1, -1);
+                if (fx_ver_t::parse(ver, &parsed, false))
+                {
+                    trace::verbose(_X("Found SDK version [%s]"), ver.c_str());
+
+                    sdk_info info(sdk_dir, parsed);
+
+                    sdk_infos->push_back(info);
+                }
+            }
+        }
+    }
+
+    std::sort(sdk_infos->begin(), sdk_infos->end(), compare_by_version);
+}
+
+/*static*/ bool sdk_info::print_all_sdks(const pal::string_t& own_dir, const pal::string_t& leading_whitespace)
+{
+    std::vector<sdk_info> sdk_infos;
+    get_all_sdk_infos(own_dir, &sdk_infos);
+    for (sdk_info info : sdk_infos)
+    {
+        trace::println(_X("%s%s [%s]"), leading_whitespace.c_str(), info.version.as_str().c_str(), info.path.c_str());
+    }
+
+    return sdk_infos.size() > 0;
+}

--- a/src/corehost/cli/fxr/sdk_info.h
+++ b/src/corehost/cli/fxr/sdk_info.h
@@ -1,0 +1,25 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#ifndef __SDK_INFO_H_
+#define __SDK_INFO_H_
+
+#include "libhost.h"
+
+struct sdk_info
+{
+    sdk_info(pal::string_t path, fx_ver_t version)
+        : path(path)
+        , version(version) { }
+
+    static void get_all_sdk_infos(
+        const pal::string_t& own_dir,
+        std::vector<sdk_info>* sdk_infos);
+
+    static bool print_all_sdks(const pal::string_t& own_dir, const pal::string_t& leading_whitespace);
+
+    pal::string_t path;
+    fx_ver_t version;
+};
+
+#endif // __SDK_INFO_H_


### PR DESCRIPTION
Fixes https://github.com/dotnet/core-setup/issues/3742

Includes some minor refactoring of moving helper methods from fx_muxer.cpp to new files to avoid continued pollution of that (large) file.