### PR TITLE
Enable source link

### DIFF
--- a/dir.props
+++ b/dir.props
@@ -190,7 +190,8 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <DebugType Condition="'$(DebugType)' == ''">portable</DebugType>
+    <DebugType Condition="'$(DebugType)' == ''">Portable</DebugType>
+    <UseSourceLink>true</UseSourceLink>
   </PropertyGroup>
 
   <!-- Set up Default symbol and optimization for Configuration -->


### PR DESCRIPTION
Source link wasn't enabled for the assemblies built in this repo i.e. Microsoft.Extensions.Dependencymodel.