### PR TITLE
Avoid logging to stderr if core_servicing location is empty (#4110)

### DIFF
--- a/src/corehost/cli/deps_resolver.cpp
+++ b/src/corehost/cli/deps_resolver.cpp
@@ -689,7 +689,7 @@ bool deps_resolver_t::resolve_probe_dirs(
     std::unordered_set<pal::string_t> items;
 
     pal::string_t core_servicing = m_core_servicing;
-    pal::realpath(&core_servicing);
+    pal::realpath(&core_servicing, true);
 
     // Filter out non-serviced assets so the paths can be added after servicing paths.
     pal::string_t non_serviced;


### PR DESCRIPTION
Direct port of this commit from master: https://github.com/dotnet/core-setup/commit/f6bf0a83c66883fd1380fe0c3ce9b6d1e112f564
 
Issue: https://github.com/dotnet/core-setup/issues/3852
PR (master): https://github.com/dotnet/core-setup/pull/4110

Waiting for shiproom approval for 2.1 RTW before merging.