### PR TITLE
Port ReleaseTools changes to release/1.0.0

### DIFF
--- a/buildpipeline/Core-Setup-CentOS-x64.json
+++ b/buildpipeline/Core-Setup-CentOS-x64.json
@@ -108,10 +108,10 @@
         "definitionType": "task"
       },
       "inputs": {
-        "scriptPath": "$(Build.SourcesDirectory)/DotNet-Core-Release-Tools/msbuildrun.sh",
+        "scriptPath": "$(ReleaseToolsDir)/msbuildrun.sh",
         "args": "--target DownloadFromAzure --properties ContainerName=$(CoreFxAzureContainer),DownloadDirectory=$(Build.SourcesDirectory)/AzureCoreFxDownload,AccountName=$(AzureAccountName),AccessToken=$(AzureAccessToken),FilterBlobNames=Release/",
         "disableAutoCwd": "false",
-        "cwd": "$(Build.SourcesDirectory)/DotNet-Core-Release-Tools",
+        "cwd": "$(ReleaseToolsDir)",
         "failOnStandardError": "false"
       }
     },
@@ -128,10 +128,10 @@
         "definitionType": "task"
       },
       "inputs": {
-        "scriptPath": "$(Build.SourcesDirectory)/DotNet-Core-Release-Tools/msbuildrun.sh",
+        "scriptPath": "$(ReleaseToolsDir)/msbuildrun.sh",
         "args": "--target AddSourceToNuGetConfig --properties NuGetConfigFile=$(Build.SourcesDirectory)/NuGet.Config,SourceName=LocalDownload,SourcePath=./AzureCoreFxDownload/Release",
         "disableAutoCwd": "false",
-        "cwd": "$(Build.SourcesDirectory)/DotNet-Core-Release-Tools",
+        "cwd": "$(ReleaseToolsDir)",
         "failOnStandardError": "false"
       }
     },
@@ -148,10 +148,10 @@
         "definitionType": "task"
       },
       "inputs": {
-        "scriptPath": "$(Build.SourcesDirectory)/DotNet-Core-Release-Tools/msbuildrun.sh",
+        "scriptPath": "$(ReleaseToolsDir)/msbuildrun.sh",
         "args": "--target AddSourceToNuGetConfig --properties NuGetConfigFile=$(Build.SourcesDirectory)/NuGet.Config,SourceName=LocalDownload2,SourcePath=./AzureCoreFxDownload/Release/pkg",
         "disableAutoCwd": "false",
-        "cwd": "$(Build.SourcesDirectory)/DotNet-Core-Release-Tools",
+        "cwd": "$(ReleaseToolsDir)",
         "failOnStandardError": "false"
       }
     },
@@ -362,8 +362,11 @@
     "ReleaseToolsGitUrl": {
       "value": "https://dn-bot:$(VsoPassword)@devdiv.visualstudio.com/DevDiv/_git/DotNet-Core-Release-Tools"
     },
+    "ReleaseToolsDir": {
+      "value": "$(Build.SourcesDirectory)/DotNet-Core-Release-Tools"
+    },
     "PB_InternalBuild": {
-      "value": false
+      "value": "false"
     }
   },
   "demands": [

--- a/buildpipeline/Core-Setup-CentOS-x64.json
+++ b/buildpipeline/Core-Setup-CentOS-x64.json
@@ -23,6 +23,24 @@
     },
     {
       "enabled": true,
+      "continueOnError": true,
+      "alwaysRun": true,
+      "displayName": "Remove Release Tools directory",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "filename": "rm",
+        "arguments": "-rf DotNet-Core-Release-Tools",
+        "workingFolder": "",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "enabled": true,
       "continueOnError": false,
       "alwaysRun": false,
       "displayName": "git checkout",
@@ -36,6 +54,104 @@
         "filename": "git",
         "arguments": "checkout $(SourceVersion)",
         "workingFolder": "",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Clone release tools",
+      "condition": "ne(variables.PB_InternalBuild, 'true')",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "filename": "git",
+        "arguments": "clone $(ReleaseToolsGitUrl)",
+        "workingFolder": "",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Create Internal drop directory",
+      "condition": "ne(variables.PB_InternalBuild, 'true')",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "filename": "mkdir",
+        "arguments": "$(Build.SourcesDirectory)/AzureCoreFxDownload",
+        "workingFolder": "",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Download Azure Internal drop",
+      "condition": "ne(variables.PB_InternalBuild, 'true')",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "6c731c3c-3c68-459a-a5c9-bde6e6595b5b",
+        "versionSpec": "2.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "scriptPath": "$(Build.SourcesDirectory)/DotNet-Core-Release-Tools/msbuildrun.sh",
+        "args": "--target DownloadFromAzure --properties ContainerName=$(CoreFxAzureContainer),DownloadDirectory=$(Build.SourcesDirectory)/AzureCoreFxDownload,AccountName=$(AzureAccountName),AccessToken=$(AzureAccessToken),FilterBlobNames=Release/",
+        "disableAutoCwd": "false",
+        "cwd": "$(Build.SourcesDirectory)/DotNet-Core-Release-Tools",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Add CoreFX drop to NuGet.Config",
+      "condition": "ne(variables.PB_InternalBuild, 'true')",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "6c731c3c-3c68-459a-a5c9-bde6e6595b5b",
+        "versionSpec": "2.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "scriptPath": "$(Build.SourcesDirectory)/DotNet-Core-Release-Tools/msbuildrun.sh",
+        "args": "--target AddSourceToNuGetConfig --properties NuGetConfigFile=$(Build.SourcesDirectory)/NuGet.Config,SourceName=LocalDownload,SourcePath=./AzureCoreFxDownload/Release",
+        "disableAutoCwd": "false",
+        "cwd": "$(Build.SourcesDirectory)/DotNet-Core-Release-Tools",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Add CoreCLR drop to NuGet.Config (AzureCoreFxDownload/Release/pkg)",
+      "condition": "ne(variables.PB_InternalBuild, 'true')",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "6c731c3c-3c68-459a-a5c9-bde6e6595b5b",
+        "versionSpec": "2.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "scriptPath": "$(Build.SourcesDirectory)/DotNet-Core-Release-Tools/msbuildrun.sh",
+        "args": "--target AddSourceToNuGetConfig --properties NuGetConfigFile=$(Build.SourcesDirectory)/NuGet.Config,SourceName=LocalDownload2,SourcePath=./AzureCoreFxDownload/Release/pkg",
+        "disableAutoCwd": "false",
+        "cwd": "$(Build.SourcesDirectory)/DotNet-Core-Release-Tools",
         "failOnStandardError": "false"
       }
     },
@@ -91,6 +207,44 @@
       "inputs": {
         "filename": "perl",
         "arguments": "pkg/Tools/scripts/docker/cleanup-docker.sh",
+        "workingFolder": "",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": true,
+      "alwaysRun": true,
+      "displayName": "Remove Azure CoreFX drop directory",
+      "condition": "ne(variables.PB_InternalBuild, 'true')",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "filename": "rm",
+        "arguments": "-rf $(Build.SourcesDirectory)/AzureCoreFxDownload",
+        "workingFolder": "",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": true,
+      "alwaysRun": true,
+      "displayName": "Remove Release Tools directory",
+      "condition": "ne(variables.PB_InternalBuild, 'true')",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "filename": "rm",
+        "arguments": "-rf DotNet-Core-Release-Tools",
         "workingFolder": "",
         "failOnStandardError": "false"
       }
@@ -189,6 +343,27 @@
     },
     "GITHUB_PASSWORD": {
       "value": "ENV_VAR_EMPTY_WORKAROUND"
+    },
+    "CoreFxAzureContainer": {
+      "value": "ENV_VAR_EMPTY_WORKAROUND",
+      "allowOverride": true
+    },
+    "AzureAccountName": {
+      "value": "ENV_VAR_EMPTY_WORKAROUND"
+    },
+    "AzureAccessToken": {
+      "value": null,
+      "isSecret": true
+    },
+    "VsoPassword": {
+      "value": null,
+      "isSecret": true
+    },
+    "ReleaseToolsGitUrl": {
+      "value": "https://dn-bot:$(VsoPassword)@devdiv.visualstudio.com/DevDiv/_git/DotNet-Core-Release-Tools"
+    },
+    "PB_InternalBuild": {
+      "value": false
     }
   },
   "demands": [

--- a/buildpipeline/Core-Setup-Debian8-x64.json
+++ b/buildpipeline/Core-Setup-Debian8-x64.json
@@ -108,10 +108,10 @@
         "definitionType": "task"
       },
       "inputs": {
-        "scriptPath": "$(Build.SourcesDirectory)/DotNet-Core-Release-Tools/msbuildrun.sh",
+        "scriptPath": "$(ReleaseToolsDir)/msbuildrun.sh",
         "args": "--target DownloadFromAzure --properties ContainerName=$(CoreFxAzureContainer),DownloadDirectory=$(Build.SourcesDirectory)/AzureCoreFxDownload,AccountName=$(AzureAccountName),AccessToken=$(AzureAccessToken),FilterBlobNames=Release/",
         "disableAutoCwd": "false",
-        "cwd": "$(Build.SourcesDirectory)/DotNet-Core-Release-Tools",
+        "cwd": "$(ReleaseToolsDir)",
         "failOnStandardError": "false"
       }
     },
@@ -128,10 +128,10 @@
         "definitionType": "task"
       },
       "inputs": {
-        "scriptPath": "$(Build.SourcesDirectory)/DotNet-Core-Release-Tools/msbuildrun.sh",
+        "scriptPath": "$(ReleaseToolsDir)/msbuildrun.sh",
         "args": "--target AddSourceToNuGetConfig --properties NuGetConfigFile=$(Build.SourcesDirectory)/NuGet.Config,SourceName=LocalDownload,SourcePath=./AzureCoreFxDownload/Release",
         "disableAutoCwd": "false",
-        "cwd": "$(Build.SourcesDirectory)/DotNet-Core-Release-Tools",
+        "cwd": "$(ReleaseToolsDir)",
         "failOnStandardError": "false"
       }
     },
@@ -148,10 +148,10 @@
         "definitionType": "task"
       },
       "inputs": {
-        "scriptPath": "$(Build.SourcesDirectory)/DotNet-Core-Release-Tools/msbuildrun.sh",
+        "scriptPath": "$(ReleaseToolsDir)/msbuildrun.sh",
         "args": "--target AddSourceToNuGetConfig --properties NuGetConfigFile=$(Build.SourcesDirectory)/NuGet.Config,SourceName=LocalDownload2,SourcePath=./AzureCoreFxDownload/Release/pkg",
         "disableAutoCwd": "false",
-        "cwd": "$(Build.SourcesDirectory)/DotNet-Core-Release-Tools",
+        "cwd": "$(ReleaseToolsDir)",
         "failOnStandardError": "false"
       }
     },
@@ -362,8 +362,11 @@
     "ReleaseToolsGitUrl": {
       "value": "https://dn-bot:$(VsoPassword)@devdiv.visualstudio.com/DevDiv/_git/DotNet-Core-Release-Tools"
     },
+    "ReleaseToolsDir": {
+      "value": "$(Build.SourcesDirectory)/DotNet-Core-Release-Tools"
+    },
     "PB_InternalBuild": {
-      "value": false
+      "value": "false"
     }
   },
   "demands": [

--- a/buildpipeline/Core-Setup-Debian8-x64.json
+++ b/buildpipeline/Core-Setup-Debian8-x64.json
@@ -23,6 +23,24 @@
     },
     {
       "enabled": true,
+      "continueOnError": true,
+      "alwaysRun": true,
+      "displayName": "Remove Release Tools directory",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "filename": "rm",
+        "arguments": "-rf DotNet-Core-Release-Tools",
+        "workingFolder": "",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "enabled": true,
       "continueOnError": false,
       "alwaysRun": false,
       "displayName": "git checkout",
@@ -36,6 +54,104 @@
         "filename": "git",
         "arguments": "checkout $(SourceVersion)",
         "workingFolder": "",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Clone release tools",
+      "condition": "ne(variables.PB_InternalBuild, 'true')",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "filename": "git",
+        "arguments": "clone $(ReleaseToolsGitUrl)",
+        "workingFolder": "",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Create Internal drop directory",
+      "condition": "ne(variables.PB_InternalBuild, 'true')",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "filename": "mkdir",
+        "arguments": "$(Build.SourcesDirectory)/AzureCoreFxDownload",
+        "workingFolder": "",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Download Azure Internal drop",
+      "condition": "ne(variables.PB_InternalBuild, 'true')",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "6c731c3c-3c68-459a-a5c9-bde6e6595b5b",
+        "versionSpec": "2.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "scriptPath": "$(Build.SourcesDirectory)/DotNet-Core-Release-Tools/msbuildrun.sh",
+        "args": "--target DownloadFromAzure --properties ContainerName=$(CoreFxAzureContainer),DownloadDirectory=$(Build.SourcesDirectory)/AzureCoreFxDownload,AccountName=$(AzureAccountName),AccessToken=$(AzureAccessToken),FilterBlobNames=Release/",
+        "disableAutoCwd": "false",
+        "cwd": "$(Build.SourcesDirectory)/DotNet-Core-Release-Tools",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Add CoreFX drop to NuGet.Config",
+      "condition": "ne(variables.PB_InternalBuild, 'true')",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "6c731c3c-3c68-459a-a5c9-bde6e6595b5b",
+        "versionSpec": "2.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "scriptPath": "$(Build.SourcesDirectory)/DotNet-Core-Release-Tools/msbuildrun.sh",
+        "args": "--target AddSourceToNuGetConfig --properties NuGetConfigFile=$(Build.SourcesDirectory)/NuGet.Config,SourceName=LocalDownload,SourcePath=./AzureCoreFxDownload/Release",
+        "disableAutoCwd": "false",
+        "cwd": "$(Build.SourcesDirectory)/DotNet-Core-Release-Tools",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Add CoreCLR drop to NuGet.Config (AzureCoreFxDownload/Release/pkg)",
+      "condition": "ne(variables.PB_InternalBuild, 'true')",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "6c731c3c-3c68-459a-a5c9-bde6e6595b5b",
+        "versionSpec": "2.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "scriptPath": "$(Build.SourcesDirectory)/DotNet-Core-Release-Tools/msbuildrun.sh",
+        "args": "--target AddSourceToNuGetConfig --properties NuGetConfigFile=$(Build.SourcesDirectory)/NuGet.Config,SourceName=LocalDownload2,SourcePath=./AzureCoreFxDownload/Release/pkg",
+        "disableAutoCwd": "false",
+        "cwd": "$(Build.SourcesDirectory)/DotNet-Core-Release-Tools",
         "failOnStandardError": "false"
       }
     },
@@ -91,6 +207,44 @@
       "inputs": {
         "filename": "perl",
         "arguments": "pkg/Tools/scripts/docker/cleanup-docker.sh",
+        "workingFolder": "",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": true,
+      "alwaysRun": true,
+      "displayName": "Remove Azure CoreFX drop directory",
+      "condition": "ne(variables.PB_InternalBuild, 'true')",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "filename": "rm",
+        "arguments": "-rf $(Build.SourcesDirectory)/AzureCoreFxDownload",
+        "workingFolder": "",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": true,
+      "alwaysRun": true,
+      "displayName": "Remove Release Tools directory",
+      "condition": "ne(variables.PB_InternalBuild, 'true')",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "filename": "rm",
+        "arguments": "-rf DotNet-Core-Release-Tools",
         "workingFolder": "",
         "failOnStandardError": "false"
       }
@@ -189,6 +343,27 @@
     },
     "GITHUB_PASSWORD": {
       "value": "ENV_VAR_EMPTY_WORKAROUND"
+    },
+    "CoreFxAzureContainer": {
+      "value": "ENV_VAR_EMPTY_WORKAROUND",
+      "allowOverride": true
+    },
+    "AzureAccountName": {
+      "value": "ENV_VAR_EMPTY_WORKAROUND"
+    },
+    "AzureAccessToken": {
+      "value": null,
+      "isSecret": true
+    },
+    "VsoPassword": {
+      "value": null,
+      "isSecret": true
+    },
+    "ReleaseToolsGitUrl": {
+      "value": "https://dn-bot:$(VsoPassword)@devdiv.visualstudio.com/DevDiv/_git/DotNet-Core-Release-Tools"
+    },
+    "PB_InternalBuild": {
+      "value": false
     }
   },
   "demands": [

--- a/buildpipeline/Core-Setup-OSX-x64.json
+++ b/buildpipeline/Core-Setup-OSX-x64.json
@@ -108,10 +108,10 @@
         "definitionType": "task"
       },
       "inputs": {
-        "scriptPath": "$(Build.SourcesDirectory)/DotNet-Core-Release-Tools/msbuildrun.sh",
+        "scriptPath": "$(ReleaseToolsDir)/msbuildrun.sh",
         "args": "--bootstrap1.0 --target DownloadFromAzure --properties ContainerName=$(CoreFxAzureContainer),DownloadDirectory=$(Build.SourcesDirectory)/AzureCoreFxDownload,AccountName=$(AzureAccountName),AccessToken=$(AzureAccessToken),FilterBlobNames=Release/",
         "disableAutoCwd": "false",
-        "cwd": "$(Build.SourcesDirectory)/DotNet-Core-Release-Tools",
+        "cwd": "$(ReleaseToolsDir)",
         "failOnStandardError": "false"
       }
     },
@@ -128,10 +128,10 @@
         "definitionType": "task"
       },
       "inputs": {
-        "scriptPath": "$(Build.SourcesDirectory)/DotNet-Core-Release-Tools/msbuildrun.sh",
+        "scriptPath": "$(ReleaseToolsDir)/msbuildrun.sh",
         "args": "--bootstrap1.0 --target AddSourceToNuGetConfig --properties NuGetConfigFile=$(Build.SourcesDirectory)/NuGet.Config,SourceName=LocalDownload,SourcePath=./AzureCoreFxDownload/Release",
         "disableAutoCwd": "false",
-        "cwd": "$(Build.SourcesDirectory)/DotNet-Core-Release-Tools",
+        "cwd": "$(ReleaseToolsDir)",
         "failOnStandardError": "false"
       }
     },
@@ -148,10 +148,10 @@
         "definitionType": "task"
       },
       "inputs": {
-        "scriptPath": "$(Build.SourcesDirectory)/DotNet-Core-Release-Tools/msbuildrun.sh",
+        "scriptPath": "$(ReleaseToolsDir)/msbuildrun.sh",
         "args": "--target AddSourceToNuGetConfig --properties NuGetConfigFile=$(Build.SourcesDirectory)/NuGet.Config,SourceName=LocalDownload2,SourcePath=./AzureCoreFxDownload/Release/pkg",
         "disableAutoCwd": "false",
-        "cwd": "$(Build.SourcesDirectory)/DotNet-Core-Release-Tools",
+        "cwd": "$(ReleaseToolsDir)",
         "failOnStandardError": "false"
       }
     },
@@ -362,8 +362,11 @@
     "ReleaseToolsGitUrl": {
       "value": "https://dn-bot:$(VsoPassword)@devdiv.visualstudio.com/DevDiv/_git/DotNet-Core-Release-Tools"
     },
+    "ReleaseToolsDir": {
+      "value": "$(Build.SourcesDirectory)/DotNet-Core-Release-Tools"
+    },
     "PB_InternalBuild": {
-      "value": false
+      "value": "false"
     }
   },
   "demands": [

--- a/buildpipeline/Core-Setup-OSX-x64.json
+++ b/buildpipeline/Core-Setup-OSX-x64.json
@@ -23,6 +23,24 @@
     },
     {
       "enabled": true,
+      "continueOnError": true,
+      "alwaysRun": true,
+      "displayName": "Remove Release Tools directory",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "filename": "rm",
+        "arguments": "-rf DotNet-Core-Release-Tools",
+        "workingFolder": "",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "enabled": true,
       "continueOnError": false,
       "alwaysRun": false,
       "displayName": "git checkout",
@@ -36,6 +54,104 @@
         "filename": "git",
         "arguments": "checkout $(SourceVersion)",
         "workingFolder": "",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Clone release tools",
+      "condition": "ne(variables.PB_InternalBuild, 'true')",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "filename": "git",
+        "arguments": "clone $(ReleaseToolsGitUrl)",
+        "workingFolder": "",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Create Internal drop directory",
+      "condition": "ne(variables.PB_InternalBuild, 'true')",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "filename": "mkdir",
+        "arguments": "$(Build.SourcesDirectory)/AzureCoreFxDownload",
+        "workingFolder": "",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Download Azure Internal drop",
+      "condition": "ne(variables.PB_InternalBuild, 'true')",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "6c731c3c-3c68-459a-a5c9-bde6e6595b5b",
+        "versionSpec": "2.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "scriptPath": "$(Build.SourcesDirectory)/DotNet-Core-Release-Tools/msbuildrun.sh",
+        "args": "--bootstrap1.0 --target DownloadFromAzure --properties ContainerName=$(CoreFxAzureContainer),DownloadDirectory=$(Build.SourcesDirectory)/AzureCoreFxDownload,AccountName=$(AzureAccountName),AccessToken=$(AzureAccessToken),FilterBlobNames=Release/",
+        "disableAutoCwd": "false",
+        "cwd": "$(Build.SourcesDirectory)/DotNet-Core-Release-Tools",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Add CoreFX drop to NuGet.Config",
+      "condition": "ne(variables.PB_InternalBuild, 'true')",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "6c731c3c-3c68-459a-a5c9-bde6e6595b5b",
+        "versionSpec": "2.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "scriptPath": "$(Build.SourcesDirectory)/DotNet-Core-Release-Tools/msbuildrun.sh",
+        "args": "--bootstrap1.0 --target AddSourceToNuGetConfig --properties NuGetConfigFile=$(Build.SourcesDirectory)/NuGet.Config,SourceName=LocalDownload,SourcePath=./AzureCoreFxDownload/Release",
+        "disableAutoCwd": "false",
+        "cwd": "$(Build.SourcesDirectory)/DotNet-Core-Release-Tools",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Add CoreCLR drop to NuGet.Config (AzureCoreFxDownload/Release/pkg)",
+      "condition": "ne(variables.PB_InternalBuild, 'true')",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "6c731c3c-3c68-459a-a5c9-bde6e6595b5b",
+        "versionSpec": "2.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "scriptPath": "$(Build.SourcesDirectory)/DotNet-Core-Release-Tools/msbuildrun.sh",
+        "args": "--target AddSourceToNuGetConfig --properties NuGetConfigFile=$(Build.SourcesDirectory)/NuGet.Config,SourceName=LocalDownload2,SourcePath=./AzureCoreFxDownload/Release/pkg",
+        "disableAutoCwd": "false",
+        "cwd": "$(Build.SourcesDirectory)/DotNet-Core-Release-Tools",
         "failOnStandardError": "false"
       }
     },
@@ -91,6 +207,44 @@
       "inputs": {
         "filename": "perl",
         "arguments": "pkg/Tools/scripts/docker/cleanup-docker.sh",
+        "workingFolder": "",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": true,
+      "alwaysRun": true,
+      "displayName": "Remove Azure CoreFX drop directory",
+      "condition": "ne(variables.PB_InternalBuild, 'true')",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "filename": "rm",
+        "arguments": "-rf $(Build.SourcesDirectory)/AzureCoreFxDownload",
+        "workingFolder": "",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": true,
+      "alwaysRun": true,
+      "displayName": "Remove Release Tools directory",
+      "condition": "ne(variables.PB_InternalBuild, 'true')",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "filename": "rm",
+        "arguments": "-rf DotNet-Core-Release-Tools",
         "workingFolder": "",
         "failOnStandardError": "false"
       }
@@ -189,6 +343,27 @@
     },
     "GITHUB_PASSWORD": {
       "value": "ENV_VAR_EMPTY_WORKAROUND"
+    },
+    "CoreFxAzureContainer": {
+      "value": "ENV_VAR_EMPTY_WORKAROUND",
+      "allowOverride": true
+    },
+    "AzureAccountName": {
+      "value": "ENV_VAR_EMPTY_WORKAROUND"
+    },
+    "AzureAccessToken": {
+      "value": null,
+      "isSecret": true
+    },
+    "VsoPassword": {
+      "value": null,
+      "isSecret": true
+    },
+    "ReleaseToolsGitUrl": {
+      "value": "https://dn-bot:$(VsoPassword)@devdiv.visualstudio.com/DevDiv/_git/DotNet-Core-Release-Tools"
+    },
+    "PB_InternalBuild": {
+      "value": false
     }
   },
   "demands": [

--- a/buildpipeline/Core-Setup-RHEL7-x64.json
+++ b/buildpipeline/Core-Setup-RHEL7-x64.json
@@ -108,10 +108,10 @@
         "definitionType": "task"
       },
       "inputs": {
-        "scriptPath": "$(Build.SourcesDirectory)/DotNet-Core-Release-Tools/msbuildrun.sh",
+        "scriptPath": "$(ReleaseToolsDir)/msbuildrun.sh",
         "args": "--target DownloadFromAzure --properties ContainerName=$(CoreFxAzureContainer),DownloadDirectory=$(Build.SourcesDirectory)/AzureCoreFxDownload,AccountName=$(AzureAccountName),AccessToken=$(AzureAccessToken),FilterBlobNames=Release/",
         "disableAutoCwd": "false",
-        "cwd": "$(Build.SourcesDirectory)/DotNet-Core-Release-Tools",
+        "cwd": "$(ReleaseToolsDir)",
         "failOnStandardError": "false"
       }
     },
@@ -128,10 +128,10 @@
         "definitionType": "task"
       },
       "inputs": {
-        "scriptPath": "$(Build.SourcesDirectory)/DotNet-Core-Release-Tools/msbuildrun.sh",
+        "scriptPath": "$(ReleaseToolsDir)/msbuildrun.sh",
         "args": "--target AddSourceToNuGetConfig --properties NuGetConfigFile=$(Build.SourcesDirectory)/NuGet.Config,SourceName=LocalDownload,SourcePath=./AzureCoreFxDownload/Release",
         "disableAutoCwd": "false",
-        "cwd": "$(Build.SourcesDirectory)/DotNet-Core-Release-Tools",
+        "cwd": "$(ReleaseToolsDir)",
         "failOnStandardError": "false"
       }
     },
@@ -148,10 +148,10 @@
         "definitionType": "task"
       },
       "inputs": {
-        "scriptPath": "$(Build.SourcesDirectory)/DotNet-Core-Release-Tools/msbuildrun.sh",
+        "scriptPath": "$(ReleaseToolsDir)/msbuildrun.sh",
         "args": "--target AddSourceToNuGetConfig --properties NuGetConfigFile=$(Build.SourcesDirectory)/NuGet.Config,SourceName=LocalDownload2,SourcePath=./AzureCoreFxDownload/Release/pkg",
         "disableAutoCwd": "false",
-        "cwd": "$(Build.SourcesDirectory)/DotNet-Core-Release-Tools",
+        "cwd": "$(ReleaseToolsDir)",
         "failOnStandardError": "false"
       }
     },
@@ -410,8 +410,11 @@
     "ReleaseToolsGitUrl": {
       "value": "https://dn-bot:$(VsoPassword)@devdiv.visualstudio.com/DevDiv/_git/DotNet-Core-Release-Tools"
     },
+    "ReleaseToolsDir": {
+      "value": "$(Build.SourcesDirectory)/DotNet-Core-Release-Tools"
+    },
     "PB_InternalBuild": {
-      "value": false
+      "value": "false"
     }
   },
   "demands": [

--- a/buildpipeline/Core-Setup-RHEL7-x64.json
+++ b/buildpipeline/Core-Setup-RHEL7-x64.json
@@ -23,6 +23,24 @@
     },
     {
       "enabled": true,
+      "continueOnError": true,
+      "alwaysRun": true,
+      "displayName": "Remove Release Tools directory",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "filename": "rm",
+        "arguments": "-rf DotNet-Core-Release-Tools",
+        "workingFolder": "",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "enabled": true,
       "continueOnError": false,
       "alwaysRun": false,
       "displayName": "git checkout",
@@ -36,6 +54,104 @@
         "filename": "git",
         "arguments": "checkout $(SourceVersion)",
         "workingFolder": "",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Clone release tools",
+      "condition": "ne(variables.PB_InternalBuild, 'true')",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "filename": "git",
+        "arguments": "clone $(ReleaseToolsGitUrl)",
+        "workingFolder": "",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Create Internal drop directory",
+      "condition": "ne(variables.PB_InternalBuild, 'true')",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "filename": "mkdir",
+        "arguments": "$(Build.SourcesDirectory)/AzureCoreFxDownload",
+        "workingFolder": "",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Download Azure Internal drop",
+      "condition": "ne(variables.PB_InternalBuild, 'true')",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "6c731c3c-3c68-459a-a5c9-bde6e6595b5b",
+        "versionSpec": "2.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "scriptPath": "$(Build.SourcesDirectory)/DotNet-Core-Release-Tools/msbuildrun.sh",
+        "args": "--target DownloadFromAzure --properties ContainerName=$(CoreFxAzureContainer),DownloadDirectory=$(Build.SourcesDirectory)/AzureCoreFxDownload,AccountName=$(AzureAccountName),AccessToken=$(AzureAccessToken),FilterBlobNames=Release/",
+        "disableAutoCwd": "false",
+        "cwd": "$(Build.SourcesDirectory)/DotNet-Core-Release-Tools",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Add CoreFX drop to NuGet.Config",
+      "condition": "ne(variables.PB_InternalBuild, 'true')",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "6c731c3c-3c68-459a-a5c9-bde6e6595b5b",
+        "versionSpec": "2.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "scriptPath": "$(Build.SourcesDirectory)/DotNet-Core-Release-Tools/msbuildrun.sh",
+        "args": "--target AddSourceToNuGetConfig --properties NuGetConfigFile=$(Build.SourcesDirectory)/NuGet.Config,SourceName=LocalDownload,SourcePath=./AzureCoreFxDownload/Release",
+        "disableAutoCwd": "false",
+        "cwd": "$(Build.SourcesDirectory)/DotNet-Core-Release-Tools",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Add CoreCLR drop to NuGet.Config (AzureCoreFxDownload/Release/pkg)",
+      "condition": "ne(variables.PB_InternalBuild, 'true')",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "6c731c3c-3c68-459a-a5c9-bde6e6595b5b",
+        "versionSpec": "2.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "scriptPath": "$(Build.SourcesDirectory)/DotNet-Core-Release-Tools/msbuildrun.sh",
+        "args": "--target AddSourceToNuGetConfig --properties NuGetConfigFile=$(Build.SourcesDirectory)/NuGet.Config,SourceName=LocalDownload2,SourcePath=./AzureCoreFxDownload/Release/pkg",
+        "disableAutoCwd": "false",
+        "cwd": "$(Build.SourcesDirectory)/DotNet-Core-Release-Tools",
         "failOnStandardError": "false"
       }
     },
@@ -128,6 +244,44 @@
       "inputs": {
         "filename": "perl",
         "arguments": "pkg/Tools/scripts/docker/cleanup-docker.sh",
+        "workingFolder": "",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": true,
+      "alwaysRun": true,
+      "displayName": "Remove Azure CoreFX drop directory",
+      "condition": "ne(variables.PB_InternalBuild, 'true')",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "filename": "rm",
+        "arguments": "-rf $(Build.SourcesDirectory)/AzureCoreFxDownload",
+        "workingFolder": "",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": true,
+      "alwaysRun": true,
+      "displayName": "Remove Release Tools directory",
+      "condition": "ne(variables.PB_InternalBuild, 'true')",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "filename": "rm",
+        "arguments": "-rf DotNet-Core-Release-Tools",
         "workingFolder": "",
         "failOnStandardError": "false"
       }
@@ -237,6 +391,27 @@
     },
     "DockerImageName": {
       "value": "microsoft/dotnet-buildtools-prereqs:rhel7_prereqs_2"
+    },
+    "CoreFxAzureContainer": {
+      "value": "ENV_VAR_EMPTY_WORKAROUND",
+      "allowOverride": true
+    },
+    "AzureAccountName": {
+      "value": "ENV_VAR_EMPTY_WORKAROUND"
+    },
+    "AzureAccessToken": {
+      "value": null,
+      "isSecret": true
+    },
+    "VsoPassword": {
+      "value": null,
+      "isSecret": true
+    },
+    "ReleaseToolsGitUrl": {
+      "value": "https://dn-bot:$(VsoPassword)@devdiv.visualstudio.com/DevDiv/_git/DotNet-Core-Release-Tools"
+    },
+    "PB_InternalBuild": {
+      "value": false
     }
   },
   "demands": [

--- a/buildpipeline/Core-Setup-Signing-Windows-x64.json
+++ b/buildpipeline/Core-Setup-Signing-Windows-x64.json
@@ -25,6 +25,26 @@
     },
     {
       "enabled": true,
+      "continueOnError": true,
+      "alwaysRun": true,
+      "displayName": "Remove Release Tools directory",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "e213ff0f-5d5c-4791-802d-52ea3e7be1f1",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "scriptType": "inlineScript",
+        "scriptName": "",
+        "arguments": "",
+        "workingFolder": "",
+        "inlineScript": "rm -Recurse -Force -ErrorAction Ignore DotNet-Core-Release-Tools",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "enabled": true,
       "continueOnError": false,
       "alwaysRun": false,
       "displayName": "git checkout",
@@ -45,6 +65,44 @@
       "enabled": true,
       "continueOnError": false,
       "alwaysRun": false,
+      "displayName": "Clone release tools",
+      "condition": "ne(variables.PB_InternalBuild, 'true')",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "filename": "git",
+        "arguments": "clone $(ReleaseToolsGitUrl)",
+        "workingFolder": "",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Create Internal drop directory",
+      "condition": "ne(variables.PB_InternalBuild, 'true')",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "filename": "mkdir",
+        "arguments": "$(Build.SourcesDirectory)\\AzureCoreFxDownload",
+        "workingFolder": "",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
       "displayName": "Install Signing Plugin",
       "timeoutInMinutes": 0,
       "task": {
@@ -57,6 +115,69 @@
         "zipSources": "false",
         "version": "",
         "feedSource": "https://devdiv.pkgs.visualstudio.com/DefaultCollection/_packaging/MicroBuildToolset/nuget/v3/index.json"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Download Azure Internal drop",
+      "condition": "ne(variables.PB_InternalBuild, 'true')",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "e213ff0f-5d5c-4791-802d-52ea3e7be1f1",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "scriptType": "filePath",
+        "scriptName": "DotNet-Core-Release-Tools/msbuildrun.ps1",
+        "arguments": "-RepositoryRoot $(Build.SourcesDirectory)\\DotNet-Core-Release-Tools -Target DownloadFromAzure -Properties ContainerName=$(CoreFxAzureContainer),DownloadDirectory=$(Build.SourcesDirectory)\\AzureCoreFxDownload,AccountName=$(AzureAccountName),AccessToken=$(AzureAccessToken),FilterBlobNames=Release/",
+        "inlineScript": "# You can write your powershell scripts inline here. \n# You can also pass predefined and custom variables to this scripts using arguments\n\n Write-Host \"Hello World\"",
+        "workingFolder": "",
+        "failOnStandardError": "true"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Add CoreFX drop to NuGet.Config",
+      "condition": "ne(variables.PB_InternalBuild, 'true')",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "e213ff0f-5d5c-4791-802d-52ea3e7be1f1",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "scriptType": "filePath",
+        "scriptName": "DotNet-Core-Release-Tools/msbuildrun.ps1",
+        "arguments": "-RepositoryRoot $(Build.SourcesDirectory)\\DotNet-Core-Release-Tools -Target AddSourceToNuGetConfig -Properties NuGetConfigFile=$(Build.SourcesDirectory)\\NuGet.Config,SourceName=LocalDownload,SourcePath=$(Build.SourcesDirectory)\\AzureCoreFxDownload\\Release",
+        "inlineScript": "# You can write your powershell scripts inline here. \n# You can also pass predefined and custom variables to this scripts using arguments\n\n Write-Host \"Hello World\"",
+        "workingFolder": "",
+        "failOnStandardError": "true"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Add CoreCLR drop to NuGet.Config (AzureCoreFxDownload/Release/pkg)",
+      "condition": "ne(variables.PB_InternalBuild, 'true')",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "e213ff0f-5d5c-4791-802d-52ea3e7be1f1",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "scriptType": "filePath",
+        "scriptName": "DotNet-Core-Release-Tools/msbuildrun.ps1",
+        "arguments": "-RepositoryRoot $(Build.SourcesDirectory)\\DotNet-Core-Release-Tools -Target AddSourceToNuGetConfig -Properties NuGetConfigFile=$(Build.SourcesDirectory)\\NuGet.Config,SourceName=LocalDownload2,SourcePath=$(Build.SourcesDirectory)\\AzureCoreFxDownload\\Release\\pkg",
+        "inlineScript": "",
+        "workingFolder": "",
+        "failOnStandardError": "true"
       }
     },
     {
@@ -381,6 +502,44 @@
       }
     },
     {
+      "enabled": true,
+      "continueOnError": true,
+      "alwaysRun": true,
+      "displayName": "Remove Release Tools directory",
+      "condition": "ne(variables.PB_InternalBuild, 'true')",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "filename": "rmdir",
+        "arguments": "/q /s DotNet-Core-Release-Tools",
+        "workingFolder": "",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": true,
+      "alwaysRun": true,
+      "displayName": "Remove Azure CoreFX drop directory",
+      "condition": "ne(variables.PB_InternalBuild, 'true')",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "filename": "rmdir",
+        "arguments": "/q /s AzureCoreFxDownload",
+        "workingFolder": "",
+        "failOnStandardError": "false"
+      }
+    },
+    {
       "environment": {},
       "enabled": true,
       "continueOnError": true,
@@ -491,6 +650,27 @@
     },
     "system.debug": {
       "value": "false"
+    },
+    "CoreFxAzureContainer": {
+      "value": "ENV_VAR_EMPTY_WORKAROUND",
+      "allowOverride": true
+    },
+    "AzureAccountName": {
+      "value": "ENV_VAR_EMPTY_WORKAROUND"
+    },
+    "AzureAccessToken": {
+      "value": null,
+      "isSecret": true
+    },
+    "VsoPassword": {
+      "value": null,
+      "isSecret": true
+    },
+    "ReleaseToolsGitUrl": {
+      "value": "https://dn-bot:$(VsoPassword)@devdiv.visualstudio.com/DevDiv/_git/DotNet-Core-Release-Tools"
+    },
+    "PB_InternalBuild": {
+      "value": false
     }
   },
   "demands": [
@@ -501,7 +681,7 @@
       "branches": [
         "+refs/heads/*"
       ],
-      "artifacts": [ ],
+      "artifacts": [],
       "artifactTypesToDelete": [
         "FilePath",
         "SymbolStore"

--- a/buildpipeline/Core-Setup-Signing-Windows-x64.json
+++ b/buildpipeline/Core-Setup-Signing-Windows-x64.json
@@ -670,7 +670,7 @@
       "value": "https://dn-bot:$(VsoPassword)@devdiv.visualstudio.com/DevDiv/_git/DotNet-Core-Release-Tools"
     },
     "PB_InternalBuild": {
-      "value": false
+      "value": "false"
     }
   },
   "demands": [

--- a/buildpipeline/Core-Setup-Signing-Windows-x86.json
+++ b/buildpipeline/Core-Setup-Signing-Windows-x86.json
@@ -673,7 +673,7 @@
       "value": "https://dn-bot:$(VsoPassword)@devdiv.visualstudio.com/DevDiv/_git/DotNet-Core-Release-Tools"
     },
     "PB_InternalBuild": {
-      "value": false
+      "value": "false"
     }
   },
   "demands": [

--- a/buildpipeline/Core-Setup-Signing-Windows-x86.json
+++ b/buildpipeline/Core-Setup-Signing-Windows-x86.json
@@ -25,6 +25,26 @@
     }, 
     {
       "enabled": true,
+      "continueOnError": true,
+      "alwaysRun": true,
+      "displayName": "Remove Release Tools directory",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "e213ff0f-5d5c-4791-802d-52ea3e7be1f1",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "scriptType": "inlineScript",
+        "scriptName": "",
+        "arguments": "",
+        "workingFolder": "",
+        "inlineScript": "rm -Recurse -Force -ErrorAction Ignore DotNet-Core-Release-Tools",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "enabled": true,
       "continueOnError": false,
       "alwaysRun": false,
       "displayName": "git checkout",
@@ -45,6 +65,44 @@
       "enabled": true,
       "continueOnError": false,
       "alwaysRun": false,
+      "displayName": "Clone release tools",
+      "condition": "ne(variables.PB_InternalBuild, 'true')",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "filename": "git",
+        "arguments": "clone $(ReleaseToolsGitUrl)",
+        "workingFolder": "",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Create Internal drop directory",
+      "condition": "ne(variables.PB_InternalBuild, 'true')",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "filename": "mkdir",
+        "arguments": "$(Build.SourcesDirectory)\\AzureCoreFxDownload",
+        "workingFolder": "",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
       "displayName": "Install Signing Plugin",
       "timeoutInMinutes": 0,
       "task": {
@@ -57,6 +115,69 @@
         "zipSources": "false",
         "version": "",
         "feedSource": "https://devdiv.pkgs.visualstudio.com/DefaultCollection/_packaging/MicroBuildToolset/nuget/v3/index.json"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Download Azure Internal drop",
+      "condition": "ne(variables.PB_InternalBuild, 'true')",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "e213ff0f-5d5c-4791-802d-52ea3e7be1f1",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "scriptType": "filePath",
+        "scriptName": "DotNet-Core-Release-Tools/msbuildrun.ps1",
+        "arguments": "-RepositoryRoot $(Build.SourcesDirectory)\\DotNet-Core-Release-Tools -Target DownloadFromAzure -Properties ContainerName=$(CoreFxAzureContainer),DownloadDirectory=$(Build.SourcesDirectory)\\AzureCoreFxDownload,AccountName=$(AzureAccountName),AccessToken=$(AzureAccessToken),FilterBlobNames=Release/",
+        "inlineScript": "# You can write your powershell scripts inline here. \n# You can also pass predefined and custom variables to this scripts using arguments\n\n Write-Host \"Hello World\"",
+        "workingFolder": "",
+        "failOnStandardError": "true"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Add CoreFX drop to NuGet.Config",
+      "condition": "ne(variables.PB_InternalBuild, 'true')",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "e213ff0f-5d5c-4791-802d-52ea3e7be1f1",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "scriptType": "filePath",
+        "scriptName": "DotNet-Core-Release-Tools/msbuildrun.ps1",
+        "arguments": "-RepositoryRoot $(Build.SourcesDirectory)\\DotNet-Core-Release-Tools -Target AddSourceToNuGetConfig -Properties NuGetConfigFile=$(Build.SourcesDirectory)\\NuGet.Config,SourceName=LocalDownload,SourcePath=$(Build.SourcesDirectory)\\AzureCoreFxDownload\\Release",
+        "inlineScript": "# You can write your powershell scripts inline here. \n# You can also pass predefined and custom variables to this scripts using arguments\n\n Write-Host \"Hello World\"",
+        "workingFolder": "",
+        "failOnStandardError": "true"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Add CoreCLR drop to NuGet.Config (AzureCoreFxDownload/Release/pkg)",
+      "condition": "ne(variables.PB_InternalBuild, 'true')",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "e213ff0f-5d5c-4791-802d-52ea3e7be1f1",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "scriptType": "filePath",
+        "scriptName": "DotNet-Core-Release-Tools/msbuildrun.ps1",
+        "arguments": "-RepositoryRoot $(Build.SourcesDirectory)\\DotNet-Core-Release-Tools -Target AddSourceToNuGetConfig -Properties NuGetConfigFile=$(Build.SourcesDirectory)\\NuGet.Config,SourceName=LocalDownload2,SourcePath=$(Build.SourcesDirectory)\\AzureCoreFxDownload\\Release\\pkg",
+        "inlineScript": "",
+        "workingFolder": "",
+        "failOnStandardError": "true"
       }
     },
     {
@@ -381,6 +502,44 @@
       }
     },
     {
+      "enabled": true,
+      "continueOnError": true,
+      "alwaysRun": true,
+      "displayName": "Remove Release Tools directory",
+      "condition": "ne(variables.PB_InternalBuild, 'true')",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "filename": "rmdir",
+        "arguments": "/q /s DotNet-Core-Release-Tools",
+        "workingFolder": "",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": true,
+      "alwaysRun": true,
+      "displayName": "Remove Azure CoreFX drop directory",
+      "condition": "ne(variables.PB_InternalBuild, 'true')",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "filename": "rmdir",
+        "arguments": "/q /s AzureCoreFxDownload",
+        "workingFolder": "",
+        "failOnStandardError": "false"
+      }
+    },
+    {
       "environment": {},
       "enabled": true,
       "continueOnError": true,
@@ -494,6 +653,27 @@
     },
     "system.debug": {
       "value": "false"
+    },
+    "CoreFxAzureContainer": {
+      "value": "ENV_VAR_EMPTY_WORKAROUND",
+      "allowOverride": true
+    },
+    "AzureAccountName": {
+      "value": "ENV_VAR_EMPTY_WORKAROUND"
+    },
+    "AzureAccessToken": {
+      "value": null,
+      "isSecret": true
+    },
+    "VsoPassword": {
+      "value": null,
+      "isSecret": true
+    },
+    "ReleaseToolsGitUrl": {
+      "value": "https://dn-bot:$(VsoPassword)@devdiv.visualstudio.com/DevDiv/_git/DotNet-Core-Release-Tools"
+    },
+    "PB_InternalBuild": {
+      "value": false
     }
   },
   "demands": [
@@ -504,7 +684,7 @@
       "branches": [
         "+refs/heads/*"
       ],
-      "artifacts": [ ],
+      "artifacts": [],
       "artifactTypesToDelete": [
         "FilePath",
         "SymbolStore"

--- a/buildpipeline/Core-Setup-Ubuntu14.04-x64.json
+++ b/buildpipeline/Core-Setup-Ubuntu14.04-x64.json
@@ -108,10 +108,10 @@
         "definitionType": "task"
       },
       "inputs": {
-        "scriptPath": "$(Build.SourcesDirectory)/DotNet-Core-Release-Tools/msbuildrun.sh",
+        "scriptPath": "$(ReleaseToolsDir)/msbuildrun.sh",
         "args": "--target DownloadFromAzure --properties ContainerName=$(CoreFxAzureContainer),DownloadDirectory=$(Build.SourcesDirectory)/AzureCoreFxDownload,AccountName=$(AzureAccountName),AccessToken=$(AzureAccessToken),FilterBlobNames=Release/",
         "disableAutoCwd": "false",
-        "cwd": "$(Build.SourcesDirectory)/DotNet-Core-Release-Tools",
+        "cwd": "$(ReleaseToolsDir)",
         "failOnStandardError": "false"
       }
     },
@@ -128,10 +128,10 @@
         "definitionType": "task"
       },
       "inputs": {
-        "scriptPath": "$(Build.SourcesDirectory)/DotNet-Core-Release-Tools/msbuildrun.sh",
+        "scriptPath": "$(ReleaseToolsDir)/msbuildrun.sh",
         "args": "--target AddSourceToNuGetConfig --properties NuGetConfigFile=$(Build.SourcesDirectory)/NuGet.Config,SourceName=LocalDownload,SourcePath=./AzureCoreFxDownload/Release",
         "disableAutoCwd": "false",
-        "cwd": "$(Build.SourcesDirectory)/DotNet-Core-Release-Tools",
+        "cwd": "$(ReleaseToolsDir)",
         "failOnStandardError": "false"
       }
     },
@@ -148,10 +148,10 @@
         "definitionType": "task"
       },
       "inputs": {
-        "scriptPath": "$(Build.SourcesDirectory)/DotNet-Core-Release-Tools/msbuildrun.sh",
+        "scriptPath": "$(ReleaseToolsDir)/msbuildrun.sh",
         "args": "--target AddSourceToNuGetConfig --properties NuGetConfigFile=$(Build.SourcesDirectory)/NuGet.Config,SourceName=LocalDownload2,SourcePath=./AzureCoreFxDownload/Release/pkg",
         "disableAutoCwd": "false",
-        "cwd": "$(Build.SourcesDirectory)/DotNet-Core-Release-Tools",
+        "cwd": "$(ReleaseToolsDir)",
         "failOnStandardError": "false"
       }
     },
@@ -380,8 +380,11 @@
     "ReleaseToolsGitUrl": {
       "value": "https://dn-bot:$(VsoPassword)@devdiv.visualstudio.com/DevDiv/_git/DotNet-Core-Release-Tools"
     },
+    "ReleaseToolsDir": {
+      "value": "$(Build.SourcesDirectory)/DotNet-Core-Release-Tools"
+    },
     "PB_InternalBuild": {
-      "value": false
+      "value": "false"
     }
   },
   "demands": [

--- a/buildpipeline/Core-Setup-Ubuntu14.04-x64.json
+++ b/buildpipeline/Core-Setup-Ubuntu14.04-x64.json
@@ -23,6 +23,24 @@
     },
     {
       "enabled": true,
+      "continueOnError": true,
+      "alwaysRun": true,
+      "displayName": "Remove Release Tools directory",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "filename": "rm",
+        "arguments": "-rf DotNet-Core-Release-Tools",
+        "workingFolder": "",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "enabled": true,
       "continueOnError": false,
       "alwaysRun": false,
       "displayName": "git checkout",
@@ -36,6 +54,104 @@
         "filename": "git",
         "arguments": "checkout $(SourceVersion)",
         "workingFolder": "",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Clone release tools",
+      "condition": "ne(variables.PB_InternalBuild, 'true')",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "filename": "git",
+        "arguments": "clone $(ReleaseToolsGitUrl)",
+        "workingFolder": "",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Create Internal drop directory",
+      "condition": "ne(variables.PB_InternalBuild, 'true')",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "filename": "mkdir",
+        "arguments": "$(Build.SourcesDirectory)/AzureCoreFxDownload",
+        "workingFolder": "",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Download Azure Internal drop",
+      "condition": "ne(variables.PB_InternalBuild, 'true')",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "6c731c3c-3c68-459a-a5c9-bde6e6595b5b",
+        "versionSpec": "2.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "scriptPath": "$(Build.SourcesDirectory)/DotNet-Core-Release-Tools/msbuildrun.sh",
+        "args": "--target DownloadFromAzure --properties ContainerName=$(CoreFxAzureContainer),DownloadDirectory=$(Build.SourcesDirectory)/AzureCoreFxDownload,AccountName=$(AzureAccountName),AccessToken=$(AzureAccessToken),FilterBlobNames=Release/",
+        "disableAutoCwd": "false",
+        "cwd": "$(Build.SourcesDirectory)/DotNet-Core-Release-Tools",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Add CoreFX drop to NuGet.Config",
+      "condition": "ne(variables.PB_InternalBuild, 'true')",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "6c731c3c-3c68-459a-a5c9-bde6e6595b5b",
+        "versionSpec": "2.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "scriptPath": "$(Build.SourcesDirectory)/DotNet-Core-Release-Tools/msbuildrun.sh",
+        "args": "--target AddSourceToNuGetConfig --properties NuGetConfigFile=$(Build.SourcesDirectory)/NuGet.Config,SourceName=LocalDownload,SourcePath=./AzureCoreFxDownload/Release",
+        "disableAutoCwd": "false",
+        "cwd": "$(Build.SourcesDirectory)/DotNet-Core-Release-Tools",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Add CoreCLR drop to NuGet.Config (AzureCoreFxDownload/Release/pkg)",
+      "condition": "ne(variables.PB_InternalBuild, 'true')",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "6c731c3c-3c68-459a-a5c9-bde6e6595b5b",
+        "versionSpec": "2.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "scriptPath": "$(Build.SourcesDirectory)/DotNet-Core-Release-Tools/msbuildrun.sh",
+        "args": "--target AddSourceToNuGetConfig --properties NuGetConfigFile=$(Build.SourcesDirectory)/NuGet.Config,SourceName=LocalDownload2,SourcePath=./AzureCoreFxDownload/Release/pkg",
+        "disableAutoCwd": "false",
+        "cwd": "$(Build.SourcesDirectory)/DotNet-Core-Release-Tools",
         "failOnStandardError": "false"
       }
     },
@@ -91,6 +207,44 @@
       "inputs": {
         "filename": "perl",
         "arguments": "pkg/Tools/scripts/docker/cleanup-docker.sh",
+        "workingFolder": "",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": true,
+      "alwaysRun": true,
+      "displayName": "Remove Azure CoreFX drop directory",
+      "condition": "ne(variables.PB_InternalBuild, 'true')",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "filename": "rm",
+        "arguments": "-rf $(Build.SourcesDirectory)/AzureCoreFxDownload",
+        "workingFolder": "",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": true,
+      "alwaysRun": true,
+      "displayName": "Remove Release Tools directory",
+      "condition": "ne(variables.PB_InternalBuild, 'true')",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "filename": "rm",
+        "arguments": "-rf DotNet-Core-Release-Tools",
         "workingFolder": "",
         "failOnStandardError": "false"
       }
@@ -207,6 +361,27 @@
     },
     "CLI_NUGET_API_KEY": {
       "value": "ENV_VAR_EMPTY_WORKAROUND"
+    },
+    "CoreFxAzureContainer": {
+      "value": "ENV_VAR_EMPTY_WORKAROUND",
+      "allowOverride": true
+    },
+    "AzureAccountName": {
+      "value": "ENV_VAR_EMPTY_WORKAROUND"
+    },
+    "AzureAccessToken": {
+      "value": null,
+      "isSecret": true
+    },
+    "VsoPassword": {
+      "value": null,
+      "isSecret": true
+    },
+    "ReleaseToolsGitUrl": {
+      "value": "https://dn-bot:$(VsoPassword)@devdiv.visualstudio.com/DevDiv/_git/DotNet-Core-Release-Tools"
+    },
+    "PB_InternalBuild": {
+      "value": false
     }
   },
   "demands": [

--- a/buildpipeline/Core-Setup-Ubuntu16.04-x64.json
+++ b/buildpipeline/Core-Setup-Ubuntu16.04-x64.json
@@ -108,10 +108,10 @@
         "definitionType": "task"
       },
       "inputs": {
-        "scriptPath": "$(Build.SourcesDirectory)/DotNet-Core-Release-Tools/msbuildrun.sh",
+        "scriptPath": "$(ReleaseToolsDir)/msbuildrun.sh",
         "args": "--target DownloadFromAzure --properties ContainerName=$(CoreFxAzureContainer),DownloadDirectory=$(Build.SourcesDirectory)/AzureCoreFxDownload,AccountName=$(AzureAccountName),AccessToken=$(AzureAccessToken),FilterBlobNames=Release/",
         "disableAutoCwd": "false",
-        "cwd": "$(Build.SourcesDirectory)/DotNet-Core-Release-Tools",
+        "cwd": "$(ReleaseToolsDir)",
         "failOnStandardError": "false"
       }
     },
@@ -128,10 +128,10 @@
         "definitionType": "task"
       },
       "inputs": {
-        "scriptPath": "$(Build.SourcesDirectory)/DotNet-Core-Release-Tools/msbuildrun.sh",
+        "scriptPath": "$(ReleaseToolsDir)/msbuildrun.sh",
         "args": "--target AddSourceToNuGetConfig --properties NuGetConfigFile=$(Build.SourcesDirectory)/NuGet.Config,SourceName=LocalDownload,SourcePath=./AzureCoreFxDownload/Release",
         "disableAutoCwd": "false",
-        "cwd": "$(Build.SourcesDirectory)/DotNet-Core-Release-Tools",
+        "cwd": "$(ReleaseToolsDir)",
         "failOnStandardError": "false"
       }
     },
@@ -148,10 +148,10 @@
         "definitionType": "task"
       },
       "inputs": {
-        "scriptPath": "$(Build.SourcesDirectory)/DotNet-Core-Release-Tools/msbuildrun.sh",
+        "scriptPath": "$(ReleaseToolsDir)/msbuildrun.sh",
         "args": "--target AddSourceToNuGetConfig --properties NuGetConfigFile=$(Build.SourcesDirectory)/NuGet.Config,SourceName=LocalDownload2,SourcePath=./AzureCoreFxDownload/Release/pkg",
         "disableAutoCwd": "false",
-        "cwd": "$(Build.SourcesDirectory)/DotNet-Core-Release-Tools",
+        "cwd": "$(ReleaseToolsDir)",
         "failOnStandardError": "false"
       }
     },
@@ -372,8 +372,11 @@
     "ReleaseToolsGitUrl": {
       "value": "https://dn-bot:$(VsoPassword)@devdiv.visualstudio.com/DevDiv/_git/DotNet-Core-Release-Tools"
     },
+    "ReleaseToolsDir": {
+      "value": "$(Build.SourcesDirectory)/DotNet-Core-Release-Tools"
+    },
     "PB_InternalBuild": {
-      "value": false
+      "value": "false"
     }
   },
   "demands": [

--- a/buildpipeline/Core-Setup-Ubuntu16.04-x64.json
+++ b/buildpipeline/Core-Setup-Ubuntu16.04-x64.json
@@ -23,6 +23,24 @@
     },
     {
       "enabled": true,
+      "continueOnError": true,
+      "alwaysRun": true,
+      "displayName": "Remove Release Tools directory",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "filename": "rm",
+        "arguments": "-rf DotNet-Core-Release-Tools",
+        "workingFolder": "",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "enabled": true,
       "continueOnError": false,
       "alwaysRun": false,
       "displayName": "git checkout",
@@ -36,6 +54,104 @@
         "filename": "git",
         "arguments": "checkout $(SourceVersion)",
         "workingFolder": "",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Clone release tools",
+      "condition": "ne(variables.PB_InternalBuild, 'true')",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "filename": "git",
+        "arguments": "clone $(ReleaseToolsGitUrl)",
+        "workingFolder": "",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Create Internal drop directory",
+      "condition": "ne(variables.PB_InternalBuild, 'true')",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "filename": "mkdir",
+        "arguments": "$(Build.SourcesDirectory)/AzureCoreFxDownload",
+        "workingFolder": "",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Download Azure Internal drop",
+      "condition": "ne(variables.PB_InternalBuild, 'true')",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "6c731c3c-3c68-459a-a5c9-bde6e6595b5b",
+        "versionSpec": "2.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "scriptPath": "$(Build.SourcesDirectory)/DotNet-Core-Release-Tools/msbuildrun.sh",
+        "args": "--target DownloadFromAzure --properties ContainerName=$(CoreFxAzureContainer),DownloadDirectory=$(Build.SourcesDirectory)/AzureCoreFxDownload,AccountName=$(AzureAccountName),AccessToken=$(AzureAccessToken),FilterBlobNames=Release/",
+        "disableAutoCwd": "false",
+        "cwd": "$(Build.SourcesDirectory)/DotNet-Core-Release-Tools",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Add CoreFX drop to NuGet.Config",
+      "condition": "ne(variables.PB_InternalBuild, 'true')",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "6c731c3c-3c68-459a-a5c9-bde6e6595b5b",
+        "versionSpec": "2.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "scriptPath": "$(Build.SourcesDirectory)/DotNet-Core-Release-Tools/msbuildrun.sh",
+        "args": "--target AddSourceToNuGetConfig --properties NuGetConfigFile=$(Build.SourcesDirectory)/NuGet.Config,SourceName=LocalDownload,SourcePath=./AzureCoreFxDownload/Release",
+        "disableAutoCwd": "false",
+        "cwd": "$(Build.SourcesDirectory)/DotNet-Core-Release-Tools",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Add CoreCLR drop to NuGet.Config (AzureCoreFxDownload/Release/pkg)",
+      "condition": "ne(variables.PB_InternalBuild, 'true')",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "6c731c3c-3c68-459a-a5c9-bde6e6595b5b",
+        "versionSpec": "2.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "scriptPath": "$(Build.SourcesDirectory)/DotNet-Core-Release-Tools/msbuildrun.sh",
+        "args": "--target AddSourceToNuGetConfig --properties NuGetConfigFile=$(Build.SourcesDirectory)/NuGet.Config,SourceName=LocalDownload2,SourcePath=./AzureCoreFxDownload/Release/pkg",
+        "disableAutoCwd": "false",
+        "cwd": "$(Build.SourcesDirectory)/DotNet-Core-Release-Tools",
         "failOnStandardError": "false"
       }
     },
@@ -91,6 +207,44 @@
       "inputs": {
         "filename": "perl",
         "arguments": "pkg/Tools/scripts/docker/cleanup-docker.sh",
+        "workingFolder": "",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": true,
+      "alwaysRun": true,
+      "displayName": "Remove Azure CoreFX drop directory",
+      "condition": "ne(variables.PB_InternalBuild, 'true')",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "filename": "rm",
+        "arguments": "-rf $(Build.SourcesDirectory)/AzureCoreFxDownload",
+        "workingFolder": "",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": true,
+      "alwaysRun": true,
+      "displayName": "Remove Release Tools directory",
+      "condition": "ne(variables.PB_InternalBuild, 'true')",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "filename": "rm",
+        "arguments": "-rf DotNet-Core-Release-Tools",
         "workingFolder": "",
         "failOnStandardError": "false"
       }
@@ -199,6 +353,27 @@
     },
     "REPO_PASS": {
       "value": "ENV_VAR_EMPTY_WORKAROUND"
+    },
+    "CoreFxAzureContainer": {
+      "value": "ENV_VAR_EMPTY_WORKAROUND",
+      "allowOverride": true
+    },
+    "AzureAccountName": {
+      "value": "ENV_VAR_EMPTY_WORKAROUND"
+    },
+    "AzureAccessToken": {
+      "value": null,
+      "isSecret": true
+    },
+    "VsoPassword": {
+      "value": null,
+      "isSecret": true
+    },
+    "ReleaseToolsGitUrl": {
+      "value": "https://dn-bot:$(VsoPassword)@devdiv.visualstudio.com/DevDiv/_git/DotNet-Core-Release-Tools"
+    },
+    "PB_InternalBuild": {
+      "value": false
     }
   },
   "demands": [

--- a/buildpipeline/Core-Setup-Windows-arm32.json
+++ b/buildpipeline/Core-Setup-Windows-arm32.json
@@ -25,6 +25,26 @@
     },
     {
       "enabled": true,
+      "continueOnError": true,
+      "alwaysRun": true,
+      "displayName": "Remove Release Tools directory",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "e213ff0f-5d5c-4791-802d-52ea3e7be1f1",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "scriptType": "inlineScript",
+        "scriptName": "",
+        "arguments": "",
+        "workingFolder": "",
+        "inlineScript": "rm -Recurse -Force -ErrorAction Ignore DotNet-Core-Release-Tools",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "enabled": true,
       "continueOnError": false,
       "alwaysRun": false,
       "displayName": "git checkout",
@@ -45,6 +65,107 @@
       "enabled": true,
       "continueOnError": false,
       "alwaysRun": false,
+      "displayName": "Clone release tools",
+      "condition": "ne(variables.PB_InternalBuild, 'true')",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "filename": "git",
+        "arguments": "clone $(ReleaseToolsGitUrl)",
+        "workingFolder": "",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Create Internal drop directory",
+      "condition": "ne(variables.PB_InternalBuild, 'true')",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "filename": "mkdir",
+        "arguments": "$(Build.SourcesDirectory)\\AzureCoreFxDownload",
+        "workingFolder": "",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Download Azure Internal drop",
+      "condition": "ne(variables.PB_InternalBuild, 'true')",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "e213ff0f-5d5c-4791-802d-52ea3e7be1f1",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "scriptType": "filePath",
+        "scriptName": "DotNet-Core-Release-Tools/msbuildrun.ps1",
+        "arguments": "-RepositoryRoot $(Build.SourcesDirectory)\\DotNet-Core-Release-Tools -Target DownloadFromAzure -Properties ContainerName=$(CoreFxAzureContainer),DownloadDirectory=$(Build.SourcesDirectory)\\AzureCoreFxDownload,AccountName=$(AzureAccountName),AccessToken=$(AzureAccessToken),FilterBlobNames=Release/",
+        "inlineScript": "# You can write your powershell scripts inline here. \n# You can also pass predefined and custom variables to this scripts using arguments\n\n Write-Host \"Hello World\"",
+        "workingFolder": "",
+        "failOnStandardError": "true"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Add CoreFX drop to NuGet.Config",
+      "condition": "ne(variables.PB_InternalBuild, 'true')",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "e213ff0f-5d5c-4791-802d-52ea3e7be1f1",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "scriptType": "filePath",
+        "scriptName": "DotNet-Core-Release-Tools/msbuildrun.ps1",
+        "arguments": "-RepositoryRoot $(Build.SourcesDirectory)\\DotNet-Core-Release-Tools -Target AddSourceToNuGetConfig -Properties NuGetConfigFile=$(Build.SourcesDirectory)\\NuGet.Config,SourceName=LocalDownload,SourcePath=$(Build.SourcesDirectory)\\AzureCoreFxDownload\\Release",
+        "inlineScript": "# You can write your powershell scripts inline here. \n# You can also pass predefined and custom variables to this scripts using arguments\n\n Write-Host \"Hello World\"",
+        "workingFolder": "",
+        "failOnStandardError": "true"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Add CoreCLR drop to NuGet.Config (AzureCoreFxDownload/Release/pkg)",
+      "condition": "ne(variables.PB_InternalBuild, 'true')",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "e213ff0f-5d5c-4791-802d-52ea3e7be1f1",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "scriptType": "filePath",
+        "scriptName": "DotNet-Core-Release-Tools/msbuildrun.ps1",
+        "arguments": "-RepositoryRoot $(Build.SourcesDirectory)\\DotNet-Core-Release-Tools -Target AddSourceToNuGetConfig -Properties NuGetConfigFile=$(Build.SourcesDirectory)\\NuGet.Config,SourceName=LocalDownload2,SourcePath=$(Build.SourcesDirectory)\\AzureCoreFxDownload\\Release\\pkg",
+        "inlineScript": "",
+        "workingFolder": "",
+        "failOnStandardError": "true"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
       "displayName": "Run script build.cmd",
       "timeoutInMinutes": 0,
       "task": {
@@ -56,6 +177,44 @@
         "filename": "build.cmd",
         "arguments": "-Configuration Release -Targets Init,Compile,Package,Publish -TargetArch arm -Framework netcoreapp2.0 $(BuildArguments)",
         "modifyEnvironment": "false",
+        "workingFolder": "",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": true,
+      "alwaysRun": true,
+      "displayName": "Remove Release Tools directory",
+      "condition": "ne(variables.PB_InternalBuild, 'true')",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "filename": "rmdir",
+        "arguments": "/q /s DotNet-Core-Release-Tools",
+        "workingFolder": "",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": true,
+      "alwaysRun": true,
+      "displayName": "Remove Azure CoreFX drop directory",
+      "condition": "ne(variables.PB_InternalBuild, 'true')",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "filename": "rmdir",
+        "arguments": "/q /s AzureCoreFxDownload",
         "workingFolder": "",
         "failOnStandardError": "false"
       }
@@ -160,6 +319,27 @@
     "PUBLISH_TO_AZURE_BLOB": {
       "value": "false",
       "allowOverride": true
+    },
+    "CoreFxAzureContainer": {
+      "value": "ENV_VAR_EMPTY_WORKAROUND",
+      "allowOverride": true
+    },
+    "AzureAccountName": {
+      "value": "ENV_VAR_EMPTY_WORKAROUND"
+    },
+    "AzureAccessToken": {
+      "value": null,
+      "isSecret": true
+    },
+    "VsoPassword": {
+      "value": null,
+      "isSecret": true
+    },
+    "ReleaseToolsGitUrl": {
+      "value": "https://dn-bot:$(VsoPassword)@devdiv.visualstudio.com/DevDiv/_git/DotNet-Core-Release-Tools"
+    },
+    "PB_InternalBuild": {
+      "value": false
     }
   },
   "demands": [

--- a/buildpipeline/Core-Setup-Windows-arm32.json
+++ b/buildpipeline/Core-Setup-Windows-arm32.json
@@ -339,7 +339,7 @@
       "value": "https://dn-bot:$(VsoPassword)@devdiv.visualstudio.com/DevDiv/_git/DotNet-Core-Release-Tools"
     },
     "PB_InternalBuild": {
-      "value": false
+      "value": "false"
     }
   },
   "demands": [


### PR DESCRIPTION
This ports the changes from the ReleaseTools branch into the open, allowing us to run our internal builds against the same definitions as our normal builds (rather than maintaining two separate sets of build definitions). 

This will also require passing `PB_InternalBuild=true` from the Internal pipebuild.

@dagood @weshaggard PTAL