### PR TITLE
Remove extra whitespace in host help output

### DIFF
--- a/src/corehost/cli/fxr/fx_muxer.cpp
+++ b/src/corehost/cli/fxr/fx_muxer.cpp
@@ -912,14 +912,13 @@ void fx_muxer_t::muxer_usage(bool is_sdk_present)
     }
     trace::println(_X("  --list-runtimes                     Display the installed runtimes"));
     trace::println(_X("  --list-sdks                         Display the installed SDKs"));
-    trace::println();
 
     if (!is_sdk_present)
     {
+        trace::println();
         trace::println(_X("Common Options:"));
         trace::println(_X("  -h|--help                           Displays this help."));
         trace::println(_X("  --info                              Display .NET Core information."));
-        trace::println();
     }
 }
 

--- a/src/corehost/corehost.cpp
+++ b/src/corehost/corehost.cpp
@@ -262,7 +262,7 @@ int run(const int argc, const pal::char_t* argv[])
         trace::println();
         trace::println(_X("Options:"));
         trace::println(_X("  -h|--help         Display help."));
-        trace::println(_X("  --info            Display .NET Core information.."));
+        trace::println(_X("  --info            Display .NET Core information."));
         trace::println(_X("  --list-sdks       Display the installed SDKs."));
         trace::println(_X("  --list-runtimes   Display the installed runtimes."));
         trace::println();


### PR DESCRIPTION
Removes an extra line and extra dot in the help output.

Fixes https://github.com/dotnet/core-setup/issues/3841
