### PR TITLE
Turn off symbol exports to prevent dynamic collisions

### DIFF
--- a/src/corehost/cli/dll/CMakeLists.txt
+++ b/src/corehost/cli/dll/CMakeLists.txt
@@ -12,6 +12,8 @@ else()
     add_compile_options(-fPIC)
 endif()
 
+add_compile_options(-fvisibility=hidden)
+
 include(../setup.cmake)
 
 # Include directories

--- a/src/corehost/cli/exe/apphost/CMakeLists.txt
+++ b/src/corehost/cli/exe/apphost/CMakeLists.txt
@@ -5,6 +5,8 @@ cmake_minimum_required (VERSION 2.6)
 project(apphost)
 set(DOTNET_HOST_EXE_NAME "apphost")
 
+add_compile_options(-fvisibility=hidden)
+
 # Add RPATH to the apphost binary that allows using local copies of shared libraries
 # dotnet core depends on for special scenarios when system wide installation of such 
 # dependencies is not possible for some reason.

--- a/src/corehost/cli/exe/dotnet/CMakeLists.txt
+++ b/src/corehost/cli/exe/dotnet/CMakeLists.txt
@@ -4,6 +4,7 @@
 cmake_minimum_required (VERSION 2.6)
 project(dotnet)
 set(DOTNET_HOST_EXE_NAME "dotnet")
+add_compile_options(-fvisibility=hidden)
 set(SOURCES 
     ../../fxr/fx_ver.cpp)
 include(../exe.cmake)

--- a/src/corehost/cli/fxr/CMakeLists.txt
+++ b/src/corehost/cli/fxr/CMakeLists.txt
@@ -12,6 +12,8 @@ else()
     add_compile_options(-fPIC)
 endif()
 
+add_compile_options(-fvisibility=hidden)
+
 include(../setup.cmake)
 
 # Include directories

--- a/src/corehost/common/pal.h
+++ b/src/corehost/common/pal.h
@@ -139,7 +139,7 @@ namespace pal
 
 #else
     #ifdef COREHOST_MAKE_DLL
-        #define SHARED_API extern "C"
+        #define SHARED_API extern "C" __attribute__((__visibility__("default")))
     #else
         #define SHARED_API
     #endif


### PR DESCRIPTION
This turns off symbol export and prevents dotnet.exe, hostfxr and hostpolicy from colliding with the same types which can cause various memory issues etc. when they become out-of-sync over time.

It seems I did not have to create an export list, as re-using the existing `SHARED_API` define with `__attribute__((__visibility__("default")))` enabled per-method symbols.

fixes https://github.com/dotnet/corefx/issues/27571

Verified on OSX per the linked issue repro steps, and also verified by diffing via `nm -g` (which returns the external\global symbols) on the hostfxr.dylib to make sure the cross-compiled code does not show up. In addition, the existing symbols we want to be public (e.g. `hostfxr_main` are exported without mangling.