### PR TITLE
Fix issue with apphost deps resolver

### DIFF
--- a/src/corehost/cli/args.cpp
+++ b/src/corehost/cli/args.cpp
@@ -90,7 +90,7 @@ bool parse_arguments(
             trace::error(_X("Failed to locate managed application [%s]"), args.managed_application.c_str());
             return false;
         }
-        args.app_root = init.host_info.dotnet_root;
+        args.app_root = get_directory(init.host_info.app_path);
         args.app_argv = &argv[1];
         args.app_argc = argc - 1;
     }


### PR DESCRIPTION
Fix issue introduced by https://github.com/dotnet/core-setup/pull/3888

The app root was getting set to the incorrect directory, causing deps resolution to fail to load additional assemblies.

I added this scenario to the test issue at https://github.com/dotnet/core-setup/issues/3910

cc @wli3