### PR TITLE
Fix whitespace in SyncToolsVersion.props

### DIFF
--- a/pkg/init-tools.cmd
+++ b/pkg/init-tools.cmd
@@ -21,8 +21,7 @@ set SYNC_JSON_CONTENTS={ "dependencies": { "Microsoft.DotNet.BuildTools": "%SYNC
 
 set MSBUILD_PROJECT_PATH=%PACKAGES_DIR%
 set MSBUILD_PROJECT_FILE=%MSBUILD_PROJECT_PATH%\SyncToolsVersion.props
-set MSBUILD_PROJECT_CONTENTS= ^
- ^^^<?xml version=^"1.0^" encoding=^"utf-8^"?^^^> ^
+set MSBUILD_PROJECT_CONTENTS=^^^<?xml version=^"1.0^" encoding=^"utf-8^"?^^^> ^
  ^^^<Project ToolsVersion=^"12.0^" DefaultTargets=^"Build^" xmlns=^"http://schemas.microsoft.com/developer/msbuild/2003^"^^^> ^
   ^^^<PropertyGroup^^^> ^
     ^^^<SyncToolsVersion^^^>%SYNCTOOLS_VERSION%^^^</SyncToolsVersion^^^> ^


### PR DESCRIPTION
The generated .props file must start without any leading whitespace.