### PR TITLE
Use OS specific path for test result file

### DIFF
--- a/src/test/dir.proj
+++ b/src/test/dir.proj
@@ -86,7 +86,7 @@
     <PropertyGroup>
       <TestArgs>--no-restore $(MSBuildPassThroughPropertyList)</TestArgs>
       <IsCrossArch Condition="'$(TargetArchitecture)' == 'arm' or '$(TargetArchitecture)' == 'arm64' or '$(TargetArchitecture)' == 'armel'">true</IsCrossArch>
-      <TestResultsXml>$(TestsOutputDir)$(TestProjectFilename)-testResults.trx</TestResultsXml>
+      <TestResultsXml>$(SystemPathTestsOutputDir)$(TestProjectFilename)-testResults.trx</TestResultsXml>
     </PropertyGroup>
     <Exec Command="$(DotnetToolCommand) test $(TestArgs) --logger &quot;trx;LogFileName=$(TestResultsXml)&quot;"
           WorkingDirectory="$(TestWorkingDirectory)"


### PR DESCRIPTION
This fixes a bug that we write out path with forward slashes even on windows. So the path can't be used as-is to open the result file in UI tools.

Fixes #4343 