### PR TITLE
[1.1] Add NUGET_FEED_URL to env-vars in build pipelines

### DIFF
--- a/buildpipeline/Core-Setup-CentOS-x64.json
+++ b/buildpipeline/Core-Setup-CentOS-x64.json
@@ -166,7 +166,7 @@
       "allowOverride": true
     },
     "BuildArguments": {
-      "value": "--skip-prereqs --configuration $(BuildConfiguration)  --docker centos.7 --targets Default --env-vars NUGET_API_KEY=$(NUGET_API_KEY),GITHUB_PASSWORD=$(GITHUB_PASSWORD),REPO_PASS=$(REPO_PASS),CONNECTION_STRING=$(CONNECTION_STRING)",
+      "value": "--skip-prereqs --configuration $(BuildConfiguration)  --docker centos.7 --targets Default --env-vars NUGET_FEED_URL=$(NUGET_FEED_URL), NUGET_API_KEY=$(NUGET_API_KEY),GITHUB_PASSWORD=$(GITHUB_PASSWORD),REPO_PASS=$(REPO_PASS),CONNECTION_STRING=$(CONNECTION_STRING)",
       "allowOverride": true
     },
     "CONNECTION_STRING": {

--- a/buildpipeline/Core-Setup-CentOS-x64.json
+++ b/buildpipeline/Core-Setup-CentOS-x64.json
@@ -166,7 +166,7 @@
       "allowOverride": true
     },
     "BuildArguments": {
-      "value": "--skip-prereqs --configuration $(BuildConfiguration)  --docker centos.7 --targets Default --env-vars NUGET_FEED_URL=$(NUGET_FEED_URL), NUGET_API_KEY=$(NUGET_API_KEY),GITHUB_PASSWORD=$(GITHUB_PASSWORD),REPO_PASS=$(REPO_PASS),CONNECTION_STRING=$(CONNECTION_STRING)",
+      "value": "--skip-prereqs --configuration $(BuildConfiguration)  --docker centos.7 --targets Default --env-vars NUGET_FEED_URL=$(NUGET_FEED_URL),NUGET_API_KEY=$(NUGET_API_KEY),GITHUB_PASSWORD=$(GITHUB_PASSWORD),REPO_PASS=$(REPO_PASS),CONNECTION_STRING=$(CONNECTION_STRING)",
       "allowOverride": true
     },
     "CONNECTION_STRING": {

--- a/buildpipeline/Core-Setup-Debian8-x64.json
+++ b/buildpipeline/Core-Setup-Debian8-x64.json
@@ -166,7 +166,7 @@
       "allowOverride": true
     },
     "BuildArguments": {
-      "value": "--skip-prereqs --configuration $(BuildConfiguration)  --docker debian.8 --targets Default --env-vars NUGET_FEED_URL=$(NUGET_FEED_URL), NUGET_API_KEY=$(NUGET_API_KEY),GITHUB_PASSWORD=$(GITHUB_PASSWORD),REPO_PASS=$(REPO_PASS),CONNECTION_STRING=$(CONNECTION_STRING)",
+      "value": "--skip-prereqs --configuration $(BuildConfiguration)  --docker debian.8 --targets Default --env-vars NUGET_FEED_URL=$(NUGET_FEED_URL),NUGET_API_KEY=$(NUGET_API_KEY),GITHUB_PASSWORD=$(GITHUB_PASSWORD),REPO_PASS=$(REPO_PASS),CONNECTION_STRING=$(CONNECTION_STRING)",
       "allowOverride": true
     },
     "CONNECTION_STRING": {

--- a/buildpipeline/Core-Setup-Debian8-x64.json
+++ b/buildpipeline/Core-Setup-Debian8-x64.json
@@ -166,7 +166,7 @@
       "allowOverride": true
     },
     "BuildArguments": {
-      "value": "--skip-prereqs --configuration $(BuildConfiguration)  --docker debian.8 --targets Default --env-vars NUGET_API_KEY=$(NUGET_API_KEY),GITHUB_PASSWORD=$(GITHUB_PASSWORD),REPO_PASS=$(REPO_PASS),CONNECTION_STRING=$(CONNECTION_STRING)",
+      "value": "--skip-prereqs --configuration $(BuildConfiguration)  --docker debian.8 --targets Default --env-vars NUGET_FEED_URL=$(NUGET_FEED_URL), NUGET_API_KEY=$(NUGET_API_KEY),GITHUB_PASSWORD=$(GITHUB_PASSWORD),REPO_PASS=$(REPO_PASS),CONNECTION_STRING=$(CONNECTION_STRING)",
       "allowOverride": true
     },
     "CONNECTION_STRING": {

--- a/buildpipeline/Core-Setup-Debian9-x64.json
+++ b/buildpipeline/Core-Setup-Debian9-x64.json
@@ -166,7 +166,7 @@
       "allowOverride": true
     },
     "BuildArguments": {
-      "value": "--skip-prereqs --configuration $(BuildConfiguration)  --docker debian.9 --skiptests --targets Default --env-vars NUGET_FEED_URL=$(NUGET_FEED_URL), NUGET_API_KEY=$(NUGET_API_KEY),GITHUB_PASSWORD=$(GITHUB_PASSWORD),REPO_PASS=$(REPO_PASS),CONNECTION_STRING=$(CONNECTION_STRING)",
+      "value": "--skip-prereqs --configuration $(BuildConfiguration)  --docker debian.9 --skiptests --targets Default --env-vars NUGET_FEED_URL=$(NUGET_FEED_URL),NUGET_API_KEY=$(NUGET_API_KEY),GITHUB_PASSWORD=$(GITHUB_PASSWORD),REPO_PASS=$(REPO_PASS),CONNECTION_STRING=$(CONNECTION_STRING)",
       "allowOverride": true
     },
     "CONNECTION_STRING": {

--- a/buildpipeline/Core-Setup-Debian9-x64.json
+++ b/buildpipeline/Core-Setup-Debian9-x64.json
@@ -166,7 +166,7 @@
       "allowOverride": true
     },
     "BuildArguments": {
-      "value": "--skip-prereqs --configuration $(BuildConfiguration)  --docker debian.9 --skiptests --targets Default --env-vars NUGET_API_KEY=$(NUGET_API_KEY),GITHUB_PASSWORD=$(GITHUB_PASSWORD),REPO_PASS=$(REPO_PASS),CONNECTION_STRING=$(CONNECTION_STRING)",
+      "value": "--skip-prereqs --configuration $(BuildConfiguration)  --docker debian.9 --skiptests --targets Default --env-vars NUGET_FEED_URL=$(NUGET_FEED_URL), NUGET_API_KEY=$(NUGET_API_KEY),GITHUB_PASSWORD=$(GITHUB_PASSWORD),REPO_PASS=$(REPO_PASS),CONNECTION_STRING=$(CONNECTION_STRING)",
       "allowOverride": true
     },
     "CONNECTION_STRING": {

--- a/buildpipeline/Core-Setup-Fedora24-x64.json
+++ b/buildpipeline/Core-Setup-Fedora24-x64.json
@@ -165,7 +165,7 @@
       "value": "Release"
     },
     "BuildArguments": {
-      "value": "--skip-prereqs --configuration $(BuildConfiguration)  --docker fedora.24 --targets Default --env-vars NUGET_API_KEY=$(NUGET_API_KEY),GITHUB_PASSWORD=$(GITHUB_PASSWORD),REPO_PASS=$(REPO_PASS),CONNECTION_STRING=$(CONNECTION_STRING)"
+      "value": "--skip-prereqs --configuration $(BuildConfiguration)  --docker fedora.24 --targets Default --env-vars NUGET_FEED_URL=$(NUGET_FEED_URL), NUGET_API_KEY=$(NUGET_API_KEY),GITHUB_PASSWORD=$(GITHUB_PASSWORD),REPO_PASS=$(REPO_PASS),CONNECTION_STRING=$(CONNECTION_STRING)"
     },
     "CONNECTION_STRING": {
       "value": "ENV_VAR_EMPTY_WORKAROUND"

--- a/buildpipeline/Core-Setup-Fedora24-x64.json
+++ b/buildpipeline/Core-Setup-Fedora24-x64.json
@@ -165,7 +165,7 @@
       "value": "Release"
     },
     "BuildArguments": {
-      "value": "--skip-prereqs --configuration $(BuildConfiguration)  --docker fedora.24 --targets Default --env-vars NUGET_FEED_URL=$(NUGET_FEED_URL), NUGET_API_KEY=$(NUGET_API_KEY),GITHUB_PASSWORD=$(GITHUB_PASSWORD),REPO_PASS=$(REPO_PASS),CONNECTION_STRING=$(CONNECTION_STRING)"
+      "value": "--skip-prereqs --configuration $(BuildConfiguration)  --docker fedora.24 --targets Default --env-vars NUGET_FEED_URL=$(NUGET_FEED_URL),NUGET_API_KEY=$(NUGET_API_KEY),GITHUB_PASSWORD=$(GITHUB_PASSWORD),REPO_PASS=$(REPO_PASS),CONNECTION_STRING=$(CONNECTION_STRING)"
     },
     "CONNECTION_STRING": {
       "value": "ENV_VAR_EMPTY_WORKAROUND"

--- a/buildpipeline/Core-Setup-Fedora27-x64.json
+++ b/buildpipeline/Core-Setup-Fedora27-x64.json
@@ -165,7 +165,7 @@
       "value": "Release"
     },
     "BuildArguments": {
-      "value": "--skip-prereqs --configuration $(BuildConfiguration)  --docker fedora.27 --skiptests --targets Default --env-vars NUGET_FEED_URL=$(NUGET_FEED_URL), NUGET_API_KEY=$(NUGET_API_KEY),GITHUB_PASSWORD=$(GITHUB_PASSWORD),REPO_PASS=$(REPO_PASS),CONNECTION_STRING=$(CONNECTION_STRING)"
+      "value": "--skip-prereqs --configuration $(BuildConfiguration)  --docker fedora.27 --skiptests --targets Default --env-vars NUGET_FEED_URL=$(NUGET_FEED_URL),NUGET_API_KEY=$(NUGET_API_KEY),GITHUB_PASSWORD=$(GITHUB_PASSWORD),REPO_PASS=$(REPO_PASS),CONNECTION_STRING=$(CONNECTION_STRING)"
     },
     "CONNECTION_STRING": {
       "value": "ENV_VAR_EMPTY_WORKAROUND"

--- a/buildpipeline/Core-Setup-Fedora27-x64.json
+++ b/buildpipeline/Core-Setup-Fedora27-x64.json
@@ -165,7 +165,7 @@
       "value": "Release"
     },
     "BuildArguments": {
-      "value": "--skip-prereqs --configuration $(BuildConfiguration)  --docker fedora.27 --skiptests --targets Default --env-vars NUGET_API_KEY=$(NUGET_API_KEY),GITHUB_PASSWORD=$(GITHUB_PASSWORD),REPO_PASS=$(REPO_PASS),CONNECTION_STRING=$(CONNECTION_STRING)"
+      "value": "--skip-prereqs --configuration $(BuildConfiguration)  --docker fedora.27 --skiptests --targets Default --env-vars NUGET_FEED_URL=$(NUGET_FEED_URL), NUGET_API_KEY=$(NUGET_API_KEY),GITHUB_PASSWORD=$(GITHUB_PASSWORD),REPO_PASS=$(REPO_PASS),CONNECTION_STRING=$(CONNECTION_STRING)"
     },
     "CONNECTION_STRING": {
       "value": "ENV_VAR_EMPTY_WORKAROUND"

--- a/buildpipeline/Core-Setup-Fedora28-x64.json
+++ b/buildpipeline/Core-Setup-Fedora28-x64.json
@@ -165,7 +165,7 @@
       "value": "Release"
     },
     "BuildArguments": {
-      "value": "--skip-prereqs --configuration $(BuildConfiguration)  --docker fedora.28 --skiptests --targets Default --env-vars NUGET_FEED_URL=$(NUGET_FEED_URL), NUGET_API_KEY=$(NUGET_API_KEY),GITHUB_PASSWORD=$(GITHUB_PASSWORD),REPO_PASS=$(REPO_PASS),CONNECTION_STRING=$(CONNECTION_STRING)"
+      "value": "--skip-prereqs --configuration $(BuildConfiguration)  --docker fedora.28 --skiptests --targets Default --env-vars NUGET_FEED_URL=$(NUGET_FEED_URL),NUGET_API_KEY=$(NUGET_API_KEY),GITHUB_PASSWORD=$(GITHUB_PASSWORD),REPO_PASS=$(REPO_PASS),CONNECTION_STRING=$(CONNECTION_STRING)"
     },
     "CONNECTION_STRING": {
       "value": "ENV_VAR_EMPTY_WORKAROUND"

--- a/buildpipeline/Core-Setup-Fedora28-x64.json
+++ b/buildpipeline/Core-Setup-Fedora28-x64.json
@@ -165,7 +165,7 @@
       "value": "Release"
     },
     "BuildArguments": {
-      "value": "--skip-prereqs --configuration $(BuildConfiguration)  --docker fedora.28 --skiptests --targets Default --env-vars NUGET_API_KEY=$(NUGET_API_KEY),GITHUB_PASSWORD=$(GITHUB_PASSWORD),REPO_PASS=$(REPO_PASS),CONNECTION_STRING=$(CONNECTION_STRING)"
+      "value": "--skip-prereqs --configuration $(BuildConfiguration)  --docker fedora.28 --skiptests --targets Default --env-vars NUGET_FEED_URL=$(NUGET_FEED_URL), NUGET_API_KEY=$(NUGET_API_KEY),GITHUB_PASSWORD=$(GITHUB_PASSWORD),REPO_PASS=$(REPO_PASS),CONNECTION_STRING=$(CONNECTION_STRING)"
     },
     "CONNECTION_STRING": {
       "value": "ENV_VAR_EMPTY_WORKAROUND"

--- a/buildpipeline/Core-Setup-OSX-x64.json
+++ b/buildpipeline/Core-Setup-OSX-x64.json
@@ -166,7 +166,7 @@
       "allowOverride": true
     },
     "BuildArguments": {
-      "value": "--skip-prereqs --configuration $(BuildConfiguration) --targets Default --env-vars NUGET_FEED_URL=$(NUGET_FEED_URL), NUGET_API_KEY=$(NUGET_API_KEY),GITHUB_PASSWORD=$(GITHUB_PASSWORD),REPO_PASS=$(REPO_PASS),CONNECTION_STRING=$(CONNECTION_STRING)",
+      "value": "--skip-prereqs --configuration $(BuildConfiguration) --targets Default --env-vars NUGET_FEED_URL=$(NUGET_FEED_URL),NUGET_API_KEY=$(NUGET_API_KEY),GITHUB_PASSWORD=$(GITHUB_PASSWORD),REPO_PASS=$(REPO_PASS),CONNECTION_STRING=$(CONNECTION_STRING)",
       "allowOverride": true
     },
     "CONNECTION_STRING": {

--- a/buildpipeline/Core-Setup-OSX-x64.json
+++ b/buildpipeline/Core-Setup-OSX-x64.json
@@ -166,7 +166,7 @@
       "allowOverride": true
     },
     "BuildArguments": {
-      "value": "--skip-prereqs --configuration $(BuildConfiguration) --targets Default --env-vars NUGET_API_KEY=$(NUGET_API_KEY),GITHUB_PASSWORD=$(GITHUB_PASSWORD),REPO_PASS=$(REPO_PASS),CONNECTION_STRING=$(CONNECTION_STRING)",
+      "value": "--skip-prereqs --configuration $(BuildConfiguration) --targets Default --env-vars NUGET_FEED_URL=$(NUGET_FEED_URL), NUGET_API_KEY=$(NUGET_API_KEY),GITHUB_PASSWORD=$(GITHUB_PASSWORD),REPO_PASS=$(REPO_PASS),CONNECTION_STRING=$(CONNECTION_STRING)",
       "allowOverride": true
     },
     "CONNECTION_STRING": {

--- a/buildpipeline/Core-Setup-OpenSuse42.1-x64.json
+++ b/buildpipeline/Core-Setup-OpenSuse42.1-x64.json
@@ -165,7 +165,7 @@
       "value": "Release"
     },
     "BuildArguments": {
-      "value": "--skip-prereqs --configuration $(BuildConfiguration)  --docker opensuse.42.1 --skiptests --targets Default --env-vars NUGET_FEED_URL=$(NUGET_FEED_URL), NUGET_API_KEY=$(NUGET_API_KEY),GITHUB_PASSWORD=$(GITHUB_PASSWORD),REPO_PASS=$(REPO_PASS),CONNECTION_STRING=$(CONNECTION_STRING)"
+      "value": "--skip-prereqs --configuration $(BuildConfiguration)  --docker opensuse.42.1 --skiptests --targets Default --env-vars NUGET_FEED_URL=$(NUGET_FEED_URL),NUGET_API_KEY=$(NUGET_API_KEY),GITHUB_PASSWORD=$(GITHUB_PASSWORD),REPO_PASS=$(REPO_PASS),CONNECTION_STRING=$(CONNECTION_STRING)"
     },
     "CONNECTION_STRING": {
       "value": "ENV_VAR_EMPTY_WORKAROUND"

--- a/buildpipeline/Core-Setup-OpenSuse42.1-x64.json
+++ b/buildpipeline/Core-Setup-OpenSuse42.1-x64.json
@@ -165,7 +165,7 @@
       "value": "Release"
     },
     "BuildArguments": {
-      "value": "--skip-prereqs --configuration $(BuildConfiguration)  --docker opensuse.42.1 --skiptests --targets Default --env-vars NUGET_API_KEY=$(NUGET_API_KEY),GITHUB_PASSWORD=$(GITHUB_PASSWORD),REPO_PASS=$(REPO_PASS),CONNECTION_STRING=$(CONNECTION_STRING)"
+      "value": "--skip-prereqs --configuration $(BuildConfiguration)  --docker opensuse.42.1 --skiptests --targets Default --env-vars NUGET_FEED_URL=$(NUGET_FEED_URL), NUGET_API_KEY=$(NUGET_API_KEY),GITHUB_PASSWORD=$(GITHUB_PASSWORD),REPO_PASS=$(REPO_PASS),CONNECTION_STRING=$(CONNECTION_STRING)"
     },
     "CONNECTION_STRING": {
       "value": "ENV_VAR_EMPTY_WORKAROUND"

--- a/buildpipeline/Core-Setup-OpenSuse42.3-x64.json
+++ b/buildpipeline/Core-Setup-OpenSuse42.3-x64.json
@@ -165,7 +165,7 @@
       "value": "Release"
     },
     "BuildArguments": {
-      "value": "--skip-prereqs --configuration $(BuildConfiguration)  --docker opensuse.42.3 --skiptests --targets Default --env-vars NUGET_FEED_URL=$(NUGET_FEED_URL), NUGET_API_KEY=$(NUGET_API_KEY),GITHUB_PASSWORD=$(GITHUB_PASSWORD),REPO_PASS=$(REPO_PASS),CONNECTION_STRING=$(CONNECTION_STRING)"
+      "value": "--skip-prereqs --configuration $(BuildConfiguration)  --docker opensuse.42.3 --skiptests --targets Default --env-vars NUGET_FEED_URL=$(NUGET_FEED_URL),NUGET_API_KEY=$(NUGET_API_KEY),GITHUB_PASSWORD=$(GITHUB_PASSWORD),REPO_PASS=$(REPO_PASS),CONNECTION_STRING=$(CONNECTION_STRING)"
     },
     "CONNECTION_STRING": {
       "value": "ENV_VAR_EMPTY_WORKAROUND"

--- a/buildpipeline/Core-Setup-OpenSuse42.3-x64.json
+++ b/buildpipeline/Core-Setup-OpenSuse42.3-x64.json
@@ -165,7 +165,7 @@
       "value": "Release"
     },
     "BuildArguments": {
-      "value": "--skip-prereqs --configuration $(BuildConfiguration)  --docker opensuse.42.3 --skiptests --targets Default --env-vars NUGET_API_KEY=$(NUGET_API_KEY),GITHUB_PASSWORD=$(GITHUB_PASSWORD),REPO_PASS=$(REPO_PASS),CONNECTION_STRING=$(CONNECTION_STRING)"
+      "value": "--skip-prereqs --configuration $(BuildConfiguration)  --docker opensuse.42.3 --skiptests --targets Default --env-vars NUGET_FEED_URL=$(NUGET_FEED_URL), NUGET_API_KEY=$(NUGET_API_KEY),GITHUB_PASSWORD=$(GITHUB_PASSWORD),REPO_PASS=$(REPO_PASS),CONNECTION_STRING=$(CONNECTION_STRING)"
     },
     "CONNECTION_STRING": {
       "value": "ENV_VAR_EMPTY_WORKAROUND"

--- a/buildpipeline/Core-Setup-RHEL7-x64.json
+++ b/buildpipeline/Core-Setup-RHEL7-x64.json
@@ -203,7 +203,7 @@
       "allowOverride": true
     },
     "BuildArguments": {
-      "value": "--skip-prereqs --configuration $(BuildConfiguration) --targets Default --env-vars NUGET_API_KEY=$(NUGET_API_KEY),GITHUB_PASSWORD=$(GITHUB_PASSWORD),REPO_PASS=$(REPO_PASS),CONNECTION_STRING='$(CONNECTION_STRING)'",
+      "value": "--skip-prereqs --configuration $(BuildConfiguration) --targets Default --env-vars NUGET_FEED_URL=$(NUGET_FEED_URL), NUGET_API_KEY=$(NUGET_API_KEY),GITHUB_PASSWORD=$(GITHUB_PASSWORD),REPO_PASS=$(REPO_PASS),CONNECTION_STRING='$(CONNECTION_STRING)'",
       "allowOverride": true
     },
     "BuildEnvironmentVariables": {

--- a/buildpipeline/Core-Setup-RHEL7-x64.json
+++ b/buildpipeline/Core-Setup-RHEL7-x64.json
@@ -203,7 +203,7 @@
       "allowOverride": true
     },
     "BuildArguments": {
-      "value": "--skip-prereqs --configuration $(BuildConfiguration) --targets Default --env-vars NUGET_FEED_URL=$(NUGET_FEED_URL), NUGET_API_KEY=$(NUGET_API_KEY),GITHUB_PASSWORD=$(GITHUB_PASSWORD),REPO_PASS=$(REPO_PASS),CONNECTION_STRING='$(CONNECTION_STRING)'",
+      "value": "--skip-prereqs --configuration $(BuildConfiguration) --targets Default --env-vars NUGET_FEED_URL=$(NUGET_FEED_URL),NUGET_API_KEY=$(NUGET_API_KEY),GITHUB_PASSWORD=$(GITHUB_PASSWORD),REPO_PASS=$(REPO_PASS),CONNECTION_STRING='$(CONNECTION_STRING)'",
       "allowOverride": true
     },
     "BuildEnvironmentVariables": {

--- a/buildpipeline/Core-Setup-Ubuntu14.04-x64.json
+++ b/buildpipeline/Core-Setup-Ubuntu14.04-x64.json
@@ -166,7 +166,7 @@
       "allowOverride": true
     },
     "BuildArguments": {
-      "value": "--skip-prereqs --configuration $(BuildConfiguration) --docker ubuntu.14.04 --targets Default --env-vars NUGET_FEED_URL=$(NUGET_FEED_URL), NUGET_API_KEY=$(NUGET_API_KEY),GITHUB_PASSWORD=$(GITHUB_PASSWORD),REPO_PASS=$(REPO_PASS),CONNECTION_STRING=$(CONNECTION_STRING)",
+      "value": "--skip-prereqs --configuration $(BuildConfiguration) --docker ubuntu.14.04 --targets Default --env-vars NUGET_FEED_URL=$(NUGET_FEED_URL),NUGET_API_KEY=$(NUGET_API_KEY),GITHUB_PASSWORD=$(GITHUB_PASSWORD),REPO_PASS=$(REPO_PASS),CONNECTION_STRING=$(CONNECTION_STRING)",
       "allowOverride": true
     },
     "CONNECTION_STRING": {

--- a/buildpipeline/Core-Setup-Ubuntu14.04-x64.json
+++ b/buildpipeline/Core-Setup-Ubuntu14.04-x64.json
@@ -166,7 +166,7 @@
       "allowOverride": true
     },
     "BuildArguments": {
-      "value": "--skip-prereqs --configuration $(BuildConfiguration) --docker ubuntu.14.04 --targets Default --env-vars NUGET_API_KEY=$(NUGET_API_KEY),GITHUB_PASSWORD=$(GITHUB_PASSWORD),REPO_PASS=$(REPO_PASS),CONNECTION_STRING=$(CONNECTION_STRING)",
+      "value": "--skip-prereqs --configuration $(BuildConfiguration) --docker ubuntu.14.04 --targets Default --env-vars NUGET_FEED_URL=$(NUGET_FEED_URL), NUGET_API_KEY=$(NUGET_API_KEY),GITHUB_PASSWORD=$(GITHUB_PASSWORD),REPO_PASS=$(REPO_PASS),CONNECTION_STRING=$(CONNECTION_STRING)",
       "allowOverride": true
     },
     "CONNECTION_STRING": {

--- a/buildpipeline/Core-Setup-Ubuntu16.04-x64.json
+++ b/buildpipeline/Core-Setup-Ubuntu16.04-x64.json
@@ -165,7 +165,7 @@
       "value": "Release"
     },
     "BuildArguments": {
-      "value": "--skip-prereqs --configuration $(BuildConfiguration)  --docker ubuntu.16.04 --targets Default --env-vars NUGET_API_KEY=$(NUGET_API_KEY),GITHUB_PASSWORD=$(GITHUB_PASSWORD),REPO_PASS=$(REPO_PASS),CONNECTION_STRING=$(CONNECTION_STRING)"
+      "value": "--skip-prereqs --configuration $(BuildConfiguration)  --docker ubuntu.16.04 --targets Default --env-vars NUGET_FEED_URL=$(NUGET_FEED_URL), NUGET_API_KEY=$(NUGET_API_KEY),GITHUB_PASSWORD=$(GITHUB_PASSWORD),REPO_PASS=$(REPO_PASS),CONNECTION_STRING=$(CONNECTION_STRING)"
     },
     "CONNECTION_STRING": {
       "value": "ENV_VAR_EMPTY_WORKAROUND"

--- a/buildpipeline/Core-Setup-Ubuntu16.04-x64.json
+++ b/buildpipeline/Core-Setup-Ubuntu16.04-x64.json
@@ -165,7 +165,7 @@
       "value": "Release"
     },
     "BuildArguments": {
-      "value": "--skip-prereqs --configuration $(BuildConfiguration)  --docker ubuntu.16.04 --targets Default --env-vars NUGET_FEED_URL=$(NUGET_FEED_URL), NUGET_API_KEY=$(NUGET_API_KEY),GITHUB_PASSWORD=$(GITHUB_PASSWORD),REPO_PASS=$(REPO_PASS),CONNECTION_STRING=$(CONNECTION_STRING)"
+      "value": "--skip-prereqs --configuration $(BuildConfiguration)  --docker ubuntu.16.04 --targets Default --env-vars NUGET_FEED_URL=$(NUGET_FEED_URL),NUGET_API_KEY=$(NUGET_API_KEY),GITHUB_PASSWORD=$(GITHUB_PASSWORD),REPO_PASS=$(REPO_PASS),CONNECTION_STRING=$(CONNECTION_STRING)"
     },
     "CONNECTION_STRING": {
       "value": "ENV_VAR_EMPTY_WORKAROUND"

--- a/buildpipeline/Core-Setup-Ubuntu18.04-x64.json
+++ b/buildpipeline/Core-Setup-Ubuntu18.04-x64.json
@@ -165,7 +165,7 @@
       "value": "Release"
     },
     "BuildArguments": {
-      "value": "--skip-prereqs --configuration $(BuildConfiguration)  --docker ubuntu.18.04 --skiptests --targets Default --env-vars NUGET_FEED_URL=$(NUGET_FEED_URL), NUGET_API_KEY=$(NUGET_API_KEY),GITHUB_PASSWORD=$(GITHUB_PASSWORD),REPO_PASS=$(REPO_PASS),CONNECTION_STRING=$(CONNECTION_STRING)"
+      "value": "--skip-prereqs --configuration $(BuildConfiguration)  --docker ubuntu.18.04 --skiptests --targets Default --env-vars NUGET_FEED_URL=$(NUGET_FEED_URL),NUGET_API_KEY=$(NUGET_API_KEY),GITHUB_PASSWORD=$(GITHUB_PASSWORD),REPO_PASS=$(REPO_PASS),CONNECTION_STRING=$(CONNECTION_STRING)"
     },
     "CONNECTION_STRING": {
       "value": "ENV_VAR_EMPTY_WORKAROUND"

--- a/buildpipeline/Core-Setup-Ubuntu18.04-x64.json
+++ b/buildpipeline/Core-Setup-Ubuntu18.04-x64.json
@@ -165,7 +165,7 @@
       "value": "Release"
     },
     "BuildArguments": {
-      "value": "--skip-prereqs --configuration $(BuildConfiguration)  --docker ubuntu.18.04 --skiptests --targets Default --env-vars NUGET_API_KEY=$(NUGET_API_KEY),GITHUB_PASSWORD=$(GITHUB_PASSWORD),REPO_PASS=$(REPO_PASS),CONNECTION_STRING=$(CONNECTION_STRING)"
+      "value": "--skip-prereqs --configuration $(BuildConfiguration)  --docker ubuntu.18.04 --skiptests --targets Default --env-vars NUGET_FEED_URL=$(NUGET_FEED_URL), NUGET_API_KEY=$(NUGET_API_KEY),GITHUB_PASSWORD=$(GITHUB_PASSWORD),REPO_PASS=$(REPO_PASS),CONNECTION_STRING=$(CONNECTION_STRING)"
     },
     "CONNECTION_STRING": {
       "value": "ENV_VAR_EMPTY_WORKAROUND"


### PR DESCRIPTION
The 1.1 pipebuilds were not updated with the secret flushing a few months back, so publishing and finalization steps are getting skipped because of missing environment variables.

@MattGal and @eerhardt PTAL.