### PR TITLE
Make logging consistent across platforms for pal::get_symbol

### DIFF
--- a/src/corehost/cli/fxr/hostfxr.cpp
+++ b/src/corehost/cli/fxr/hostfxr.cpp
@@ -39,7 +39,7 @@ int load_host_library_common(
     *load_fn = (corehost_load_fn)pal::get_symbol(*h_host, "corehost_load");
     *unload_fn = (corehost_unload_fn)pal::get_symbol(*h_host, "corehost_unload");
 
-    return (*load_fn) && (*unload_fn)
+    return (*load_fn != nullptr) && (*unload_fn != nullptr)
         ? StatusCode::Success
         : StatusCode::CoreHostEntryPointFailure;
 }
@@ -61,7 +61,7 @@ int load_host_library(
     // Obtain entrypoint symbol
     *main_fn = (corehost_main_fn)pal::get_symbol(*h_host, "corehost_main");
 
-    return (*main_fn)
+    return (*main_fn != nullptr)
         ? StatusCode::Success
         : StatusCode::CoreHostEntryPointFailure;
 }
@@ -83,7 +83,7 @@ int load_host_library_with_return(
     // Obtain entrypoint symbol
     *main_fn = (corehost_main_with_output_buffer_fn)pal::get_symbol(*h_host, "corehost_main_with_output_buffer");
 
-    return (*main_fn)
+    return (*main_fn != nullptr)
         ? StatusCode::Success
         : StatusCode::CoreHostEntryPointFailure;
 }

--- a/src/corehost/common/pal.unix.cpp
+++ b/src/corehost/common/pal.unix.cpp
@@ -79,12 +79,7 @@ bool pal::load_library(const string_t* path, dll_t* dll)
 
 pal::proc_t pal::get_symbol(dll_t library, const char* name)
 {
-    auto result = dlsym(library, name);
-    if (result == nullptr)
-    {
-        trace::error(_X("Failed to resolve library symbol %s, error: %s"), name, dlerror());
-    }
-    return result;
+    return dlsym(library, name);
 }
 
 void pal::unload_library(dll_t library)

--- a/src/corehost/common/pal.unix.cpp
+++ b/src/corehost/common/pal.unix.cpp
@@ -79,7 +79,13 @@ bool pal::load_library(const string_t* path, dll_t* dll)
 
 pal::proc_t pal::get_symbol(dll_t library, const char* name)
 {
-    return dlsym(library, name);
+    auto result = dlsym(library, name);
+    if (result == nullptr)
+    {
+        trace::info(_X("Probed for and did not find library symbol %s, error: %s"), name, dlerror());
+    }
+
+    return result;
 }
 
 void pal::unload_library(dll_t library)

--- a/src/corehost/common/pal.windows.cpp
+++ b/src/corehost/common/pal.windows.cpp
@@ -131,7 +131,13 @@ bool pal::load_library(const string_t* in_path, dll_t* dll)
 
 pal::proc_t pal::get_symbol(dll_t library, const char* name)
 {
-    return ::GetProcAddress(library, name);
+    auto result = ::GetProcAddress(library, name);
+    if (result == nullptr)
+    {
+        trace::info(_X("Probed for and did not resolve library symbol %s"), name);
+    }
+
+    return result;
 }
 
 void pal::unload_library(dll_t library)

--- a/src/corehost/corehost.cpp
+++ b/src/corehost/corehost.cpp
@@ -271,7 +271,7 @@ int run(const int argc, const pal::char_t* argv[])
     // Obtain the entrypoints.
     int rc;
     hostfxr_main_startupinfo_fn main_fn_v2 = (hostfxr_main_startupinfo_fn)pal::get_symbol(fxr, "hostfxr_main_startupinfo");
-    if (main_fn_v2)
+    if (main_fn_v2 != nullptr)
     {
         const pal::char_t* host_path_cstr = host_path.c_str();
         const pal::char_t* dotnet_root_cstr = dotnet_root.empty() ? nullptr : dotnet_root.c_str();
@@ -304,7 +304,7 @@ int run(const int argc, const pal::char_t* argv[])
             // For compat, use the v1 interface. This requires additional file I\O to re-parse parameters and
             // for apphost, does not support DOTNET_ROOT or dll with different name for exe.
             hostfxr_main_fn main_fn_v1 = (hostfxr_main_fn)pal::get_symbol(fxr, "hostfxr_main");
-            if (main_fn_v1)
+            if (main_fn_v1 != nullptr)
             {
                 rc = main_fn_v1(argc, argv);
             }


### PR DESCRIPTION
Remove the `trace::error` under Linux\OSX when calling `pal::get_symbol` when no symbol was found. Windows does not log the error in this case and it is not necessarily an error when this occurs.

I did verify that the uses of get_symbol do verify against nullptr for the error cases.

Another change was to add explicit comparisons to `nullptr` although that is not causing any issues.

This is a partial fix for https://github.com/dotnet/core-setup/issues/4007. We still need to determine why preview bits of hostfxr are installed with released bits of SDK.
