### PR TITLE
[1.1] Add support for Fedora27, remove xlocale.h import

### DIFF
--- a/pkg/init-tools.sh
+++ b/pkg/init-tools.sh
@@ -43,25 +43,16 @@ get_current_linux_name() {
         echo "debian"
         return 0
     elif [ "$(cat /etc/*-release | grep -cim1 fedora)" -eq 1 ]; then
-        if [ "$(cat /etc/*-release | grep -cim1 23)" -eq 1 ]; then
-            echo "fedora.23"
-            return 0
-        fi
-        if [ "$(cat /etc/*-release | grep -cim1 24)" -eq 1 ]; then
-            echo "fedora.24"
-            return 0
-        fi
+        echo -n "fedora."; cat /etc/*-release | grep  VERSION_ID= | cut -d "=" -f2
+        return 0;
     elif [ "$(cat /etc/*-release | grep -cim1 opensuse)" -eq 1 ]; then
         if [ "$(cat /etc/*-release | grep -cim1 13.2)" -eq 1 ]; then
             echo "opensuse.13.2"
             return 0
         fi
-        if [ "$(cat /etc/*-release | grep -cim1 42.1)" -eq 1 ]; then
-            echo "opensuse.42.1"
-            return 0
-        fi
+        echo "opensuse.42.1"
+        return 0
     fi
-
     # Cannot determine Linux distribution, assuming Ubuntu 14.04.
     echo "ubuntu"
     return 0

--- a/src/corehost/cli/json/casablanca/include/cpprest/asyncrt_utils.h
+++ b/src/corehost/cli/json/casablanca/include/cpprest/asyncrt_utils.h
@@ -39,11 +39,7 @@
 #endif
 
 #ifndef _WIN32
-//#include <boost/algorithm/string.hpp>
-#ifdef __GLIBC__
-#include <xlocale.h>
 #include <sys/time.h>
-#endif
 #endif
 
 /// Various utilities for string conversions and date and time manipulation.


### PR DESCRIPTION
Add init-tools lines for fedora27 and set opensuse42.1 as the default linux name when we know it's opensuse but don't recognize the version number .

Also removes a reference to xlocale.h as it was removed from glibc 2.26+.

Not sure who is active in this repo to look at this, so taking a shotgun approach with my CCs:
@janvorli @eerhardt @dagood @steveharter @weshaggard @markwilkie 