### PR TITLE
Import build.common.props in publish.proj

### DIFF
--- a/pkg/publish.proj
+++ b/pkg/publish.proj
@@ -8,6 +8,7 @@
   <Import Project="$(MSBuildThisFileDirectory)dir.props" />
   <Import Project="$(ToolsDir)PublishContent.targets" />
   <Import Project="$(ToolsDir)versioning.targets" />
+  <Import Project="$(ToolsDir)Build.Common.Props" />
   <Import Project="$(MSBuildThisFileDirectory)dir.targets" />
   <Import Project="$(MSBuildThisFileDirectory)bin\AzureBlob.props" />
 


### PR DESCRIPTION
This should allow us to correctly import the Microbuild targets, meaning packages will get signed correctly in official builds.

CC @dagood @weshaggard