### PR TITLE
Replace System.Security with System.Net.Security in 2.0.0

### DIFF
--- a/src/pkg/projects/Microsoft.NETCore.App/netcoreapp1.1.props
+++ b/src/pkg/projects/Microsoft.NETCore.App/netcoreapp1.1.props
@@ -42,7 +42,7 @@
     <NETCoreApp11Dependency Include="runtime.native.System.Net.Http">
       <Version>4.3.1-servicing-26605-03</Version>
     </NETCoreApp11Dependency>
-    <NETCoreApp11Dependency Include="runtime.native.System.Security">
+    <NETCoreApp11Dependency Include="runtime.native.System.Net.Security">
       <Version>4.3.1-servicing-26605-03</Version>
     </NETCoreApp11Dependency>
     <NETCoreApp11Dependency Include="runtime.native.System.Security.Cryptography.OpenSsl">


### PR DESCRIPTION
The package is actually runtime.System.Net.Security, not Runtime.System.Security. This is why we couldn't find an entry for it in the package index @safern 