### PR TITLE
Remove unused variables

### DIFF
--- a/buildpipeline/Core-Setup-Linux-Arm-BT.json
+++ b/buildpipeline/Core-Setup-Linux-Arm-BT.json
@@ -292,9 +292,6 @@
       "value": "-ConfigurationGroup=$(BuildConfiguration) $(PB_AdditionalBuildArguments)",
       "allowOverride": true
     },
-    "CONNECTION_STRING": {
-      "value": "PassedViaPipeBuild"
-    },
     "DEB_REPO_PASSWORD": {
       "value": null,
       "isSecret": true
@@ -314,10 +311,6 @@
     "PB_DebianId_ubuntu1610-x64": {
       "value": null,
       "isSecret": true
-    },
-    "PUBLISH_TO_AZURE_BLOB": {
-      "value": "true",
-      "allowOverride": true
     },
     "DOTNET_BUILD_CONTAINER_TAG": {
       "value": "core-setup-$(PB_DockerOS)-$(Build.BuildId)"

--- a/buildpipeline/Core-Setup-Linux-BT.json
+++ b/buildpipeline/Core-Setup-Linux-BT.json
@@ -995,10 +995,6 @@
       "value": null,
       "isSecret": true
     },
-    "PUBLISH_TO_AZURE_BLOB": {
-      "value": "true",
-      "allowOverride": true
-    },
     "DOTNET_BUILD_CONTAINER_TAG": {
       "value": "core-setup-$(PB_DockerOS)-$(Build.BuildId)"
     },

--- a/buildpipeline/Core-Setup-OSX-BT.json
+++ b/buildpipeline/Core-Setup-OSX-BT.json
@@ -163,13 +163,6 @@
       "value": "-ConfigurationGroup=$(BuildConfiguration) $(PB_AdditionalBuildArguments)",
       "allowOverride": true
     },
-    "CONNECTION_STRING": {
-      "value": "PassedViaPipeBuild"
-    },
-    "PUBLISH_TO_AZURE_BLOB": {
-      "value": "true",
-      "allowOverride": true
-    },
     "GITHUB_PASSWORD": {
       "value": "PassedViaPipeBuild"
     },

--- a/buildpipeline/Core-Setup-Windows-Arm-BT.json
+++ b/buildpipeline/Core-Setup-Windows-Arm-BT.json
@@ -408,12 +408,6 @@
     "STORAGE_CONTAINER": {
       "value": "dotnet"
     },
-    "CONNECTION_STRING": {
-      "value": "PassedViaPipeBuild"
-    },
-    "PUBLISH_TO_AZURE_BLOB": {
-      "value": "true"
-    },
     "GITHUB_PASSWORD": {
       "value": "PassedViaPipeBuild"
     },

--- a/buildpipeline/Core-Setup-Windows-BT.json
+++ b/buildpipeline/Core-Setup-Windows-BT.json
@@ -608,9 +608,6 @@
     "CertificateId": {
       "value": "400"
     },
-    "CONNECTION_STRING": {
-      "value": "PassedViaPipeBuild"
-    },
     "COREHOST_TRACE": {
       "value": "0",
       "allowOverride": true
@@ -698,9 +695,6 @@
       "value": "--branch $(PB_Branch) https://$(PB_VsoAccountName):$(PB_VsoPassword)@devdiv.visualstudio.com/DevDiv/_git/DotNet-Core-Setup-Trusted"
     },
     "PUBLISH_RID_AGNOSTIC_PACKAGES": {
-      "value": "true"
-    },
-    "PUBLISH_TO_AZURE_BLOB": {
       "value": "true"
     },
     "SourceVersion": {

--- a/tools-local/scripts/common/_common.sh
+++ b/tools-local/scripts/common/_common.sh
@@ -13,9 +13,6 @@ COMMONDIR="$( cd -P "$( dirname "$COMMONSOURCE" )" && pwd )"
 
 source "$COMMONDIR/_prettyprint.sh"
 
-# Other variables are set by the outer build script
-export CHANNEL=$RELEASE_SUFFIX
-
 [ -z "$DOTNET_INSTALL_DIR" ] && export DOTNET_INSTALL_DIR=$REPOROOT/.dotnet_stage0/$RID
 [ -z "$DOTNET_CLI_VERSION" ] && export DOTNET_CLI_VERSION=0.1.0.0
 [ -z "$DOTNET_ON_PATH" ] && export DOTNET_ON_PATH=$STAGE2_DIR && export PATH=$STAGE2_DIR/bin:$PATH

--- a/tools-local/scripts/dockerrun.sh
+++ b/tools-local/scripts/dockerrun.sh
@@ -99,16 +99,6 @@ echo "Using code from: $DOCKER_HOST_SHARE_DIR"
 docker run $INTERACTIVE -t --rm --sig-proxy=true \
     --name $DOTNET_BUILD_CONTAINER_NAME \
     -v $DOCKER_HOST_SHARE_DIR:/opt/code \
-    -e CHANNEL \
-    -e CONNECTION_STRING \
-    -e REPO_ID \
-    -e REPO_USER \
-    -e REPO_PASS \
-    -e REPO_SERVER \
-    -e DOTNET_BUILD_SKIP_CROSSGEN \
-    -e PUBLISH_TO_AZURE_BLOB \
-    -e DOCKER_HUB_REPO \
-    -e DOCKER_HUB_TRIGGER_TOKEN \
     -e NUGET_FEED_URL \
     -e NUGET_SYMBOLS_FEED_URL \
     -e NUGET_API_KEY \


### PR DESCRIPTION
Discovered this when running the product construction build for core-setup.  REPO_PASS wasn't able to be set because the backing secret had been disabled in KV.  Looked through its usage in core-setup and saw no uses.  I went through the same environment block in the docker configuration run and eliminated anything without a use.