### PR TITLE
[release/2.1] Remove brand suffix for stable builds

### DIFF
--- a/BranchInfo.props
+++ b/BranchInfo.props
@@ -12,7 +12,7 @@
     <IncludeBuildNumberInPackageVersion Condition="'$(StabilizePackageVersion)' != 'true'">true</IncludeBuildNumberInPackageVersion>
 
     <ReleaseSuffix>$(PreReleaseLabel)</ReleaseSuffix>
-    <ReleaseBrandSuffix>Release Candidate 1</ReleaseBrandSuffix>
+    <ReleaseBrandSuffix Condition="'$(IncludePreReleaseLabelInPackageVersion)' == 'true'">Release Candidate 1</ReleaseBrandSuffix>
     <Channel>master</Channel>
     <BranchName>master</BranchName>
     <ContainerName>dotnet</ContainerName>


### PR DESCRIPTION
This removes the brand suffix from the installers for
stable builds.

cc @rakeshsinghranchi @leecow @mmitche 