### PR TITLE
Ubuntu 18.04 has libcurl dependency updated from libcurl3 to libcurl4

### DIFF
--- a/src/pkg/packaging/deb/dotnet-runtime-deps-debian_config_ubuntu.18.04-x64.json
+++ b/src/pkg/packaging/deb/dotnet-runtime-deps-debian_config_ubuntu.18.04-x64.json
@@ -30,7 +30,7 @@
 
     "debian_dependencies":{
         "libc6":{},
-        "libcurl3":{},
+        "libcurl4":{},
         "libgcc1":{},
         "libgssapi-krb5-2":{},
         "liblttng-ust0":{},


### PR DESCRIPTION
Fixes : https://github.com/dotnet/core-setup/issues/3791