### PR TITLE
Fix core-setup.task project for source-build

### DIFF
--- a/dependencies.props
+++ b/dependencies.props
@@ -33,6 +33,7 @@
 
   <!-- infrastructure and test only dependencies -->
   <PropertyGroup>
+    <NugetProjectModelPackageVersion>4.3.0-preview2-4095</NugetProjectModelPackageVersion>
     <MicrosoftBuildPackageVersion>15.7.0-preview-000143</MicrosoftBuildPackageVersion>
     <MicrosoftBuildFrameworkPackageVersion>$(MicrosoftBuildPackageVersion)</MicrosoftBuildFrameworkPackageVersion>
     <MicrosoftBuildTasksCorePackageVersion>$(MicrosoftBuildPackageVersion)</MicrosoftBuildTasksCorePackageVersion>

--- a/dir.props
+++ b/dir.props
@@ -128,6 +128,7 @@
 
   <!-- list of projects to perform batch restore -->
   <ItemGroup>
+    <SdkRestoreProjects Include="$(MSBuildThisFileDirectory)tools-local/tasks/core-setup.tasks.csproj" />
     <SdkRestoreProjects Include="$(MSBuildThisFileDirectory)src\pkg\deps\deps.csproj" />
     <SdkRestoreProjects Include="$(MSBuildThisFileDirectory)src\managed\Microsoft.DotNet.PlatformAbstractions\Microsoft.DotNet.PlatformAbstractions.csproj" />
     <SdkRestoreProjects Include="$(MSBuildThisFileDirectory)src\managed\Microsoft.Extensions.DependencyModel\Microsoft.Extensions.DependencyModel.csproj" />

--- a/tools-local/tasks/core-setup.tasks.csproj
+++ b/tools-local/tasks/core-setup.tasks.csproj
@@ -12,7 +12,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="NuGet.ProjectModel">
-      <Version>4.3.0-preview2-4095</Version>
+      <Version>$(NugetProjectModelPackageVersion)</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.DependencyModel">
       <Version>1.1.1</Version>


### PR DESCRIPTION
Need to restore with the overridden restore sources so
restoring during batch restore.

Update to use convention for NugetPackage versions so
it can be overridden with versions.

cc @eerhardt 