### PR TITLE
Fix issue with framework-dependent apphost launched from own directory

### DIFF
--- a/src/corehost/cli/libhost.cpp
+++ b/src/corehost/cli/libhost.cpp
@@ -51,18 +51,28 @@ void get_runtime_config_paths(const pal::string_t& path, const pal::string_t& na
 
 host_mode_t detect_operating_mode(const host_startup_info_t& host_info)
 {
-    if (coreclr_exists_in_dir(host_info.dotnet_root) || pal::file_exists(host_info.app_path))
+    bool has_local_coreclr = coreclr_exists_in_dir(host_info.dotnet_root);
+    if (has_local_coreclr || pal::file_exists(host_info.app_path))
     {
-        pal::string_t own_deps_json = host_info.dotnet_root;
-        pal::string_t own_deps_filename = host_info.get_app_name() + _X(".deps.json");
-        pal::string_t own_config_filename = host_info.get_app_name() + _X(".runtimeconfig.json");
-        append_path(&own_deps_json, own_deps_filename.c_str());
+        pal::string_t deps_in_dotnet_root = host_info.dotnet_root;
+        pal::string_t deps_filename = host_info.get_app_name() + _X(".deps.json");
+        append_path(&deps_in_dotnet_root, deps_filename.c_str());
         if (trace::is_enabled())
         {
-            trace::info(_X("Detecting mode... CoreCLR present in dotnet root [%s] and checking if [%s] file present=[%d]"),
-                host_info.dotnet_root.c_str(), own_deps_filename.c_str(), pal::file_exists(own_deps_json));
+            trace::info(_X("Detecting mode... Checking CoreCLR presence in dotnet root [%s]=[%d] and checking presence of [%s]=[%d]"),
+                host_info.dotnet_root.c_str(), has_local_coreclr, deps_filename.c_str(), pal::file_exists(deps_in_dotnet_root));
         }
-        return ((pal::file_exists(own_deps_json) || !pal::file_exists(own_config_filename)) && pal::file_exists(host_info.app_path)) ? host_mode_t::apphost : host_mode_t::split_fx;
+
+        if (has_local_coreclr)
+        {
+            // Name of runtimeconfig file; since no path it is checked for in current working directory
+            pal::string_t config_in_cwd = host_info.get_app_name() + _X(".runtimeconfig.json");
+
+            // Detect standalone apphost or legacy split mode (specifying --depsfile and --runtimeconfig)
+            return (pal::file_exists(deps_in_dotnet_root) || !pal::file_exists(config_in_cwd)) && pal::file_exists(host_info.app_path) ? host_mode_t::apphost : host_mode_t::split_fx;
+        }
+
+        return host_mode_t::apphost;
     }
     else
     {

--- a/src/corehost/cli/libhost.cpp
+++ b/src/corehost/cli/libhost.cpp
@@ -51,33 +51,31 @@ void get_runtime_config_paths(const pal::string_t& path, const pal::string_t& na
 
 host_mode_t detect_operating_mode(const host_startup_info_t& host_info)
 {
-    bool has_local_coreclr = coreclr_exists_in_dir(host_info.dotnet_root);
-    if (has_local_coreclr || pal::file_exists(host_info.app_path))
+    if (coreclr_exists_in_dir(host_info.dotnet_root))
     {
+        // Detect between standalone apphost or legacy split mode (specifying --depsfile and --runtimeconfig)
+
         pal::string_t deps_in_dotnet_root = host_info.dotnet_root;
         pal::string_t deps_filename = host_info.get_app_name() + _X(".deps.json");
         append_path(&deps_in_dotnet_root, deps_filename.c_str());
-        if (trace::is_enabled())
-        {
-            trace::info(_X("Detecting mode... Checking CoreCLR presence in dotnet root [%s]=[%d] and checking presence of [%s]=[%d]"),
-                host_info.dotnet_root.c_str(), has_local_coreclr, deps_filename.c_str(), pal::file_exists(deps_in_dotnet_root));
-        }
+        bool deps_exists = pal::file_exists(deps_in_dotnet_root);
 
-        if (has_local_coreclr)
-        {
-            // Name of runtimeconfig file; since no path it is checked for in current working directory
-            pal::string_t config_in_cwd = host_info.get_app_name() + _X(".runtimeconfig.json");
+        trace::info(_X("Detecting mode... CoreCLR present in dotnet root [%d] and checking if [%s] file present=[%d]"),
+            host_info.dotnet_root.c_str(), deps_filename.c_str(), deps_exists);
 
-            // Detect standalone apphost or legacy split mode (specifying --depsfile and --runtimeconfig)
-            return (pal::file_exists(deps_in_dotnet_root) || !pal::file_exists(config_in_cwd)) && pal::file_exists(host_info.app_path) ? host_mode_t::apphost : host_mode_t::split_fx;
-        }
+        // Name of runtimeconfig file; since no path is included here the check is in the current working directory
+        pal::string_t config_in_cwd = host_info.get_app_name() + _X(".runtimeconfig.json");
 
+        return (deps_exists || !pal::file_exists(config_in_cwd)) && pal::file_exists(host_info.app_path) ? host_mode_t::apphost : host_mode_t::split_fx;
+    }
+
+    if (pal::file_exists(host_info.app_path))
+    {
+        // Framework-dependent apphost
         return host_mode_t::apphost;
     }
-    else
-    {
-        return host_mode_t::muxer;
-    }
+
+    return host_mode_t::muxer;
 }
 
 void try_patch_roll_forward_in_dir(const pal::string_t& cur_dir, const fx_ver_t& start_ver, pal::string_t* max_str)


### PR DESCRIPTION
If a framework-dependent apphost is launched from its own directory, it fails because the code to detect the mode picks the legacy "split fx" mode instead of "apphost" (which was the old "standalone" mode before the  framework-dependent apphost feature was added). 

The framework-dependent apphost feature added in 2.1 did not change the semantics of this area of code (but should have). The fix is to assume if the CLR is not installed locally then assume the mode is "apphost". I am not sure if anyone uses the split_fx mode anymore, but I kept the code as compatible as possible in either case; any use of split_fx in 2.1.x would be a roll-forward from 1.x.

Fixes https://github.com/dotnet/core-setup/issues/4169

Also this will need to be ported to 2.1.x. I will create a new issue for that.

cc @jeffschwMSFT 