### PR TITLE
Enable package signing

### DIFF
--- a/publish/publish-type.proj
+++ b/publish/publish-type.proj
@@ -8,7 +8,8 @@
   <PropertyGroup>
     <BuildDependsOn>
       ValidateProperties;
-      DownloadFilesFromContainer
+      DownloadFilesFromContainer;
+      SignPackages
     </BuildDependsOn>
 
     <BuildDependsOn Condition="$(PublishType.Contains('blob'))">
@@ -38,7 +39,7 @@
     <Error Condition="'$(PublishBlobFeedKey)' == ''" Text="Missing required property 'PublishBlobFeedKey'" />
 
     <PropertyGroup>
-      <!-- map the properties to the values expexed by the Feeds.targets file -->
+      <!-- map the properties to the values expected by the Feeds.targets file -->
       <ExpectedFeedUrl>$(PublishBlobFeedUrl)</ExpectedFeedUrl>
       <AccountKey>$(PublishBlobFeedKey)</AccountKey>
     </PropertyGroup>
@@ -74,6 +75,20 @@
         <ManifestArtifactData>ShipInstaller=dotnetcli</ManifestArtifactData>
       </FilesToPublish>
     </ItemGroup>
+  </Target>
+
+  <Target Name="GetPackagesToSign" DependsOnTargets="DownloadFilesFromContainer">
+    <ItemGroup>
+      <FilesToSign Include="@(ShippedNugetPackage)">
+        <Authenticode>NuGet</Authenticode>
+      </FilesToSign>
+    </ItemGroup>
+    <Message Importance="High" Text="Attempting to sign package '%(FilesToSign.Identity)'" />
+  </Target>
+
+  <Target Name="SignPackages"
+          Condition="'$(SkipSigning)' != 'true' and '$(SignType)' != 'public'"
+          DependsOnTargets="GetPackagesToSign;SignFiles">
   </Target>
 
   <!--


### PR DESCRIPTION
This adds signing for packaging when publishing for
orchestrated builds. The standalone builds currently won't
sign packages but that shouldn't be an issue as we don't publish
those officially. We also have an issue to converge the publishing
for both build flavors which will fix this. See
https://github.com/dotnet/core-setup/issues/3428

cc @mmitche 