### PR TITLE
Mark DependencyModel stable for shipping in 1.1.9.

### DIFF
--- a/src/Microsoft.DotNet.PlatformAbstractions/project.json
+++ b/src/Microsoft.DotNet.PlatformAbstractions/project.json
@@ -1,6 +1,6 @@
 {
   "description": "Abstractions for making code that uses file system and environment testable.",
-  "version": "1.1.9-servicing-*",
+  "version": "1.1.9",
   "buildOptions": {
     "warningsAsErrors": true,
     "keyFile": "../../tools/Key.snk",

--- a/src/Microsoft.Extensions.DependencyModel/project.json
+++ b/src/Microsoft.Extensions.DependencyModel/project.json
@@ -1,6 +1,6 @@
 {
   "description": "Abstractions for reading `.deps` files.",
-  "version": "1.1.9-servicing-*",
+  "version": "1.1.9",
   "buildOptions": {
     "warningsAsErrors": true,
     "keyFile": "../../tools/Key.snk"


### PR DESCRIPTION
This should not be merged until we mark the rest of the 1.1.9 release as 'stable'.  This PR is mostly for tracking purposes, to ensure we don't forgot to stablize and ship the DependencyModel nupkg in 1.1.9.