### PR TITLE
Add linux-musl build leg

### DIFF
--- a/buildpipeline/pipeline.json
+++ b/buildpipeline/pipeline.json
@@ -63,6 +63,21 @@
         {
           "Name": "Core-Setup-Linux-Arm-BT",
           "Parameters": {
+            "PB_DockerTag": "alpine-3.6-3148f11-20171119021156",
+            "PB_TargetArchitecture": "x64",
+            "PB_AdditionalBuildArguments":"-TargetArchitecture=x64 -PortableBuild=false -strip-symbols -SkipTests=$(PB_SkipTests)",
+            "PB_AdditionalMSBuildArguments":"/p:OutputRid=linux-musl-x64 /p:DotNetRestoreSources=$(PB_RestoreSource) /p:StabilizePackageVersion=$(PB_IsStable) /p:PackageVersionStamp=$(PB_VersionStamp)",
+            "PB_PortableBuild": "false"
+          },
+          "ReportingParameters": {
+            "OperatingSystem": "Linux-musl",
+            "Type": "build/product/",
+            "Platform": "x64"
+          }
+        },
+        {
+          "Name": "Core-Setup-Linux-Arm-BT",
+          "Parameters": {
             "PB_DockerTag": "ubuntu-14.04-cross-e435274-20180323032140",
             "PB_TargetArchitecture": "arm",
             "PB_AdditionalBuildArguments":"-TargetArchitecture=arm -PortableBuild=true -SkipTests=true -CrossBuild=true -strip-symbols",

--- a/src/pkg/projects/netcoreappRIDs.props
+++ b/src/pkg/projects/netcoreappRIDs.props
@@ -7,6 +7,7 @@
 
   <ItemGroup>
     <OfficialBuildRID Include="linux-x64" />
+    <OfficialBuildRID Include="linux-musl-x64" />
     <OfficialBuildRID Include="rhel.6-x64" />
     <OfficialBuildRID Include="alpine.3.6-x64" />
     <OfficialBuildRID Include="osx-x64" />
@@ -27,8 +28,8 @@
       <Platform>arm64</Platform>
     </OfficialBuildRID>
 
-    <!-- The following RIDs are not officically supported and are not 
-         built during official builds, however we wish to include them 
+    <!-- The following RIDs are not officically supported and are not
+         built during official builds, however we wish to include them
          in our runtime.json to enable others to provide them.  -->
     <UnofficialBuildRID Include="tizen.4.0.0-armel">
       <Platform>armel</Platform>


### PR DESCRIPTION
@eerhardt @janvorli 

I expect this to fail until we have a published coreclr/corefx build for linux-musl. 