### PR TITLE
packaging for FreeBSD

### DIFF
--- a/src/pkg/projects/Microsoft.NETCore.DotNetAppHost/runtime.FreeBSD.Microsoft.NETCore.DotNetAppHost.props
+++ b/src/pkg/projects/Microsoft.NETCore.DotNetAppHost/runtime.FreeBSD.Microsoft.NETCore.DotNetAppHost.props
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <ArchitectureSpecificNativeFile Include="$(DotNetHostBinDir)/apphost" />
+
+    <File Include="@(ArchitectureSpecificNativeFile)">
+      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
+    </File>
+    <File Include="$(VersionTxtFile)" />
+  </ItemGroup>
+</Project>

--- a/src/pkg/projects/Microsoft.NETCore.DotNetHost/runtime.FreeBSD.Microsoft.NETCore.DotNetHost.props
+++ b/src/pkg/projects/Microsoft.NETCore.DotNetHost/runtime.FreeBSD.Microsoft.NETCore.DotNetHost.props
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <ArchitectureSpecificNativeFile Include="$(DotNetHostBinDir)/dotnet" />
+
+    <File Include="@(ArchitectureSpecificNativeFile)">
+      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
+    </File>
+    <File Include="$(VersionTxtFile)" />
+  </ItemGroup>
+</Project>

--- a/src/pkg/projects/Microsoft.NETCore.DotNetHostPolicy/runtime.FreeBSD.Microsoft.NETCore.DotNetHostPolicy.props
+++ b/src/pkg/projects/Microsoft.NETCore.DotNetHostPolicy/runtime.FreeBSD.Microsoft.NETCore.DotNetHostPolicy.props
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <ArchitectureSpecificNativeFile Include="$(DotNetHostBinDir)/libhostpolicy.so"/>
+
+    <File Include="@(ArchitectureSpecificNativeFile)">
+      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
+    </File>
+    <File Include="$(VersionTxtFile)" />
+  </ItemGroup>
+</Project>

--- a/src/pkg/projects/Microsoft.NETCore.DotNetHostResolver/runtime.FreeBSD.Microsoft.NETCore.DotNetHostResolver.props
+++ b/src/pkg/projects/Microsoft.NETCore.DotNetHostResolver/runtime.FreeBSD.Microsoft.NETCore.DotNetHostResolver.props
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <ArchitectureSpecificNativeFile Include="$(DotNetHostBinDir)/libhostfxr.so"/>
+
+    <File Include="@(ArchitectureSpecificNativeFile)">
+      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
+    </File>
+    <File Include="$(VersionTxtFile)" />
+  </ItemGroup>
+</Project>

--- a/src/sharedFramework/sharedFramework.proj
+++ b/src/sharedFramework/sharedFramework.proj
@@ -123,6 +123,7 @@
       <SharedFrameworkDepsFile>$(SharedFrameworkNameAndVersionRoot)\$(SharedFrameworkName).deps.json</SharedFrameworkDepsFile>
       <RuntimeGraphGeneratorRuntime Condition="'$(OSGroup)'=='Windows_NT'">win</RuntimeGraphGeneratorRuntime>
       <RuntimeGraphGeneratorRuntime Condition="'$(OSGroup)'=='OSX'">osx</RuntimeGraphGeneratorRuntime>
+      <RuntimeGraphGeneratorRuntime Condition="'$(OSGroup)'=='FreeBSD'">freebsd</RuntimeGraphGeneratorRuntime>
       <RuntimeGraphGeneratorRuntime Condition="'$(RuntimeGraphGeneratorRuntime)'==''">linux</RuntimeGraphGeneratorRuntime>
     </PropertyGroup>
 


### PR DESCRIPTION
This is similar to https://github.com/dotnet/coreclr/pull/18764
This is essentially copy from Linux version.
With this change (and few more) I can finish source-build to to core-setup on FreeBSD.
crossgen has some troubles so I disabled it for now in my build tree. 

Published runtime can run Hello world. 

big thanks to @eerhardt for helping me sort this out. 

```
source-build2]$ ./build.sh  /p:RootRepo=core-setup /p:TargetRid=freebsd.11-x64
```
rid is casse sensitive and needs to match through all other repos.
(and it does not by default) 
