### PR TITLE
Set property IntermediateOutputPath for microbuild signing

### DIFF
--- a/pkg/publish.proj
+++ b/pkg/publish.proj
@@ -14,11 +14,12 @@
 
   <PropertyGroup>
     <PackageDownloadDirectory>$(MSBuildThisFileDirectory)packages\AzureTransfer\</PackageDownloadDirectory>
+    <!-- SignFiles needs IntermediateOutputPath & OutDir to be set -->
     <IntermediateOutputPath>$(MSBuildThisFileDirectory)bin\obj</IntermediateOutputPath>
+    <OutDir>$(PackageDownloadDirectory)</OutDir>
     <SignPattern>$(PackageDownloadDirectory)*.nupkg</SignPattern>
     <SymbolPattern>$(PackageDownloadDirectory)*.symbols.nupkg</SymbolPattern>
     <PublishPattern>$(PackageDownloadDirectory)*</PublishPattern>
-    <OutDir>$(PackageDownloadDirectory)</OutDir>
     <UnsignedFolder Condition="'$(Unsigned)' == 'true'">/Unsigned</UnsignedFolder>
     <BlobNamePrefix>$(Channel)/Binaries/$(BuildNumber)$(UnsignedFolder)</BlobNamePrefix>
   </PropertyGroup>

--- a/pkg/publish.proj
+++ b/pkg/publish.proj
@@ -14,6 +14,7 @@
 
   <PropertyGroup>
     <PackageDownloadDirectory>$(MSBuildThisFileDirectory)packages\AzureTransfer\</PackageDownloadDirectory>
+    <IntermediateOutputPath>$(MSBuildThisFileDirectory)bin\obj</IntermediateOutputPath>
     <SignPattern>$(PackageDownloadDirectory)*.nupkg</SignPattern>
     <SymbolPattern>$(PackageDownloadDirectory)*.symbols.nupkg</SymbolPattern>
     <PublishPattern>$(PackageDownloadDirectory)*</PublishPattern>


### PR DESCRIPTION
My test build for signing failed because `IntermediatesDirectory` (which gets set to `IntermediateOutputPath`) was unset: https://devdiv.visualstudio.com/DefaultCollection/DevDiv/Default/_build/results?buildId=1847834&view=logs

This defaults that property. CoreFx/CoreClr set the property to essentially `bin\obj` (https://github.com/dotnet/coreclr/blob/2d0167f7002643dc1bd77602805439fb889d39bf/dir.props#L104), and it does not appear to be used in any special way by the `SignFiles` target.

@weshaggard PTAL