### PR TITLE
Fix typo in --info output

### DIFF
--- a/src/corehost/cli/fxr/fx_muxer.cpp
+++ b/src/corehost/cli/fxr/fx_muxer.cpp
@@ -882,7 +882,7 @@ void muxer_info(pal::string_t own_dir)
     }
 
     trace::println();
-    trace::println(_X("The.NET Core runtimes installed:"));
+    trace::println(_X(".NET Core runtimes installed:"));
     if (!framework_info::print_all_frameworks(own_dir, _X("  ")))
     {
         trace::println(_X("  No runtimes were found."));


### PR DESCRIPTION
Fix --info typo related to PR https://github.com/dotnet/core-setup/pull/3722/files

(remove irrelevant "The")