### PR TITLE
Re-enable Debian 9 support

### DIFF
--- a/build_projects/dotnet-host-build/DebTargets.cs
+++ b/build_projects/dotnet-host-build/DebTargets.cs
@@ -131,6 +131,9 @@ namespace Microsoft.DotNet.Host.Build
             var debFile = c.BuildContext.Get<string>("SharedFrameworkInstallerFile");
             var debianConfigFile = Path.Combine(Dirs.DebPackagingConfig, "dotnet-sharedframework-debian_config.json");
 
+            bool isDebian9 = c.BuildContext.Get<string>("TargetRID") == "debian.9-x64";
+            var libSslPackageName = isDebian9 ? "libssl1.0.2" : "libssl1.0.0";
+
             var debianConfigVariables = new Dictionary<string, string>()
             {
                 { "SHARED_HOST_DEBIAN_VERSION", sharedHostVersion },
@@ -139,7 +142,8 @@ namespace Microsoft.DotNet.Host.Build
                 { "SHARED_FRAMEWORK_DEBIAN_PACKAGE_NAME", packageName },
                 { "SHARED_FRAMEWORK_NUGET_NAME", Monikers.SharedFrameworkName },
                 { "SHARED_FRAMEWORK_NUGET_VERSION",  c.BuildContext.Get<string>("SharedFrameworkNugetVersion")},
-                { "SHARED_FRAMEWORK_BRAND_NAME", Monikers.SharedFxBrandName }
+                { "SHARED_FRAMEWORK_BRAND_NAME", Monikers.SharedFxBrandName },
+                { "LIBSSL_PACKAGE_NAME", libSslPackageName }
             };
 
             var debCreator = new DebPackageCreator(

--- a/build_projects/dotnet-host-build/PublishTargets.cs
+++ b/build_projects/dotnet-host-build/PublishTargets.cs
@@ -249,7 +249,7 @@ namespace Microsoft.DotNet.Host.Build
                  { "sharedfx_RHEL_x64", false },
                  { "sharedfx_OSX_x64", false },
                  { "sharedfx_Debian_x64", false },
-                 //{ "sharedfx_Debian_9_x64", false }, See https://github.com/dotnet/core-setup/issues/4173
+                 { "sharedfx_Debian_9_x64", false },
                  { "sharedfx_CentOS_x64", false },
                  { "sharedfx_Fedora_24_x64", false },
                  { "sharedfx_Fedora_27_x64", false },

--- a/buildpipeline/pipeline.json
+++ b/buildpipeline/pipeline.json
@@ -32,6 +32,14 @@
           }
         },
         {
+          "Name": "Core-Setup-Debian9-x64",
+          "ReportingParameters": {
+            "OperatingSystem": "Debian 9",
+            "Type": "build/product/",
+            "Platform": "x64"
+          }
+        },
+        {
           "Name": "Core-Setup-Fedora24-x64",
           "ReportingParameters": {
             "OperatingSystem": "Fedora 24",
@@ -63,7 +71,7 @@
             "Platform": "x64"
           }
         },
-       {
+        {
           "Name": "Core-Setup-OpenSuse42.3-x64",
           "ReportingParameters": {
             "OperatingSystem": "OpenSuse 42.3",

--- a/packaging/deb/dotnet-sharedframework-debian_config.json
+++ b/packaging/deb/dotnet-sharedframework-debian_config.json
@@ -30,7 +30,7 @@
 
     "debian_dependencies":{
         "%HOSTFXR_DEBIAN_PACKAGE_NAME%" : {},
-        "libssl1.0.0" : {}
+        "%LIBSSL_PACKAGE_NAME%" :  {}
     },
 
     "debian_ignored_dependencies" : [


### PR DESCRIPTION
Needed to fix the .deb packaging on Debian 9 because it automatically creates a -dbgsym package, which broke our logic of copying the output .deb file. The fix is to disable -dbgsym packages.

Also need to change the libssl version we are dependent on in Debian 9.

Fix #4173 

/cc @ianhays @joshfree @danmosemsft 