### PR TITLE
Don't log error trace messages when calling file_exists

### DIFF
--- a/src/corehost/common/pal.h
+++ b/src/corehost/common/pal.h
@@ -201,7 +201,7 @@ namespace pal
     }
         
     bool touch_file(const pal::string_t& path);
-    bool realpath(string_t* path);
+    bool realpath(string_t* path, bool skip_error_logging = false);
     bool file_exists(const string_t& path);
     inline bool directory_exists(const string_t& path) { return file_exists(path); }
     void readdir(const string_t& path, const string_t& pattern, std::vector<pal::string_t>* list);

--- a/src/corehost/common/pal.unix.cpp
+++ b/src/corehost/common/pal.unix.cpp
@@ -509,7 +509,7 @@ bool pal::getenv(const pal::char_t* name, pal::string_t* recv)
     return (recv->length() > 0);
 }
 
-bool pal::realpath(pal::string_t* path)
+bool pal::realpath(pal::string_t* path, bool skip_error_logging)
 {
     auto resolved = ::realpath(path->c_str(), nullptr);
     if (resolved == nullptr)
@@ -518,9 +518,15 @@ bool pal::realpath(pal::string_t* path)
         {
             return false;
         }
-        perror("realpath()");
+
+        if (!skip_error_logging)
+        {
+            perror("realpath()");
+        }
+        
         return false;
     }
+
     path->assign(resolved);
     ::free(resolved);
     return true;

--- a/src/corehost/common/pal.windows.cpp
+++ b/src/corehost/common/pal.windows.cpp
@@ -367,7 +367,7 @@ bool pal::clr_palstring(const char* cstr, pal::string_t* out)
 }
 
 // Return if path is valid and file exists, return true and adjust path as appropriate.
-bool pal::realpath(string_t* path)
+bool pal::realpath(string_t* path, bool skip_error_logging)
 {
     if (LongFile::IsNormalized(path->c_str()))
     {
@@ -382,7 +382,10 @@ bool pal::realpath(string_t* path)
     auto size = ::GetFullPathNameW(path->c_str(), MAX_PATH, buf, nullptr);
     if (size == 0)
     {
-        trace::error(_X("Error resolving full path [%s]"), path->c_str());
+        if (!skip_error_logging)
+        {
+            trace::error(_X("Error resolving full path [%s]"), path->c_str());
+        }
         return false;
     }
 
@@ -400,7 +403,10 @@ bool pal::realpath(string_t* path)
 
         if (size == 0)
         {
-            trace::error(_X("Error resolving full path [%s]"), path->c_str());
+            if (!skip_error_logging)
+            {
+                trace::error(_X("Error resolving full path [%s]"), path->c_str());
+            }
             return false;
         }
 
@@ -436,7 +442,7 @@ bool pal::file_exists(const string_t& path)
     }
 
     string_t tmp(path);
-    return pal::realpath(&tmp);
+    return pal::realpath(&tmp, true);
 }
 
 static void readdir(const pal::string_t& path, const pal::string_t& pattern, bool onlydirectories, std::vector<pal::string_t>* list)


### PR DESCRIPTION
The `file_exists` method was recently refactored to call `realpath` which logs a message when the path can't be resolved. This is causing unnecessary logging in general. However, it appears to also cause issues for docker when logging from the background "breadcrumbs" thread where `realpath` writes to `stderr` but under docker that appears in `stdout` which creates a poor user experience.

This fix is to remove the unnecessary logging. The issue https://github.com/dotnet/core-setup/issues/3911 was created to track the underlying issue.

Fixes https://github.com/dotnet/core-setup/issues/3852
