### PR TITLE
Mark more packages as stable for 1.0.12, plus fix nuget.versioning

### DIFF
--- a/build_projects/dotnet-host-build/project.json
+++ b/build_projects/dotnet-host-build/project.json
@@ -6,7 +6,7 @@
   },
   "dependencies": {
     "NETStandard.Library": "1.6.0",
-    "Microsoft.NETCore.Runtime.CoreCLR": "1.0.7-servicing-25107-01",
+    "Microsoft.NETCore.Runtime.CoreCLR": "1.0.14",
     "Microsoft.CSharp": "4.0.1",
     "System.Dynamic.Runtime": "4.0.11",
     "System.Reflection.Metadata": "1.3.0",

--- a/build_projects/update-dependencies/project.json
+++ b/build_projects/update-dependencies/project.json
@@ -7,12 +7,12 @@
   "dependencies": {
     "NETStandard.Library": "1.6.0",
     "Microsoft.CSharp": "4.0.1",
-    "Microsoft.NETCore.Runtime.CoreCLR": "1.0.7-servicing-25107-01",
+    "Microsoft.NETCore.Runtime.CoreCLR": "1.0.14",
     "System.Runtime.Serialization.Primitives": "4.1.1",
     "Microsoft.DotNet.Cli.Build.Framework": {
       "target": "project"
     },
-    "NuGet.Versioning": "3.5.0-rc-1285",
+    "NuGet.Versioning": "3.5.0-rc1-final",
     "Newtonsoft.Json": "7.0.1",
     "Octokit": "0.18.0",
     "Microsoft.Net.Http": "2.2.29"

--- a/tools/independent/RuntimeGraphGenerator/project.json
+++ b/tools/independent/RuntimeGraphGenerator/project.json
@@ -11,7 +11,7 @@
     "Microsoft.DotNet.ProjectModel": "1.0.0-rc2-002794",
     "Microsoft.DotNet.Cli.Utils": "1.0.0-preview2-002794",
     "NETStandard.Library": "1.6.0",
-    "Microsoft.NETCore.Runtime.CoreCLR": "1.0.7-servicing-25107-01"
+    "Microsoft.NETCore.Runtime.CoreCLR": "1.0.14"
   },
   "frameworks": {
     "netcoreapp1.0": {


### PR DESCRIPTION
CC @weshaggard this should resolve the errors in the Maestro build for core-setup.

Also @dagood, these files aren't getting touched by the auto-update PRs - is there an easy way to fix that?