### PR TITLE
Always run end.ps1/sh scripts release/2.1

### DIFF
--- a/buildpipeline/Core-Setup-Linux-Arm-BT.json
+++ b/buildpipeline/Core-Setup-Linux-Arm-BT.json
@@ -256,6 +256,7 @@
       "continueOnError": true,
       "displayName": "run end.sh",
       "timeoutInMinutes": 0,
+      "condition": "always()",
       "alwaysRun": true,
       "task": {
         "id": "10f1f9a1-74b0-47ab-87bf-e3c9c68e8b0d",

--- a/buildpipeline/Core-Setup-Linux-BT.json
+++ b/buildpipeline/Core-Setup-Linux-BT.json
@@ -874,6 +874,7 @@
       "continueOnError": true,
       "displayName": "run end.sh",
       "timeoutInMinutes": 0,
+      "condition": "always()",
       "alwaysRun": true,
       "task": {
         "id": "10f1f9a1-74b0-47ab-87bf-e3c9c68e8b0d",

--- a/buildpipeline/Core-Setup-OSX-BT.json
+++ b/buildpipeline/Core-Setup-OSX-BT.json
@@ -129,6 +129,7 @@
       "continueOnError": true,
       "displayName": "run end.sh",
       "timeoutInMinutes": 0,
+      "condition": "always()",
       "alwaysRun": true,
       "task": {
         "id": "10f1f9a1-74b0-47ab-87bf-e3c9c68e8b0d",

--- a/buildpipeline/Core-Setup-Publish.json
+++ b/buildpipeline/Core-Setup-Publish.json
@@ -316,6 +316,7 @@
       "alwaysRun": true,
       "displayName": "run end.ps1",
       "timeoutInMinutes": 0,
+      "condition": "always()",
       "task": {
         "id": "e213ff0f-5d5c-4791-802d-52ea3e7be1f1",
         "versionSpec": "2.*",

--- a/buildpipeline/Core-Setup-Signing-Validation.json
+++ b/buildpipeline/Core-Setup-Signing-Validation.json
@@ -158,6 +158,7 @@
       "alwaysRun": true,
       "displayName": "run end.ps1",
       "timeoutInMinutes": 0,
+      "condition": "always()",
       "task": {
         "id": "e213ff0f-5d5c-4791-802d-52ea3e7be1f1",
         "versionSpec": "2.*",

--- a/buildpipeline/Core-Setup-Windows-Arm-BT.json
+++ b/buildpipeline/Core-Setup-Windows-Arm-BT.json
@@ -362,6 +362,7 @@
       "alwaysRun": true,
       "displayName": "run end.ps1",
       "timeoutInMinutes": 0,
+      "condition": "always()",
       "task": {
         "id": "e213ff0f-5d5c-4791-802d-52ea3e7be1f1",
         "versionSpec": "2.*",

--- a/buildpipeline/Core-Setup-Windows-BT.json
+++ b/buildpipeline/Core-Setup-Windows-BT.json
@@ -566,6 +566,7 @@
       "alwaysRun": true,
       "displayName": "run end.ps1",
       "timeoutInMinutes": 0,
+      "condition": "always()",
       "task": {
         "id": "e213ff0f-5d5c-4791-802d-52ea3e7be1f1",
         "versionSpec": "2.*",


### PR DESCRIPTION
These steps need to run regardless of any previous steps failing.

See dotnet/core-eng#3860

