### PR TITLE
Disable multilevel lookup during build

### DIFF
--- a/run.ps1
+++ b/run.ps1
@@ -5,6 +5,9 @@ $restorePackagesPath = Join-Path $PSScriptRoot "packages"
 # We do not want to run the first-time experience.
 $env:DOTNET_SKIP_FIRST_TIME_EXPERIENCE = 1
 
+# Don't resolve runtime, shared framework, or SDK from other locations to ensure build determinism
+$env:DOTNET_MULTILEVEL_LOOKUP=0
+
 $initTools = Join-Path $PSScriptRoot "init-tools.cmd"
 & $initTools
 

--- a/run.sh
+++ b/run.sh
@@ -5,6 +5,9 @@ __scriptpath=$(cd "$(dirname "$0")"; pwd -P)
 # We do not want to run the first-time experience.
 export DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1
 
+# Don't resolve runtime, shared framework, or SDK from other locations to ensure build determinism 
+export DOTNET_MULTILEVEL_LOOKUP=0
+
 # Source the init-tools.sh script rather than execute in order to preserve ulimit values in child-processes. https://github.com/dotnet/corefx/issues/19152
 . $__scriptpath/init-tools.sh
 

--- a/src/test/HostActivationTests/GivenThatICareAboutDotnetArgValidationScenarios.cs
+++ b/src/test/HostActivationTests/GivenThatICareAboutDotnetArgValidationScenarios.cs
@@ -94,7 +94,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.ArgValidation
             dotnet.Exec("--fx-version")
                 .CaptureStdOut()
                 .CaptureStdErr()
-                .Execute()
+                .Execute(fExpectedToFail: true)
                 .Should()
                 .Fail()
                 .And


### PR DESCRIPTION
@vitek-karas ran into an issue where a "newer" version of the SDK was being used to build the tests, causing a test failure. The "newer" version was actually a 15.* version that we used temporary in an old preview build when we were planning on changing the version numbers.

If the global location has a newer SDK or runtime we should not use it during local build to ensure we are building and testing with the expected environment at `Tools\dotnetcli\sdk\<version>` and runtime at `Tools\dotnetcli\shared\Microsoft.NETCore.App\<version>`

Issue is listed as the 3rd item in https://github.com/dotnet/core-setup/issues/4099

Note: there may be test fallout; we at least need to agree to the build change first.