### PR TITLE
Remove c++ compiler warnings

### DIFF
--- a/src/corehost/cli/dll/CMakeLists.txt
+++ b/src/corehost/cli/dll/CMakeLists.txt
@@ -10,9 +10,8 @@ if(WIN32)
     add_compile_options($<$<CONFIG:Debug>:/MTd>)
 else()
     add_compile_options(-fPIC)
+    add_compile_options(-fvisibility=hidden)
 endif()
-
-add_compile_options(-fvisibility=hidden)
 
 include(../setup.cmake)
 

--- a/src/corehost/cli/exe/apphost/CMakeLists.txt
+++ b/src/corehost/cli/exe/apphost/CMakeLists.txt
@@ -5,8 +5,6 @@ cmake_minimum_required (VERSION 2.6)
 project(apphost)
 set(DOTNET_HOST_EXE_NAME "apphost")
 
-add_compile_options(-fvisibility=hidden)
-
 # Add RPATH to the apphost binary that allows using local copies of shared libraries
 # dotnet core depends on for special scenarios when system wide installation of such 
 # dependencies is not possible for some reason.

--- a/src/corehost/cli/exe/dotnet/CMakeLists.txt
+++ b/src/corehost/cli/exe/dotnet/CMakeLists.txt
@@ -4,7 +4,6 @@
 cmake_minimum_required (VERSION 2.6)
 project(dotnet)
 set(DOTNET_HOST_EXE_NAME "dotnet")
-add_compile_options(-fvisibility=hidden)
 set(SOURCES 
     ../../fxr/fx_ver.cpp)
 include(../exe.cmake)

--- a/src/corehost/cli/exe/exe.cmake
+++ b/src/corehost/cli/exe/exe.cmake
@@ -8,6 +8,7 @@ if(WIN32)
     add_compile_options($<$<CONFIG:Debug>:/MTd>)
 else()
     add_compile_options(-fPIE)
+    add_compile_options(-fvisibility=hidden)
 endif()
 
 include(../../setup.cmake)

--- a/src/corehost/cli/fxr/CMakeLists.txt
+++ b/src/corehost/cli/fxr/CMakeLists.txt
@@ -10,9 +10,8 @@ if(WIN32)
     add_compile_options($<$<CONFIG:Debug>:/MTd>)
 else()
     add_compile_options(-fPIC)
+    add_compile_options(-fvisibility=hidden)
 endif()
-
-add_compile_options(-fvisibility=hidden)
 
 include(../setup.cmake)
 

--- a/src/corehost/cli/runtime_config.cpp
+++ b/src/corehost/cli/runtime_config.cpp
@@ -85,7 +85,7 @@ bool runtime_config_t::parse_opts(const json_value& opts)
         {
             m_properties[property.first] = property.second.is_string()
                 ? property.second.as_string()
-                : property.second.to_string();
+                : property.second.serialize();
         }
     }
 

--- a/src/corehost/common/utils.cpp
+++ b/src/corehost/common/utils.cpp
@@ -226,9 +226,8 @@ bool parse_known_args(
     {
         pal::string_t arg = argv[arg_i];
         pal::string_t arg_lower = pal::to_lower(arg);
-        if (std::find_if(known_opts.begin(), known_opts.end(), 
-                        [&value_to_look = arg_lower]
-                        (const host_option& hostoption) -> bool { return value_to_look == hostoption.option; })
+        if (std::find_if(known_opts.begin(), known_opts.end(),
+            [&](const host_option& hostoption) { return arg_lower == hostoption.option; })
             == known_opts.end())
         {
             // Unknown argument.

--- a/src/test/HostActivationTests/GivenThatICareAboutDotnetArgValidationScenarios.cs
+++ b/src/test/HostActivationTests/GivenThatICareAboutDotnetArgValidationScenarios.cs
@@ -88,6 +88,23 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.ArgValidation
                 .HaveStdErrContaining($"dotnet exec needs a managed .dll or .exe extension. The application specified was '{assemblyName}'");
         }
 
+        [Fact]
+        public void Detect_Missing_Argument_Value()
+        {
+            var fixture = PreviouslyBuiltAndRestoredPortableTestProjectFixture
+                .Copy();
+
+            var dotnet = fixture.BuiltDotnet;
+
+            dotnet.Exec("--fx-version")
+                .CaptureStdOut()
+                .CaptureStdErr()
+                .Execute()
+                .Should()
+                .Fail()
+                .And
+                .HaveStdErrContaining($"Failed to parse supported options or their values:");
+        }
 
         // Return a non-exisitent path that contains a mix of / and \
         private string GetNonexistentAndUnnormalizedPath()


### PR DESCRIPTION
Removes C++ compiler warnings.

One test was added because of code changes required for (`src/core-setup/src/corehost/common/utils.cpp(230,27): warning GDA27E57B: initialized lambda captures are a C++14 extension`)

Fixes https://github.com/dotnet/core-setup/issues/4102

cc @jeffschwMSFT 