### PR TITLE
[Arm/Arm64] Redist crosscomponent crossgen

### DIFF
--- a/src/pkg/projects/Microsoft.NETCore.App/src/Microsoft.NETCore.App.depproj
+++ b/src/pkg/projects/Microsoft.NETCore.App/src/Microsoft.NETCore.App.depproj
@@ -146,9 +146,15 @@
         <TargetPath Condition="'%(FilesToPackage.IsNative)' != 'true'">runtimes/$(NuGetRuntimeIdentifier)/lib/$(PackageTargetFramework)</TargetPath>
         <TargetPath Condition="'%(FilesToPackage.IsNative)' == 'true'">runtimes/$(NuGetRuntimeIdentifier)/native</TargetPath>
       </FilesToPackage>
-      <FilesToPackage Include="$(_runtimePackagePath)/tools/*.*">
+      <_ToolsToPackage Include="$(_runtimePackagePath)/tools/**/*.*"/>
+      <FilesToPackage Include="@(_ToolsToPackage)">
         <NuGetPackageId>$(_runtimePackageId)</NuGetPackageId>
-        <TargetPath>tools</TargetPath>
+        <TargetPath>tools/%(RecursiveDir)</TargetPath>
+        <IsNative>true</IsNative>
+      </FilesToPackage>
+      <FilesToPackage Condition="'$(_crossDir)' != ''" Include="$(_jitPackagePath)/runtimes$(_crossDir)/native/*.*">
+        <TargetPath>runtimes$(_crossDir)/native</TargetPath>
+        <IsNative>true</IsNative>
       </FilesToPackage>
     </ItemGroup>
 


### PR DESCRIPTION
Fixes #3987

For arm64 adds:
```
tools/x64_arm64/crossgen
runtime/x64_arm64/native/libclrjit.so
```
to runtime.linux-arm64.Microsoft.NETCore.App*.nupkg

Tested by unzipping above.

Should do the same for arm (untested)

@eerhardt @echesakovMSFT @weshaggard @kasper3 PTAL