### PR TITLE
Bump PlatformAbstrctions and DependencyModel version to match the rest of the branch.

### DIFF
--- a/src/Microsoft.DotNet.PlatformAbstractions/project.json
+++ b/src/Microsoft.DotNet.PlatformAbstractions/project.json
@@ -1,6 +1,6 @@
 {
   "description": "Abstractions for making code that uses file system and environment testable.",
-  "version": "1.1.4-servicing-*",
+  "version": "1.1.9-servicing-*",
   "buildOptions": {
     "warningsAsErrors": true,
     "keyFile": "../../tools/Key.snk",

--- a/src/Microsoft.Extensions.DependencyModel/project.json
+++ b/src/Microsoft.Extensions.DependencyModel/project.json
@@ -1,14 +1,12 @@
 {
   "description": "Abstractions for reading `.deps` files.",
-  "version": "1.1.4-servicing-*",
+  "version": "1.1.9-servicing-*",
   "buildOptions": {
     "warningsAsErrors": true,
     "keyFile": "../../tools/Key.snk"
   },
   "dependencies": {
-    "Microsoft.DotNet.PlatformAbstractions": {
-      "target": "project"
-    },
+    "Microsoft.DotNet.PlatformAbstractions": "1.1.2",
     "Newtonsoft.Json": "9.0.1"
   },
   "frameworks": {


### PR DESCRIPTION
NOTE: Since we need to service DependencyModel, but not PlatformAbstractions, pin the dependency on the latest shipped package.

This change should be merged now.  And once it is merged, I'll create another PR to mark DependencyModel as "stable" version that should be merged right before we ship 1.1.9.

/cc @ianhays 