### PR TITLE
Update CoreFx Dependencies for 2.0.0

### DIFF
--- a/dependencies.props
+++ b/dependencies.props
@@ -17,7 +17,7 @@
 
   <PropertyGroup>
     <MicrosoftNETCorePlatformsPackageVersion>2.0.2</MicrosoftNETCorePlatformsPackageVersion>
-    <MicrosoftPrivateCoreFxNETCoreAppPackageVersion>4.4.4-servicing-26403-03</MicrosoftPrivateCoreFxNETCoreAppPackageVersion>
+    <MicrosoftPrivateCoreFxNETCoreAppPackageVersion>4.4.4-servicing-26605-01</MicrosoftPrivateCoreFxNETCoreAppPackageVersion>
     <MicrosoftPrivateCoreFxUAPPackageVersion>4.4.0-preview3-25526-01</MicrosoftPrivateCoreFxUAPPackageVersion>
     <MicrosoftNETCoreRuntimeCoreCLRPackageVersion>2.0.7</MicrosoftNETCoreRuntimeCoreCLRPackageVersion>
     <NETStandardLibraryPackageVersion>2.0.3</NETStandardLibraryPackageVersion>

--- a/src/pkg/projects/Microsoft.NETCore.App/netcoreapp1.1.props
+++ b/src/pkg/projects/Microsoft.NETCore.App/netcoreapp1.1.props
@@ -25,7 +25,7 @@
       <Version>1.1.8</Version>
     </NETCoreApp11Dependency>
     <NETCoreApp11Dependency Include="Microsoft.NETCore.Targets">
-      <Version>1.1.2</Version>
+      <Version>1.1.3-servicing-26605-03</Version>
     </NETCoreApp11Dependency>
     <NETCoreApp11Dependency Include="Microsoft.VisualBasic">
       <Version>10.1.0</Version>
@@ -33,14 +33,23 @@
     <NETCoreApp11Dependency Include="NETStandard.Library">
       <Version>1.6.1</Version>
     </NETCoreApp11Dependency>
+    <NETCoreApp11Dependency Include="runtime.native.System">
+      <Version>4.3.1-servicing-26605-03</Version>
+    </NETCoreApp11Dependency>
     <NETCoreApp11Dependency Include="runtime.native.System.IO.Compression">
-      <Version>4.3.1</Version>
+      <Version>4.3.2-servicing-26605-03</Version>
+    </NETCoreApp11Dependency>
+    <NETCoreApp11Dependency Include="runtime.native.System.Net.Http">
+      <Version>4.3.1-servicing-26605-03</Version>
+    </NETCoreApp11Dependency>
+    <NETCoreApp11Dependency Include="runtime.native.System.Security">
+      <Version>4.3.1-servicing-26605-03</Version>
     </NETCoreApp11Dependency>
     <NETCoreApp11Dependency Include="runtime.native.System.Security.Cryptography.OpenSsl">
-      <Version>4.3.2</Version>
+      <Version>4.3.3-servicing-26605-03</Version>
     </NETCoreApp11Dependency>
     <NETCoreApp11Dependency Include="runtime.native.System.Security.Cryptography">
-      <Version>4.3.3</Version>
+      <Version>4.3.4-servicing-26605-03</Version>
     </NETCoreApp11Dependency>
     <NETCoreApp11Dependency Include="runtime.native.System.Security.Cryptography.Apple">
       <Version>4.3.1</Version>


### PR DESCRIPTION
Consume new CoreFx version for non-stable Core-Setup build. We ran CoreFx builds for all 3 release branches, but not CoreClr builds - therefore Core-Setup 1.x.x took no updates as the only CoreFx package we published was the PackageBaseline. As such, this should be all that is needed for 2.0.0.

@safern please confirm