### PR TITLE
Run VsDevCmd.bat in sign-and-publish job in 1.0.0

### DIFF
--- a/buildpipeline/Core-Setup-Sign-And-Publish.json
+++ b/buildpipeline/Core-Setup-Sign-And-Publish.json
@@ -24,6 +24,25 @@
       }
     },
     {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Run script $(VS140COMNTOOLS)\\VsDevCmd.bat",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "bfc8bf76-e7ac-4a8c-9a55-a944a9f632fd",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "filename": "$(VS140COMNTOOLS)\\VsDevCmd.bat",
+        "arguments": "",
+        "modifyEnvironment": "true",
+        "workingFolder": "",
+        "failOnStandardError": "false"
+      }
+    },
+    {
       "environment": {},
       "enabled": true,
       "continueOnError": false,


### PR DESCRIPTION
We need this in order for the build to locate msbuild. We're running on Dev14 machines, so running this batch file is sufficient for setting the right env vars. 

CC @MattGal 