### PR TITLE
Change main thread to join to breadcrumb thread when exception thrown

### DIFF
--- a/src/corehost/cli/breadcrumbs.cpp
+++ b/src/corehost/cli/breadcrumbs.cpp
@@ -7,13 +7,22 @@
 #include "trace.h"
 #include "breadcrumbs.h"
 
-breadcrumb_writer_t::breadcrumb_writer_t(const std::unordered_set<pal::string_t>* files)
+breadcrumb_writer_t::breadcrumb_writer_t(bool enabled, const std::unordered_set<pal::string_t>* files)
     : m_status(false)
+    , m_enabled(enabled)
     , m_files(files)
 {
-    if (!pal::get_default_breadcrumb_store(&m_breadcrumb_store))
+    if (enabled && !pal::get_default_breadcrumb_store(&m_breadcrumb_store))
     {
         m_breadcrumb_store.clear();
+    }
+}
+
+breadcrumb_writer_t::~breadcrumb_writer_t()
+{
+    if (m_enabled)
+    {
+        end_write();
     }
 }
 
@@ -21,6 +30,7 @@ breadcrumb_writer_t::breadcrumb_writer_t(const std::unordered_set<pal::string_t>
 // thread to write breadcrumbs.
 void breadcrumb_writer_t::begin_write()
 {
+    assert(m_enabled);
     trace::verbose(_X("--- Begin breadcrumb write"));
     if (m_breadcrumb_store.empty())
     {
@@ -88,4 +98,3 @@ bool breadcrumb_writer_t::end_write()
     trace::verbose(_X("--- End breadcrumb write %d"), m_status);
     return m_status;
 }
-

--- a/src/corehost/cli/breadcrumbs.cpp
+++ b/src/corehost/cli/breadcrumbs.cpp
@@ -30,23 +30,25 @@ breadcrumb_writer_t::~breadcrumb_writer_t()
 // thread to write breadcrumbs.
 void breadcrumb_writer_t::begin_write()
 {
-    assert(m_enabled);
-    trace::verbose(_X("--- Begin breadcrumb write"));
-    if (m_breadcrumb_store.empty())
+    if (m_enabled)
     {
-        trace::verbose(_X("Breadcrumb store was not obtained... skipping write."));
-        m_status = false;
-        return;
-    }
+        trace::verbose(_X("--- Begin breadcrumb write"));
+        if (m_breadcrumb_store.empty())
+        {
+            trace::verbose(_X("Breadcrumb store was not obtained... skipping write."));
+            m_status = false;
+            return;
+        }
 
-    trace::verbose(_X("Number of breadcrumb files to write is %d"), m_files->size());
-    if (m_files->empty())
-    {
-        m_status = true;
-        return;
+        trace::verbose(_X("Number of breadcrumb files to write is %d"), m_files->size());
+        if (m_files->empty())
+        {
+            m_status = true;
+            return;
+        }
+        m_thread = std::thread(write_worker_callback, this);
+        trace::verbose(_X("Breadcrumbs will be written using a background thread"));
     }
-    m_thread = std::thread(write_worker_callback, this);
-    trace::verbose(_X("Breadcrumbs will be written using a background thread"));
 }
 
 // Write the breadcrumbs. This method should be called

--- a/src/corehost/cli/breadcrumbs.h
+++ b/src/corehost/cli/breadcrumbs.h
@@ -9,18 +9,20 @@
 class breadcrumb_writer_t
 {
 public:
-    breadcrumb_writer_t(const std::unordered_set<pal::string_t>* files);
+    breadcrumb_writer_t(bool enabled, const std::unordered_set<pal::string_t>* files);
+    ~breadcrumb_writer_t();
 
     void begin_write();
-    bool end_write();
 
 private:
     void write_callback();
+    bool end_write();
     static void write_worker_callback(breadcrumb_writer_t* p_this);
 
     pal::string_t m_breadcrumb_store;
     std::thread m_thread;
     const std::unordered_set<pal::string_t>* m_files;
+    bool m_enabled;
     volatile bool m_status;
 };
 

--- a/src/corehost/cli/hostpolicy.cpp
+++ b/src/corehost/cli/hostpolicy.cpp
@@ -275,12 +275,9 @@ int run(const arguments_t& args, pal::string_t* out_host_command_result = nullpt
     std::vector<char> managed_app;
     pal::pal_clrstring(args.managed_application, &managed_app);
 
+    // Leave breadcrumbs for servicing.
     breadcrumb_writer_t writer(breadcrumbs_enabled, &breadcrumbs);
-    if (breadcrumbs_enabled)
-    {
-        // Leave breadcrumbs for servicing.
-        writer.begin_write();
-    }
+    writer.begin_write();
 
     // Previous hostpolicy trace messages must be printed before executing assembly
     trace::flush();

--- a/src/corehost/cli/hostpolicy.cpp
+++ b/src/corehost/cli/hostpolicy.cpp
@@ -209,7 +209,7 @@ int run(const arguments_t& args, pal::string_t* out_host_command_result = nullpt
         return exit_code;
     }
 
-   // Bind CoreCLR
+    // Bind CoreCLR
     trace::verbose(_X("CoreCLR path = '%s', CoreCLR dir = '%s'"), clr_path.c_str(), clr_dir.c_str());
     if (!coreclr::bind(clr_dir))
     {
@@ -275,7 +275,7 @@ int run(const arguments_t& args, pal::string_t* out_host_command_result = nullpt
     std::vector<char> managed_app;
     pal::pal_clrstring(args.managed_application, &managed_app);
 
-    breadcrumb_writer_t writer(&breadcrumbs);
+    breadcrumb_writer_t writer(breadcrumbs_enabled, &breadcrumbs);
     if (breadcrumbs_enabled)
     {
         // Leave breadcrumbs for servicing.
@@ -309,13 +309,9 @@ int run(const arguments_t& args, pal::string_t* out_host_command_result = nullpt
 
     coreclr::unload();
 
-    if (breadcrumbs_enabled)
-    {
-        // Finish breadcrumb writing
-        writer.end_write();
-    }
-
     return exit_code;
+
+    // The breadcrumb destructor will join to the background thread to finish writing
 }
 
 SHARED_API int corehost_load(host_interface_t* init)

--- a/src/test/Assets/TestProjects/PortableAppWithException/PortableAppWithException.csproj
+++ b/src/test/Assets/TestProjects/PortableAppWithException/PortableAppWithException.csproj
@@ -1,0 +1,9 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>$(NETCoreAppFramework)</TargetFramework>
+    <OutputType>Exe</OutputType>
+    <RuntimeFrameworkVersion>$(MNAVersion)</RuntimeFrameworkVersion>
+  </PropertyGroup>
+
+</Project>

--- a/src/test/Assets/TestProjects/PortableAppWithException/Program.cs
+++ b/src/test/Assets/TestProjects/PortableAppWithException/Program.cs
@@ -1,0 +1,15 @@
+using System;
+
+namespace PortableAppWithException
+{
+    public static class Program
+    {
+        public static void Main(string[] args)
+        {
+            Console.WriteLine("Hello World!");
+            Console.WriteLine(string.Join(Environment.NewLine, args));
+
+            throw new Exception("Goodbye World!");
+        }
+    }
+}

--- a/src/test/HostActivationTests/GivenThatICareAboutNativeHostApis.cs
+++ b/src/test/HostActivationTests/GivenThatICareAboutNativeHostApis.cs
@@ -29,7 +29,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.NativeHostApis
                 return;
             }
 
-            var fixture = sharedTestState.PreviouslyPublishedAndRestoredPortableTestProjectFixture.Copy();
+            var fixture = sharedTestState.PreviouslyPublishedAndRestoredPortableApiTestProjectFixture.Copy();
             var dotnet = fixture.BuiltDotnet;
             var appDll = fixture.TestProject.AppDll;
 
@@ -52,29 +52,78 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.NativeHostApis
                 .HaveStdOutContaining("hostfxr_get_native_search_directories buffer:[" + dotnet.GreatestVersionSharedFxPath);
         }
 
+        [Fact]
+        public void Breadcrumb_thread_finishes_when_app_closes_normally()
+        {
+            var fixture = sharedTestState.PreviouslyPublishedAndRestoredPortableAppProjectFixture.Copy();
+            var dotnet = fixture.BuiltDotnet;
+            var appDll = fixture.TestProject.AppDll;
+
+            dotnet.Exec(appDll)
+                .EnvironmentVariable("COREHOST_TRACE", "1")
+                .CaptureStdOut()
+                .CaptureStdErr()
+                .Execute()
+                .Should()
+                .Pass()
+                .And
+                .HaveStdOutContaining("Hello World")
+                .And
+                .HaveStdErrContaining("Waiting for breadcrumb thread to exit...");
+        }
+
+        [Fact]
+        public void Breadcrumb_thread_does_not_finish_when_app_has_unhandled_exception()
+        {
+            var fixture = sharedTestState.PreviouslyPublishedAndRestoredPortableAppWithExceptionProjectFixture.Copy();
+            var dotnet = fixture.BuiltDotnet;
+            var appDll = fixture.TestProject.AppDll;
+
+            dotnet.Exec(appDll)
+                .EnvironmentVariable("COREHOST_TRACE", "1")
+                .CaptureStdOut()
+                .CaptureStdErr()
+                .Execute(fExpectedToFail: true)
+                .Should()
+                .Fail()
+                .And
+                .HaveStdErrContaining("Unhandled Exception: System.Exception: Goodbye World")
+                .And
+                // The breadcrumb thread does not wait since destructors are not called when an exception is thrown.
+                // However, destructors will be called when the caller (such as a custom host) is compiled with SEH Exceptions (/EHa) and has a try\catch.
+                // Todo: add a native host test app so we can verify this behavior.
+                .NotHaveStdErrContaining("Waiting for breadcrumb thread to exit...");
+        }
+
         public class SharedTestState : IDisposable
         {
-            public TestProjectFixture PreviouslyBuiltAndRestoredPortableTestProjectFixture { get; set; }
-            public TestProjectFixture PreviouslyPublishedAndRestoredPortableTestProjectFixture { get; set; }
+            public TestProjectFixture PreviouslyPublishedAndRestoredPortableApiTestProjectFixture { get; set; }
+            public TestProjectFixture PreviouslyPublishedAndRestoredPortableAppProjectFixture { get; set; }
+            public TestProjectFixture PreviouslyPublishedAndRestoredPortableAppWithExceptionProjectFixture { get; set; }
             public RepoDirectoriesProvider RepoDirectories { get; set; }
 
             public SharedTestState()
             {
                 RepoDirectories = new RepoDirectoriesProvider();
 
-                PreviouslyBuiltAndRestoredPortableTestProjectFixture = new TestProjectFixture("HostApiInvokerApp", RepoDirectories)
+                PreviouslyPublishedAndRestoredPortableApiTestProjectFixture = new TestProjectFixture("HostApiInvokerApp", RepoDirectories)
                     .EnsureRestored(RepoDirectories.CorehostPackages)
                     .BuildProject();
 
-                PreviouslyPublishedAndRestoredPortableTestProjectFixture = new TestProjectFixture("HostApiInvokerApp", RepoDirectories)
+                PreviouslyPublishedAndRestoredPortableAppProjectFixture = new TestProjectFixture("PortableApp", RepoDirectories)
+                    .EnsureRestored(RepoDirectories.CorehostPackages)
+                    .PublishProject();
+
+                PreviouslyPublishedAndRestoredPortableAppWithExceptionProjectFixture = new TestProjectFixture("PortableAppWithException", RepoDirectories)
                     .EnsureRestored(RepoDirectories.CorehostPackages)
                     .PublishProject();
             }
 
             public void Dispose()
             {
-                PreviouslyBuiltAndRestoredPortableTestProjectFixture.Dispose();
-                PreviouslyPublishedAndRestoredPortableTestProjectFixture.Dispose();
+                PreviouslyPublishedAndRestoredPortableApiTestProjectFixture.Dispose();
+                PreviouslyPublishedAndRestoredPortableAppProjectFixture.Dispose();
+                PreviouslyPublishedAndRestoredPortableAppWithExceptionProjectFixture.Dispose();
             }
         }
     }

--- a/src/test/HostActivationTests/GivenThatICareAboutNativeHostApis.cs
+++ b/src/test/HostActivationTests/GivenThatICareAboutNativeHostApis.cs
@@ -60,6 +60,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.NativeHostApis
             var appDll = fixture.TestProject.AppDll;
 
             dotnet.Exec(appDll)
+                .EnvironmentVariable("CORE_BREADCRUMBS", sharedTestState.BreadcrumbLocation)
                 .EnvironmentVariable("COREHOST_TRACE", "1")
                 .CaptureStdOut()
                 .CaptureStdErr()
@@ -80,6 +81,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.NativeHostApis
             var appDll = fixture.TestProject.AppDll;
 
             dotnet.Exec(appDll)
+                .EnvironmentVariable("CORE_BREADCRUMBS", sharedTestState.BreadcrumbLocation)
                 .EnvironmentVariable("COREHOST_TRACE", "1")
                 .CaptureStdOut()
                 .CaptureStdErr()
@@ -102,6 +104,8 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.NativeHostApis
             public TestProjectFixture PreviouslyPublishedAndRestoredPortableAppWithExceptionProjectFixture { get; set; }
             public RepoDirectoriesProvider RepoDirectories { get; set; }
 
+            public string BreadcrumbLocation { get; set; }
+
             public SharedTestState()
             {
                 RepoDirectories = new RepoDirectoriesProvider();
@@ -117,6 +121,15 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.NativeHostApis
                 PreviouslyPublishedAndRestoredPortableAppWithExceptionProjectFixture = new TestProjectFixture("PortableAppWithException", RepoDirectories)
                     .EnsureRestored(RepoDirectories.CorehostPackages)
                     .PublishProject();
+
+                if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                {
+                    BreadcrumbLocation = Path.Combine(
+                        PreviouslyPublishedAndRestoredPortableAppWithExceptionProjectFixture.TestProject.OutputDirectory,
+                        "opt",
+                        "corebreadcrumbs");
+                    Directory.CreateDirectory(BreadcrumbLocation);
+                }
             }
 
             public void Dispose()


### PR DESCRIPTION
A custom host that catches exceptions currently hits an access violation during clr shutdown because of a background thread that references invalid memory.

Fixes https://github.com/dotnet/core-setup/issues/4315

A couple unit tests were added. However, they do not actually verify the AV is not thrown, as that would require significant infrastructure to host C++ native tests. Instead I manually verified that the access violation no longer occurs by:
1) Create a managed app that throws an exception
2) Create a custom host compiled with SEH
3) Invoke hostfxr's hostfxr_main() with a try\catch and launching the managed app from (1)
4) Verify that there is no longer an access violation and that the try\catch works properly

This will need to be ported to the 2.2 branch when that branch is created; a port issue will be logged.

cc @pakrym 
cc @jeffschwMSFT 