### PR TITLE
Fix SyncToolsVersion.props header 1.1.0

### DIFF
--- a/pkg/init-tools.cmd
+++ b/pkg/init-tools.cmd
@@ -22,7 +22,8 @@ set SYNC_JSON_CONTENTS={ "dependencies": { "Microsoft.DotNet.BuildTools": "%SYNC
 set MSBUILD_PROJECT_PATH=%PACKAGES_DIR%
 set MSBUILD_PROJECT_FILE=%MSBUILD_PROJECT_PATH%\SyncToolsVersion.props
 set MSBUILD_PROJECT_CONTENTS= ^
- ^^^<Project Sdk=^"Microsoft.NET.Sdk^"^^^> ^
+ ^^^<?xml version=^"1.0^" encoding=^"utf-8^"?^^^> ^
+ ^^^<Project ToolsVersion=^"12.0^" DefaultTargets=^"Build^" xmlns=^"http://schemas.microsoft.com/developer/msbuild/2003^"^^^> ^
   ^^^<PropertyGroup^^^> ^
     ^^^<SyncToolsVersion^^^>%SYNCTOOLS_VERSION%^^^</SyncToolsVersion^^^> ^
   ^^^</PropertyGroup^^^> ^


### PR DESCRIPTION
We need to use the msbuild 2003 header style for the generated props file, not the SDK style.