### PR TITLE
Add host versioning tests

### DIFF
--- a/src/test/Assets/TestProjects/StandaloneApp20/Program.cs
+++ b/src/test/Assets/TestProjects/StandaloneApp20/Program.cs
@@ -1,0 +1,16 @@
+using System;
+
+namespace StandaloneApp
+{
+    public static class Program
+    {
+        public static void Main(string[] args)
+        {
+            Console.WriteLine("Hello World!");
+            Console.WriteLine(string.Join(Environment.NewLine, args));
+
+            // A small operation involving NewtonSoft.Json to ensure the assembly is loaded properly
+            var t = typeof(Newtonsoft.Json.JsonReader);
+        }
+    }
+}

--- a/src/test/Assets/TestProjects/StandaloneApp20/StandaloneApp20.csproj
+++ b/src/test/Assets/TestProjects/StandaloneApp20/StandaloneApp20.csproj
@@ -1,0 +1,15 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+	<AssemblyName>StandaloneApp</AssemblyName>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <OutputType>Exe</OutputType>
+    <RuntimeIdentifier>$(TestTargetRid)</RuntimeIdentifier>
+    <RuntimeFrameworkVersion>2.0.7</RuntimeFrameworkVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
+  </ItemGroup>
+
+</Project>

--- a/src/test/Assets/TestProjects/StandaloneApp21/Program.cs
+++ b/src/test/Assets/TestProjects/StandaloneApp21/Program.cs
@@ -1,0 +1,16 @@
+using System;
+
+namespace StandaloneApp
+{
+    public static class Program
+    {
+        public static void Main(string[] args)
+        {
+            Console.WriteLine("Hello World!");
+            Console.WriteLine(string.Join(Environment.NewLine, args));
+
+            // A small operation involving NewtonSoft.Json to ensure the assembly is loaded properly
+            var t = typeof(Newtonsoft.Json.JsonReader);
+        }
+    }
+}

--- a/src/test/Assets/TestProjects/StandaloneApp21/StandaloneApp21.csproj
+++ b/src/test/Assets/TestProjects/StandaloneApp21/StandaloneApp21.csproj
@@ -1,0 +1,15 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+	<AssemblyName>StandaloneApp</AssemblyName>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <OutputType>Exe</OutputType>
+    <RuntimeIdentifier>$(TestTargetRid)</RuntimeIdentifier>
+    <RuntimeFrameworkVersion>2.1.0</RuntimeFrameworkVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
+  </ItemGroup>
+
+</Project>

--- a/src/test/HostActivationTests/GivenThatICareAboutHostVersionCompatibility.cs
+++ b/src/test/HostActivationTests/GivenThatICareAboutHostVersionCompatibility.cs
@@ -1,0 +1,179 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using FluentAssertions;
+using Microsoft.DotNet.Cli.Build.Framework;
+using Microsoft.DotNet.CoreSetup.Test;
+using Microsoft.DotNet.CoreSetup.Test.HostActivation.StandaloneApp;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Runtime.InteropServices;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.RegularExpressions;
+using Xunit;
+
+namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.VersionCompatibility
+{
+    public class GivenThatICareAboutHostVersionCompatibility
+    {
+        private static TestProjectFixture Fixture20 { get; set; }
+        private static TestProjectFixture Fixture21 { get; set; }
+        private static TestProjectFixture FixtureLatest { get; set; }
+
+        static GivenThatICareAboutHostVersionCompatibility()
+        {
+            // If these versions are changed, also change the corresponding .csproj
+            Fixture20 = CreateTestFixture("StandaloneApp20", "netcoreapp2.0", "2.0.7");
+            Fixture21 = CreateTestFixture("StandaloneApp21", "netcoreapp2.1", "2.1.0");
+            FixtureLatest = GivenThatICareAboutStandaloneAppActivation.PreviouslyPublishedAndRestoredStandaloneTestProjectFixture;
+        }
+
+        public static IEnumerable<object[]> PreviousVersions
+        {
+            get
+            {
+                if (Fixture20 != null)
+                {
+                    yield return new object[] { Fixture20 };
+                }
+
+                if (Fixture21 != null)
+                {
+                    yield return new object[] { Fixture21 };
+                }
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(PreviousVersions))]
+        public void Latest_Host_Is_Backwards_Compatible_With_Older_Runtime(TestProjectFixture previousVersionFixture)
+        {
+            TestProjectFixture fixture = previousVersionFixture.Copy();
+            string appExe = fixture.TestProject.AppExe;
+
+            Assert.NotEqual(fixture.Framework, FixtureLatest.Framework);
+            Assert.NotEqual(fixture.RepoDirProvider.MicrosoftNETCoreAppVersion, FixtureLatest.RepoDirProvider.MicrosoftNETCoreAppVersion);
+
+            // Baseline (no changes)
+            Command.Create(appExe)
+                .EnvironmentVariable("COREHOST_TRACE", "1")
+                .CaptureStdErr()
+                .CaptureStdOut()
+                .Execute()
+                .Should()
+                .Pass()
+                .And
+                .HaveStdOutContaining("Hello World")
+                .And
+                .HaveStdErrContaining($"--- Invoked apphost [version: {fixture.RepoDirProvider.MicrosoftNETCoreAppVersion}");
+
+            // Use the newer apphost
+            // This emulates the case when:
+            //  1) Newer runtime installed
+            //  2) Newer runtime uninstalled (installer preserves newer apphost)
+            File.Copy(FixtureLatest.TestProject.AppExe, fixture.TestProject.AppExe, true);
+            Command.Create(appExe)
+                .EnvironmentVariable("COREHOST_TRACE", "1")
+                .CaptureStdErr()
+                .CaptureStdOut()
+                .Execute()
+                .Should()
+                .Pass()
+                .And
+                .HaveStdOutContaining("Hello World")
+                .And
+                .HaveStdErrContaining($"--- Invoked apphost [version: {FixtureLatest.RepoDirProvider.MicrosoftNETCoreAppVersion}");
+
+            // Use the newer apphost and hostFxr
+            // This emulates the case when:
+            //  1) Newer runtime installed
+            //  2) A roll-forward to the newer runtime did not occur
+            File.Copy(FixtureLatest.TestProject.HostFxrDll, fixture.TestProject.HostFxrDll, true);
+            Command.Create(appExe)
+                .EnvironmentVariable("COREHOST_TRACE", "1")
+                .CaptureStdErr()
+                .CaptureStdOut()
+                .Execute()
+                .Should()
+                .Pass()
+                .And
+                .HaveStdOutContaining("Hello World")
+                .And
+                .HaveStdErrContaining($"--- Invoked apphost [version: {FixtureLatest.RepoDirProvider.MicrosoftNETCoreAppVersion}");
+        }
+
+        [Theory]
+        [MemberData(nameof(PreviousVersions))]
+        public void Old_Host_Is_Forward_Compatible_With_Latest_Runtime(TestProjectFixture previousVersionFixture)
+        {
+            TestProjectFixture fixture = FixtureLatest.Copy();
+            string appExe = fixture.TestProject.AppExe;
+
+            Assert.NotEqual(fixture.Framework, previousVersionFixture.Framework);
+            Assert.NotEqual(fixture.RepoDirProvider.MicrosoftNETCoreAppVersion, previousVersionFixture.RepoDirProvider.MicrosoftNETCoreAppVersion);
+
+            // Baseline (no changes)
+            Command.Create(appExe)
+                .EnvironmentVariable("COREHOST_TRACE", "1")
+                .CaptureStdErr()
+                .CaptureStdOut()
+                .Execute()
+                .Should()
+                .Pass()
+                .And
+                .HaveStdOutContaining("Hello World")
+                .And
+                .HaveStdErrContaining($"--- Invoked apphost [version: {fixture.RepoDirProvider.MicrosoftNETCoreAppVersion}");
+
+            // Use the older apphost and hostfxr
+            // This emulates the case when:
+            //  1) One-off deployment of older runtime (not in global location)
+            //  2) Older apphost executed, but found newer runtime because of multi-level lookup
+            //     Note that we currently don't have multi-level on hostfxr so we will always find the older\one-off hostfxr
+            File.Copy(previousVersionFixture.TestProject.AppExe, fixture.TestProject.AppExe, true);
+            File.Copy(previousVersionFixture.TestProject.HostFxrDll, fixture.TestProject.HostFxrDll, true);
+            Command.Create(appExe)
+                .EnvironmentVariable("COREHOST_TRACE", "1")
+                .CaptureStdErr()
+                .CaptureStdOut()
+                .Execute()
+                .Should()
+                .Pass()
+                .And
+                .HaveStdOutContaining("Hello World")
+                .And
+                .HaveStdErrContaining($"--- Invoked apphost [version: {previousVersionFixture.RepoDirProvider.MicrosoftNETCoreAppVersion}");
+        }
+
+        private static TestProjectFixture CreateTestFixture(string testName, string netCoreAppFramework, string mnaVersion)
+        {
+            var repoDirectories = new RepoDirectoriesProvider(microsoftNETCoreAppVersion: mnaVersion);
+
+            // Use standalone instead of framework-dependent for ease of deployment.
+            var publishFixture = new TestProjectFixture(testName, repoDirectories, framework: netCoreAppFramework, assemblyName: "StandaloneApp");
+
+            try 
+            {
+                publishFixture
+                    .EnsureRestoredForRid(publishFixture.CurrentRid, repoDirectories.CorehostPackages)
+                    .PublishProject(runtime: publishFixture.CurrentRid);
+            }
+            catch (BuildFailureException)
+            {
+                // Some RIDs didn't exist in 2.0+ so if we get an error publishing, ignore.
+                // However, to catch real issues, allow Windows and OSX to throw here since they currently should never fail because of RIDs.
+                if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ||
+                    RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+                {
+                    throw;
+                }
+
+                return null;
+            }
+
+            return publishFixture;
+        }
+    }
+}

--- a/src/test/HostActivationTests/GivenThatICareAboutStandaloneAppActivation.cs
+++ b/src/test/HostActivationTests/GivenThatICareAboutStandaloneAppActivation.cs
@@ -19,8 +19,8 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.StandaloneApp
 {
     public class GivenThatICareAboutStandaloneAppActivation
     {
-        private static TestProjectFixture PreviouslyBuiltAndRestoredStandaloneTestProjectFixture { get; set; }
-        private static TestProjectFixture PreviouslyPublishedAndRestoredStandaloneTestProjectFixture { get; set; }
+        public static TestProjectFixture PreviouslyBuiltAndRestoredStandaloneTestProjectFixture { get; private set; }
+        public static TestProjectFixture PreviouslyPublishedAndRestoredStandaloneTestProjectFixture { get; private set; }
         private static RepoDirectoriesProvider RepoDirectories { get; set; }
 
         static GivenThatICareAboutStandaloneAppActivation()

--- a/src/test/TestUtils/RepoDirectoriesProvider.cs
+++ b/src/test/TestUtils/RepoDirectoriesProvider.cs
@@ -41,7 +41,8 @@ namespace Microsoft.DotNet.CoreSetup.Test
             string builtDotnet = null,
             string nugetPackages = null,
             string corehostPackages = null,
-            string dotnetSdk = null)
+            string dotnetSdk = null,
+            string microsoftNETCoreAppVersion = null)
         {
             _repoRoot = repoRoot ?? GetRepoRootDirectory();
 
@@ -50,7 +51,7 @@ namespace Microsoft.DotNet.CoreSetup.Test
             _targetRID = Environment.GetEnvironmentVariable("TEST_TARGETRID");
             _buildRID = Environment.GetEnvironmentVariable("BUILDRID");
             _buildArchitecture = Environment.GetEnvironmentVariable("BUILD_ARCHITECTURE");
-            _mnaVersion = Environment.GetEnvironmentVariable("MNA_VERSION");
+            _mnaVersion = microsoftNETCoreAppVersion ?? Environment.GetEnvironmentVariable("MNA_VERSION");
 
             string configuration = Environment.GetEnvironmentVariable("BUILD_CONFIGURATION");
             string osPlatformConfig = $"{_buildRID}.{configuration}";

--- a/src/test/TestUtils/TestProject.cs
+++ b/src/test/TestUtils/TestProject.cs
@@ -24,12 +24,14 @@ namespace Microsoft.DotNet.CoreSetup.Test
         private string _appExe;
         private string _hostPolicyDll;
         private string _hostFxrDll;
+        private string _assemblyName;
 
         public string ProjectDirectory => _projectDirectory;
         public string ProjectName => _projectName;
 
         public string OutputDirectory { get { return _outputDirectory; } set { _outputDirectory = value; } }
         public string ExeExtension { get { return _exeExtension; } set { _exeExtension = value; } }
+        public string AssemblyName { get { return _assemblyName; } set { _assemblyName = value; } }
         public string ProjectFile { get { return _projectFile; } set { _projectFile = value; } }
         public string ProjectAssetsJson { get { return _projectAssetsJson; } set { _projectAssetsJson = value; } }
         public string RuntimeConfigJson { get { return _runtimeConfigJson; } set { _runtimeConfigJson = value; } }
@@ -45,13 +47,15 @@ namespace Microsoft.DotNet.CoreSetup.Test
             string exeExtension,
             string sharedLibraryExtension,
             string sharedLibraryPrefix,
-            string outputDirectory = null)
+            string outputDirectory = null,
+            string assemblyName = null)
         {
             _projectDirectory = projectDirectory;
             _exeExtension = exeExtension;
             _sharedLibraryExtension = sharedLibraryExtension;
             _sharedLibraryPrefix = sharedLibraryPrefix;
             _projectName = Path.GetFileName(_projectDirectory);
+            _assemblyName = assemblyName ?? _projectName;
             _projectFile = Path.Combine(_projectDirectory, $"{_projectName}.csproj");
             _projectAssetsJson = Path.Combine(_projectDirectory, "obj", "project.assets.json");
 
@@ -69,11 +73,11 @@ namespace Microsoft.DotNet.CoreSetup.Test
 
         public void LoadOutputFiles()
         {
-            _appDll = Path.Combine(_outputDirectory, $"{_projectName}.dll");
-            _appExe = Path.Combine(_outputDirectory, $"{_projectName}{_exeExtension}");
-            _depsJson = Path.Combine(_outputDirectory, $"{_projectName}.deps.json");
-            _runtimeConfigJson = Path.Combine(_outputDirectory, $"{_projectName}.runtimeconfig.json");
-            _runtimeDevConfigJson = Path.Combine(_outputDirectory, $"{_projectName}.runtimeconfig.dev.json");
+            _appDll = Path.Combine(_outputDirectory, $"{_assemblyName}.dll");
+            _appExe = Path.Combine(_outputDirectory, $"{_assemblyName}{_exeExtension}");
+            _depsJson = Path.Combine(_outputDirectory, $"{_assemblyName}.deps.json");
+            _runtimeConfigJson = Path.Combine(_outputDirectory, $"{_assemblyName}.runtimeconfig.json");
+            _runtimeDevConfigJson = Path.Combine(_outputDirectory, $"{_assemblyName}.runtimeconfig.dev.json");
             _hostPolicyDll = Path.Combine(_outputDirectory, $"{_sharedLibraryPrefix}hostpolicy{_sharedLibraryExtension}");
             _hostFxrDll = Path.Combine(_outputDirectory, $"{_sharedLibraryPrefix}hostfxr{_sharedLibraryExtension}");
         }

--- a/src/test/TestUtils/TestProjectFixture.cs
+++ b/src/test/TestUtils/TestProjectFixture.cs
@@ -23,6 +23,7 @@ namespace Microsoft.DotNet.CoreSetup.Test
         private string _testArtifactDirectory;
         private string _currentRid;
         private string _framework;
+        private string _assemblyName;
 
         private RepoDirectoriesProvider _repoDirectoriesProvider;
 
@@ -53,7 +54,8 @@ namespace Microsoft.DotNet.CoreSetup.Test
             string dotnetInstallPath = null,
             string currentRid = null,
             string builtDotnetOutputPath = null,
-            string framework = null)
+            string framework = null,
+            string assemblyName = null)
         {
             ValidateRequiredDirectories(repoDirectoriesProvider);
 
@@ -78,13 +80,17 @@ namespace Microsoft.DotNet.CoreSetup.Test
             _currentRid = currentRid ?? repoDirectoriesProvider.TargetRID;
 
             _builtDotnet = new DotNetCli(repoDirectoriesProvider.BuiltDotnet);
+
+            _assemblyName = assemblyName;
+
             InitializeTestProject(
                 _testProjectName,
                 _testProjectSourceDirectory,
                 _testArtifactDirectory,
                 _exeExtension,
                 _sharedLibraryExtension,
-                _sharedLibraryPrefix);
+                _sharedLibraryPrefix,
+                _assemblyName);
         }
 
         public TestProjectFixture(TestProjectFixture fixtureToCopy)
@@ -101,13 +107,15 @@ namespace Microsoft.DotNet.CoreSetup.Test
             _builtDotnet = fixtureToCopy._builtDotnet;
             _sourceTestProject = fixtureToCopy._sourceTestProject;
             _framework = fixtureToCopy._framework;
+            _assemblyName = fixtureToCopy._assemblyName;
 
             _testProject = CopyTestProject(
                 fixtureToCopy.TestProject,
                 _testArtifactDirectory,
                 _exeExtension,
                 _sharedLibraryExtension,
-                _sharedLibraryPrefix);
+                _sharedLibraryPrefix,
+                _assemblyName);
         }
 
         private void InitializeTestProject(
@@ -116,21 +124,24 @@ namespace Microsoft.DotNet.CoreSetup.Test
             string testArtifactDirectory,
             string exeExtension,
             string sharedLibraryExtension,
-            string sharedLibraryPrefix)
+            string sharedLibraryPrefix,
+            string assemblyName)
         {
             var sourceTestProjectPath = Path.Combine(testProjectSourceDirectory, testProjectName);
             _sourceTestProject = new TestProject(
                 sourceTestProjectPath,
                 exeExtension,
                 sharedLibraryExtension,
-                sharedLibraryPrefix);
+                sharedLibraryPrefix,
+                assemblyName: assemblyName);
 
             _testProject = CopyTestProject(
                 _sourceTestProject,
                 testArtifactDirectory,
                 exeExtension,
                 sharedLibraryExtension,
-                sharedLibraryPrefix);
+                sharedLibraryPrefix,
+                assemblyName);
         }
 
         private TestProject CopyTestProject(
@@ -138,7 +149,8 @@ namespace Microsoft.DotNet.CoreSetup.Test
             string testArtifactDirectory,
             string exeExtension,
             string sharedLibraryExtension,
-            string sharedLibraryPrefix)
+            string sharedLibraryPrefix,
+            string assemblyName)
         {
             string copiedTestProjectDirectory = CalculateTestProjectDirectory(
                 sourceTestProject.ProjectName,
@@ -151,7 +163,8 @@ namespace Microsoft.DotNet.CoreSetup.Test
                 copiedTestProjectDirectory,
                 exeExtension,
                 sharedLibraryExtension,
-                sharedLibraryPrefix);
+                sharedLibraryPrefix,
+                assemblyName: assemblyName);
         }
 
         private void EnsureDirectoryBuildProps(string testArtifactDirectory)


### PR DESCRIPTION
Add tests that verify the apphost and hostfxr are backwards and forward compatible.

This will catch potential future issues with binary contracts between apphost\dotnet->hostfxr->hostpolicy and issues associated with unix\osx symbol-based export merging.

The apphost is used in a standalone mode (instead of dotnet muxer in shared mode) to make the tests easier to write and maintain. Only versions 2.0.x and 2.1 are currently verified (not 1.0 or 1.1 because they didn't use apphost).

Fixes https://github.com/dotnet/core-setup/issues/3777

cc @jeffschwMSFT 