### PR TITLE
On minor roll-forward framework wins over app when same versions in deps.json

### DIFF
--- a/src/corehost/cli/deps_resolver.cpp
+++ b/src/corehost/cli/deps_resolver.cpp
@@ -465,9 +465,9 @@ bool deps_resolver_t::resolve_tpa_list(
             {
                 deps_resolved_asset_t* existing_entry = &existing->second;
 
-                // If deps entry is newer than existing, then see if it should be replaced
+                // If deps entry is same or newer than existing, then see if it should be replaced
                 if (entry.asset.assembly_version > existing_entry->asset.assembly_version ||
-                    (entry.asset.assembly_version == existing_entry->asset.assembly_version && entry.asset.file_version > existing_entry->asset.file_version))
+                    (entry.asset.assembly_version == existing_entry->asset.assembly_version && entry.asset.file_version >= existing_entry->asset.file_version))
                 {
                     if (probe_deps_entry(entry, deps_dir, fx_level, &resolved_path))
                     {


### PR DESCRIPTION
To be merged post-RC for RTW

Direct port of https://github.com/dotnet/core-setup/commit/46d60b06b7f85ca492e9e895e904a27fc3f86c23
from this [PR in master](https://github.com/dotnet/core-setup/pull/4076)

Fixes https://github.com/dotnet/core-setup/issues/4047

