### PR TITLE
Enable installer tests for .NET Runtime Windows Packages

### DIFF
--- a/buildpipeline/Core-Setup-Windows-BT.json
+++ b/buildpipeline/Core-Setup-Windows-BT.json
@@ -418,10 +418,40 @@
       "enabled": true,
       "continueOnError": false,
       "alwaysRun": false,
-      "displayName": "Build and run tests",
+      "displayName": "Test Msi",
       "timeoutInMinutes": 0,
       "condition": "and(succeeded(), ne(variables.PB_SkipTests, 'true'))",
       "refName": "Task19",
+      "task": {
+      "id": "c6c4c611-aa2e-4a33-b606-5eaba2196824",
+      "versionSpec": "1.*",
+      "definitionType": "task"
+    },
+    "inputs": {
+      "solution": "$(PB_SourcesDirectory)\\src\\test\\dir.proj",
+      "msbuildLocationMethod": "version",
+      "msbuildVersion": "latest",
+      "msbuildArchitecture": "x64",
+      "msbuildLocation": "",
+      "platform": "$(PB_TargetArchitecture)",
+      "configuration": "$(BuildConfiguration)",
+      "msbuildArguments": "/t:TestInstallers ",
+      "clean": "false",
+      "maximumCpuCount": "false",
+      "restoreNugetPackages": "false",
+      "logProjectEvents": "false",
+      "createLogFile": "false"
+    }
+    },
+    {
+      "environment": {},
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Build and run tests",
+      "timeoutInMinutes": 0,
+      "condition": "and(succeeded(), ne(variables.PB_SkipTests, 'true'))",
+      "refName": "Task20",
       "task": {
         "id": "c6c4c611-aa2e-4a33-b606-5eaba2196824",
         "versionSpec": "1.*",
@@ -450,7 +480,7 @@
       "alwaysRun": false,
       "displayName": "Publish",
       "timeoutInMinutes": 0,
-      "refName": "Task20",
+      "refName": "Task21",
       "task": {
         "id": "c6c4c611-aa2e-4a33-b606-5eaba2196824",
         "versionSpec": "1.*",
@@ -480,7 +510,7 @@
       "displayName": "Cleanup VSTS Agent",
       "timeoutInMinutes": 0,
       "condition": "always()",
-      "refName": "Task21",
+      "refName": "Task22",
       "task": {
         "id": "c6c4c611-aa2e-4a33-b606-5eaba2196824",
         "versionSpec": "1.*",
@@ -510,7 +540,7 @@
       "displayName": "Perform Cleanup Tasks",
       "timeoutInMinutes": 0,
       "condition": "always()",
-      "refName": "Task22",
+      "refName": "Task23",
       "task": {
         "id": "521a94ea-9e68-468a-8167-6dcf361ea776",
         "versionSpec": "1.*",

--- a/buildpipeline/Core-Setup-Windows-BT.json
+++ b/buildpipeline/Core-Setup-Windows-BT.json
@@ -418,40 +418,10 @@
       "enabled": true,
       "continueOnError": false,
       "alwaysRun": false,
-      "displayName": "Test Msi",
-      "timeoutInMinutes": 0,
-      "condition": "and(succeeded(), ne(variables.PB_SkipTests, 'true'))",
-      "refName": "Task19",
-      "task": {
-      "id": "c6c4c611-aa2e-4a33-b606-5eaba2196824",
-      "versionSpec": "1.*",
-      "definitionType": "task"
-    },
-    "inputs": {
-      "solution": "$(PB_SourcesDirectory)\\src\\test\\dir.proj",
-      "msbuildLocationMethod": "version",
-      "msbuildVersion": "latest",
-      "msbuildArchitecture": "x64",
-      "msbuildLocation": "",
-      "platform": "$(PB_TargetArchitecture)",
-      "configuration": "$(BuildConfiguration)",
-      "msbuildArguments": "/t:TestInstallers ",
-      "clean": "false",
-      "maximumCpuCount": "false",
-      "restoreNugetPackages": "false",
-      "logProjectEvents": "false",
-      "createLogFile": "false"
-    }
-    },
-    {
-      "environment": {},
-      "enabled": true,
-      "continueOnError": false,
-      "alwaysRun": false,
       "displayName": "Build and run tests",
       "timeoutInMinutes": 0,
       "condition": "and(succeeded(), ne(variables.PB_SkipTests, 'true'))",
-      "refName": "Task20",
+      "refName": "Task19",
       "task": {
         "id": "c6c4c611-aa2e-4a33-b606-5eaba2196824",
         "versionSpec": "1.*",
@@ -480,7 +450,7 @@
       "alwaysRun": false,
       "displayName": "Publish",
       "timeoutInMinutes": 0,
-      "refName": "Task21",
+      "refName": "Task20",
       "task": {
         "id": "c6c4c611-aa2e-4a33-b606-5eaba2196824",
         "versionSpec": "1.*",
@@ -510,7 +480,7 @@
       "displayName": "Cleanup VSTS Agent",
       "timeoutInMinutes": 0,
       "condition": "always()",
-      "refName": "Task22",
+      "refName": "Task21",
       "task": {
         "id": "c6c4c611-aa2e-4a33-b606-5eaba2196824",
         "versionSpec": "1.*",
@@ -540,7 +510,7 @@
       "displayName": "Perform Cleanup Tasks",
       "timeoutInMinutes": 0,
       "condition": "always()",
-      "refName": "Task23",
+      "refName": "Task22",
       "task": {
         "id": "521a94ea-9e68-468a-8167-6dcf361ea776",
         "versionSpec": "1.*",
@@ -797,10 +767,10 @@
   "drafts": [],
   "queue": {
     "id": 36,
-    "name": "DotNet-Build",
+    "name": "DotNetCore-Build",
     "pool": {
       "id": 39,
-      "name": "DotNet-Build"
+      "name": "DotNetCore-Build"
     }
   },
   "id": 6102,

--- a/src/test/dir.proj
+++ b/src/test/dir.proj
@@ -10,10 +10,13 @@
         RestoreTests;
         BuildTests;
         RunTests;
+	TestInstallers;
     </BuildTestTargets>
   </PropertyGroup>
   
   <Target Name="Build" DependsOnTargets="$(BuildTestTargets)" />
+
+  <Target Name="TestInstallers" DependsOnTargets="TestDocker;TestMsi" />
 
   <Target Name="DetermineTestOutputDirectory">
     <GetTargetMachineInfo>
@@ -127,8 +130,6 @@
     <Copy SourceFiles="@(SharedFrameworkPublishFiles)"
           DestinationFiles="@(SharedFrameworkPublishFiles->'$(TestsOutputDir)sharedFrameworkPublish/%(RecursiveDir)%(Filename)%(Extension)')" />
   </Target>
-
-  <Target Name="TestInstallers" DependsOnTargets="TestDocker;TestMsi" />
 
   <Target Name="TestMsi"
          Condition="'$(OSGroup)' == 'Windows_NT' and '$(GenerateMSI)' == 'true' and '$(DockerPresent)' == 'true' "  >

--- a/src/test/dir.proj
+++ b/src/test/dir.proj
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="dir.props" />
+  <Import Project="../../src/pkg/packaging/windows/package.props" />
   <UsingTask TaskName="GetTargetMachineInfo" AssemblyFile="$(BuildToolsTaskDir)Microsoft.DotNet.Build.Tasks.dll" />
 
   <PropertyGroup>
@@ -11,7 +12,7 @@
         RunTests;
     </BuildTestTargets>
   </PropertyGroup>
-
+  
   <Target Name="Build" DependsOnTargets="$(BuildTestTargets)" />
 
   <Target Name="DetermineTestOutputDirectory">
@@ -125,6 +126,54 @@
 
     <Copy SourceFiles="@(SharedFrameworkPublishFiles)"
           DestinationFiles="@(SharedFrameworkPublishFiles->'$(TestsOutputDir)sharedFrameworkPublish/%(RecursiveDir)%(Filename)%(Extension)')" />
+  </Target>
+
+  <Target Name="TestInstallers" DependsOnTargets="TestDocker;TestMsi" />
+
+  <Target Name="TestMsi"
+         Condition="'$(OSGroup)' == 'Windows_NT' and '$(GenerateMSI)' == 'true' and '$(DockerPresent)' == 'true' "  >
+
+   <PropertyGroup>
+     <TestMsiPowershellScript>$(TestDir)\test-installer\testmsi.ps1</TestMsiPowershellScript>
+     <ProductionVersion>$(MajorVersion).$(MinorVersion).$(PatchVersion)</ProductionVersion>
+     <RuntimeExe>$(CombinedInstallerFile)</RuntimeExe>   
+   </PropertyGroup>
+
+   <ItemGroup>
+     <MsiFileName Include="$(SharedHostInstallerFile)" />
+     <MsiFileName Include="$(HostFxrInstallerFile)" />
+     <MsiFileName Include="$(SharedFrameworkInstallerFile)" />
+   </ItemGroup>
+	
+   <PropertyGroup>
+     <TestOSPlatformConfig>$(TestTargetRid).$(ConfigurationGroup)</TestOSPlatformConfig>
+     <TestsOutputDir Condition="'$(TestsOutputDir)' == ''">$(BaseOutputPath)tests/$(TestOSPlatformConfig)/</TestsOutputDir>
+     <MsiTestsOutputDir>$(TestsOutputDir)Msi.Tests/</MsiTestsOutputDir>
+   </PropertyGroup>
+
+   <RemoveDir Condition="Exists('$(MsiTestsOutputDir)')" Directories="$(MsiTestsOutputDir)" />
+   <MakeDir Directories="$(MsiTestsOutputDir)" />
+
+   <Exec Command ="powershell -NoProfile -NoLogo $(TestMsiPowershellScript) -TestDir $(MsiTestsOutputDir) -InputMsi @(MsiFileName, ', ') -InputExe $(RuntimeExe) -ProductVersion $(ProductionVersion)" />
+
+  </Target>
+
+  <Target Name="TestDocker">
+
+    <!-- run Docker -->
+    <Exec Command="docker -v" ContinueOnError="true">
+      <Output TaskParameter="ExitCode" PropertyName="DockerExitCode" />
+    </Exec>
+
+    <!-- Check if it returned 0 -->
+    <PropertyGroup>
+      <DockerPresent>false</DockerPresent>
+      <DockerPresent Condition=" '$(DockerExitCode)' == '0' ">true</DockerPresent>
+    </PropertyGroup>
+
+    <Message Condition=" '$(DockerPresent)'  != 'true' "
+             Text="Docker Not found, Msi Tests will not be executed."
+             Importance="Normal" />
   </Target>
 
 </Project>

--- a/src/test/test-installer/Msi.Tests/ExeManager.cs
+++ b/src/test/test-installer/Msi.Tests/ExeManager.cs
@@ -3,10 +3,6 @@
 
 using System;
 using System.Diagnostics;
-using System.IO;
-using System.Linq;
-using Microsoft.Deployment.WindowsInstaller;
-using Microsoft.Deployment.WindowsInstaller.Package;
 
 namespace Msi.Tests
 {

--- a/src/test/test-installer/Msi.Tests/ExeManager.cs
+++ b/src/test/test-installer/Msi.Tests/ExeManager.cs
@@ -1,0 +1,58 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using Microsoft.Deployment.WindowsInstaller;
+using Microsoft.Deployment.WindowsInstaller.Package;
+
+namespace Msi.Tests
+{
+    public class ExeManager
+    {
+        private string _bundleFile;
+
+        public ExeManager(string exeFile)
+        {
+            _bundleFile = exeFile;
+        }
+
+        public bool Install(string customLocation = null)
+        {
+            string dotnetHome = "";
+            if (!string.IsNullOrEmpty(customLocation))
+            {
+                dotnetHome = $"DOTNETHOME={customLocation}";
+            }
+
+            RunBundle(dotnetHome);
+
+            return true;
+        }
+
+        public bool UnInstall()
+        {
+            RunBundle("/uninstall");
+
+            return true;
+        }
+
+        private void RunBundle(string additionalArguments)
+        {
+            var arguments = $"/q /norestart {additionalArguments}";
+            var process = Process.Start(_bundleFile, arguments);
+
+            if (!process.WaitForExit(5 * 60 * 1000))
+            {
+                throw new InvalidOperationException($"Failed to wait for the installation operation to complete. Check to see if the installation process is still running. Command line: {_bundleFile} {arguments}");
+            }
+
+            else if (0 != process.ExitCode)
+            {
+                throw new InvalidOperationException($"The installation operation failed with exit code: {process.ExitCode}. Command line: {_bundleFile} {arguments}");
+            }
+        }
+    }
+}

--- a/src/test/test-installer/Msi.Tests/InstallationTests.cs
+++ b/src/test/test-installer/Msi.Tests/InstallationTests.cs
@@ -1,0 +1,61 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.IO;
+using System.Collections.Generic;
+using Xunit;
+
+[assembly: CollectionBehavior(DisableTestParallelization = true)]
+
+namespace Msi.Tests
+{
+    public class InstallationTests 
+    {
+        private ExeManager _exeMgr;
+
+        public InstallationTests()
+        {
+	    // test assume that the exe to be tested is available via environment variable %RUNTIME_EXE%
+            var exeFile = Environment.GetEnvironmentVariable("RUNTIME_EXE");
+	    if(string.IsNullOrEmpty(exeFile))
+            {
+                throw new InvalidOperationException("%RUNTIME_EXE% must point to the exe that is to be tested");
+            }
+	    _exeMgr = new ExeManager(exeFile);
+        } 
+
+	public static IEnumerable<object[]> ListMsiMgr(){
+
+		// test assume that the list of msi to be tested is available via environment variable %MSI_LIST%
+		var msiList = Environment.GetEnvironmentVariable("MSI_LIST");
+	        if(string.IsNullOrEmpty(msiList))
+      		{
+                	throw new InvalidOperationException("%MSI_LIST% must point to the list of msi that is to be tested");
+            	}
+		string[] lines = System.IO.File.ReadAllLines(msiList);
+		foreach( string msi in lines){
+		    yield return new object[] { new MsiManager(msi) }; 
+		}
+	}
+
+	[Theory]
+	[MemberData(nameof(ListMsiMgr))]
+	public void MsiInstallTest(MsiManager msiMgr){
+		InstallTest(msiMgr, _exeMgr);
+	}
+
+	public void InstallTest(MsiManager _msiMgr, ExeManager _exeMgr)
+        {
+            // make sure that the msi is not already installed, if so the machine is in a bad state
+            Assert.False(_msiMgr.IsInstalled, "The dotnet CLI msi is already installed");
+
+            _exeMgr.Install();
+            Assert.True(_msiMgr.IsInstalled);
+
+            _exeMgr.UnInstall();
+            Assert.False(_msiMgr.IsInstalled);
+        }
+
+   }
+}

--- a/src/test/test-installer/Msi.Tests/Msi.Tests.csproj
+++ b/src/test/test-installer/Msi.Tests/Msi.Tests.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk" >
+	
+  <PropertyGroup>
+	<TargetFrameworks>net46</TargetFrameworks>
+	<AssemblyName>Msi.Tests</AssemblyName>
+	<GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
+  </PropertyGroup>
+  <ItemGroup>
+	<PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
+        <PackageReference Include="xunit" Version="2.2.0" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
+	<PackageReference Include="Microsoft.Deployment.WindowsInstaller" Version="1.0.0" />
+  </ItemGroup>		
+</Project>

--- a/src/test/test-installer/Msi.Tests/MsiManager.cs
+++ b/src/test/test-installer/Msi.Tests/MsiManager.cs
@@ -1,0 +1,59 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using Microsoft.Deployment.WindowsInstaller;
+using Microsoft.Deployment.WindowsInstaller.Package;
+
+namespace Msi.Tests
+{
+    public class MsiManager
+    {
+        private string _msiFile;
+        private string _productCode;
+        private InstallPackage _installPackage;
+
+        public ProductInstallation Installation
+        {
+            get
+            {
+                return ProductInstallation.AllProducts.SingleOrDefault(p => p.ProductCode == _productCode);
+            }
+        }
+
+        public string InstallLocation
+        {
+            get
+            {
+                return IsInstalled ? Installation.InstallLocation : null;
+            }
+        }
+
+        public bool IsInstalled
+        {
+            get
+            {
+                var prodInstall = Installation;
+                return Installation == null ? false : prodInstall.IsInstalled;
+            }
+        }
+
+        public MsiManager(string msiFile)
+        {
+            _msiFile = msiFile;
+
+            var ispackage = Installer.VerifyPackage(msiFile);
+            if (!ispackage)
+            {
+                throw new ArgumentException("Not a valid MSI file", msiFile);
+            }
+
+            _installPackage = new InstallPackage(msiFile, DatabaseOpenMode.ReadOnly);
+            _productCode = _installPackage.Property["ProductCode"];
+        }
+
+    }
+}

--- a/src/test/test-installer/Msi.Tests/PropertyTests.cs
+++ b/src/test/test-installer/Msi.Tests/PropertyTests.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using System.IO;
+using Microsoft.Deployment.WindowsInstaller;
+using Xunit;
+using System.Collections.Generic;
+
+namespace Msi.Tests
+{
+    public class PropertyTests
+    {
+	private string _prodVersion;
+
+	public PropertyTests()
+	{
+	     _prodVersion = Environment.GetEnvironmentVariable("PROD_VERSION");
+	}
+	
+	public static IEnumerable<object[]> ListMsi()
+	{
+
+		// test assume that the list of msi to be tested is available via environment variable %MSI_LIST%
+                var msiList = Environment.GetEnvironmentVariable("MSI_LIST");
+		if(string.IsNullOrEmpty(msiList))
+                {
+                        throw new InvalidOperationException("%MSI_LIST% must point to the list of msi that is to be tested");
+                }
+                string[] lines = System.IO.File.ReadAllLines(msiList);
+                foreach( string msi in lines){
+                    yield return new object[] { msi };
+                }
+        }
+
+        [Theory]
+        [MemberData(nameof(ListMsi))]
+        public void ProductNameTest(string msi)
+	{
+                 using (var database = new Database(msi, DatabaseOpenMode.ReadOnly))
+		    {
+			    string prodName = database.ExecutePropertyQuery("ProductName");
+			    Assert.True(prodName.Contains(_prodVersion), "Different brand name");
+		    }
+        }
+
+    }
+}

--- a/src/test/test-installer/testmsi.ps1
+++ b/src/test/test-installer/testmsi.ps1
@@ -1,0 +1,112 @@
+# Copyright (c) .NET Foundation and contributors. All rights reserved.
+# Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+param(
+    [string]$TestDir,
+    [string[]]$InputMsi,
+    [string]$InputExe,
+    [string]$ProductVersion
+)
+
+$RepoRoot = Convert-Path "$PSScriptRoot\..\..\.."
+$CommonScript = "$RepoRoot\tools-local\scripts\common\_common.ps1"
+
+Write-Output "$RepoRoot"
+
+if(-Not (Test-Path "$CommonScript"))
+{
+    Exit -1
+} 
+. "$CommonScript"
+
+$dotNetCli = "$RepoRoot\Tools\dotnetcli"
+$dotNetExe = Join-Path $dotNetCli "dotnet.exe"
+
+if(-Not (Test-Path $dotNetCli))
+{
+    throw "$dotNetCli not found" 
+}
+
+
+function CopyInstaller([string]$destination)
+{
+    # Copy the .msi and the .exe to the TestDir directory so
+    # the tests running in the docker container have access to them.
+    foreach($msi in $InputMsi)
+    {
+    	Copy-Item $msi -Destination $destination
+    }
+
+    Copy-Item $InputExe -Destination $destination -ErrorAction Ignore
+}
+
+function CopyDotnetCli([string]$destination)
+{
+    if( Test-Path $destination\dotnetcli )
+    {
+    	Remove-Item -Path "$destination\dotnetcli\*" -Recurse
+    }
+    robocopy $dotNetCli $destination\dotnetcli /S | Out-Null
+    #Copy-Item -Path $dotNetCli -Destination $destination -Recurse
+}
+
+function CreateMsiListFile()
+{
+    if( Test-Path $msiListPath )
+    {
+    	Remove-Item $msiListPath
+    }
+    foreach($msi in $InputMsi)
+    {
+    	[System.IO.Path]::GetFileName($msi) | Out-File -filepath $msiListPath -Append
+    }
+}
+
+
+Write-Output "Running tests for MSI installer at $inputMsi."
+
+$testName = "Msi.Tests"
+$testProj="$PSScriptRoot\$testName\$testName.csproj"
+
+$dockerDir= Join-Path $TestDir "dockerDir"
+
+$listMsiFileName="ListMsi.txt"
+$msiListPath="$dockerDir\$listMsiFileName"
+
+try {
+     
+    & $dotNetExe restore $testProj
+
+    if($LastExitCode -ne 0)
+    {
+        throw "dotnet restore failed with exit code $LastExitCode."     
+    }
+
+    & $dotNetExe build --no-restore --output $dockerDir $testProj
+
+    if($LastExitCode -ne 0)
+    {
+        throw "dotnet build failed with exit code $LastExitCode."
+    }
+
+    Write-Output "Running installer tests"
+   
+    CopyInstaller $dockerDir
+    CopyDotnetCli $dockerDir
+    CreateMsiListFile
+
+    $RuntimeExeFileName = [System.IO.Path]::GetFileName($InputExe)
+
+    docker run --rm -v "$dockerDir\:C:\sharedFolder" -e RUNTIME_EXE=$RuntimeExeFileName -e MSI_LIST=$listMsiFileName -e PROD_VERSION=$ProductVersion microsoft/windowsservercore C:\sharedFolder\dotnetcli\dotnet.exe vstest C:\sharedFolder\$testName.dll | Out-Host
+
+    if($LastExitCode -ne 0)
+    {
+        throw "dotnet test failed with exit code $LastExitCode."     
+    }
+    
+}
+
+finally {
+    Write-Output "End of test"
+}
+Exit 0

--- a/src/test/test-installer/testmsi.ps1
+++ b/src/test/test-installer/testmsi.ps1
@@ -89,13 +89,13 @@ try {
         throw "dotnet build failed with exit code $LastExitCode."
     }
 
-    Write-Output "Running installer tests"
-   
     CopyInstaller $dockerDir
     CopyDotnetCli $dockerDir
     CreateMsiListFile
 
     $RuntimeExeFileName = [System.IO.Path]::GetFileName($InputExe)
+
+    Write-Output "Running installer tests in Docker container"
 
     docker run --rm -v "$dockerDir\:C:\sharedFolder" -e RUNTIME_EXE=$RuntimeExeFileName -e MSI_LIST=$listMsiFileName -e PROD_VERSION=$ProductVersion microsoft/windowsservercore C:\sharedFolder\dotnetcli\dotnet.exe vstest C:\sharedFolder\$testName.dll | Out-Host
 


### PR DESCRIPTION
This will enable installing runtime bundle and ensure the following : 
1. Bundle installs successfully
2. Bundle carries all the three msi ( host,hostfxr and runtime ) 

Test runs only on docker and skips if docker is not found on the machine or --skiptest is being passed.
