### PR TITLE
Add linux-arm64 to OfficialBuildRID

### DIFF
--- a/src/pkg/projects/netcoreappRIDs.props
+++ b/src/pkg/projects/netcoreappRIDs.props
@@ -26,7 +26,7 @@
     <OfficialBuildRID Include="linux-arm64">
       <Platform>arm64</Platform>
     </OfficialBuildRID>
-    
+
     <!-- The following RIDs are not officically supported and are not 
          built during official builds, however we wish to include them 
          in our runtime.json to enable others to provide them.  -->

--- a/src/pkg/projects/netcoreappRIDs.props
+++ b/src/pkg/projects/netcoreappRIDs.props
@@ -23,7 +23,10 @@
     <OfficialBuildRID Include="linux-arm">
       <Platform>arm</Platform>
     </OfficialBuildRID>
-
+    <OfficialBuildRID Include="linux-arm64">
+      <Platform>arm64</Platform>
+    </OfficialBuildRID>
+    
     <!-- The following RIDs are not officically supported and are not 
          built during official builds, however we wish to include them 
          in our runtime.json to enable others to provide them.  -->


### PR DESCRIPTION
We added an official build for linux-arm64, but we didn't update the OfficialBuildRID list.

/cc @janvorli @sdmaclea 