### PR TITLE
Use current version of DependencyModel

### DIFF
--- a/tools-local/tasks/core-setup.tasks.csproj
+++ b/tools-local/tasks/core-setup.tasks.csproj
@@ -14,9 +14,7 @@
     <PackageReference Include="NuGet.ProjectModel">
       <Version>$(NugetProjectModelPackageVersion)</Version>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.DependencyModel">
-      <Version>1.1.1</Version>
-    </PackageReference>
+    <ProjectReference Include="..\..\src\managed\Microsoft.Extensions.DependencyModel\Microsoft.Extensions.DependencyModel.csproj"/>
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' != 'net46'">
     <Reference Include="$(BuildToolsTaskCoreDir)Microsoft.DotNet.Build.CloudTestTasks.dll" />

--- a/tools-local/tasks/core-setup.tasks.csproj
+++ b/tools-local/tasks/core-setup.tasks.csproj
@@ -14,7 +14,9 @@
     <PackageReference Include="NuGet.ProjectModel">
       <Version>$(NugetProjectModelPackageVersion)</Version>
     </PackageReference>
-    <ProjectReference Include="..\..\src\managed\Microsoft.Extensions.DependencyModel\Microsoft.Extensions.DependencyModel.csproj"/>
+    <PackageReference Include="Microsoft.Extensions.DependencyModel">
+      <Version>2.1.0-preview2-26306-03</Version>
+    </PackageReference>
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' != 'net46'">
     <Reference Include="$(BuildToolsTaskCoreDir)Microsoft.DotNet.Build.CloudTestTasks.dll" />


### PR DESCRIPTION
Update the core-setup.tasks.dll to a newer Microsoft.Extensions.DependencyModel so that it properly generates the version metadata in Microsoft.NETCore.App.deps.json. The version of Microsoft.Extensions.DependencyModel selected is the same as the SDK's (2.1.300-rc1-008673) reference which adds support to use the newer DependencyModel.

Fixes #4082 