### PR TITLE
Build Microsoft.NETCore.App and all of the DotNetHost packages for 1.1.9 servicing.

### DIFF
--- a/pkg/projects/packages.builds
+++ b/pkg/projects/packages.builds
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
 
   <PropertyGroup>
-    <BuildAllPackages Condition="'$(BuildAllPackages)' == ''">true</BuildAllPackages>
+    <BuildAllPackages Condition="'$(BuildAllPackages)' == ''">false</BuildAllPackages>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(BuildAllPackages)' == 'true'" >
@@ -12,7 +12,7 @@
 
   <ItemGroup Condition="'$(BuildAllPackages)' == 'false'" >
     <Project Include="Microsoft.NETCore.App\Microsoft.NETCore.App.builds" />
-    <Project Include="Microsoft.NETCore.DotNetHost\Microsoft.NETCore.DotNetHostPolicy.builds" />
+    <Project Include="Microsoft.NETCore.DotNetHost\*.builds" />
   </ItemGroup>
 
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />


### PR DESCRIPTION
We made a mistake and started building **all** packages for release/1.1.  This causes problems because there are still UWP packages in this repo, which we don't want to build.

Making it so just the packages we need are built.