### PR TITLE
Enable Microbuild Signing in Core-Setup 2.0.0

### DIFF
--- a/buildpipeline/Core-Setup-Publish.json
+++ b/buildpipeline/Core-Setup-Publish.json
@@ -3,6 +3,27 @@
     {
       "environment": {},
       "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Install Signing Plugin",
+      "timeoutInMinutes": 0,
+      "condition": "and(succeeded(), in(variables.PB_SignType, 'real', 'test'))",
+      "task": {
+        "id": "30666190-6959-11e5-9f96-f56098202fef",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "signType": "real",
+        "zipSources": "true",
+        "version": "",
+        "feedSource": "https://devdiv.pkgs.visualstudio.com/DefaultCollection/_packaging/MicroBuildToolset/nuget/v3/index.json",
+        "esrpSigning": "$(PB_UseEsrpSigning)"
+      }
+    },
+    {
+      "environment": {},
+      "enabled": true,
       "continueOnError": true,
       "displayName": "run begin.ps1",
       "timeoutInMinutes": 0,

--- a/publish/publish.proj
+++ b/publish/publish.proj
@@ -149,8 +149,10 @@
   </Target>
 
   <Target Name="PublishCoreHostPackagesToFeed"
-          DependsOnTargets="CheckIfAllBuildsHavePublished"
-          Condition="'@(_MissingBlobNames)' == '' AND '$(NuGetFeedUrl)' != ''">
+          DependsOnTargets="CheckIfAllBuildsHavePublished;DownloadCoreHostPackagesFromAzure;SignPackages;DoPushCoreHostPackagesToFeed"
+          Condition="'@(_MissingBlobNames)' == '' AND '$(NuGetFeedUrl)' != ''"/>
+
+  <Target Name="DownloadCoreHostPackagesFromAzure">
     <Error Condition="'$(NuGetApiKey)' == ''" Text="Missing required property NuGetApiKey" />
     <Error Condition="'$(AzureAccessToken)' == ''" Text="Missing required property 'AzureAccessToken'" />
     <Error Condition="'$(AzureAccountName)' == ''" Text="Missing required property 'AzureAccountName'" />
@@ -185,6 +187,23 @@
     </ItemGroup>
     <Error Condition="'@(_DownloadedSymbolsPackages)' != '' and '$(NuGetSymbolsFeedUrl)' == ''" Text="Missing required property NuGetSymbolsFeedUrl" />
     
+  </Target>
+
+  <Target Name="GetPackagesToSign">
+    <ItemGroup>
+      <FilesToSign Include="@(_DownloadedStandardPackages)">
+        <Authenticode>NuGet</Authenticode>
+      </FilesToSign>
+    </ItemGroup>
+    <Message Importance="High" Text="Attempting to sign package '%(FilesToSign.Identity)'" />
+  </Target>
+
+  <Target Name="SignPackages"
+          Condition="'$(SkipSigning)' != 'true' and '$(SignType)' != 'public'"
+          DependsOnTargets="GetPackagesToSign;SignFiles">
+  </Target>
+
+  <Target Name="DoPushCoreHostPackagesToFeed">
     <Message Text="Pushing CoreHost packages to $(NuGetFeedUrl)" />
     <PropertyGroup>
       <NuGetPushCommand>$(DotnetToolCommand) nuget push --source $(NuGetFeedUrl) --api-key $(NuGetApiKey) --timeout $(NuGetPushTimeoutSeconds)</NuGetPushCommand>


### PR DESCRIPTION
For issue https://github.com/dotnet/core-eng/issues/3393

This will also require passing `PB_UseEsrpSigning` from the 2.0.0 pipebuild

@weshaggard @eerhardt @dagood PTAL, especially at publish.proj