### PR TITLE
[Arm64] Fix cross/build-rootfs.sh

### DIFF
--- a/cross/build-rootfs.sh
+++ b/cross/build-rootfs.sh
@@ -71,7 +71,7 @@ for i in "$@" ; do
             __LLDB_Package="lldb-3.8-dev"
             ;;
         lldb3.9)
-            __LLDB_Package="lldb-3.9-dev"
+            __LLDB_Package="liblldb-3.9-dev"
             ;;
         no-lldb)
             unset __LLDB_Package


### PR DESCRIPTION
Correct building of arm64 rootfs..  Arm64 did not support lldb until 3.9.  Arm64 uses liblldb-*-dev naming convention.

Required to create arm64 docker cross image

@janvorli @jashook @MichaelSimons @eerhardt PTAL