### PR TITLE
Avoid logging to stderr if core_servicing location is empty

### DIFF
--- a/src/corehost/cli/deps_resolver.cpp
+++ b/src/corehost/cli/deps_resolver.cpp
@@ -689,7 +689,7 @@ bool deps_resolver_t::resolve_probe_dirs(
     std::unordered_set<pal::string_t> items;
 
     pal::string_t core_servicing = m_core_servicing;
-    pal::realpath(&core_servicing);
+    pal::realpath(&core_servicing, true);
 
     // Filter out non-serviced assets so the paths can be added after servicing paths.
     pal::string_t non_serviced;


### PR DESCRIPTION
Addresses https://github.com/dotnet/core-setup/issues/3852 by not logging to stderr when the call to realpath() fails when resolving the servicing location. 

The issue is the servicing location "\Program Files (x86)" does not exist, and the call to realpath() fails. Note if that directory is manually created, the error also goes away.

Verified by reproducing the original problem, and then replacing the hostpolicy.dll in the Docker container with the "fixed" version. Then the "Error resolving full path []" message was not displayed.

Will ask shiproom for permission to add to 2.1.0.