### PR TITLE
Update CoreClr version to servicing for 1.0.13

### DIFF
--- a/pkg/projects/Microsoft.NETCore.App/Microsoft.NETCore.App.pkgproj
+++ b/pkg/projects/Microsoft.NETCore.App/Microsoft.NETCore.App.pkgproj
@@ -76,7 +76,7 @@
       <Version>1.0.2</Version>
     </NETCoreApp10Dependency>
     <NETCoreApp10Dependency Include="Microsoft.NETCore.Runtime.CoreCLR">
-      <Version>1.0.12</Version>
+      <Version>1.0.13-servicing-26320-01</Version>
     </NETCoreApp10Dependency>
     <NETCoreApp10Dependency Include="Microsoft.VisualBasic">
       <Version>10.0.1</Version>


### PR DESCRIPTION
CC @weshaggard, @safern 

Need to merge this before queuing servicing build for core-setup 1.1.0