### PR TITLE
Clean up disk space after test runs

### DIFF
--- a/src/test/HostActivationTests/GivenThatICareAboutDotnetArgValidationScenarios.cs
+++ b/src/test/HostActivationTests/GivenThatICareAboutDotnetArgValidationScenarios.cs
@@ -11,24 +11,19 @@ using Xunit;
 
 namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.ArgValidation
 {
-    public class GivenThatICareAboutDotnetArgValidationScenarios
+    public class GivenThatICareAboutDotnetArgValidationScenarios : IClassFixture<GivenThatICareAboutDotnetArgValidationScenarios.SharedTestState>
     {
-        private RepoDirectoriesProvider RepoDirectories { get; set; }
-        private TestProjectFixture PreviouslyBuiltAndRestoredPortableTestProjectFixture { get; set; }
+        private SharedTestState sharedTestState;
 
-        public GivenThatICareAboutDotnetArgValidationScenarios()
+        public GivenThatICareAboutDotnetArgValidationScenarios(GivenThatICareAboutDotnetArgValidationScenarios.SharedTestState fixture)
         {
-            RepoDirectories = new RepoDirectoriesProvider();
-
-            PreviouslyBuiltAndRestoredPortableTestProjectFixture = new TestProjectFixture("PortableApp", RepoDirectories)
-                .EnsureRestored(RepoDirectories.CorehostPackages)
-                .BuildProject();
+            sharedTestState = fixture;
         }
 
         [Fact]
         public void Muxer_Exec_With_Missing_App_Assembly_Fails()
         {
-            var fixture = PreviouslyBuiltAndRestoredPortableTestProjectFixture
+            var fixture = sharedTestState.PreviouslyBuiltAndRestoredPortableTestProjectFixture
                 .Copy();
 
             var dotnet = fixture.BuiltDotnet;
@@ -48,7 +43,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.ArgValidation
         [Fact]
         public void Muxer_Exec_With_Missing_App_Assembly_And_Bad_Extension_Fails()
         {
-            var fixture = PreviouslyBuiltAndRestoredPortableTestProjectFixture
+            var fixture = sharedTestState.PreviouslyBuiltAndRestoredPortableTestProjectFixture
                 .Copy();
 
             var dotnet = fixture.BuiltDotnet;
@@ -68,7 +63,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.ArgValidation
         [Fact]
         public void Muxer_Exec_With_Bad_Extension_Fails()
         {
-            var fixture = PreviouslyBuiltAndRestoredPortableTestProjectFixture
+            var fixture = sharedTestState.PreviouslyBuiltAndRestoredPortableTestProjectFixture
                 .Copy();
 
             var dotnet = fixture.BuiltDotnet;
@@ -91,7 +86,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.ArgValidation
         [Fact]
         public void Detect_Missing_Argument_Value()
         {
-            var fixture = PreviouslyBuiltAndRestoredPortableTestProjectFixture
+            var fixture = sharedTestState.PreviouslyBuiltAndRestoredPortableTestProjectFixture
                 .Copy();
 
             var dotnet = fixture.BuiltDotnet;
@@ -109,7 +104,27 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.ArgValidation
         // Return a non-exisitent path that contains a mix of / and \
         private string GetNonexistentAndUnnormalizedPath()
         {
-            return Path.Combine(PreviouslyBuiltAndRestoredPortableTestProjectFixture.SdkDotnet.BinPath, @"x\y/");
+            return Path.Combine(sharedTestState.PreviouslyBuiltAndRestoredPortableTestProjectFixture.SdkDotnet.BinPath, @"x\y/");
+        }
+
+        public class SharedTestState : IDisposable
+        {
+            public RepoDirectoriesProvider RepoDirectories { get; set; }
+            public TestProjectFixture PreviouslyBuiltAndRestoredPortableTestProjectFixture { get; set; }
+
+            public SharedTestState()
+            {
+                RepoDirectories = new RepoDirectoriesProvider();
+
+                PreviouslyBuiltAndRestoredPortableTestProjectFixture = new TestProjectFixture("PortableApp", RepoDirectories)
+                    .EnsureRestored(RepoDirectories.CorehostPackages)
+                    .BuildProject();
+            }
+
+            public void Dispose()
+            {
+                PreviouslyBuiltAndRestoredPortableTestProjectFixture.Dispose();
+            }
         }
     }
 }

--- a/src/test/HostActivationTests/GivenThatICareAboutDotnetTestXunitScenarios.cs
+++ b/src/test/HostActivationTests/GivenThatICareAboutDotnetTestXunitScenarios.cs
@@ -22,22 +22,27 @@ namespace Microsoft.DotNet.Tools.Publish.Tests
         [Fact]
         public void Muxer_activation_of_dotnet_test_XUnit_on_Portable_Test_App_Succeeds()
         {
-            var portableTestAppFixture = new TestProjectFixture("PortableTestApp", RepoDirectories)
-                .EnsureRestored(RepoDirectories.CorehostPackages)
-                .BuildProject();
+            using (var portableTestAppFixture = new TestProjectFixture("PortableTestApp", RepoDirectories))
+            {
+                portableTestAppFixture
+                    .EnsureRestored(RepoDirectories.CorehostPackages)
+                    .BuildProject();
 
-            ActivateDotnetTestXunitOnTestProject(RepoDirectories, portableTestAppFixture);
+                ActivateDotnetTestXunitOnTestProject(RepoDirectories, portableTestAppFixture);
+            }
         }
 
         [Fact]
         public void Muxer_activation_of_dotnet_test_XUnit_on_Standalone_Test_App_Succeeds()
         {
-            var standaloneTestAppFixture = new TestProjectFixture("StandaloneTestApp", RepoDirectories);
-            standaloneTestAppFixture
-                .EnsureRestoredForRid(standaloneTestAppFixture.CurrentRid, RepoDirectories.CorehostPackages)
-                .BuildProject(runtime: standaloneTestAppFixture.CurrentRid);
+            using (var standaloneTestAppFixture = new TestProjectFixture("StandaloneTestApp", RepoDirectories))
+            {
+                standaloneTestAppFixture
+                    .EnsureRestoredForRid(standaloneTestAppFixture.CurrentRid, RepoDirectories.CorehostPackages)
+                    .BuildProject(runtime: standaloneTestAppFixture.CurrentRid);
 
-            ActivateDotnetTestXunitOnTestProject(RepoDirectories, standaloneTestAppFixture);
+                ActivateDotnetTestXunitOnTestProject(RepoDirectories, standaloneTestAppFixture);
+            }
         }
 
         public void ActivateDotnetTestXunitOnTestProject(

--- a/src/test/HostActivationTests/GivenThatICareAboutMultilevelSharedFxLookup.cs
+++ b/src/test/HostActivationTests/GivenThatICareAboutMultilevelSharedFxLookup.cs
@@ -7,7 +7,7 @@ using Xunit;
 
 namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.MultilevelSharedFxLookup
 {
-    public class GivenThatICareAboutMultilevelSharedFxLookup
+    public class GivenThatICareAboutMultilevelSharedFxLookup : IDisposable
     {
         private const string SystemCollectionsImmutableFileVersion = "1.2.3.4";
         private const string SystemCollectionsImmutableAssemblyVersion = "1.0.1.2";
@@ -119,6 +119,16 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.MultilevelSharedFxLooku
             _globalFoundUberFxMessage = $"Chose FX version [{_globalSharedUberFxBaseDir}";
         }
 
+        public void Dispose()
+        {
+            PreviouslyBuiltAndRestoredPortableTestProjectFixture.Dispose();
+
+            if (!TestProject.PreserveTestRuns())
+            {
+                Directory.Delete(_multilevelDir, true);
+            }
+        }
+
         [Fact]
         public void SharedFxLookup_Must_Verify_Folders_in_the_Correct_Order()
         {
@@ -200,9 +210,6 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.MultilevelSharedFxLooku
                 .Pass()
                 .And
                 .HaveStdOutContaining("Microsoft.NETCore.App 9999.0.0");
-
-            SharedFramework.DeleteAvailableSharedFxVersions(_exeSharedFxBaseDir, "9999.0.0");
-            SharedFramework.DeleteAvailableSharedFxVersions(_cwdSharedFxBaseDir, "9999.0.0");
         }
 
         [Fact]
@@ -264,8 +271,6 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.MultilevelSharedFxLooku
                 .HaveStdOutContaining("Microsoft.NETCore.App 9999.0.3")
                 .And
                 .HaveStdOutContaining("Microsoft.NETCore.App 9999.0.0-dummy3");
-
-            SharedFramework.DeleteAvailableSharedFxVersions(_exeSharedFxBaseDir, "9999.0.0", "9999.0.2", "9999.0.0-dummy2", "9999.0.3", "9999.0.0-dummy3");
         }
 
         [Fact]
@@ -332,8 +337,6 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.MultilevelSharedFxLooku
                 .HaveStdOutContaining("Microsoft.NETCore.App 10000.1.1")
                 .And
                 .HaveStdOutContaining("Microsoft.NETCore.App 10000.1.3");
-
-            SharedFramework.DeleteAvailableSharedFxVersions(_exeSharedFxBaseDir, "9999.1.1", "10000.1.1", "10000.1.3");
         }
 
         [Fact]
@@ -412,8 +415,6 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.MultilevelSharedFxLooku
                 .HaveStdOutContaining("Microsoft.NETCore.App 9999.1.1")
                 .And
                 .HaveStdOutContaining("Microsoft.NETCore.App 10000.1.1");
-
-            SharedFramework.DeleteAvailableSharedFxVersions(_exeSharedFxBaseDir, "9999.1.1", "10000.1.1");
         }
 
         [Fact]
@@ -516,8 +517,6 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.MultilevelSharedFxLooku
                 .HaveStdOutContaining("Microsoft.NETCore.App 9999.2.1-dummy1")
                 .And
                 .HaveStdOutContaining("Microsoft.NETCore.App 9999.2.2-dummy1");
-
-            SharedFramework.DeleteAvailableSharedFxVersions(_exeSharedFxBaseDir, "9999.1.1-dummy1", "9999.2.1", "9999.2.1-dummy1", "9999.2.2-dummy1");
         }
 
         [Fact]
@@ -582,8 +581,6 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.MultilevelSharedFxLooku
                 .HaveStdOutContaining("9999.0.0")
                 .And
                 .HaveStdOutContaining("9999.0.1-dummy1");
-
-            SharedFramework.DeleteAvailableSharedFxVersions(_exeSharedFxBaseDir, "9999.0.0-dummy2", "9999.0.0-dummy3", "9999.0.0", "9999.0.1-dummy1");
         }
 
         [Fact]
@@ -633,8 +630,6 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.MultilevelSharedFxLooku
                 .HaveStdOutContaining("Microsoft.NETCore.App 9999.0.1")
                 .And
                 .HaveStdOutContaining("Microsoft.NETCore.App 9999.1.0");
-
-            SharedFramework.DeleteAvailableSharedFxVersions(_exeSharedFxBaseDir, "9998.0.1", "9998.1.0", "9999.0.0", "9999.0.1", "9999.1.0");
         }
 
         [Fact]
@@ -711,9 +706,6 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.MultilevelSharedFxLooku
                 .HaveStdOutContaining("Microsoft.UberFramework 7777.0.0")
                 .And
                 .HaveStdOutContaining("Microsoft.UberFramework 7777.0.1");
-
-            SharedFramework.DeleteAvailableSharedFxVersions(_exeSharedFxBaseDir, "9999.0.0", "9999.0.1");
-            SharedFramework.DeleteAvailableSharedFxVersions(_exeSharedUberFxBaseDir, "7777.0.0", "7777.0.1");
         }
 
         [Fact]
@@ -801,9 +793,6 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.MultilevelSharedFxLooku
                 .HaveStdErrContaining(Path.Combine(_exeFoundUberFxMessage, "7777.0.0"))
                 .And
                 .HaveStdErrContaining("Property TestProperty = AppValue");
-
-            SharedFramework.DeleteAvailableSharedFxVersions(_exeSharedFxBaseDir, "9999.1.0");
-            SharedFramework.DeleteAvailableSharedFxVersions(_exeSharedUberFxBaseDir, "7777.0.0");
         }
 
         [Fact]
@@ -892,9 +881,6 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.MultilevelSharedFxLooku
                 .Fail()
                 .And
                 .HaveStdErrContaining("It was not possible to find any compatible framework version");
-
-            SharedFramework.DeleteAvailableSharedFxVersions(_exeSharedFxBaseDir, "9999.1.0");
-            SharedFramework.DeleteAvailableSharedFxVersions(_exeSharedUberFxBaseDir, "7777.0.0");
         }
 
         [Fact]
@@ -933,9 +919,6 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.MultilevelSharedFxLooku
                 .Pass()
                 .And
                 .HaveStdErrContaining($"Replacing deps entry [{uberFile}, AssemblyVersion:1.0.1.2, FileVersion:{SystemCollectionsImmutableFileVersion}] with [{netCoreAppFile}");
-
-            SharedFramework.DeleteAvailableSharedFxVersions(_exeSharedFxBaseDir, "9999.1.0");
-            SharedFramework.DeleteAvailableSharedFxVersions(_exeSharedUberFxBaseDir, "7777.0.0");
         }
 
         [Fact]
@@ -974,9 +957,6 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.MultilevelSharedFxLooku
                 .HaveStdErrContaining(Path.Combine("7777.0.0", "System.Collections.Immutable.dll"))
                 .And
                 .NotHaveStdErrContaining(Path.Combine("9999.1.0", "System.Collections.Immutable.dll"));
-
-            SharedFramework.DeleteAvailableSharedFxVersions(_exeSharedFxBaseDir, "9999.0.1");
-            SharedFramework.DeleteAvailableSharedFxVersions(_exeSharedUberFxBaseDir, "7777.0.0");
         }
 
         [Fact]
@@ -1026,9 +1006,6 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.MultilevelSharedFxLooku
                 .Pass()
                 .And
                 .HaveStdErrContaining($"Replacing deps entry [{appAssembly}, AssemblyVersion:{SystemCollectionsImmutableAssemblyVersion}, FileVersion:{SystemCollectionsImmutableFileVersion}] with [{uberAssembly}, AssemblyVersion:{SystemCollectionsImmutableAssemblyVersion}, FileVersion:{SystemCollectionsImmutableFileVersion}]");
-
-            SharedFramework.DeleteAvailableSharedFxVersions(_exeSharedFxBaseDir, "9999.0.0");
-            SharedFramework.DeleteAvailableSharedFxVersions(_exeSharedUberFxBaseDir, "7777.1.0");
         }
 
         [Fact]
@@ -1082,9 +1059,6 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.MultilevelSharedFxLooku
                 .NotHaveStdErrContaining($"Adding tpa entry: {netcoreAssembly}, AssemblyVersion: {SystemCollectionsImmutableAssemblyVersion}, FileVersion :{SystemCollectionsImmutableFileVersion}")
                 .And
                 .NotHaveStdErrContaining($"Replacing deps entry");
-
-            SharedFramework.DeleteAvailableSharedFxVersions(_exeSharedFxBaseDir, "9999.0.0");
-            SharedFramework.DeleteAvailableSharedFxVersions(_exeSharedUberFxBaseDir, "7777.0.0");
         }
 
         static private JObject GetAdditionalFramework(string fxName, string fxVersion, bool? applyPatches, int? rollForwardOnNoCandidateFx)

--- a/src/test/HostActivationTests/GivenThatICareAboutNativeHostApis.cs
+++ b/src/test/HostActivationTests/GivenThatICareAboutNativeHostApis.cs
@@ -10,23 +10,13 @@ using Microsoft.DotNet.CoreSetup.Test;
 
 namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.NativeHostApis
 {
-    public class GivenThatICareAboutNativeHostApis
+    public class GivenThatICareAboutNativeHostApis : IClassFixture<GivenThatICareAboutNativeHostApis.SharedTestState>
     {
-        private static TestProjectFixture PreviouslyBuiltAndRestoredPortableTestProjectFixture { get; set; }
-        private static TestProjectFixture PreviouslyPublishedAndRestoredPortableTestProjectFixture { get; set; }
-        private static RepoDirectoriesProvider RepoDirectories { get; set; }
+        private SharedTestState sharedTestState;
 
-        static GivenThatICareAboutNativeHostApis()
+        public GivenThatICareAboutNativeHostApis(GivenThatICareAboutNativeHostApis.SharedTestState fixture)
         {
-            RepoDirectories = new RepoDirectoriesProvider();
-
-            PreviouslyBuiltAndRestoredPortableTestProjectFixture = new TestProjectFixture("HostApiInvokerApp", RepoDirectories)
-                .EnsureRestored(RepoDirectories.CorehostPackages)
-                .BuildProject();
-
-            PreviouslyPublishedAndRestoredPortableTestProjectFixture = new TestProjectFixture("HostApiInvokerApp", RepoDirectories)
-                .EnsureRestored(RepoDirectories.CorehostPackages)
-                .PublishProject();
+            sharedTestState = fixture;
         }
 
         [Fact]
@@ -39,7 +29,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.NativeHostApis
                 return;
             }
 
-            var fixture = PreviouslyPublishedAndRestoredPortableTestProjectFixture.Copy();
+            var fixture = sharedTestState.PreviouslyPublishedAndRestoredPortableTestProjectFixture.Copy();
             var dotnet = fixture.BuiltDotnet;
             var appDll = fixture.TestProject.AppDll;
 
@@ -60,6 +50,32 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.NativeHostApis
                 .HaveStdOutContaining("hostfxr_get_native_search_directories:Success")
                 .And
                 .HaveStdOutContaining("hostfxr_get_native_search_directories buffer:[" + dotnet.GreatestVersionSharedFxPath);
+        }
+
+        public class SharedTestState : IDisposable
+        {
+            public TestProjectFixture PreviouslyBuiltAndRestoredPortableTestProjectFixture { get; set; }
+            public TestProjectFixture PreviouslyPublishedAndRestoredPortableTestProjectFixture { get; set; }
+            public RepoDirectoriesProvider RepoDirectories { get; set; }
+
+            public SharedTestState()
+            {
+                RepoDirectories = new RepoDirectoriesProvider();
+
+                PreviouslyBuiltAndRestoredPortableTestProjectFixture = new TestProjectFixture("HostApiInvokerApp", RepoDirectories)
+                    .EnsureRestored(RepoDirectories.CorehostPackages)
+                    .BuildProject();
+
+                PreviouslyPublishedAndRestoredPortableTestProjectFixture = new TestProjectFixture("HostApiInvokerApp", RepoDirectories)
+                    .EnsureRestored(RepoDirectories.CorehostPackages)
+                    .PublishProject();
+            }
+
+            public void Dispose()
+            {
+                PreviouslyBuiltAndRestoredPortableTestProjectFixture.Dispose();
+                PreviouslyPublishedAndRestoredPortableTestProjectFixture.Dispose();
+            }
         }
     }
 }

--- a/src/test/HostActivationTests/GivenThatICareAboutPortableAppActivation.cs
+++ b/src/test/HostActivationTests/GivenThatICareAboutPortableAppActivation.cs
@@ -15,29 +15,19 @@ using Xunit;
 
 namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.PortableApp
 {
-    public class GivenThatICareAboutPortableAppActivation
+    public class GivenThatICareAboutPortableAppActivation : IClassFixture<GivenThatICareAboutPortableAppActivation.SharedTestState>
     {
-        private static TestProjectFixture PreviouslyBuiltAndRestoredPortableTestProjectFixture { get; set; }
-        private static TestProjectFixture PreviouslyPublishedAndRestoredPortableTestProjectFixture { get; set; }
-        private static RepoDirectoriesProvider RepoDirectories { get; set; }
+        private SharedTestState sharedTestState;
 
-        static GivenThatICareAboutPortableAppActivation()
+        public GivenThatICareAboutPortableAppActivation(GivenThatICareAboutPortableAppActivation.SharedTestState fixture)
         {
-            RepoDirectories = new RepoDirectoriesProvider();
-
-            PreviouslyBuiltAndRestoredPortableTestProjectFixture = new TestProjectFixture("PortableApp", RepoDirectories)
-                .EnsureRestored(RepoDirectories.CorehostPackages)
-                .BuildProject();
-
-            PreviouslyPublishedAndRestoredPortableTestProjectFixture = new TestProjectFixture("PortableApp", RepoDirectories)
-                .EnsureRestored(RepoDirectories.CorehostPackages)
-                .PublishProject();
+            sharedTestState = fixture;
         }
 
         [Fact]
         public void Muxer_activation_of_Build_Output_Portable_DLL_with_DepsJson_and_RuntimeConfig_Local_Succeeds()
         {
-            var fixture = PreviouslyBuiltAndRestoredPortableTestProjectFixture
+            var fixture = sharedTestState.PreviouslyBuiltAndRestoredPortableTestProjectFixture
                 .Copy();
 
             var dotnet = fixture.BuiltDotnet;
@@ -65,7 +55,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.PortableApp
         [Fact]
         public void Muxer_activation_of_Build_Output_Portable_DLL_with_DepsJson_having_Assembly_with_Different_File_Extension_Fails()
         {
-            var fixture = PreviouslyBuiltAndRestoredPortableTestProjectFixture
+            var fixture = sharedTestState.PreviouslyBuiltAndRestoredPortableTestProjectFixture
                 .Copy();
 
             var dotnet = fixture.BuiltDotnet;
@@ -88,7 +78,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.PortableApp
         [Fact]
         public void Muxer_activation_of_Apps_with_AltDirectorySeparatorChar()
         {
-            var fixture = PreviouslyBuiltAndRestoredPortableTestProjectFixture
+            var fixture = sharedTestState.PreviouslyBuiltAndRestoredPortableTestProjectFixture
                 .Copy();
 
             var dotnet = fixture.BuiltDotnet;
@@ -106,7 +96,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.PortableApp
         [Fact]
         public void Muxer_Exec_activation_of_Build_Output_Portable_DLL_with_DepsJson_Local_and_RuntimeConfig_Remote_Without_AdditionalProbingPath_Fails()
         {
-            var fixture = PreviouslyBuiltAndRestoredPortableTestProjectFixture
+            var fixture = sharedTestState.PreviouslyBuiltAndRestoredPortableTestProjectFixture
                 .Copy();
 
             MoveRuntimeConfigToSubdirectory(fixture);
@@ -126,7 +116,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.PortableApp
         [Fact]
         public void Muxer_Exec_activation_of_Build_Output_Portable_DLL_with_DepsJson_Local_and_RuntimeConfig_Remote_With_AdditionalProbingPath_Succeeds()
         {
-            var fixture = PreviouslyBuiltAndRestoredPortableTestProjectFixture
+            var fixture = sharedTestState.PreviouslyBuiltAndRestoredPortableTestProjectFixture
                 .Copy();
 
             MoveRuntimeConfigToSubdirectory(fixture);
@@ -134,7 +124,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.PortableApp
             var dotnet = fixture.BuiltDotnet;
             var appDll = fixture.TestProject.AppDll;
             var runtimeConfig = fixture.TestProject.RuntimeConfigJson;
-            var additionalProbingPath = RepoDirectories.NugetPackages;
+            var additionalProbingPath = sharedTestState.RepoDirectories.NugetPackages;
 
             dotnet.Exec(
                     "exec",
@@ -153,9 +143,9 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.PortableApp
         [Fact]
         public void Muxer_Activation_With_Templated_AdditionalProbingPath_Succeeds()
         {
-            var fixture = PreviouslyBuiltAndRestoredPortableTestProjectFixture
+            var fixture = sharedTestState.PreviouslyBuiltAndRestoredPortableTestProjectFixture
                 .Copy();
-            
+
             var store_path = CreateAStore(fixture);
             var dotnet = fixture.BuiltDotnet;
             var appDll = fixture.TestProject.AppDll;
@@ -182,14 +172,14 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.PortableApp
                 .And
                 .HaveStdOutContaining("Hello World")
                 .And
-                .HaveStdErrContaining($"Adding tpa entry: {Path.Combine(store_path,fixture.RepoDirProvider.BuildArchitecture, fixture.Framework)}");
+                .HaveStdErrContaining($"Adding tpa entry: {Path.Combine(store_path, fixture.RepoDirProvider.BuildArchitecture, fixture.Framework)}");
         }
 
         [Fact]
         public void Muxer_Exec_activation_of_Build_Output_Portable_DLL_with_DepsJson_Remote_and_RuntimeConfig_Local_Succeeds()
         {
-            var fixture = PreviouslyBuiltAndRestoredPortableTestProjectFixture
-                 .Copy();
+            var fixture = sharedTestState.PreviouslyBuiltAndRestoredPortableTestProjectFixture
+                .Copy();
 
             MoveDepsJsonToSubdirectory(fixture);
 
@@ -211,7 +201,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.PortableApp
         [Fact]
         public void Muxer_activation_of_Publish_Output_Portable_DLL_with_DepsJson_and_RuntimeConfig_Local_Succeeds()
         {
-            var fixture = PreviouslyPublishedAndRestoredPortableTestProjectFixture
+            var fixture = sharedTestState.PreviouslyPublishedAndRestoredPortableTestProjectFixture
                 .Copy();
 
             var dotnet = fixture.BuiltDotnet;
@@ -240,7 +230,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.PortableApp
         [Fact]
         public void Muxer_Exec_activation_of_Publish_Output_Portable_DLL_with_DepsJson_Local_and_RuntimeConfig_Remote_Succeeds()
         {
-            var fixture = PreviouslyPublishedAndRestoredPortableTestProjectFixture
+            var fixture = sharedTestState.PreviouslyPublishedAndRestoredPortableTestProjectFixture
                 .Copy();
 
             MoveRuntimeConfigToSubdirectory(fixture);
@@ -262,8 +252,8 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.PortableApp
         [Fact]
         public void Muxer_Exec_activation_of_Publish_Output_Portable_DLL_with_DepsJson_Remote_and_RuntimeConfig_Local_Fails()
         {
-            var fixture = PreviouslyPublishedAndRestoredPortableTestProjectFixture
-                 .Copy();
+            var fixture = sharedTestState.PreviouslyPublishedAndRestoredPortableTestProjectFixture
+                .Copy();
 
             MoveDepsJsonToSubdirectory(fixture);
 
@@ -282,7 +272,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.PortableApp
         [Fact]
         public void Framework_Dependent_AppHost_Succeeds()
         {
-            var fixture = PreviouslyPublishedAndRestoredPortableTestProjectFixture
+            var fixture = sharedTestState.PreviouslyPublishedAndRestoredPortableTestProjectFixture
                 .Copy();
 
             // Since SDK doesn't support building framework dependent apphost yet, emulate that behavior
@@ -291,7 +281,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.PortableApp
             var appDllName = Path.GetFileName(fixture.TestProject.AppDll);
 
             string hostExeName = $"apphost{Constants.ExeSuffix}";
-            string builtAppHost = Path.Combine(RepoDirectories.HostArtifacts, hostExeName);
+            string builtAppHost = Path.Combine(sharedTestState.RepoDirectories.HostArtifacts, hostExeName);
             string appDir = Path.GetDirectoryName(appExe);
             string appDirHostExe = Path.Combine(appDir, hostExeName);
 
@@ -387,6 +377,32 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.PortableApp
             testProjectFixture.StoreProject(outputDirectory :storeoutputDirectory);
             
             return storeoutputDirectory;
+        }
+
+        public class SharedTestState : IDisposable
+        {
+            public TestProjectFixture PreviouslyBuiltAndRestoredPortableTestProjectFixture { get; set; }
+            public TestProjectFixture PreviouslyPublishedAndRestoredPortableTestProjectFixture { get; set; }
+            public RepoDirectoriesProvider RepoDirectories { get; set; }
+
+            public SharedTestState()
+            {
+                RepoDirectories = new RepoDirectoriesProvider();
+
+                PreviouslyBuiltAndRestoredPortableTestProjectFixture = new TestProjectFixture("PortableApp", RepoDirectories)
+                    .EnsureRestored(RepoDirectories.CorehostPackages)
+                    .BuildProject();
+
+                PreviouslyPublishedAndRestoredPortableTestProjectFixture = new TestProjectFixture("PortableApp", RepoDirectories)
+                    .EnsureRestored(RepoDirectories.CorehostPackages)
+                    .PublishProject();
+            }
+
+            public void Dispose()
+            {
+                PreviouslyBuiltAndRestoredPortableTestProjectFixture.Dispose();
+                PreviouslyPublishedAndRestoredPortableTestProjectFixture.Dispose();
+            }
         }
     }
 }

--- a/src/test/HostActivationTests/GivenThatICareAboutResourceLookup.cs
+++ b/src/test/HostActivationTests/GivenThatICareAboutResourceLookup.cs
@@ -12,29 +12,19 @@ using Microsoft.DotNet.CoreSetup.Test;
 
 namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.ResourceLookup
 {
-    public class GivenThatICareAboutResourceLookup
+    public class GivenThatICareAboutResourceLookup : IClassFixture<GivenThatICareAboutResourceLookup.SharedTestState>
     {
-        private static TestProjectFixture PreviouslyBuiltAndRestoredResourceLookupTestProjectFixture { get; set; }
-        private static TestProjectFixture PreviouslyPublishedAndRestoredResourceLookupTestProjectFixture { get; set; }
-        private static RepoDirectoriesProvider RepoDirectories { get; set; }
+        private SharedTestState sharedTestState;
 
-        static GivenThatICareAboutResourceLookup()
+        public GivenThatICareAboutResourceLookup(GivenThatICareAboutResourceLookup.SharedTestState fixture)
         {
-            RepoDirectories = new RepoDirectoriesProvider();
-
-            PreviouslyBuiltAndRestoredResourceLookupTestProjectFixture = new TestProjectFixture("ResourceLookup", RepoDirectories)
-                .EnsureRestored(RepoDirectories.CorehostPackages)
-                .BuildProject();
-
-            PreviouslyPublishedAndRestoredResourceLookupTestProjectFixture = new TestProjectFixture("ResourceLookup", RepoDirectories)
-                .EnsureRestored(RepoDirectories.CorehostPackages)
-                .PublishProject();
+            sharedTestState = fixture;
         }
 
         [Fact]
         public void Muxer_activation_of_Build_Output_Resource_DLL_with_DepsJson_and_RuntimeConfig_Local_Succeeds()
         {
-            var fixture = PreviouslyBuiltAndRestoredResourceLookupTestProjectFixture
+            var fixture = sharedTestState.PreviouslyBuiltAndRestoredResourceLookupTestProjectFixture
                 .Copy();
 
             var dotnet = fixture.BuiltDotnet;
@@ -62,7 +52,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.ResourceLookup
         [Fact]
         public void Muxer_activation_of_Publish_Output_ResourceLookup_DLL_with_DepsJson_and_RuntimeConfig_Local_Succeeds()
         {
-            var fixture = PreviouslyPublishedAndRestoredResourceLookupTestProjectFixture
+            var fixture = sharedTestState.PreviouslyPublishedAndRestoredResourceLookupTestProjectFixture
                 .Copy();
 
             var dotnet = fixture.BuiltDotnet;
@@ -85,6 +75,32 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.ResourceLookup
                 .Pass()
                 .And
                 .HaveStdOutContaining("Hello World");
+        }
+
+        public class SharedTestState : IDisposable
+        {
+            public TestProjectFixture PreviouslyBuiltAndRestoredResourceLookupTestProjectFixture { get; set; }
+            public TestProjectFixture PreviouslyPublishedAndRestoredResourceLookupTestProjectFixture { get; set; }
+            public RepoDirectoriesProvider RepoDirectories { get; set; }
+
+            public SharedTestState()
+            {
+                RepoDirectories = new RepoDirectoriesProvider();
+
+                PreviouslyBuiltAndRestoredResourceLookupTestProjectFixture = new TestProjectFixture("ResourceLookup", RepoDirectories)
+                    .EnsureRestored(RepoDirectories.CorehostPackages)
+                    .BuildProject();
+
+                PreviouslyPublishedAndRestoredResourceLookupTestProjectFixture = new TestProjectFixture("ResourceLookup", RepoDirectories)
+                    .EnsureRestored(RepoDirectories.CorehostPackages)
+                    .PublishProject();
+            }
+
+            public void Dispose()
+            {
+                PreviouslyBuiltAndRestoredResourceLookupTestProjectFixture.Dispose();
+                PreviouslyPublishedAndRestoredResourceLookupTestProjectFixture.Dispose();
+            }
         }
     }
 }

--- a/src/test/HostActivationTests/GivenThatICareAboutStandaloneAppActivation.cs
+++ b/src/test/HostActivationTests/GivenThatICareAboutStandaloneAppActivation.cs
@@ -17,36 +17,19 @@ using Microsoft.DotNet.InternalAbstractions;
 
 namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.StandaloneApp
 {
-    public class GivenThatICareAboutStandaloneAppActivation
+    public class GivenThatICareAboutStandaloneAppActivation : IClassFixture<GivenThatICareAboutStandaloneAppActivation.SharedTestState>
     {
-        public static TestProjectFixture PreviouslyBuiltAndRestoredStandaloneTestProjectFixture { get; private set; }
-        public static TestProjectFixture PreviouslyPublishedAndRestoredStandaloneTestProjectFixture { get; private set; }
-        private static RepoDirectoriesProvider RepoDirectories { get; set; }
+        private SharedTestState sharedTestState;
 
-        static GivenThatICareAboutStandaloneAppActivation()
+        public GivenThatICareAboutStandaloneAppActivation(GivenThatICareAboutStandaloneAppActivation.SharedTestState fixture)
         {
-            RepoDirectories = new RepoDirectoriesProvider();
-
-            var buildFixture = new TestProjectFixture("StandaloneApp", RepoDirectories);
-            buildFixture
-                .EnsureRestoredForRid(buildFixture.CurrentRid, RepoDirectories.CorehostPackages)
-                .BuildProject(runtime: buildFixture.CurrentRid);
-
-            var publishFixture = new TestProjectFixture("StandaloneApp", RepoDirectories);
-            publishFixture
-                .EnsureRestoredForRid(publishFixture.CurrentRid, RepoDirectories.CorehostPackages)
-                .PublishProject(runtime: publishFixture.CurrentRid);
-
-            ReplaceTestProjectOutputHostInTestProjectFixture(buildFixture);
-
-            PreviouslyBuiltAndRestoredStandaloneTestProjectFixture = buildFixture;
-            PreviouslyPublishedAndRestoredStandaloneTestProjectFixture = publishFixture;
+            sharedTestState = fixture;
         }
 
         [Fact]
         public void Running_Build_Output_Standalone_EXE_with_DepsJson_and_RuntimeConfig_Local_Succeeds()
         {
-            var fixture = PreviouslyBuiltAndRestoredStandaloneTestProjectFixture
+            var fixture = sharedTestState.PreviouslyBuiltAndRestoredStandaloneTestProjectFixture
                 .Copy();
 
             var appExe = fixture.TestProject.AppExe;
@@ -64,7 +47,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.StandaloneApp
         [Fact]
         public void Running_Publish_Output_Standalone_EXE_with_DepsJson_and_RuntimeConfig_Local_Succeeds()
         {
-            var fixture = PreviouslyPublishedAndRestoredStandaloneTestProjectFixture
+            var fixture = sharedTestState.PreviouslyPublishedAndRestoredStandaloneTestProjectFixture
                 .Copy();
 
             var appExe = fixture.TestProject.AppExe;
@@ -82,13 +65,13 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.StandaloneApp
         [Fact]
         public void Running_Publish_Output_Standalone_EXE_with_Unbound_AppHost_Fails()
         {
-            var fixture = PreviouslyPublishedAndRestoredStandaloneTestProjectFixture
+            var fixture = sharedTestState.PreviouslyPublishedAndRestoredStandaloneTestProjectFixture
                 .Copy();
 
             var appExe = fixture.TestProject.AppExe;
 
             string hostExeName = $"apphost{Constants.ExeSuffix}";
-            string builtAppHost = Path.Combine(RepoDirectories.HostArtifacts, hostExeName);
+            string builtAppHost = Path.Combine(sharedTestState.RepoDirectories.HostArtifacts, hostExeName);
             File.Copy(builtAppHost, appExe, true);
 
             int exitCode = Command.Create(appExe)
@@ -111,13 +94,13 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.StandaloneApp
         [Fact]
         public void Running_Publish_Output_Standalone_EXE_By_Renaming_dotnet_exe_Fails()
         {
-            var fixture = PreviouslyPublishedAndRestoredStandaloneTestProjectFixture
+            var fixture = sharedTestState.PreviouslyPublishedAndRestoredStandaloneTestProjectFixture
                 .Copy();
 
             var appExe = fixture.TestProject.AppExe;
 
             string hostExeName = $"dotnet{Constants.ExeSuffix}";
-            string builtHost = Path.Combine(RepoDirectories.HostArtifacts, hostExeName);
+            string builtHost = Path.Combine(sharedTestState.RepoDirectories.HostArtifacts, hostExeName);
             File.Copy(builtHost, appExe, true);
 
             int exitCode = Command.Create(appExe)
@@ -140,7 +123,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.StandaloneApp
         [Fact]
         public void Running_Publish_Output_Standalone_EXE_By_Renaming_apphost_exe_Succeeds()
         {
-            var fixture = PreviouslyPublishedAndRestoredStandaloneTestProjectFixture
+            var fixture = sharedTestState.PreviouslyPublishedAndRestoredStandaloneTestProjectFixture
                 .Copy();
 
             var appExe = fixture.TestProject.AppExe;
@@ -161,7 +144,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.StandaloneApp
         [Fact]
         public void Running_Publish_Output_Standalone_EXE_With_Relative_Embedded_Path_Succeeds()
         {
-            var fixture = PreviouslyPublishedAndRestoredStandaloneTestProjectFixture
+            var fixture = sharedTestState.PreviouslyPublishedAndRestoredStandaloneTestProjectFixture
                 .Copy();
 
             var appExe = fixture.TestProject.AppExe;
@@ -198,7 +181,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.StandaloneApp
         [Fact]
         public void Running_Publish_Output_Standalone_EXE_With_DOTNET_ROOT_Fails()
         {
-            var fixture = PreviouslyPublishedAndRestoredStandaloneTestProjectFixture
+            var fixture = sharedTestState.PreviouslyPublishedAndRestoredStandaloneTestProjectFixture
                 .Copy();
 
             var appExe = fixture.TestProject.AppExe;
@@ -243,13 +226,13 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.StandaloneApp
         [Fact]
         public void Running_Publish_Output_Standalone_EXE_with_Bound_AppHost_Succeeds()
         {
-            var fixture = PreviouslyPublishedAndRestoredStandaloneTestProjectFixture
+            var fixture = sharedTestState.PreviouslyPublishedAndRestoredStandaloneTestProjectFixture
                 .Copy();
 
             var appExe = fixture.TestProject.AppExe;
 
             string hostExeName = $"apphost{Constants.ExeSuffix}";
-            string builtAppHost = Path.Combine(RepoDirectories.HostArtifacts, hostExeName);
+            string builtAppHost = Path.Combine(sharedTestState.RepoDirectories.HostArtifacts, hostExeName);
             string appName = Path.GetFileNameWithoutExtension(appExe);
             string appDll = $"{appName}.dll";
             string appDir = Path.GetDirectoryName(appExe);
@@ -279,31 +262,64 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.StandaloneApp
                 .HaveStdOutContaining("Hello World");
         }
 
-        /*
-         * This method is needed to workaround dotnet build not placing the host from the package
-         * graph in the build output.
-         * https://github.com/dotnet/cli/issues/2343
-         */
-        private static void ReplaceTestProjectOutputHostInTestProjectFixture(TestProjectFixture testProjectFixture)
+        public class SharedTestState : IDisposable
         {
-            var dotnet = testProjectFixture.BuiltDotnet;
+            public TestProjectFixture PreviouslyBuiltAndRestoredStandaloneTestProjectFixture { get; set; }
+            public TestProjectFixture PreviouslyPublishedAndRestoredStandaloneTestProjectFixture { get; set; }
+            public RepoDirectoriesProvider RepoDirectories { get; set; }
 
-            var testProjectHostPolicy = testProjectFixture.TestProject.HostPolicyDll;
-            var testProjectHostFxr = testProjectFixture.TestProject.HostFxrDll;
-
-            if (!File.Exists(testProjectHostPolicy))
+            public SharedTestState()
             {
-                throw new Exception("host or hostpolicy does not exist in test project output. Is this a standalone app?");
+                RepoDirectories = new RepoDirectoriesProvider();
+
+                var buildFixture = new TestProjectFixture("StandaloneApp", RepoDirectories);
+                buildFixture
+                    .EnsureRestoredForRid(buildFixture.CurrentRid, RepoDirectories.CorehostPackages)
+                    .BuildProject(runtime: buildFixture.CurrentRid);
+
+                var publishFixture = new TestProjectFixture("StandaloneApp", RepoDirectories);
+                publishFixture
+                    .EnsureRestoredForRid(publishFixture.CurrentRid, RepoDirectories.CorehostPackages)
+                    .PublishProject(runtime: publishFixture.CurrentRid);
+
+                ReplaceTestProjectOutputHostInTestProjectFixture(buildFixture);
+
+                PreviouslyBuiltAndRestoredStandaloneTestProjectFixture = buildFixture;
+                PreviouslyPublishedAndRestoredStandaloneTestProjectFixture = publishFixture;
             }
 
-            var dotnetHostPolicy = Path.Combine(dotnet.GreatestVersionSharedFxPath, $"{testProjectFixture.SharedLibraryPrefix}hostpolicy{testProjectFixture.SharedLibraryExtension}");
-            var dotnetHostFxr = Path.Combine(dotnet.GreatestVersionHostFxrPath, $"{testProjectFixture.SharedLibraryPrefix}hostfxr{testProjectFixture.SharedLibraryExtension}");
-
-            File.Copy(dotnetHostPolicy, testProjectHostPolicy, true);
-
-            if (File.Exists(testProjectHostFxr))
+            public void Dispose()
             {
-                File.Copy(dotnetHostFxr, testProjectHostFxr, true);
+                PreviouslyBuiltAndRestoredStandaloneTestProjectFixture.Dispose();
+                PreviouslyPublishedAndRestoredStandaloneTestProjectFixture.Dispose();
+            }
+
+            /*
+             * This method is needed to workaround dotnet build not placing the host from the package
+             * graph in the build output.
+             * https://github.com/dotnet/cli/issues/2343
+             */
+            private static void ReplaceTestProjectOutputHostInTestProjectFixture(TestProjectFixture testProjectFixture)
+            {
+                var dotnet = testProjectFixture.BuiltDotnet;
+
+                var testProjectHostPolicy = testProjectFixture.TestProject.HostPolicyDll;
+                var testProjectHostFxr = testProjectFixture.TestProject.HostFxrDll;
+
+                if (!File.Exists(testProjectHostPolicy))
+                {
+                    throw new Exception("host or hostpolicy does not exist in test project output. Is this a standalone app?");
+                }
+
+                var dotnetHostPolicy = Path.Combine(dotnet.GreatestVersionSharedFxPath, $"{testProjectFixture.SharedLibraryPrefix}hostpolicy{testProjectFixture.SharedLibraryExtension}");
+                var dotnetHostFxr = Path.Combine(dotnet.GreatestVersionHostFxrPath, $"{testProjectFixture.SharedLibraryPrefix}hostfxr{testProjectFixture.SharedLibraryExtension}");
+
+                File.Copy(dotnetHostPolicy, testProjectHostPolicy, true);
+
+                if (File.Exists(testProjectHostFxr))
+                {
+                    File.Copy(dotnetHostFxr, testProjectHostFxr, true);
+                }
             }
         }
     }

--- a/src/test/TestUtils/TestProject.cs
+++ b/src/test/TestUtils/TestProject.cs
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 
 namespace Microsoft.DotNet.CoreSetup.Test
 {
-    public class TestProject
+    public class TestProject : IDisposable
     {
         private string _projectDirectory;
         private string _projectName;
@@ -66,6 +66,14 @@ namespace Microsoft.DotNet.CoreSetup.Test
             }
         }
 
+        public void Dispose()
+        {
+            if (!PreserveTestRuns())
+            {
+                Directory.Delete(_projectDirectory, true);
+            }
+        }
+
         public void CopyProjectFiles(string directory)
         {
             CopyRecursive(_projectDirectory, directory, overwrite: true);
@@ -114,6 +122,11 @@ namespace Microsoft.DotNet.CoreSetup.Test
                     File.Copy(file, dest, overwrite: true);
                 }
             }
+        }
+
+        public static bool PreserveTestRuns()
+        {
+            return Environment.GetEnvironmentVariable("PRESERVE_TEST_RUNS") == "1";
         }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/dotnet/core-setup/issues/4098

- Added Dispose to the TestProjectFixture to delete any directories it created.
- Applied the XUnit IClassFixture pattern to each test class that has shared state to dispose its test fixtures.
- Applied Dispose pattern to each test class that had instance-level test fixtures or temp directories in order to dispose test fixtures and delete directories.
- Removed unnecessary methods
- For debugging, added PRESERVE_TEST_RUNS=1 environment variable in order to prevent deletion of test run (not set by default). This leaves ~11GB around but is useful when a test fails in order to re-run EXEC commands it from command line.

cc @jeffschwMSFT 
