### PR TITLE
Pass env vars to build.cmd/.sh

### DIFF
--- a/buildpipeline/Core-Setup-CentOS-x64.json
+++ b/buildpipeline/Core-Setup-CentOS-x64.json
@@ -124,7 +124,7 @@
       "allowOverride": true
     },
     "BuildArguments": {
-      "value": "--skip-prereqs --configuration $(BuildConfiguration)  --docker centos.7 --targets Default --env-vars 'NUGET_API_KEY=$(NUGET_API_KEY)','GITHUB_PASSWORD=$(GITHUB_PASSWORD)','REPO_PASS=$(REPO_PASS)'",
+      "value": "--skip-prereqs --configuration $(BuildConfiguration)  --docker centos.7 --targets Default --env-vars 'NUGET_API_KEY=$(NUGET_API_KEY)','GITHUB_PASSWORD=$(GITHUB_PASSWORD)','REPO_PASS=$(REPO_PASS)','CONNECTION_STRING=$(CONNECTION_STRING)'",
       "allowOverride": true
     },
     "CONNECTION_STRING": {

--- a/buildpipeline/Core-Setup-CentOS-x64.json
+++ b/buildpipeline/Core-Setup-CentOS-x64.json
@@ -124,7 +124,7 @@
       "allowOverride": true
     },
     "BuildArguments": {
-      "value": "--skip-prereqs --configuration $(BuildConfiguration)  --docker centos.7 --targets Default --env-vars 'NUGET_API_KEY=$(NUGET_API_KEY)', 'GITHUB_PASSWORD=$(GITHUB_PASSWORD)', 'REPO_PASS=$(REPO_PASS)'",
+      "value": "--skip-prereqs --configuration $(BuildConfiguration)  --docker centos.7 --targets Default --env-vars 'NUGET_API_KEY=$(NUGET_API_KEY)','GITHUB_PASSWORD=$(GITHUB_PASSWORD)','REPO_PASS=$(REPO_PASS)'",
       "allowOverride": true
     },
     "CONNECTION_STRING": {

--- a/buildpipeline/Core-Setup-CentOS-x64.json
+++ b/buildpipeline/Core-Setup-CentOS-x64.json
@@ -124,7 +124,7 @@
       "allowOverride": true
     },
     "BuildArguments": {
-      "value": "--skip-prereqs --configuration $(BuildConfiguration)  --docker centos.7 --targets Default",
+      "value": "--skip-prereqs --configuration $(BuildConfiguration)  --docker centos.7 --targets Default --env-vars 'NUGET_API_KEY=$(NUGET_API_KEY)', 'GITHUB_PASSWORD=$(GITHUB_PASSWORD)', 'REPO_PASS=$(REPO_PASS)'",
       "allowOverride": true
     },
     "CONNECTION_STRING": {

--- a/buildpipeline/Core-Setup-Debian8-x64.json
+++ b/buildpipeline/Core-Setup-Debian8-x64.json
@@ -124,7 +124,7 @@
       "allowOverride": true
     },
     "BuildArguments": {
-      "value": "--skip-prereqs --configuration $(BuildConfiguration)  --docker debian.8 --targets Default --env-vars 'NUGET_API_KEY=$(NUGET_API_KEY)','GITHUB_PASSWORD=$(GITHUB_PASSWORD)','REPO_PASS=$(REPO_PASS)'",
+      "value": "--skip-prereqs --configuration $(BuildConfiguration)  --docker debian.8 --targets Default --env-vars 'NUGET_API_KEY=$(NUGET_API_KEY)','GITHUB_PASSWORD=$(GITHUB_PASSWORD)','REPO_PASS=$(REPO_PASS)','CONNECTION_STRING=$(CONNECTION_STRING)'",
       "allowOverride": true
     },
     "CONNECTION_STRING": {

--- a/buildpipeline/Core-Setup-Debian8-x64.json
+++ b/buildpipeline/Core-Setup-Debian8-x64.json
@@ -124,7 +124,7 @@
       "allowOverride": true
     },
     "BuildArguments": {
-      "value": "--skip-prereqs --configuration $(BuildConfiguration)  --docker debian.8 --targets Default --env-vars 'NUGET_API_KEY=$(NUGET_API_KEY)', 'GITHUB_PASSWORD=$(GITHUB_PASSWORD)', 'REPO_PASS=$(REPO_PASS)'",
+      "value": "--skip-prereqs --configuration $(BuildConfiguration)  --docker debian.8 --targets Default --env-vars 'NUGET_API_KEY=$(NUGET_API_KEY)','GITHUB_PASSWORD=$(GITHUB_PASSWORD)','REPO_PASS=$(REPO_PASS)'",
       "allowOverride": true
     },
     "CONNECTION_STRING": {

--- a/buildpipeline/Core-Setup-Debian8-x64.json
+++ b/buildpipeline/Core-Setup-Debian8-x64.json
@@ -124,7 +124,7 @@
       "allowOverride": true
     },
     "BuildArguments": {
-      "value": "--skip-prereqs --configuration $(BuildConfiguration)  --docker debian.8 --targets Default",
+      "value": "--skip-prereqs --configuration $(BuildConfiguration)  --docker debian.8 --targets Default --env-vars 'NUGET_API_KEY=$(NUGET_API_KEY)', 'GITHUB_PASSWORD=$(GITHUB_PASSWORD)', 'REPO_PASS=$(REPO_PASS)'",
       "allowOverride": true
     },
     "CONNECTION_STRING": {

--- a/buildpipeline/Core-Setup-Fedora24-x64.json
+++ b/buildpipeline/Core-Setup-Fedora24-x64.json
@@ -123,7 +123,7 @@
       "value": "Release"
     },
     "BuildArguments": {
-      "value": "--skip-prereqs --configuration $(BuildConfiguration)  --docker fedora.24 --targets Default --env-vars 'NUGET_API_KEY=$(NUGET_API_KEY)', 'GITHUB_PASSWORD=$(GITHUB_PASSWORD)', 'REPO_PASS=$(REPO_PASS)'"
+      "value": "--skip-prereqs --configuration $(BuildConfiguration)  --docker fedora.24 --targets Default --env-vars 'NUGET_API_KEY=$(NUGET_API_KEY)','GITHUB_PASSWORD=$(GITHUB_PASSWORD)','REPO_PASS=$(REPO_PASS)'"
     },
     "CONNECTION_STRING": {
       "value": "ENV_VAR_EMPTY_WORKAROUND"

--- a/buildpipeline/Core-Setup-Fedora24-x64.json
+++ b/buildpipeline/Core-Setup-Fedora24-x64.json
@@ -123,7 +123,7 @@
       "value": "Release"
     },
     "BuildArguments": {
-      "value": "--skip-prereqs --configuration $(BuildConfiguration)  --docker fedora.24 --targets Default --env-vars 'NUGET_API_KEY=$(NUGET_API_KEY)','GITHUB_PASSWORD=$(GITHUB_PASSWORD)','REPO_PASS=$(REPO_PASS)'"
+      "value": "--skip-prereqs --configuration $(BuildConfiguration)  --docker fedora.24 --targets Default --env-vars 'NUGET_API_KEY=$(NUGET_API_KEY)','GITHUB_PASSWORD=$(GITHUB_PASSWORD)','REPO_PASS=$(REPO_PASS)','CONNECTION_STRING=$(CONNECTION_STRING)'"
     },
     "CONNECTION_STRING": {
       "value": "ENV_VAR_EMPTY_WORKAROUND"

--- a/buildpipeline/Core-Setup-Fedora24-x64.json
+++ b/buildpipeline/Core-Setup-Fedora24-x64.json
@@ -123,7 +123,7 @@
       "value": "Release"
     },
     "BuildArguments": {
-      "value": "--skip-prereqs --configuration $(BuildConfiguration)  --docker fedora.24 --targets Default"
+      "value": "--skip-prereqs --configuration $(BuildConfiguration)  --docker fedora.24 --targets Default --env-vars 'NUGET_API_KEY=$(NUGET_API_KEY)', 'GITHUB_PASSWORD=$(GITHUB_PASSWORD)', 'REPO_PASS=$(REPO_PASS)'"
     },
     "CONNECTION_STRING": {
       "value": "ENV_VAR_EMPTY_WORKAROUND"

--- a/buildpipeline/Core-Setup-OSX-x64.json
+++ b/buildpipeline/Core-Setup-OSX-x64.json
@@ -124,7 +124,7 @@
       "allowOverride": true
     },
     "BuildArguments": {
-      "value": "--skip-prereqs --configuration $(BuildConfiguration) --targets Default --env-vars 'NUGET_API_KEY=$(NUGET_API_KEY)', 'GITHUB_PASSWORD=$(GITHUB_PASSWORD)', 'REPO_PASS=$(REPO_PASS)'",
+      "value": "--skip-prereqs --configuration $(BuildConfiguration) --targets Default --env-vars 'NUGET_API_KEY=$(NUGET_API_KEY)','GITHUB_PASSWORD=$(GITHUB_PASSWORD)','REPO_PASS=$(REPO_PASS)'",
       "allowOverride": true
     },
     "CONNECTION_STRING": {

--- a/buildpipeline/Core-Setup-OSX-x64.json
+++ b/buildpipeline/Core-Setup-OSX-x64.json
@@ -124,7 +124,7 @@
       "allowOverride": true
     },
     "BuildArguments": {
-      "value": "--skip-prereqs --configuration $(BuildConfiguration) --targets Default --env-vars 'NUGET_API_KEY=$(NUGET_API_KEY)','GITHUB_PASSWORD=$(GITHUB_PASSWORD)','REPO_PASS=$(REPO_PASS)'",
+      "value": "--skip-prereqs --configuration $(BuildConfiguration) --targets Default --env-vars 'NUGET_API_KEY=$(NUGET_API_KEY)','GITHUB_PASSWORD=$(GITHUB_PASSWORD)','REPO_PASS=$(REPO_PASS)','CONNECTION_STRING=$(CONNECTION_STRING)'",
       "allowOverride": true
     },
     "CONNECTION_STRING": {

--- a/buildpipeline/Core-Setup-OSX-x64.json
+++ b/buildpipeline/Core-Setup-OSX-x64.json
@@ -124,7 +124,7 @@
       "allowOverride": true
     },
     "BuildArguments": {
-      "value": "--skip-prereqs --configuration $(BuildConfiguration) --targets Default",
+      "value": "--skip-prereqs --configuration $(BuildConfiguration) --targets Default --env-vars 'NUGET_API_KEY=$(NUGET_API_KEY)', 'GITHUB_PASSWORD=$(GITHUB_PASSWORD)', 'REPO_PASS=$(REPO_PASS)'",
       "allowOverride": true
     },
     "CONNECTION_STRING": {

--- a/buildpipeline/Core-Setup-OpenSuse42.1-x64.json
+++ b/buildpipeline/Core-Setup-OpenSuse42.1-x64.json
@@ -123,7 +123,7 @@
       "value": "Release"
     },
     "BuildArguments": {
-      "value": "--skip-prereqs --configuration $(BuildConfiguration)  --docker opensuse.42.1 --targets Default --env-vars 'NUGET_API_KEY=$(NUGET_API_KEY)', 'GITHUB_PASSWORD=$(GITHUB_PASSWORD)', 'REPO_PASS=$(REPO_PASS)'"
+      "value": "--skip-prereqs --configuration $(BuildConfiguration)  --docker opensuse.42.1 --targets Default --env-vars 'NUGET_API_KEY=$(NUGET_API_KEY)','GITHUB_PASSWORD=$(GITHUB_PASSWORD)','REPO_PASS=$(REPO_PASS)'"
     },
     "CONNECTION_STRING": {
       "value": "ENV_VAR_EMPTY_WORKAROUND"

--- a/buildpipeline/Core-Setup-OpenSuse42.1-x64.json
+++ b/buildpipeline/Core-Setup-OpenSuse42.1-x64.json
@@ -123,7 +123,7 @@
       "value": "Release"
     },
     "BuildArguments": {
-      "value": "--skip-prereqs --configuration $(BuildConfiguration)  --docker opensuse.42.1 --targets Default"
+      "value": "--skip-prereqs --configuration $(BuildConfiguration)  --docker opensuse.42.1 --targets Default --env-vars 'NUGET_API_KEY=$(NUGET_API_KEY)', 'GITHUB_PASSWORD=$(GITHUB_PASSWORD)', 'REPO_PASS=$(REPO_PASS)'"
     },
     "CONNECTION_STRING": {
       "value": "ENV_VAR_EMPTY_WORKAROUND"

--- a/buildpipeline/Core-Setup-OpenSuse42.1-x64.json
+++ b/buildpipeline/Core-Setup-OpenSuse42.1-x64.json
@@ -123,7 +123,7 @@
       "value": "Release"
     },
     "BuildArguments": {
-      "value": "--skip-prereqs --configuration $(BuildConfiguration)  --docker opensuse.42.1 --targets Default --env-vars 'NUGET_API_KEY=$(NUGET_API_KEY)','GITHUB_PASSWORD=$(GITHUB_PASSWORD)','REPO_PASS=$(REPO_PASS)'"
+      "value": "--skip-prereqs --configuration $(BuildConfiguration)  --docker opensuse.42.1 --targets Default --env-vars 'NUGET_API_KEY=$(NUGET_API_KEY)','GITHUB_PASSWORD=$(GITHUB_PASSWORD)','REPO_PASS=$(REPO_PASS)','CONNECTION_STRING=$(CONNECTION_STRING)'"
     },
     "CONNECTION_STRING": {
       "value": "ENV_VAR_EMPTY_WORKAROUND"

--- a/buildpipeline/Core-Setup-RHEL7-x64.json
+++ b/buildpipeline/Core-Setup-RHEL7-x64.json
@@ -161,7 +161,7 @@
       "allowOverride": true
     },
     "BuildArguments": {
-      "value": "--skip-prereqs --configuration $(BuildConfiguration) --targets Default",
+      "value": "--skip-prereqs --configuration $(BuildConfiguration) --targets Default --env-vars 'NUGET_API_KEY=$(NUGET_API_KEY)', 'GITHUB_PASSWORD=$(GITHUB_PASSWORD)', 'REPO_PASS=$(REPO_PASS)'",
       "allowOverride": true
     },
     "BuildEnvironmentVariables": {

--- a/buildpipeline/Core-Setup-RHEL7-x64.json
+++ b/buildpipeline/Core-Setup-RHEL7-x64.json
@@ -161,7 +161,7 @@
       "allowOverride": true
     },
     "BuildArguments": {
-      "value": "--skip-prereqs --configuration $(BuildConfiguration) --targets Default --env-vars 'NUGET_API_KEY=$(NUGET_API_KEY)','GITHUB_PASSWORD=$(GITHUB_PASSWORD)','REPO_PASS=$(REPO_PASS)'",
+      "value": "--skip-prereqs --configuration $(BuildConfiguration) --targets Default --env-vars 'NUGET_API_KEY=$(NUGET_API_KEY)','GITHUB_PASSWORD=$(GITHUB_PASSWORD)','REPO_PASS=$(REPO_PASS)','CONNECTION_STRING=$(CONNECTION_STRING)'",
       "allowOverride": true
     },
     "BuildEnvironmentVariables": {

--- a/buildpipeline/Core-Setup-RHEL7-x64.json
+++ b/buildpipeline/Core-Setup-RHEL7-x64.json
@@ -161,7 +161,7 @@
       "allowOverride": true
     },
     "BuildArguments": {
-      "value": "--skip-prereqs --configuration $(BuildConfiguration) --targets Default --env-vars 'NUGET_API_KEY=$(NUGET_API_KEY)', 'GITHUB_PASSWORD=$(GITHUB_PASSWORD)', 'REPO_PASS=$(REPO_PASS)'",
+      "value": "--skip-prereqs --configuration $(BuildConfiguration) --targets Default --env-vars 'NUGET_API_KEY=$(NUGET_API_KEY)','GITHUB_PASSWORD=$(GITHUB_PASSWORD)','REPO_PASS=$(REPO_PASS)'",
       "allowOverride": true
     },
     "BuildEnvironmentVariables": {

--- a/buildpipeline/Core-Setup-Signing-Windows-x64.json
+++ b/buildpipeline/Core-Setup-Signing-Windows-x64.json
@@ -425,7 +425,7 @@
       "allowOverride": true
     },
     "BuildArguments": {
-      "value": "-env-vars 'NUGET_API_KEY=$(NUGET_API_KEY)','GITHUB_PASSWORD=$(GITHUB_PASSWORD)','REPO_PASS=$(REPO_PASS)'"
+      "value": "-env-vars 'NUGET_API_KEY=$(NUGET_API_KEY)','GITHUB_PASSWORD=$(GITHUB_PASSWORD)','REPO_PASS=$(REPO_PASS)','CONNECTION_STRING=$(CONNECTION_STRING)'"
     },
     "COREHOST_TRACE": {
       "value": "0",

--- a/buildpipeline/Core-Setup-Signing-Windows-x64.json
+++ b/buildpipeline/Core-Setup-Signing-Windows-x64.json
@@ -135,7 +135,7 @@
       },
       "inputs": {
         "filename": "build.cmd",
-        "arguments": "-Configuration $(BuildConfiguration) -Targets Prepare,PublishSharedFrameworkAndSharedHost",
+        "arguments": "-Configuration $(BuildConfiguration) -Targets Prepare,PublishSharedFrameworkAndSharedHost $(BuildArguments)",
         "modifyEnvironment": "false",
         "workingFolder": "",
         "failOnStandardError": "false"
@@ -208,7 +208,7 @@
       },
       "inputs": {
         "filename": "build.cmd",
-        "arguments": "-Configuration $(BuildConfiguration) -Targets Prepare,Test,InitPackage,GenerateVersionBadge,GenerateZip,GenerateMsis,GenerateNugetPackages",
+        "arguments": "-Configuration $(BuildConfiguration) -Targets Prepare,Test,InitPackage,GenerateVersionBadge,GenerateZip,GenerateMsis,GenerateNugetPackages $(BuildArguments)",
         "modifyEnvironment": "false",
         "workingFolder": "",
         "failOnStandardError": "false"
@@ -254,7 +254,7 @@
       },
       "inputs": {
         "filename": "build.cmd",
-        "arguments": "-Configuration $(BuildConfiguration) -Targets Prepare,GenerateBundles",
+        "arguments": "-Configuration $(BuildConfiguration) -Targets Prepare,GenerateBundles $(BuildArguments)",
         "modifyEnvironment": "false",
         "workingFolder": "",
         "failOnStandardError": "false"
@@ -273,7 +273,7 @@
       },
       "inputs": {
         "filename": "build.cmd",
-        "arguments": "-Configuration $(BuildConfiguration) -Targets Prepare,ExtractEngineFromBundle",
+        "arguments": "-Configuration $(BuildConfiguration) -Targets Prepare,ExtractEngineFromBundle $(BuildArguments)",
         "modifyEnvironment": "false",
         "workingFolder": "",
         "failOnStandardError": "false"
@@ -319,7 +319,7 @@
       },
       "inputs": {
         "filename": "build.cmd",
-        "arguments": "-Configuration $(BuildConfiguration) -Targets Prepare,ReattachEngineToBundle",
+        "arguments": "-Configuration $(BuildConfiguration) -Targets Prepare,ReattachEngineToBundle $(BuildArguments)",
         "modifyEnvironment": "false",
         "workingFolder": "",
         "failOnStandardError": "false"
@@ -378,7 +378,7 @@
       },
       "inputs": {
         "filename": "build.cmd",
-        "arguments": "-Configuration $(BuildConfiguration) -Targets Prepare,Publish",
+        "arguments": "-Configuration $(BuildConfiguration) -Targets Prepare,Publish $(BuildArguments)",
         "modifyEnvironment": "false",
         "workingFolder": "",
         "failOnStandardError": "false"
@@ -423,6 +423,9 @@
     "BuildConfiguration": {
       "value": "Release",
       "allowOverride": true
+    },
+    "BuildArguments": {
+      "value": "-env-vars 'NUGET_API_KEY=$(NUGET_API_KEY)', 'GITHUB_PASSWORD=$(GITHUB_PASSWORD)', 'REPO_PASS=$(REPO_PASS)'"
     },
     "COREHOST_TRACE": {
       "value": "0",

--- a/buildpipeline/Core-Setup-Signing-Windows-x64.json
+++ b/buildpipeline/Core-Setup-Signing-Windows-x64.json
@@ -425,7 +425,7 @@
       "allowOverride": true
     },
     "BuildArguments": {
-      "value": "-env-vars 'NUGET_API_KEY=$(NUGET_API_KEY)', 'GITHUB_PASSWORD=$(GITHUB_PASSWORD)', 'REPO_PASS=$(REPO_PASS)'"
+      "value": "-env-vars 'NUGET_API_KEY=$(NUGET_API_KEY)','GITHUB_PASSWORD=$(GITHUB_PASSWORD)','REPO_PASS=$(REPO_PASS)'"
     },
     "COREHOST_TRACE": {
       "value": "0",

--- a/buildpipeline/Core-Setup-Signing-Windows-x86.json
+++ b/buildpipeline/Core-Setup-Signing-Windows-x86.json
@@ -398,7 +398,7 @@
       "allowOverride": true
     },
     "BuildArguments": {
-      "value": "-env-vars 'NUGET_API_KEY=$(NUGET_API_KEY)', 'GITHUB_PASSWORD=$(GITHUB_PASSWORD)', 'REPO_PASS=$(REPO_PASS)'"
+      "value": "-env-vars 'NUGET_API_KEY=$(NUGET_API_KEY)','GITHUB_PASSWORD=$(GITHUB_PASSWORD)','REPO_PASS=$(REPO_PASS)'"
     },
     "COREHOST_TRACE": {
       "value": "0",

--- a/buildpipeline/Core-Setup-Signing-Windows-x86.json
+++ b/buildpipeline/Core-Setup-Signing-Windows-x86.json
@@ -135,7 +135,7 @@
       },
       "inputs": {
         "filename": "build.cmd",
-        "arguments": "-Configuration $(BuildConfiguration) -Architecture $(BuildArchitecture) -Targets Prepare,PublishSharedFrameworkAndSharedHost",
+        "arguments": "-Configuration $(BuildConfiguration) -Architecture $(BuildArchitecture) -Targets Prepare,PublishSharedFrameworkAndSharedHost $(BuildArguments)",
         "modifyEnvironment": "false",
         "workingFolder": "",
         "failOnStandardError": "false"
@@ -181,7 +181,7 @@
       },
       "inputs": {
         "filename": "build.cmd",
-        "arguments": "-Configuration $(BuildConfiguration) -Architecture $(BuildArchitecture) -Targets Prepare,Test,GenerateVersionBadge,GenerateZip,GenerateMsis",
+        "arguments": "-Configuration $(BuildConfiguration) -Architecture $(BuildArchitecture) -Targets Prepare,Test,GenerateVersionBadge,GenerateZip,GenerateMsis $(BuildArguments)",
         "modifyEnvironment": "false",
         "workingFolder": "",
         "failOnStandardError": "false"
@@ -227,7 +227,7 @@
       },
       "inputs": {
         "filename": "build.cmd",
-        "arguments": "-Configuration $(BuildConfiguration) -Architecture $(BuildArchitecture) -Targets Prepare,GenerateBundles",
+        "arguments": "-Configuration $(BuildConfiguration) -Architecture $(BuildArchitecture) -Targets Prepare,GenerateBundles $(BuildArguments)",
         "modifyEnvironment": "false",
         "workingFolder": "",
         "failOnStandardError": "false"
@@ -246,7 +246,7 @@
       },
       "inputs": {
         "filename": "build.cmd",
-        "arguments": "-Configuration $(BuildConfiguration) -Architecture $(BuildArchitecture) -Targets Prepare,ExtractEngineFromBundle",
+        "arguments": "-Configuration $(BuildConfiguration) -Architecture $(BuildArchitecture) -Targets Prepare,ExtractEngineFromBundle $(BuildArguments)",
         "modifyEnvironment": "false",
         "workingFolder": "",
         "failOnStandardError": "false"
@@ -292,7 +292,7 @@
       },
       "inputs": {
         "filename": "build.cmd",
-        "arguments": "-Configuration $(BuildConfiguration) -Architecture $(BuildArchitecture) -Targets Prepare,ReattachEngineToBundle",
+        "arguments": "-Configuration $(BuildConfiguration) -Architecture $(BuildArchitecture) -Targets Prepare,ReattachEngineToBundle $(BuildArguments)",
         "modifyEnvironment": "false",
         "workingFolder": "",
         "failOnStandardError": "false"
@@ -351,7 +351,7 @@
       },
       "inputs": {
         "filename": "build.cmd",
-        "arguments": "-Configuration $(BuildConfiguration) -Architecture $(BuildArchitecture) -Targets Prepare,Publish",
+        "arguments": "-Configuration $(BuildConfiguration) -Architecture $(BuildArchitecture) -Targets Prepare,Publish $(BuildArguments)",
         "modifyEnvironment": "false",
         "workingFolder": "",
         "failOnStandardError": "false"
@@ -396,6 +396,9 @@
     "BuildConfiguration": {
       "value": "Release",
       "allowOverride": true
+    },
+    "BuildArguments": {
+      "value": "-env-vars 'NUGET_API_KEY=$(NUGET_API_KEY)', 'GITHUB_PASSWORD=$(GITHUB_PASSWORD)', 'REPO_PASS=$(REPO_PASS)'"
     },
     "COREHOST_TRACE": {
       "value": "0",

--- a/buildpipeline/Core-Setup-Signing-Windows-x86.json
+++ b/buildpipeline/Core-Setup-Signing-Windows-x86.json
@@ -398,7 +398,7 @@
       "allowOverride": true
     },
     "BuildArguments": {
-      "value": "-env-vars 'NUGET_API_KEY=$(NUGET_API_KEY)','GITHUB_PASSWORD=$(GITHUB_PASSWORD)','REPO_PASS=$(REPO_PASS)'"
+      "value": "-env-vars 'NUGET_API_KEY=$(NUGET_API_KEY)','GITHUB_PASSWORD=$(GITHUB_PASSWORD)','REPO_PASS=$(REPO_PASS)','CONNECTION_STRING=$(CONNECTION_STRING)'"
     },
     "COREHOST_TRACE": {
       "value": "0",

--- a/buildpipeline/Core-Setup-Ubuntu14.04-x64.json
+++ b/buildpipeline/Core-Setup-Ubuntu14.04-x64.json
@@ -124,7 +124,7 @@
       "allowOverride": true
     },
     "BuildArguments": {
-      "value": "--skip-prereqs --configuration $(BuildConfiguration) --docker ubuntu.14.04 --targets Default --env-vars 'NUGET_API_KEY=$(NUGET_API_KEY)','GITHUB_PASSWORD=$(GITHUB_PASSWORD)','REPO_PASS=$(REPO_PASS)'",
+      "value": "--skip-prereqs --configuration $(BuildConfiguration) --docker ubuntu.14.04 --targets Default --env-vars 'NUGET_API_KEY=$(NUGET_API_KEY)','GITHUB_PASSWORD=$(GITHUB_PASSWORD)','REPO_PASS=$(REPO_PASS)','CONNECTION_STRING=$(CONNECTION_STRING)'",
       "allowOverride": true
     },
     "CONNECTION_STRING": {

--- a/buildpipeline/Core-Setup-Ubuntu14.04-x64.json
+++ b/buildpipeline/Core-Setup-Ubuntu14.04-x64.json
@@ -124,7 +124,7 @@
       "allowOverride": true
     },
     "BuildArguments": {
-      "value": "--skip-prereqs --configuration $(BuildConfiguration) --docker ubuntu.14.04 --targets Default",
+      "value": "--skip-prereqs --configuration $(BuildConfiguration) --docker ubuntu.14.04 --targets Default --env-vars 'NUGET_API_KEY=$(NUGET_API_KEY)', 'GITHUB_PASSWORD=$(GITHUB_PASSWORD)', 'REPO_PASS=$(REPO_PASS)'",
       "allowOverride": true
     },
     "CONNECTION_STRING": {

--- a/buildpipeline/Core-Setup-Ubuntu14.04-x64.json
+++ b/buildpipeline/Core-Setup-Ubuntu14.04-x64.json
@@ -124,7 +124,7 @@
       "allowOverride": true
     },
     "BuildArguments": {
-      "value": "--skip-prereqs --configuration $(BuildConfiguration) --docker ubuntu.14.04 --targets Default --env-vars 'NUGET_API_KEY=$(NUGET_API_KEY)', 'GITHUB_PASSWORD=$(GITHUB_PASSWORD)', 'REPO_PASS=$(REPO_PASS)'",
+      "value": "--skip-prereqs --configuration $(BuildConfiguration) --docker ubuntu.14.04 --targets Default --env-vars 'NUGET_API_KEY=$(NUGET_API_KEY)','GITHUB_PASSWORD=$(GITHUB_PASSWORD)','REPO_PASS=$(REPO_PASS)'",
       "allowOverride": true
     },
     "CONNECTION_STRING": {

--- a/buildpipeline/Core-Setup-Ubuntu16.04-x64.json
+++ b/buildpipeline/Core-Setup-Ubuntu16.04-x64.json
@@ -126,7 +126,7 @@
       "value": "--skip-prereqs --configuration $(BuildConfiguration)  --docker ubuntu.16.04 --targets Default $(SecretBuildArguments)"
     },
     "SecretBuildArguments": {
-      "value": "--env-vars 'NUGET_API_KEY=$(NUGET_API_KEY)', 'GITHUB_PASSWORD=$(GITHUB_PASSWORD)', 'REPO_PASS=$(REPO_PASS)'"
+      "value": "--env-vars 'NUGET_API_KEY=$(NUGET_API_KEY)','GITHUB_PASSWORD=$(GITHUB_PASSWORD)','REPO_PASS=$(REPO_PASS)'"
     },
     "CONNECTION_STRING": {
       "value": "ENV_VAR_EMPTY_WORKAROUND"

--- a/buildpipeline/Core-Setup-Ubuntu16.04-x64.json
+++ b/buildpipeline/Core-Setup-Ubuntu16.04-x64.json
@@ -123,7 +123,10 @@
       "value": "Release"
     },
     "BuildArguments": {
-      "value": "--skip-prereqs --configuration $(BuildConfiguration)  --docker ubuntu.16.04 --targets Default"
+      "value": "--skip-prereqs --configuration $(BuildConfiguration)  --docker ubuntu.16.04 --targets Default $(SecretBuildArguments)"
+    },
+    "SecretBuildArguments": {
+      "value": "--env-vars 'NUGET_API_KEY=$(NUGET_API_KEY)', 'GITHUB_PASSWORD=$(GITHUB_PASSWORD)', 'REPO_PASS=$(REPO_PASS)'"
     },
     "CONNECTION_STRING": {
       "value": "ENV_VAR_EMPTY_WORKAROUND"

--- a/buildpipeline/Core-Setup-Ubuntu16.04-x64.json
+++ b/buildpipeline/Core-Setup-Ubuntu16.04-x64.json
@@ -126,7 +126,7 @@
       "value": "--skip-prereqs --configuration $(BuildConfiguration)  --docker ubuntu.16.04 --targets Default $(SecretBuildArguments)"
     },
     "SecretBuildArguments": {
-      "value": "--env-vars 'NUGET_API_KEY=$(NUGET_API_KEY)','GITHUB_PASSWORD=$(GITHUB_PASSWORD)','REPO_PASS=$(REPO_PASS)'"
+      "value": "--env-vars 'NUGET_API_KEY=$(NUGET_API_KEY)','GITHUB_PASSWORD=$(GITHUB_PASSWORD)','REPO_PASS=$(REPO_PASS)','CONNECTION_STRING=$(CONNECTION_STRING)'"
     },
     "CONNECTION_STRING": {
       "value": "ENV_VAR_EMPTY_WORKAROUND"

--- a/buildpipeline/Core-Setup-Windows-arm64.json
+++ b/buildpipeline/Core-Setup-Windows-arm64.json
@@ -31,7 +31,7 @@
       },
       "inputs": {
         "filename": "build.cmd",
-        "arguments": "-Configuration Release -Targets Init,Compile,Package,Publish -Architecure x64 -TargetArch arm64 -ToolsetDir c:\\tools\\clr -Framework netcoreapp2.0",
+        "arguments": "-Configuration Release -Targets Init,Compile,Package,Publish -Architecure x64 -TargetArch arm64 -ToolsetDir c:\\tools\\clr -Framework netcoreapp2.0 $(BuildArguments)",
         "modifyEnvironment": "false",
         "workingFolder": "",
         "failOnStandardError": "false"
@@ -82,6 +82,9 @@
     }
   ],
   "variables": {
+    "BuildArguments": {
+      "value": "--env-vars 'NUGET_API_KEY=$(NUGET_API_KEY)', 'GITHUB_PASSWORD=$(GITHUB_PASSWORD)', 'REPO_PASS=$(REPO_PASS)'"
+    },
     "NUGET_FEED_URL": {
       "value": "ENV_VAR_EMPTY_WORKAROUND"
     },

--- a/buildpipeline/Core-Setup-Windows-arm64.json
+++ b/buildpipeline/Core-Setup-Windows-arm64.json
@@ -83,7 +83,7 @@
   ],
   "variables": {
     "BuildArguments": {
-      "value": "--env-vars 'NUGET_API_KEY=$(NUGET_API_KEY)','GITHUB_PASSWORD=$(GITHUB_PASSWORD)','REPO_PASS=$(REPO_PASS)'"
+      "value": "--env-vars 'NUGET_API_KEY=$(NUGET_API_KEY)','GITHUB_PASSWORD=$(GITHUB_PASSWORD)','REPO_PASS=$(REPO_PASS)','CONNECTION_STRING=$(CONNECTION_STRING)'"
     },
     "NUGET_FEED_URL": {
       "value": "ENV_VAR_EMPTY_WORKAROUND"

--- a/buildpipeline/Core-Setup-Windows-arm64.json
+++ b/buildpipeline/Core-Setup-Windows-arm64.json
@@ -83,7 +83,7 @@
   ],
   "variables": {
     "BuildArguments": {
-      "value": "--env-vars 'NUGET_API_KEY=$(NUGET_API_KEY)', 'GITHUB_PASSWORD=$(GITHUB_PASSWORD)', 'REPO_PASS=$(REPO_PASS)'"
+      "value": "--env-vars 'NUGET_API_KEY=$(NUGET_API_KEY)','GITHUB_PASSWORD=$(GITHUB_PASSWORD)','REPO_PASS=$(REPO_PASS)'"
     },
     "NUGET_FEED_URL": {
       "value": "ENV_VAR_EMPTY_WORKAROUND"


### PR DESCRIPTION
@dagood @eerhardt PTAL

This is to fix the 1.1.0 pipebuild not getting its env vars set for the secret VSTS variables. These now need to be passed directly to build.cmd/.sh.