### PR TITLE
Remove file names from PackagePath folder

### DIFF
--- a/tools-local/setuptools/dotnet-deb-tool/dotnet-deb-tool.csproj
+++ b/tools-local/setuptools/dotnet-deb-tool/dotnet-deb-tool.csproj
@@ -13,12 +13,12 @@
     <Compile Include="..\..\..\src\test\TestUtils\ArgumentEscaper.cs" />
 
     <Content Include="tool\**">
-      <PackagePath>lib/$(TargetFramework)/tool/%(RecursiveDir)%(FileName)%(Extension)</PackagePath>
+      <PackagePath>lib/$(TargetFramework)/tool</PackagePath>
       <Pack>true</Pack>
     </Content>
     <Content Include="prefercliruntime">
       <Pack>true</Pack>
-      <PackagePath>\prefercliruntime</PackagePath>
+      <PackagePath></PackagePath>
     </Content>
 </ItemGroup>
 


### PR DESCRIPTION
We are hitting https://github.com/NuGet/Home/issues/6351, which
was resolved as a by-design change so we need to adjust to
handle it.

Paths for filenames that don't have extensions turned into
<filename>\<filename> as the file got appended to it. Without
an extension nuget assumes the target path is a directory,
for better or worse.

cc @Petermarcu here is another SDK regression caused by a nuget change.
