### PR TITLE
DependencyModel project reference to PlatformAbstractions

### DIFF
--- a/src/Microsoft.Extensions.DependencyModel/project.json
+++ b/src/Microsoft.Extensions.DependencyModel/project.json
@@ -6,7 +6,9 @@
     "keyFile": "../../tools/Key.snk"
   },
   "dependencies": {
-    "Microsoft.DotNet.PlatformAbstractions": "1.1.2",
+    "Microsoft.DotNet.PlatformAbstractions": {
+      "target": "project"
+    },
     "Newtonsoft.Json": "9.0.1"
   },
   "frameworks": {


### PR DESCRIPTION
Because we are still using project.json projects, we can't have DependencyModel reference a previously built PlatformAbstractions library. Since the project exists in the global.json solution, project.json projects always pick up the local project as a reference.
As it was, we were getting a package reference to 1.1.2, but an assembly reference to 1.1.9, and it was failing at runtime.

So instead, we will have to service both of these assemblies at the same time.

Fix #4233

/cc @JunTaoLuo 