### PR TITLE
Ensure pkg\bin directory exists before writing to it in 1.1.0

### DIFF
--- a/build_projects/dotnet-host-build/PublishTargets.cs
+++ b/build_projects/dotnet-host-build/PublishTargets.cs
@@ -181,6 +181,7 @@ namespace Microsoft.DotNet.Host.Build
                 "</Project>"
             };
 
+            System.IO.Directory.CreateDirectory(Dirs.RepoRoot + "\\pkg\\bin");
             System.IO.File.WriteAllLines(Dirs.RepoRoot + "\\pkg\\bin\\AzureBlob.props", lines);
 
             return c.Success();


### PR DESCRIPTION
I didn't check for this after adding https://github.com/dotnet/core-setup/pull/4241/commits/63bc23cd77a3a6a58da161d6e107f528ff95816f to my last PR. CreateDirectory() only creates a directory if one doesn't already exist, so we don't need to add an explicit check for that before the call is made.

CC @eerhardt @weshaggard 