### PR TITLE
Surround Connection_String with single quotes in RHEL build

### DIFF
--- a/buildpipeline/Core-Setup-RHEL7-x64.json
+++ b/buildpipeline/Core-Setup-RHEL7-x64.json
@@ -161,7 +161,7 @@
       "allowOverride": true
     },
     "BuildArguments": {
-      "value": "--skip-prereqs --configuration $(BuildConfiguration) --targets Default --env-vars NUGET_API_KEY=$(NUGET_API_KEY),GITHUB_PASSWORD=$(GITHUB_PASSWORD),REPO_PASS=$(REPO_PASS),CONNECTION_STRING=$(CONNECTION_STRING)",
+      "value": "--skip-prereqs --configuration $(BuildConfiguration) --targets Default --env-vars NUGET_API_KEY=$(NUGET_API_KEY),GITHUB_PASSWORD=$(GITHUB_PASSWORD),REPO_PASS=$(REPO_PASS),CONNECTION_STRING='$(CONNECTION_STRING)'",
       "allowOverride": true
     },
     "BuildEnvironmentVariables": {


### PR DESCRIPTION
Since CONNECTION_STRING has semicolons in it, and the invocation of build.sh in this file is part of a semicolon-delimited list of commands to send to bash, the shell treats all parts of CONNECTION_STRING that come after the first semicolon, as more bash commands. Surrounding with single-quotes should fix this, but VSTS can treat them strangely - trying unescaped single quotes as a first test.

CC @dagood, @MattGal