### PR TITLE
Enable building runtime installers for Debian.9 and OpenSuse.42 for 2.0.x product.

### DIFF
--- a/buildpipeline/Core-Setup-Linux-BT.json
+++ b/buildpipeline/Core-Setup-Linux-BT.json
@@ -602,6 +602,42 @@
       "enabled": true,
       "continueOnError": false,
       "alwaysRun": false,
+      "displayName": "Package - Debian 9",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "filename": "docker",
+        "arguments": "run --rm $(DockerCommonRunArgs_Debian8) $(PB_GitDirectory)/Tools/msbuild.sh $(PB_GitDirectory)/src/pkg/packaging/dir.proj $(AdditionalMSBuildProperties) $(DistroSpecificMSBuildArguments) /p:OutputRid=debian.9-$(PB_TargetArchitecture)",
+        "workingFolder": "",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Publish - Debian 9",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "filename": "docker",
+        "arguments": "run --rm $(DockerCommonRunArgs_Debian8) $(PB_GitDirectory)/Tools/msbuild.sh $(PB_GitDirectory)/publish/publish.proj $(DistroSpecificMSBuildArguments) $(DistroSpecificMSBuildPublishArgs) /p:OutputRid=debian.9-$(PB_TargetArchitecture)",
+        "workingFolder": "",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
       "displayName": "Initialize docker - Rhel7",
       "timeoutInMinutes": 0,
       "task": {
@@ -684,6 +720,42 @@
       "inputs": {
         "filename": "docker",
         "arguments": "run --rm $(DockerCommonRunArgs_Rhel7) $(PB_GitDirectory)/Tools/msbuild.sh $(PB_GitDirectory)/publish/publish.proj $(DistroSpecificMSBuildArguments) $(DistroSpecificMSBuildPublishArgs)",
+        "workingFolder": "",
+        "failOnStandardError": "false"
+      }
+    },
+   {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Package - OpenSUSE 42",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "filename": "docker",
+        "arguments": "run --rm $(DockerCommonRunArgs_Rhel7) $(PB_GitDirectory)/Tools/msbuild.sh $(PB_GitDirectory)/src/pkg/packaging/dir.proj $(AdditionalMSBuildProperties) $(DistroSpecificMSBuildArguments) /p:OutputRid=opensuse.42-$(PB_TargetArchitecture)",
+        "workingFolder": "",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Publish - OpenSUSE 42",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "filename": "docker",
+        "arguments": "run --rm $(DockerCommonRunArgs_Rhel7) $(PB_GitDirectory)/Tools/msbuild.sh $(PB_GitDirectory)/publish/publish.proj $(DistroSpecificMSBuildArguments) $(DistroSpecificMSBuildPublishArgs) /p:OutputRid=opensuse.42-$(PB_TargetArchitecture)",
         "workingFolder": "",
         "failOnStandardError": "false"
       }

--- a/dir.props
+++ b/dir.props
@@ -282,6 +282,7 @@
     <TargetsDebian>false</TargetsDebian>
     <TargetsRhel>false</TargetsRhel>
     <TargetsCentos>false</TargetsCentos>
+    <TargetsOpenSUSE>false</TargetsOpenSUSE>
   </PropertyGroup>
   <Choose>
     <When Condition="$(OutputRid.StartsWith('win'))">
@@ -323,6 +324,13 @@
         <TargetsUnix>true</TargetsUnix>
       </PropertyGroup>
     </When>
+    <When Condition="$(OutputRid.StartsWith('opensuse'))">
+      <PropertyGroup>
+        <TargetsOpenSUSE>true</TargetsOpenSUSE>
+        <TargetsLinux>true</TargetsLinux>
+        <TargetsUnix>true</TargetsUnix>
+      </PropertyGroup>
+    </When>
     <Otherwise>
       <PropertyGroup>
         <TargetsLinux>true</TargetsLinux>
@@ -337,7 +345,7 @@
     <InstallerExtension Condition="'$(OSGroup)' == 'Windows_NT'">.msi</InstallerExtension>
     <InstallerExtension Condition="'$(OSGroup)' == 'OSX'">.pkg</InstallerExtension>
     <InstallerExtension Condition="'$(TargetsDebian)' == 'true' or '$(TargetsUbuntu)' == 'true'">.deb</InstallerExtension>
-    <InstallerExtension Condition="'$(TargetsRhel)' == 'true' or '$(TargetsCentos)' == 'true'">.rpm</InstallerExtension>
+    <InstallerExtension Condition="'$(TargetsRhel)' == 'true' or '$(TargetsCentos)' == 'true' or '$(TargetsOpenSUSE)' == 'true'">.rpm</InstallerExtension>
     <CombinedInstallerExtension Condition="'$(OSGroup)' == 'Windows_NT'">.exe</CombinedInstallerExtension>
     <CombinedInstallerExtension Condition="'$(OSGroup)' != 'Windows_NT'">$(InstallerExtension)</CombinedInstallerExtension>
   </PropertyGroup>

--- a/publish/dir.props
+++ b/publish/dir.props
@@ -38,6 +38,7 @@
     <PublishRid Include="ubuntu.16.10-x64" />
     <PublishRid Include="ubuntu.18.04-x64" />
     <PublishRid Include="debian.8-x64" />
+    <PublishRid Include="debian.9-x64" />
     <PublishRid Include="linux-x64" />
     <PublishRid Include="win-x86" />
     <PublishRid Include="win-x64" />
@@ -46,5 +47,7 @@
     <PublishRid Include="win-arm64" />
     <PublishRid Include="linux-arm" />
     <PublishRid Include="rhel.7-x64" />
+    <PublishRid Include="opensuse.42-x64" />
+
   </ItemGroup>
 </Project>

--- a/src/pkg/packaging/deb/dotnet-sharedframework-debian.9_config.json
+++ b/src/pkg/packaging/deb/dotnet-sharedframework-debian.9_config.json
@@ -1,0 +1,41 @@
+{
+    "maintainer_name":"Microsoft",
+    "maintainer_email": "dotnetcore@microsoft.com",
+
+    "package_name": "%SHARED_FRAMEWORK_DEBIAN_PACKAGE_NAME%",
+    "install_root": "/usr/share/dotnet",
+
+    "short_description": "%SHARED_FRAMEWORK_BRAND_NAME% %SHARED_FRAMEWORK_NUGET_NAME% %SHARED_FRAMEWORK_NUGET_VERSION%",
+    "long_description": ".NET Core is a development platform that you can use to build command-line applications, microservices and modern websites. It is open source, cross-platform and is supported by Microsoft. We hope you enjoy using it! If you do, please consider joining the active community of developers that are contributing to the project on GitHub (https://github.com/dotnet/core). We happily accept issues and PRs.",
+    "homepage": "https://dotnet.github.io",
+
+    "release":{
+        "package_version":"1.0.0.0",
+        "package_revision":"1",
+        "urgency" : "low",
+        "changelog_message" : "Initial shared framework."
+    },
+
+    "control": {
+        "priority":"standard",
+        "section":"libs",
+        "architecture":"amd64"
+    },
+
+    "copyright": "2018 Microsoft",
+    "license": {
+        "type": "MIT",
+        "full_text": "Copyright (c) 2018 Microsoft\nPermission is hereby granted, free of charge, to any person obtaining a copy\nof this software and associated documentation files (the \"Software\"), to deal\nin the Software without restriction, including without limitation the rights\nto use, copy, modify, merge, publish, distribute, sublicense, and/or sell\ncopies of the Software, and to permit persons to whom the Software is\nfurnished to do so, subject to the following conditions:\nThe above copyright notice and this permission notice shall be included in all\ncopies or substantial portions of the Software.\nTHE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR\nIMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,\nFITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE\nAUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER\nLIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,\nOUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE\nSOFTWARE."
+    },
+
+    "debian_dependencies":{
+        "%HOSTFXR_DEBIAN_PACKAGE_NAME%" : {},
+        "libssl1.0.2" : {},
+        "libicu57": {} 
+    },
+
+    "debian_ignored_dependencies" : [
+        "liblldb-3.5",
+        "liblldb-3.6"
+    ]
+}

--- a/src/pkg/packaging/deb/package.targets
+++ b/src/pkg/packaging/deb/package.targets
@@ -198,6 +198,7 @@
       <InputRoot>$(SharedFrameworkPublishRoot)</InputRoot>
       <DebFile>$(SharedFrameworkInstallerFile)</DebFile>
       <ConfigJsonName>dotnet-sharedframework-debian_config.json</ConfigJsonName>
+      <ConfigJsonName  Condition="$(PackageTargetRid.StartsWith('debian.9'))">dotnet-sharedframework-debian.9_config.json</ConfigJsonName> 
       <ConfigJsonFile>$(debPackaginfConfigPath)$(ConfigJsonName)</ConfigJsonFile>
       <debIntermediatesDir>$(PackagesIntermediateDir)$(DebPackageName)/$(DebPackageVersion)</debIntermediatesDir>
     </PropertyGroup>

--- a/src/pkg/packaging/rpm/dotnet-sharedframework-opensuse.42_config.json
+++ b/src/pkg/packaging/rpm/dotnet-sharedframework-opensuse.42_config.json
@@ -1,0 +1,58 @@
+{
+    "maintainer_name": ".NET Core Team",
+    "maintainer_email": "dotnetpackages@dotnetfoundation.org",
+    "vendor": ".NET Foundation",
+
+    "package_name": "%SHARED_FRAMEWORK_RPM_PACKAGE_NAME%",
+    "install_root": "/usr/share/dotnet",
+    "install_doc": "/usr/share/doc/%SHARED_FRAMEWORK_RPM_PACKAGE_NAME%/",
+
+    "short_description": "%SHARED_FRAMEWORK_BRAND_NAME% %SHARED_FRAMEWORK_NUGET_NAME%",
+    "long_description": ".NET Core is a development platform that you can use to build command-line\napplications, microservices and modern websites. It is open source,\ncross-platform and is supported by Microsoft. We hope you enjoy using it!\nIf you do, please consider joining the active community of developers that are\ncontributing to the project on GitHub (https://github.com/dotnet/core).\nWe happily accept issues and PRs.",
+    "homepage": "https://github.com/dotnet/core",
+
+    "release":{
+        "package_version":"1.0.0.0",
+        "package_revision":"1",
+        "urgency" : "low",
+        "changelog_message" : "Initial shared framework."
+    },
+   
+    "control": {
+        "priority":"standard",
+        "section":"libs",
+        "architecture":"amd64"
+    },
+
+    "copyright": "2018 Microsoft",
+    "license": {
+        "type": "MIT",
+        "full_text": "Copyright (c) 2018 Microsoft\nPermission is hereby granted, free of charge, to any person obtaining a copy\nof this software and associated documentation files (the \"Software\"), to deal\nin the Software without restriction, including without limitation the rights\nto use, copy, modify, merge, publish, distribute, sublicense, and/or sell\ncopies of the Software, and to permit persons to whom the Software is\nfurnished to do so, subject to the following conditions:\nThe above copyright notice and this permission notice shall be included in all\ncopies or substantial portions of the Software.\nTHE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR\nIMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,\nFITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE\nAUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER\nLIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,\nOUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE\nSOFTWARE."
+    },
+    
+  "rpm_dependencies": [{
+      "package_name": "%HOSTFXR_RPM_PACKAGE_NAME%",
+      "package_version": ""
+    },
+    {
+      "package_name": "libopenssl1_0_0",
+      "package_version": ""
+    },  
+    {
+      "package_name": "libicu52_1",
+      "package_version": ""
+    }, 
+    {
+      "package_name": "libunwind",
+      "package_version": ""
+    },
+    {
+      "package_name": "libcurl4",
+      "package_version": ""
+    }],
+   
+    "directories" : [
+        "/usr/share/dotnet/shared",
+        "/usr/share/doc/%SHARED_FRAMEWORK_RPM_PACKAGE_NAME%"
+    ]
+}

--- a/src/pkg/packaging/rpm/package.targets
+++ b/src/pkg/packaging/rpm/package.targets
@@ -6,8 +6,7 @@
   <UsingTask TaskName="BuildFPMToolPreReqs" AssemblyFile="$(LocalBuildToolsTaskDir)core-setup.tasks.dll"/>
 
   <PropertyGroup>
-    <IsRPMBasedDistro Condition="$(PackageTargetRid.StartsWith('rhel')) or
-                                    $(PackageTargetRid.StartsWith('centos'))">true</IsRPMBasedDistro>
+    <IsRPMBasedDistro Condition="'$(InstallerExtension)' == '.rpm'">true</IsRPMBasedDistro>
     <BuildRpmPackage Condition="'$(IsRPMBasedDistro)' == true and '$(TargetArchitecture)' == 'x64'">true</BuildRpmPackage>
   </PropertyGroup>
 
@@ -192,6 +191,7 @@
       <InputRoot>$(SharedFrameworkPublishRoot)</InputRoot>
       <RpmFile>$(SharedFrameworkInstallerFile)</RpmFile>
       <ConfigJsonName>dotnet-sharedframework-rpm_config.json</ConfigJsonName>
+      <ConfigJsonName  Condition="$(PackageTargetRid.StartsWith('opensuse.42'))">dotnet-sharedframework-opensuse.42_config.json</ConfigJsonName>
       <ConfigJsonFile>$(rpmPackagingConfigPath)$(ConfigJsonName)</ConfigJsonFile>
       <RpmIntermediatesDir>$(PackagesIntermediateDir)$(RpmPackageName)/$(RpmPackageVersion)</RpmIntermediatesDir>
     </PropertyGroup>


### PR DESCRIPTION
Enable building native installers for Debian.9 and Opensuse 42.3 . Currently, we have been producing these packages by performing surgical changes to existing debs and rpms before uploading to feed for 2.0.x runtime installers.