### PR TITLE
Define install_Failed() before use

### DIFF
--- a/cross/build-rootfs.sh
+++ b/cross/build-rootfs.sh
@@ -10,6 +10,12 @@ usage()
     exit 1
 }
 
+install_Failed()
+{
+    echo "Failed to install/symlink packages."
+    exit 1
+}
+
 __LinuxCodeName=trusty
 __CrossDir=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 __InitialDir=$PWD
@@ -178,9 +184,3 @@ else
     usage;
     exit 1
 fi
-
-install_Failed()
-{
-    echo "Failed to install/symlink packages."
-    exit 1
-}


### PR DESCRIPTION
`cross/build-rootfs.sh` error checking logic was calling `install_Failed` before it was defined leading to incorrect error handling.

@janvorli @MichaelSimons @jashook PTAL