### PR TITLE
Stop ignoring results of Publishing Core Host packages

### DIFF
--- a/build_projects/dotnet-host-build/PublishTargets.cs
+++ b/build_projects/dotnet-host-build/PublishTargets.cs
@@ -132,8 +132,17 @@ namespace Microsoft.DotNet.Host.Build
                         "centos.x64.version",
                     };
                     
-                    c.BuildContext.RunTarget(nameof(PublishTargets.PublishCoreHostPackagesToFeed));
-                    c.BuildContext.RunTarget(nameof(PublishTargets.PublishCoreHostPackageVersionsToVersionsRepo));
+                    BuildTargetResult feedResult = c.BuildContext.RunTarget(nameof(PublishTargets.PublishCoreHostPackagesToFeed));
+                    if (!feedResult.Success)
+                    {
+                        return feedResult;
+                    }
+
+                    BuildTargetResult versionsResult = c.BuildContext.RunTarget(nameof(PublishTargets.PublishCoreHostPackageVersionsToVersionsRepo));
+                    if (!versionsResult.Success)
+                    {
+                        return versionResult;
+                    }
 
                     string sfxVersion = Utils.GetSharedFrameworkVersionFileContent(c);
                     foreach (string version in versionFiles)


### PR DESCRIPTION
Prior to this, we were swallowing the results of the calls to RunTarget, which led to silent failures like the one in https://devdiv.visualstudio.com/DevDiv/_build?buildId=1531488, where we failed in publishing packages to myget, but marked the build step as a success.

@dagood @eerhardt PTAL