### PR TITLE
Avoid logging to stderr when pal::get_symbol fails.

### DIFF
--- a/src/corehost/common/pal.unix.cpp
+++ b/src/corehost/common/pal.unix.cpp
@@ -82,7 +82,7 @@ pal::proc_t pal::get_symbol(dll_t library, const char* name)
     auto result = dlsym(library, name);
     if (result == nullptr)
     {
-        trace::error(_X("Failed to resolve library symbol %s, error: %s"), name, dlerror());
+        trace::info(_X("Probed for and did not find library symbol %s, error: %s"), name, dlerror());
     }
     return result;
 }


### PR DESCRIPTION
Port the fix from https://github.com/dotnet/core-setup/commit/9a776be820ff4ae83476c7e9e97514ecd8f3ae1d. Only one line from that fix is ported to release/2.1 (trace::error to trace::info) as that is all that is needed to fix the underlying issue.

For issue https://github.com/dotnet/core-setup/issues/4007

