### PR TITLE
Port ReleaseTools changes to release/2.0.0

### DIFF
--- a/buildpipeline/Core-Setup-Linux-Arm-BT.json
+++ b/buildpipeline/Core-Setup-Linux-Arm-BT.json
@@ -24,6 +24,24 @@
     {
       "enabled": true,
       "continueOnError": true,
+      "alwaysRun": true,
+      "displayName": "Remove Release Tools directory",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "filename": "rm",
+        "arguments": "-rf DotNet-Core-Release-Tools",
+        "workingFolder": "",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": true,
       "alwaysRun": false,
       "displayName": "Cleanup previous build",
       "timeoutInMinutes": 0,
@@ -135,6 +153,119 @@
       "enabled": true,
       "continueOnError": false,
       "alwaysRun": false,
+      "displayName": "Clone release tools",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "filename": "git",
+        "arguments": "clone $(ReleaseToolsGitUrl)",
+        "workingFolder": "",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Create CoreFX drop directory",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "filename": "mkdir",
+        "arguments": "$(PB_SourcesDirectory)/AzureCoreFxDownload",
+        "workingFolder": "",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Download Azure Internal drop",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "6c731c3c-3c68-459a-a5c9-bde6e6595b5b",
+        "versionSpec": "2.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "scriptPath": "$(Build.SourcesDirectory)/DotNet-Core-Release-Tools/msbuildrun.sh",
+        "args": "--target DownloadFromAzure --properties ContainerName=$(Internal_CoreFX_AzureContainer),DownloadDirectory=$(PB_SourcesDirectory)/AzureCoreFxDownload,AccountName=$(Internal_CoreFX_AzureAccountName),AccessToken=$(Internal_CoreFX_AzureAccessToken),FilterBlobNames=Release/",
+        "disableAutoCwd": "false",
+        "cwd": "$(Build.SourcesDirectory)/DotNet-Core-Release-Tools",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Add CoreFX drop to NuGet.config",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "6c731c3c-3c68-459a-a5c9-bde6e6595b5b",
+        "versionSpec": "2.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "scriptPath": "$(Build.SourcesDirectory)/DotNet-Core-Release-Tools/msbuildrun.sh",
+        "args": "--target AddSourceToNuGetConfig --properties NuGetConfigFile=$(PB_SourcesDirectory)/NuGet.config,SourceName=LocalDownload,SourcePath=./AzureCoreFxDownload/Release",
+        "disableAutoCwd": "false",
+        "cwd": "$(Build.SourcesDirectory)/DotNet-Core-Release-Tools",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Copy $(PB_SourcesDirectory)/AzureCoreFxDownload/Release/pkg (*.nupkg) -> $(PB_SourcesDirectory)/AzureCoreFxDownload/Release",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "5bfb729a-a7c8-4a78-a7c3-8d717bb7c13c",
+        "versionSpec": "2.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "SourceFolder": "$(PB_SourcesDirectory)/AzureCoreFxDownload/Release/pkg",
+        "Contents": "*.nupkg",
+        "TargetFolder": "$(PB_SourcesDirectory)/AzureCoreFxDownload/Release",
+        "CleanTargetFolder": "false",
+        "OverWrite": "false",
+        "flattenFolders": "true"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Add CoreCLR drop to NuGet.config (AzureCoreFxDownload/Release/pkg)",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "6c731c3c-3c68-459a-a5c9-bde6e6595b5b",
+        "versionSpec": "2.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "scriptPath": "$(Build.SourcesDirectory)/DotNet-Core-Release-Tools/msbuildrun.sh",
+        "args": "--target AddSourceToNuGetConfig --properties NuGetConfigFile=$(PB_SourcesDirectory)/NuGet.config,SourceName=LocalDownload2,SourcePath=./AzureCoreFxDownload/Release/pkg",
+        "disableAutoCwd": "false",
+        "cwd": "$(Build.SourcesDirectory)/DotNet-Core-Release-Tools",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
       "displayName": "Build",
       "timeoutInMinutes": 0,
       "task": {
@@ -144,7 +275,7 @@
       },
       "inputs": {
         "filename": "docker",
-        "arguments": "run --rm $(PB_CrossBuildArgs)$(DockerCommonRunArgs) $(PB_GitDirectory)/build.sh -OfficialBuildId=$(OfficialBuildId) $(PB_BuildArguments) -- $(PB_AdditionalMSBuildArguments)",
+        "arguments": "run --rm $(PB_CrossBuildArgs)$(DockerCommonRunArgs) $(PB_GitDirectory)/build.sh -OfficialBuildId=$(OfficialBuildId) $(PB_BuildArguments) -- $(PB_AdditionalMSBuildArguments) /p:OverridePackageSource=$(PB_GitDirectory)/AzureCoreFxDownload/Release",
         "workingFolder": "$(PB_SourcesDirectory)",
         "failOnStandardError": "false"
       }
@@ -224,6 +355,42 @@
         "cwd": "",
         "failOnStandardError": "false",
         "script": "if [ -f \"$AGENTTOOLSPATH/end.sh\" ]; then echo \"$AGENTTOOLSPATH/end.sh script found. Executing...\"; $AGENTTOOLSPATH/end.sh ; else echo \"$AGENTTOOLSPATH/end.sh script does not exist. Moving on.\" ; fi"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": true,
+      "alwaysRun": true,
+      "displayName": "Remove Azure CoreFX drop directory",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "filename": "rm",
+        "arguments": "-rf $(PB_SourcesDirectory)/AzureCoreFxDownload",
+        "workingFolder": "",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": true,
+      "alwaysRun": true,
+      "displayName": "Remove Release Tools directory",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "filename": "rm",
+        "arguments": "-rf DotNet-Core-Release-Tools",
+        "workingFolder": "",
+        "failOnStandardError": "false"
       }
     }
   ],
@@ -416,6 +583,22 @@
     "PB_ChecksumAzureAccessToken": {
       "value": null,
       "isSecret": true
+    },
+    "Internal_CoreFX_AzureContainer": {
+      "value": "PassedViaPipeBuild"
+    },
+    "Internal_CoreFX_AzureAccountName": {
+      "value": "PassedViaPipeBuild"
+    },
+    "Internal_CoreFX_AzureAccessToken": {
+      "value": null,
+      "isSecret": true
+    },
+    "ReleaseToolsGitUrl": {
+      "value": "https://dn-bot:$(PB_VsoPassword)@devdiv.visualstudio.com/DevDiv/_git/DotNet-Core-Release-Tools"
+    },
+    "OverridePackageSource": {
+      "value": "$(PB_SourcesDirectory)/AzureCoreFxDownload/Release"
     }
   },
   "demands": [

--- a/buildpipeline/Core-Setup-Linux-Arm-BT.json
+++ b/buildpipeline/Core-Setup-Linux-Arm-BT.json
@@ -200,10 +200,10 @@
         "definitionType": "task"
       },
       "inputs": {
-        "scriptPath": "$(Build.SourcesDirectory)/DotNet-Core-Release-Tools/msbuildrun.sh",
+        "scriptPath": "$(ReleaseToolsDir)/msbuildrun.sh",
         "args": "--target DownloadFromAzure --properties ContainerName=$(Internal_CoreFX_AzureContainer),DownloadDirectory=$(PB_SourcesDirectory)/AzureCoreFxDownload,AccountName=$(Internal_CoreFX_AzureAccountName),AccessToken=$(Internal_CoreFX_AzureAccessToken),FilterBlobNames=Release/",
         "disableAutoCwd": "false",
-        "cwd": "$(Build.SourcesDirectory)/DotNet-Core-Release-Tools",
+        "cwd": "$(ReleaseToolsDir)",
         "failOnStandardError": "false"
       }
     },
@@ -220,10 +220,10 @@
         "definitionType": "task"
       },
       "inputs": {
-        "scriptPath": "$(Build.SourcesDirectory)/DotNet-Core-Release-Tools/msbuildrun.sh",
+        "scriptPath": "$(ReleaseToolsDir)/msbuildrun.sh",
         "args": "--target AddSourceToNuGetConfig --properties NuGetConfigFile=$(PB_SourcesDirectory)/NuGet.config,SourceName=LocalDownload,SourcePath=./AzureCoreFxDownload/Release",
         "disableAutoCwd": "false",
-        "cwd": "$(Build.SourcesDirectory)/DotNet-Core-Release-Tools",
+        "cwd": "$(ReleaseToolsDir)",
         "failOnStandardError": "false"
       }
     },
@@ -261,10 +261,10 @@
         "definitionType": "task"
       },
       "inputs": {
-        "scriptPath": "$(Build.SourcesDirectory)/DotNet-Core-Release-Tools/msbuildrun.sh",
+        "scriptPath": "$(ReleaseToolsDir)/msbuildrun.sh",
         "args": "--target AddSourceToNuGetConfig --properties NuGetConfigFile=$(PB_SourcesDirectory)/NuGet.config,SourceName=LocalDownload2,SourcePath=./AzureCoreFxDownload/Release/pkg",
         "disableAutoCwd": "false",
-        "cwd": "$(Build.SourcesDirectory)/DotNet-Core-Release-Tools",
+        "cwd": "$(ReleaseToolsDir)",
         "failOnStandardError": "false"
       }
     },
@@ -604,6 +604,9 @@
     },
     "ReleaseToolsGitUrl": {
       "value": "https://dn-bot:$(PB_VsoPassword)@devdiv.visualstudio.com/DevDiv/_git/DotNet-Core-Release-Tools"
+    },
+    "ReleaseToolsDir": {
+      "value": "$(Build.SourcesDirectory)/DotNet-Core-Release-Tools"
     },
     "PB_InternalBuild": {
       "value": "false"

--- a/buildpipeline/Core-Setup-Linux-Arm-BT.json
+++ b/buildpipeline/Core-Setup-Linux-Arm-BT.json
@@ -275,7 +275,7 @@
       },
       "inputs": {
         "filename": "docker",
-        "arguments": "run --rm $(PB_CrossBuildArgs)$(DockerCommonRunArgs) $(PB_GitDirectory)/build.sh -OfficialBuildId=$(OfficialBuildId) $(PB_BuildArguments) -- $(PB_AdditionalMSBuildArguments) /p:OverridePackageSource=$(PB_GitDirectory)/AzureCoreFxDownload/Release",
+        "arguments": "run --rm $(PB_CrossBuildArgs)$(DockerCommonRunArgs) $(PB_GitDirectory)/build.sh -OfficialBuildId=$(OfficialBuildId) $(PB_BuildArguments) -- $(PB_AdditionalMSBuildArguments) $(OverridePackageSource)",
         "workingFolder": "$(PB_SourcesDirectory)",
         "failOnStandardError": "false"
       }
@@ -596,9 +596,6 @@
     },
     "ReleaseToolsGitUrl": {
       "value": "https://dn-bot:$(PB_VsoPassword)@devdiv.visualstudio.com/DevDiv/_git/DotNet-Core-Release-Tools"
-    },
-    "OverridePackageSource": {
-      "value": "$(PB_SourcesDirectory)/AzureCoreFxDownload/Release"
     }
   },
   "demands": [

--- a/buildpipeline/Core-Setup-Linux-Arm-BT.json
+++ b/buildpipeline/Core-Setup-Linux-Arm-BT.json
@@ -154,6 +154,7 @@
       "continueOnError": false,
       "alwaysRun": false,
       "displayName": "Clone release tools",
+      "condition": "ne(variables.PB_InternalBuild, 'true')",
       "timeoutInMinutes": 0,
       "task": {
         "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
@@ -172,6 +173,7 @@
       "continueOnError": false,
       "alwaysRun": false,
       "displayName": "Create CoreFX drop directory",
+      "condition": "ne(variables.PB_InternalBuild, 'true')",
       "timeoutInMinutes": 0,
       "task": {
         "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
@@ -190,6 +192,7 @@
       "continueOnError": false,
       "alwaysRun": false,
       "displayName": "Download Azure Internal drop",
+      "condition": "ne(variables.PB_InternalBuild, 'true')",
       "timeoutInMinutes": 0,
       "task": {
         "id": "6c731c3c-3c68-459a-a5c9-bde6e6595b5b",
@@ -209,6 +212,7 @@
       "continueOnError": false,
       "alwaysRun": false,
       "displayName": "Add CoreFX drop to NuGet.config",
+      "condition": "ne(variables.PB_InternalBuild, 'true')",
       "timeoutInMinutes": 0,
       "task": {
         "id": "6c731c3c-3c68-459a-a5c9-bde6e6595b5b",
@@ -228,6 +232,7 @@
       "continueOnError": false,
       "alwaysRun": false,
       "displayName": "Copy $(PB_SourcesDirectory)/AzureCoreFxDownload/Release/pkg (*.nupkg) -> $(PB_SourcesDirectory)/AzureCoreFxDownload/Release",
+      "condition": "ne(variables.PB_InternalBuild, 'true')",
       "timeoutInMinutes": 0,
       "task": {
         "id": "5bfb729a-a7c8-4a78-a7c3-8d717bb7c13c",
@@ -248,6 +253,7 @@
       "continueOnError": false,
       "alwaysRun": false,
       "displayName": "Add CoreCLR drop to NuGet.config (AzureCoreFxDownload/Release/pkg)",
+      "condition": "ne(variables.PB_InternalBuild, 'true')",
       "timeoutInMinutes": 0,
       "task": {
         "id": "6c731c3c-3c68-459a-a5c9-bde6e6595b5b",
@@ -336,6 +342,44 @@
       }
     },
     {
+      "enabled": true,
+      "continueOnError": true,
+      "alwaysRun": true,
+      "displayName": "Remove Azure CoreFX drop directory",
+      "condition": "ne(variables.PB_InternalBuild, 'true')",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "filename": "rm",
+        "arguments": "-rf $(PB_SourcesDirectory)/AzureCoreFxDownload",
+        "workingFolder": "",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": true,
+      "alwaysRun": true,
+      "displayName": "Remove Release Tools directory",
+      "condition": "ne(variables.PB_InternalBuild, 'true')",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "filename": "rm",
+        "arguments": "-rf DotNet-Core-Release-Tools",
+        "workingFolder": "",
+        "failOnStandardError": "false"
+      }
+    },
+    {
       "environment": {},
       "enabled": true,
       "continueOnError": true,
@@ -355,42 +399,6 @@
         "cwd": "",
         "failOnStandardError": "false",
         "script": "if [ -f \"$AGENTTOOLSPATH/end.sh\" ]; then echo \"$AGENTTOOLSPATH/end.sh script found. Executing...\"; $AGENTTOOLSPATH/end.sh ; else echo \"$AGENTTOOLSPATH/end.sh script does not exist. Moving on.\" ; fi"
-      }
-    },
-    {
-      "enabled": true,
-      "continueOnError": true,
-      "alwaysRun": true,
-      "displayName": "Remove Azure CoreFX drop directory",
-      "timeoutInMinutes": 0,
-      "task": {
-        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
-        "versionSpec": "1.*",
-        "definitionType": "task"
-      },
-      "inputs": {
-        "filename": "rm",
-        "arguments": "-rf $(PB_SourcesDirectory)/AzureCoreFxDownload",
-        "workingFolder": "",
-        "failOnStandardError": "false"
-      }
-    },
-    {
-      "enabled": true,
-      "continueOnError": true,
-      "alwaysRun": true,
-      "displayName": "Remove Release Tools directory",
-      "timeoutInMinutes": 0,
-      "task": {
-        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
-        "versionSpec": "1.*",
-        "definitionType": "task"
-      },
-      "inputs": {
-        "filename": "rm",
-        "arguments": "-rf DotNet-Core-Release-Tools",
-        "workingFolder": "",
-        "failOnStandardError": "false"
       }
     }
   ],
@@ -596,6 +604,9 @@
     },
     "ReleaseToolsGitUrl": {
       "value": "https://dn-bot:$(PB_VsoPassword)@devdiv.visualstudio.com/DevDiv/_git/DotNet-Core-Release-Tools"
+    },
+    "PB_InternalBuild": {
+      "value": "false"
     }
   },
   "demands": [

--- a/buildpipeline/Core-Setup-Linux-BT.json
+++ b/buildpipeline/Core-Setup-Linux-BT.json
@@ -200,10 +200,10 @@
         "definitionType": "task"
       },
       "inputs": {
-        "scriptPath": "$(Build.SourcesDirectory)/DotNet-Core-Release-Tools/msbuildrun.sh",
+        "scriptPath": "$(ReleaseToolsDir)/msbuildrun.sh",
         "args": "--target DownloadFromAzure --properties ContainerName=$(Internal_CoreFX_AzureContainer),DownloadDirectory=$(PB_SourcesDirectory)/AzureCoreFxDownload,AccountName=$(Internal_CoreFX_AzureAccountName),AccessToken=$(Internal_CoreFX_AzureAccessToken),FilterBlobNames=Release/",
         "disableAutoCwd": "false",
-        "cwd": "$(Build.SourcesDirectory)/DotNet-Core-Release-Tools",
+        "cwd": "$(ReleaseToolsDir)",
         "failOnStandardError": "false"
       }
     },
@@ -220,10 +220,10 @@
         "definitionType": "task"
       },
       "inputs": {
-        "scriptPath": "$(Build.SourcesDirectory)/DotNet-Core-Release-Tools/msbuildrun.sh",
+        "scriptPath": "$(ReleaseToolsDir)/msbuildrun.sh",
         "args": "--target AddSourceToNuGetConfig --properties NuGetConfigFile=$(PB_SourcesDirectory)/NuGet.config,SourceName=LocalDownload,SourcePath=./AzureCoreFxDownload/Release",
         "disableAutoCwd": "false",
-        "cwd": "$(Build.SourcesDirectory)/DotNet-Core-Release-Tools",
+        "cwd": "$(ReleaseToolsDir)",
         "failOnStandardError": "false"
       }
     },
@@ -261,10 +261,10 @@
         "definitionType": "task"
       },
       "inputs": {
-        "scriptPath": "$(Build.SourcesDirectory)/DotNet-Core-Release-Tools/msbuildrun.sh",
+        "scriptPath": "$(ReleaseToolsDir)/msbuildrun.sh",
         "args": "--target AddSourceToNuGetConfig --properties NuGetConfigFile=$(PB_SourcesDirectory)/NuGet.config,SourceName=LocalDownload2,SourcePath=./AzureCoreFxDownload/Release/pkg",
         "disableAutoCwd": "false",
-        "cwd": "$(Build.SourcesDirectory)/DotNet-Core-Release-Tools",
+        "cwd": "$(ReleaseToolsDir)",
         "failOnStandardError": "false"
       }
     },
@@ -1291,6 +1291,9 @@
     },
     "ReleaseToolsGitUrl": {
       "value": "https://dn-bot:$(PB_VsoPassword)@devdiv.visualstudio.com/DevDiv/_git/DotNet-Core-Release-Tools"
+    },
+    "ReleaseToolsDir": {
+      "value": "$(Build.SourcesDirectory)/DotNet-Core-Release-Tools"
     },
     "CLI_NUGET_API_KEY": {
       "value": ""

--- a/buildpipeline/Core-Setup-Linux-BT.json
+++ b/buildpipeline/Core-Setup-Linux-BT.json
@@ -275,7 +275,7 @@
       },
       "inputs": {
         "filename": "docker",
-        "arguments": "run --rm $(PB_CrossBuildArgs)$(DockerCommonRunArgs) $(PB_GitDirectory)/build.sh -OfficialBuildId=$(OfficialBuildId) $(PB_BuildArguments) -- /p:OverridePackageSource=$(PB_GitDirectory)/AzureCoreFxDownload/Release",
+        "arguments": "run --rm $(PB_CrossBuildArgs)$(DockerCommonRunArgs) $(PB_GitDirectory)/build.sh -OfficialBuildId=$(OfficialBuildId) $(PB_BuildArguments) -- $(OverridePackageSource)",
         "workingFolder": "$(PB_SourcesDirectory)",
         "failOnStandardError": "false"
       }
@@ -1283,9 +1283,6 @@
     },
     "ReleaseToolsGitUrl": {
       "value": "https://dn-bot:$(PB_VsoPassword)@devdiv.visualstudio.com/DevDiv/_git/DotNet-Core-Release-Tools"
-    },
-    "OverridePackageSource": {
-      "value": "$(PB_SourcesDirectory)/AzureCoreFxDownload/Release"
     },
     "CLI_NUGET_API_KEY": {
       "value": ""

--- a/buildpipeline/Core-Setup-Linux-BT.json
+++ b/buildpipeline/Core-Setup-Linux-BT.json
@@ -24,6 +24,24 @@
     {
       "enabled": true,
       "continueOnError": true,
+      "alwaysRun": true,
+      "displayName": "Remove Release Tools directory",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "filename": "rm",
+        "arguments": "-rf DotNet-Core-Release-Tools",
+        "workingFolder": "",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": true,
       "alwaysRun": false,
       "displayName": "Cleanup previous build",
       "timeoutInMinutes": 0,
@@ -135,6 +153,119 @@
       "enabled": true,
       "continueOnError": false,
       "alwaysRun": false,
+      "displayName": "Clone release tools",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "filename": "git",
+        "arguments": "clone $(ReleaseToolsGitUrl)",
+        "workingFolder": "",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Create CoreFX drop directory",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "filename": "mkdir",
+        "arguments": "$(PB_SourcesDirectory)/AzureCoreFxDownload",
+        "workingFolder": "",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Download Azure Internal drop",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "6c731c3c-3c68-459a-a5c9-bde6e6595b5b",
+        "versionSpec": "2.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "scriptPath": "$(Build.SourcesDirectory)/DotNet-Core-Release-Tools/msbuildrun.sh",
+        "args": "--target DownloadFromAzure --properties ContainerName=$(Internal_CoreFX_AzureContainer),DownloadDirectory=$(PB_SourcesDirectory)/AzureCoreFxDownload,AccountName=$(Internal_CoreFX_AzureAccountName),AccessToken=$(Internal_CoreFX_AzureAccessToken),FilterBlobNames=Release/",
+        "disableAutoCwd": "false",
+        "cwd": "$(Build.SourcesDirectory)/DotNet-Core-Release-Tools",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Add CoreFX drop to NuGet.config",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "6c731c3c-3c68-459a-a5c9-bde6e6595b5b",
+        "versionSpec": "2.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "scriptPath": "$(Build.SourcesDirectory)/DotNet-Core-Release-Tools/msbuildrun.sh",
+        "args": "--target AddSourceToNuGetConfig --properties NuGetConfigFile=$(PB_SourcesDirectory)/NuGet.config,SourceName=LocalDownload,SourcePath=./AzureCoreFxDownload/Release",
+        "disableAutoCwd": "false",
+        "cwd": "$(Build.SourcesDirectory)/DotNet-Core-Release-Tools",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Copy $(PB_SourcesDirectory)/AzureCoreFxDownload/Release/pkg (*.nupkg) -> $(PB_SourcesDirectory)/AzureCoreFxDownload/Release",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "5bfb729a-a7c8-4a78-a7c3-8d717bb7c13c",
+        "versionSpec": "2.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "SourceFolder": "$(PB_SourcesDirectory)/AzureCoreFxDownload/Release/pkg",
+        "Contents": "*.nupkg",
+        "TargetFolder": "$(PB_SourcesDirectory)/AzureCoreFxDownload/Release",
+        "CleanTargetFolder": "false",
+        "OverWrite": "false",
+        "flattenFolders": "true"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Add CoreCLR drop to NuGet.config (AzureCoreFxDownload/Release/pkg)",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "6c731c3c-3c68-459a-a5c9-bde6e6595b5b",
+        "versionSpec": "2.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "scriptPath": "$(Build.SourcesDirectory)/DotNet-Core-Release-Tools/msbuildrun.sh",
+        "args": "--target AddSourceToNuGetConfig --properties NuGetConfigFile=$(PB_SourcesDirectory)/NuGet.config,SourceName=LocalDownload2,SourcePath=./AzureCoreFxDownload/Release/pkg",
+        "disableAutoCwd": "false",
+        "cwd": "$(Build.SourcesDirectory)/DotNet-Core-Release-Tools",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
       "displayName": "Build",
       "timeoutInMinutes": 0,
       "task": {
@@ -144,7 +275,7 @@
       },
       "inputs": {
         "filename": "docker",
-        "arguments": "run --rm $(PB_CrossBuildArgs)$(DockerCommonRunArgs) $(PB_GitDirectory)/build.sh -OfficialBuildId=$(OfficialBuildId) $(PB_BuildArguments)",
+        "arguments": "run --rm $(PB_CrossBuildArgs)$(DockerCommonRunArgs) $(PB_GitDirectory)/build.sh -OfficialBuildId=$(OfficialBuildId) $(PB_BuildArguments) -- /p:OverridePackageSource=$(PB_GitDirectory)/AzureCoreFxDownload/Release",
         "workingFolder": "$(PB_SourcesDirectory)",
         "failOnStandardError": "false"
       }
@@ -839,6 +970,42 @@
         "failOnStandardError": "false",
         "script": "if [ -f \"$AGENTTOOLSPATH/end.sh\" ]; then echo \"$AGENTTOOLSPATH/end.sh script found. Executing...\"; $AGENTTOOLSPATH/end.sh ; else echo \"$AGENTTOOLSPATH/end.sh script does not exist. Moving on.\" ; fi"
       }
+    },
+    {
+      "enabled": true,
+      "continueOnError": true,
+      "alwaysRun": true,
+      "displayName": "Remove Azure CoreFX drop directory",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "filename": "rm",
+        "arguments": "-rf $(PB_SourcesDirectory)/AzureCoreFxDownload",
+        "workingFolder": "",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": true,
+      "alwaysRun": true,
+      "displayName": "Remove Release Tools directory",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "filename": "rm",
+        "arguments": "-rf DotNet-Core-Release-Tools",
+        "workingFolder": "",
+        "failOnStandardError": "false"
+      }
     }
   ],
   "options": [
@@ -1086,7 +1253,7 @@
       "value": "--name $(PB_DockerContainerName)$(DockerTag_Rhel7) -v \"$(PB_SourcesDirectory):$(PB_GitDirectory)\" -v $(Build.StagingDirectory)/sharedFrameworkPublish/:/root/sharedFrameworkPublish/ -w=\"$(PB_GitDirectory)\" $(DockerImageName_Rhel7)"
     },
     "CLI_NUGET_FEED_URL": {
-      "value": "https:%2F%2Fdotnet.myget.org/F/cli-deps/api/v2/package"
+      "value": ""
     },
     "CLI_NUGET_SYMBOLS_FEED_URL": {
       "value": "https:%2F%2Fdotnet.myget.org/F/cli-deps/symbols/api/v2/package"
@@ -1103,6 +1270,25 @@
     },
     "DockerTag_Ubuntu1804": {
       "value": "ubuntu-18.04-debpkg-66216d3-20180320152209"
+    },
+    "Internal_CoreFX_AzureContainer": {
+      "value": "PassedViaPipeBuild"
+    },
+    "Internal_CoreFX_AzureAccountName": {
+      "value": "PassedViaPipeBuild"
+    },
+    "Internal_CoreFX_AzureAccessToken": {
+      "value": null,
+      "isSecret": true
+    },
+    "ReleaseToolsGitUrl": {
+      "value": "https://dn-bot:$(PB_VsoPassword)@devdiv.visualstudio.com/DevDiv/_git/DotNet-Core-Release-Tools"
+    },
+    "OverridePackageSource": {
+      "value": "$(PB_SourcesDirectory)/AzureCoreFxDownload/Release"
+    },
+    "CLI_NUGET_API_KEY": {
+      "value": ""
     }
   },
   "demands": [

--- a/buildpipeline/Core-Setup-Linux-BT.json
+++ b/buildpipeline/Core-Setup-Linux-BT.json
@@ -154,6 +154,7 @@
       "continueOnError": false,
       "alwaysRun": false,
       "displayName": "Clone release tools",
+      "condition": "ne(variables.PB_InternalBuild, 'true')",
       "timeoutInMinutes": 0,
       "task": {
         "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
@@ -172,6 +173,7 @@
       "continueOnError": false,
       "alwaysRun": false,
       "displayName": "Create CoreFX drop directory",
+      "condition": "ne(variables.PB_InternalBuild, 'true')",
       "timeoutInMinutes": 0,
       "task": {
         "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
@@ -190,6 +192,7 @@
       "continueOnError": false,
       "alwaysRun": false,
       "displayName": "Download Azure Internal drop",
+      "condition": "ne(variables.PB_InternalBuild, 'true')",
       "timeoutInMinutes": 0,
       "task": {
         "id": "6c731c3c-3c68-459a-a5c9-bde6e6595b5b",
@@ -209,6 +212,7 @@
       "continueOnError": false,
       "alwaysRun": false,
       "displayName": "Add CoreFX drop to NuGet.config",
+      "condition": "ne(variables.PB_InternalBuild, 'true')",
       "timeoutInMinutes": 0,
       "task": {
         "id": "6c731c3c-3c68-459a-a5c9-bde6e6595b5b",
@@ -228,6 +232,7 @@
       "continueOnError": false,
       "alwaysRun": false,
       "displayName": "Copy $(PB_SourcesDirectory)/AzureCoreFxDownload/Release/pkg (*.nupkg) -> $(PB_SourcesDirectory)/AzureCoreFxDownload/Release",
+      "condition": "ne(variables.PB_InternalBuild, 'true')",
       "timeoutInMinutes": 0,
       "task": {
         "id": "5bfb729a-a7c8-4a78-a7c3-8d717bb7c13c",
@@ -248,6 +253,7 @@
       "continueOnError": false,
       "alwaysRun": false,
       "displayName": "Add CoreCLR drop to NuGet.config (AzureCoreFxDownload/Release/pkg)",
+      "condition": "ne(variables.PB_InternalBuild, 'true')",
       "timeoutInMinutes": 0,
       "task": {
         "id": "6c731c3c-3c68-459a-a5c9-bde6e6595b5b",
@@ -950,6 +956,44 @@
       }
     },
     {
+      "enabled": true,
+      "continueOnError": true,
+      "alwaysRun": true,
+      "displayName": "Remove Azure CoreFX drop directory",
+      "condition": "ne(variables.PB_InternalBuild, 'true')",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "filename": "rm",
+        "arguments": "-rf $(PB_SourcesDirectory)/AzureCoreFxDownload",
+        "workingFolder": "",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": true,
+      "alwaysRun": true,
+      "displayName": "Remove Release Tools directory",
+      "condition": "ne(variables.PB_InternalBuild, 'true')",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "filename": "rm",
+        "arguments": "-rf DotNet-Core-Release-Tools",
+        "workingFolder": "",
+        "failOnStandardError": "false"
+      }
+    },
+    {
       "environment": {},
       "enabled": true,
       "continueOnError": true,
@@ -969,42 +1013,6 @@
         "cwd": "",
         "failOnStandardError": "false",
         "script": "if [ -f \"$AGENTTOOLSPATH/end.sh\" ]; then echo \"$AGENTTOOLSPATH/end.sh script found. Executing...\"; $AGENTTOOLSPATH/end.sh ; else echo \"$AGENTTOOLSPATH/end.sh script does not exist. Moving on.\" ; fi"
-      }
-    },
-    {
-      "enabled": true,
-      "continueOnError": true,
-      "alwaysRun": true,
-      "displayName": "Remove Azure CoreFX drop directory",
-      "timeoutInMinutes": 0,
-      "task": {
-        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
-        "versionSpec": "1.*",
-        "definitionType": "task"
-      },
-      "inputs": {
-        "filename": "rm",
-        "arguments": "-rf $(PB_SourcesDirectory)/AzureCoreFxDownload",
-        "workingFolder": "",
-        "failOnStandardError": "false"
-      }
-    },
-    {
-      "enabled": true,
-      "continueOnError": true,
-      "alwaysRun": true,
-      "displayName": "Remove Release Tools directory",
-      "timeoutInMinutes": 0,
-      "task": {
-        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
-        "versionSpec": "1.*",
-        "definitionType": "task"
-      },
-      "inputs": {
-        "filename": "rm",
-        "arguments": "-rf DotNet-Core-Release-Tools",
-        "workingFolder": "",
-        "failOnStandardError": "false"
       }
     }
   ],
@@ -1286,6 +1294,9 @@
     },
     "CLI_NUGET_API_KEY": {
       "value": ""
+    },
+    "PB_InternalBuild": {
+      "value": "false"
     }
   },
   "demands": [

--- a/buildpipeline/Core-Setup-OSX-BT.json
+++ b/buildpipeline/Core-Setup-OSX-BT.json
@@ -144,10 +144,10 @@
         "definitionType": "task"
       },
       "inputs": {
-        "scriptPath": "$(Build.SourcesDirectory)/DotNet-Core-Release-Tools/msbuildrun.sh",
+        "scriptPath": "$(ReleaseToolsDir)/msbuildrun.sh",
         "args": "--target DownloadFromAzure --properties ContainerName=$(Internal_CoreFX_AzureContainer),DownloadDirectory=$(PB_SourcesDirectory)/AzureCoreFxDownload,AccountName=$(Internal_CoreFX_AzureAccountName),AccessToken=$(Internal_CoreFX_AzureAccessToken),FilterBlobNames=Release/",
         "disableAutoCwd": "false",
-        "cwd": "$(Build.SourcesDirectory)/DotNet-Core-Release-Tools",
+        "cwd": "$(ReleaseToolsDir)",
         "failOnStandardError": "false"
       }
     },
@@ -164,10 +164,10 @@
         "definitionType": "task"
       },
       "inputs": {
-        "scriptPath": "$(Build.SourcesDirectory)/DotNet-Core-Release-Tools/msbuildrun.sh",
+        "scriptPath": "$(ReleaseToolsDir)/msbuildrun.sh",
         "args": "--target AddSourceToNuGetConfig --properties NuGetConfigFile=$(PB_SourcesDirectory)/NuGet.config,SourceName=LocalDownload,SourcePath=./AzureCoreFxDownload/Release",
         "disableAutoCwd": "false",
-        "cwd": "$(Build.SourcesDirectory)/DotNet-Core-Release-Tools",
+        "cwd": "$(ReleaseToolsDir)",
         "failOnStandardError": "false"
       }
     },
@@ -205,10 +205,10 @@
         "definitionType": "task"
       },
       "inputs": {
-        "scriptPath": "$(Build.SourcesDirectory)/DotNet-Core-Release-Tools/msbuildrun.sh",
+        "scriptPath": "$(ReleaseToolsDir)/msbuildrun.sh",
         "args": "--target AddSourceToNuGetConfig --properties NuGetConfigFile=$(PB_SourcesDirectory)/NuGet.config,SourceName=LocalDownload2,SourcePath=./AzureCoreFxDownload/Release/pkg",
         "disableAutoCwd": "false",
-        "cwd": "$(Build.SourcesDirectory)/DotNet-Core-Release-Tools",
+        "cwd": "$(ReleaseToolsDir)",
         "failOnStandardError": "false"
       }
     },
@@ -447,6 +447,9 @@
     },
     "ReleaseToolsGitUrl": {
       "value": "https://dn-bot:$(PB_VsoPassword)@devdiv.visualstudio.com/DevDiv/_git/DotNet-Core-Release-Tools"
+    },
+    "ReleaseToolsDir": {
+      "value": "$(Build.SourcesDirectory)/DotNet-Core-Release-Tools"
     },
     "PB_InternalBuild": {
       "value": "false"

--- a/buildpipeline/Core-Setup-OSX-BT.json
+++ b/buildpipeline/Core-Setup-OSX-BT.json
@@ -24,6 +24,24 @@
     {
       "enabled": true,
       "continueOnError": true,
+      "alwaysRun": true,
+      "displayName": "Remove Release Tools directory",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "filename": "rm",
+        "arguments": "-rf DotNet-Core-Release-Tools",
+        "workingFolder": "",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": true,
       "alwaysRun": false,
       "displayName": "Cleanup previous build",
       "timeoutInMinutes": 0,
@@ -72,6 +90,119 @@
         "filename": "git",
         "arguments": "checkout $(SourceVersion)",
         "workingFolder": "$(PB_SourcesDirectory)",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Clone release tools",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "filename": "git",
+        "arguments": "clone $(ReleaseToolsGitUrl)",
+        "workingFolder": "",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Create CoreFX drop directory",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "filename": "mkdir",
+        "arguments": "$(PB_SourcesDirectory)/AzureCoreFxDownload",
+        "workingFolder": "",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Download Azure Internal drop",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "6c731c3c-3c68-459a-a5c9-bde6e6595b5b",
+        "versionSpec": "2.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "scriptPath": "$(Build.SourcesDirectory)/DotNet-Core-Release-Tools/msbuildrun.sh",
+        "args": "--target DownloadFromAzure --properties ContainerName=$(Internal_CoreFX_AzureContainer),DownloadDirectory=$(PB_SourcesDirectory)/AzureCoreFxDownload,AccountName=$(Internal_CoreFX_AzureAccountName),AccessToken=$(Internal_CoreFX_AzureAccessToken),FilterBlobNames=Release/",
+        "disableAutoCwd": "false",
+        "cwd": "$(Build.SourcesDirectory)/DotNet-Core-Release-Tools",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Add CoreFX drop to NuGet.config",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "6c731c3c-3c68-459a-a5c9-bde6e6595b5b",
+        "versionSpec": "2.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "scriptPath": "$(Build.SourcesDirectory)/DotNet-Core-Release-Tools/msbuildrun.sh",
+        "args": "--target AddSourceToNuGetConfig --properties NuGetConfigFile=$(PB_SourcesDirectory)/NuGet.config,SourceName=LocalDownload,SourcePath=./AzureCoreFxDownload/Release",
+        "disableAutoCwd": "false",
+        "cwd": "$(Build.SourcesDirectory)/DotNet-Core-Release-Tools",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Copy $(PB_SourcesDirectory)/AzureCoreFxDownload/Release/pkg (*.nupkg) -> $(PB_SourcesDirectory)/AzureCoreFxDownload/Release",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "5bfb729a-a7c8-4a78-a7c3-8d717bb7c13c",
+        "versionSpec": "2.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "SourceFolder": "$(PB_SourcesDirectory)/AzureCoreFxDownload/Release/pkg",
+        "Contents": "*.nupkg",
+        "TargetFolder": "$(PB_SourcesDirectory)/AzureCoreFxDownload/Release",
+        "CleanTargetFolder": "false",
+        "OverWrite": "false",
+        "flattenFolders": "true"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Add CoreCLR drop to NuGet.config (AzureCoreFxDownload/Release/pkg)",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "6c731c3c-3c68-459a-a5c9-bde6e6595b5b",
+        "versionSpec": "2.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "scriptPath": "$(Build.SourcesDirectory)/DotNet-Core-Release-Tools/msbuildrun.sh",
+        "args": "--target AddSourceToNuGetConfig --properties NuGetConfigFile=$(PB_SourcesDirectory)/NuGet.config,SourceName=LocalDownload2,SourcePath=./AzureCoreFxDownload/Release/pkg",
+        "disableAutoCwd": "false",
+        "cwd": "$(Build.SourcesDirectory)/DotNet-Core-Release-Tools",
         "failOnStandardError": "false"
       }
     },
@@ -131,6 +262,42 @@
         "cwd": "",
         "failOnStandardError": "false",
         "script": "if [ -f \"$AGENTTOOLSPATH/end.sh\" ]; then echo \"$AGENTTOOLSPATH/end.sh script found. Executing...\"; $AGENTTOOLSPATH/end.sh ; else echo \"$AGENTTOOLSPATH/end.sh script does not exist. Moving on.\" ; fi"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": true,
+      "alwaysRun": true,
+      "displayName": "Remove Azure CoreFX drop directory",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "filename": "rm",
+        "arguments": "-rf $(PB_SourcesDirectory)/AzureCoreFxDownload",
+        "workingFolder": "",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": true,
+      "alwaysRun": true,
+      "displayName": "Remove Release Tools directory",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "filename": "rm",
+        "arguments": "-rf DotNet-Core-Release-Tools",
+        "workingFolder": "",
+        "failOnStandardError": "false"
       }
     }
   ],
@@ -259,6 +426,22 @@
     },
     "PB_PortableBuild": {
       "value": "true"
+    },
+    "Internal_CoreFX_AzureContainer": {
+      "value": "PassedViaPipeBuild"
+    },
+    "Internal_CoreFX_AzureAccountName": {
+      "value": "PassedViaPipeBuild"
+    },
+    "Internal_CoreFX_AzureAccessToken": {
+      "value": null,
+      "isSecret": true
+    },
+    "ReleaseToolsGitUrl": {
+      "value": "https://dn-bot:$(PB_VsoPassword)@devdiv.visualstudio.com/DevDiv/_git/DotNet-Core-Release-Tools"
+    },
+    "OverridePackageSource": {
+      "value": "$(PB_SourcesDirectory)/AzureCoreFxDownload/Release"
     }
   },
   "demands": [

--- a/buildpipeline/Core-Setup-OSX-BT.json
+++ b/buildpipeline/Core-Setup-OSX-BT.json
@@ -98,6 +98,7 @@
       "continueOnError": false,
       "alwaysRun": false,
       "displayName": "Clone release tools",
+      "condition": "ne(variables.PB_InternalBuild, 'true')",
       "timeoutInMinutes": 0,
       "task": {
         "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
@@ -116,6 +117,7 @@
       "continueOnError": false,
       "alwaysRun": false,
       "displayName": "Create CoreFX drop directory",
+      "condition": "ne(variables.PB_InternalBuild, 'true')",
       "timeoutInMinutes": 0,
       "task": {
         "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
@@ -134,6 +136,7 @@
       "continueOnError": false,
       "alwaysRun": false,
       "displayName": "Download Azure Internal drop",
+      "condition": "ne(variables.PB_InternalBuild, 'true')",
       "timeoutInMinutes": 0,
       "task": {
         "id": "6c731c3c-3c68-459a-a5c9-bde6e6595b5b",
@@ -153,6 +156,7 @@
       "continueOnError": false,
       "alwaysRun": false,
       "displayName": "Add CoreFX drop to NuGet.config",
+      "condition": "ne(variables.PB_InternalBuild, 'true')",
       "timeoutInMinutes": 0,
       "task": {
         "id": "6c731c3c-3c68-459a-a5c9-bde6e6595b5b",
@@ -172,6 +176,7 @@
       "continueOnError": false,
       "alwaysRun": false,
       "displayName": "Copy $(PB_SourcesDirectory)/AzureCoreFxDownload/Release/pkg (*.nupkg) -> $(PB_SourcesDirectory)/AzureCoreFxDownload/Release",
+      "condition": "ne(variables.PB_InternalBuild, 'true')",
       "timeoutInMinutes": 0,
       "task": {
         "id": "5bfb729a-a7c8-4a78-a7c3-8d717bb7c13c",
@@ -192,6 +197,7 @@
       "continueOnError": false,
       "alwaysRun": false,
       "displayName": "Add CoreCLR drop to NuGet.config (AzureCoreFxDownload/Release/pkg)",
+      "condition": "ne(variables.PB_InternalBuild, 'true')",
       "timeoutInMinutes": 0,
       "task": {
         "id": "6c731c3c-3c68-459a-a5c9-bde6e6595b5b",
@@ -243,6 +249,44 @@
       }
     },
     {
+      "enabled": true,
+      "continueOnError": true,
+      "alwaysRun": true,
+      "displayName": "Remove Azure CoreFX drop directory",
+      "condition": "ne(variables.PB_InternalBuild, 'true')",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "filename": "rm",
+        "arguments": "-rf $(PB_SourcesDirectory)/AzureCoreFxDownload",
+        "workingFolder": "",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": true,
+      "alwaysRun": true,
+      "displayName": "Remove Release Tools directory",
+      "condition": "ne(variables.PB_InternalBuild, 'true')",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "filename": "rm",
+        "arguments": "-rf DotNet-Core-Release-Tools",
+        "workingFolder": "",
+        "failOnStandardError": "false"
+      }
+    },
+    {
       "environment": {},
       "enabled": true,
       "continueOnError": true,
@@ -262,42 +306,6 @@
         "cwd": "",
         "failOnStandardError": "false",
         "script": "if [ -f \"$AGENTTOOLSPATH/end.sh\" ]; then echo \"$AGENTTOOLSPATH/end.sh script found. Executing...\"; $AGENTTOOLSPATH/end.sh ; else echo \"$AGENTTOOLSPATH/end.sh script does not exist. Moving on.\" ; fi"
-      }
-    },
-    {
-      "enabled": true,
-      "continueOnError": true,
-      "alwaysRun": true,
-      "displayName": "Remove Azure CoreFX drop directory",
-      "timeoutInMinutes": 0,
-      "task": {
-        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
-        "versionSpec": "1.*",
-        "definitionType": "task"
-      },
-      "inputs": {
-        "filename": "rm",
-        "arguments": "-rf $(PB_SourcesDirectory)/AzureCoreFxDownload",
-        "workingFolder": "",
-        "failOnStandardError": "false"
-      }
-    },
-    {
-      "enabled": true,
-      "continueOnError": true,
-      "alwaysRun": true,
-      "displayName": "Remove Release Tools directory",
-      "timeoutInMinutes": 0,
-      "task": {
-        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
-        "versionSpec": "1.*",
-        "definitionType": "task"
-      },
-      "inputs": {
-        "filename": "rm",
-        "arguments": "-rf DotNet-Core-Release-Tools",
-        "workingFolder": "",
-        "failOnStandardError": "false"
       }
     }
   ],
@@ -440,8 +448,8 @@
     "ReleaseToolsGitUrl": {
       "value": "https://dn-bot:$(PB_VsoPassword)@devdiv.visualstudio.com/DevDiv/_git/DotNet-Core-Release-Tools"
     },
-    "OverridePackageSource": {
-      "value": "$(PB_SourcesDirectory)/AzureCoreFxDownload/Release"
+    "PB_InternalBuild": {
+      "value": "false"
     }
   },
   "demands": [

--- a/buildpipeline/Core-Setup-Publish.json
+++ b/buildpipeline/Core-Setup-Publish.json
@@ -279,7 +279,7 @@
       "allowOverride": true
     },
     "NUGET_FEED_URL": {
-      "value": "https:%2F%2Fdotnet.myget.org/F/dotnet-core/api/v2/package"
+      "value": ""
     },
     "NUGET_API_KEY": {
       "value": null,
@@ -290,7 +290,7 @@
       "isSecret": true
     },
     "NUGET_SYMBOLS_FEED_URL": {
-      "value": "https:%2F%2Fdotnet.myget.org/F/dotnet-core/symbols/api/v2/package"
+      "value": ""
     },
     "PB_SourcesDirectory": {
       "value": "$(Build.SourcesDirectory)\\core-setup"
@@ -346,7 +346,7 @@
     },
     "PB_VersionsRepo": {
       "value": "versions"
-    },    
+    },
     "PB_RepoName": {
       "value": "core-setup"
     },

--- a/buildpipeline/Core-Setup-Windows-Arm-BT.json
+++ b/buildpipeline/Core-Setup-Windows-Arm-BT.json
@@ -26,6 +26,26 @@
     {
       "enabled": true,
       "continueOnError": true,
+      "alwaysRun": true,
+      "displayName": "Remove Release Tools directory",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "e213ff0f-5d5c-4791-802d-52ea3e7be1f1",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "scriptType": "inlineScript",
+        "scriptName": "",
+        "arguments": "",
+        "workingFolder": "",
+        "inlineScript": "rm -Recurse -Force -ErrorAction Ignore DotNet-Core-Release-Tools",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": true,
       "alwaysRun": false,
       "displayName": "Cleanup previous build if present",
       "timeoutInMinutes": 0,
@@ -77,6 +97,122 @@
         "arguments": "checkout $(SourceVersion)",
         "workingFolder": "$(PB_SourcesDirectory)",
         "failOnStandardError": "false"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Clone release tools",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "filename": "git",
+        "arguments": "clone $(ReleaseToolsGitUrl)",
+        "workingFolder": "",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Create CoreFX drop directory",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "filename": "mkdir",
+        "arguments": "$(PB_SourcesDirectory)\\AzureCoreFxDownload",
+        "workingFolder": "",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Download Azure Internal drop",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "e213ff0f-5d5c-4791-802d-52ea3e7be1f1",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "scriptType": "filePath",
+        "scriptName": "DotNet-Core-Release-Tools/msbuildrun.ps1",
+        "arguments": "-RepositoryRoot $(Build.SourcesDirectory)\\DotNet-Core-Release-Tools -Target DownloadFromAzure -Properties ContainerName=$(Internal_CoreFX_AzureContainer),DownloadDirectory=$(PB_SourcesDirectory)\\AzureCoreFxDownload,AccountName=$(Internal_CoreFX_AzureAccountName),AccessToken=$(Internal_CoreFX_AzureAccessToken),FilterBlobNames=Release/",
+        "inlineScript": "# You can write your powershell scripts inline here. \n# You can also pass predefined and custom variables to this scripts using arguments\n\n Write-Host \"Hello World\"",
+        "workingFolder": "",
+        "failOnStandardError": "true"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Add CoreFX drop to NuGet.config",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "e213ff0f-5d5c-4791-802d-52ea3e7be1f1",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "scriptType": "filePath",
+        "scriptName": "DotNet-Core-Release-Tools/msbuildrun.ps1",
+        "arguments": "-RepositoryRoot $(Build.SourcesDirectory)\\DotNet-Core-Release-Tools -Target AddSourceToNuGetConfig -Properties NuGetConfigFile=$(PB_SourcesDirectory)\\NuGet.config,SourceName=LocalDownload,SourcePath=$(PB_SourcesDirectory)\\AzureCoreFxDownload\\Release",
+        "inlineScript": "# You can write your powershell scripts inline here. \n# You can also pass predefined and custom variables to this scripts using arguments\n\n Write-Host \"Hello World\"",
+        "workingFolder": "",
+        "failOnStandardError": "true"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Copy $(PB_SourcesDirectory)/AzureCoreFxDownload/Release/pkg (*.nupkg) -> $(PB_SourcesDirectory)/AzureCoreFxDownload/Release",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "5bfb729a-a7c8-4a78-a7c3-8d717bb7c13c",
+        "versionSpec": "2.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "SourceFolder": "$(PB_SourcesDirectory)\\AzureCoreFxDownload\\Release\\pkg",
+        "Contents": "*.nupkg",
+        "TargetFolder": "$(PB_SourcesDirectory)\\AzureCoreFxDownload\\Release",
+        "CleanTargetFolder": "false",
+        "OverWrite": "false",
+        "flattenFolders": "true"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Add CoreCLR drop to NuGet.config (AzureCoreFxDownload/Release/pkg)",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "e213ff0f-5d5c-4791-802d-52ea3e7be1f1",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "scriptType": "filePath",
+        "scriptName": "DotNet-Core-Release-Tools/msbuildrun.ps1",
+        "arguments": "-RepositoryRoot $(Build.SourcesDirectory)\\DotNet-Core-Release-Tools -Target AddSourceToNuGetConfig -Properties NuGetConfigFile=$(PB_SourcesDirectory)\\NuGet.config,SourceName=LocalDownload2,SourcePath=$(Build.SourcesDirectory)\\AzureCoreFxDownload\\Release\\pkg",
+        "inlineScript": "",
+        "workingFolder": "",
+        "failOnStandardError": "true"
       }
     },
     {
@@ -301,6 +437,42 @@
       }
     },
     {
+      "enabled": true,
+      "continueOnError": true,
+      "alwaysRun": true,
+      "displayName": "Remove Release Tools directory",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "filename": "rmdir",
+        "arguments": "/q /s DotNet-Core-Release-Tools",
+        "workingFolder": "",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": true,
+      "alwaysRun": true,
+      "displayName": "Remove Azure CoreFX drop directory",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "filename": "rmdir",
+        "arguments": "/q /s $(PB_SourcesDirectory)\\AzureCoreFxDownload",
+        "workingFolder": "",
+        "failOnStandardError": "false"
+      }
+    },
+    {
       "environment": {},
       "enabled": true,
       "continueOnError": true,
@@ -485,6 +657,22 @@
     },
     "PB_BuildFullPlatformManifest": {
       "value": "false"
+    },
+    "Internal_CoreFX_AzureContainer": {
+      "value": "PassedViaPipeBuild"
+    },
+    "Internal_CoreFX_AzureAccountName": {
+      "value": "PassedViaPipeBuild"
+    },
+    "Internal_CoreFX_AzureAccessToken": {
+      "value": null,
+      "isSecret": true
+    },
+    "ReleaseToolsGitUrl": {
+      "value": "https://dn-bot:$(PB_VsoPassword)@devdiv.visualstudio.com/DevDiv/_git/DotNet-Core-Release-Tools"
+    },
+    "OverridePackageSource": {
+      "value": "$(PB_SourcesDirectory)\\AzureCoreFxDownload\\Release"
     }
   },
   "demands": [

--- a/buildpipeline/Core-Setup-Windows-Arm-BT.json
+++ b/buildpipeline/Core-Setup-Windows-Arm-BT.json
@@ -104,6 +104,7 @@
       "continueOnError": false,
       "alwaysRun": false,
       "displayName": "Clone release tools",
+      "condition": "ne(variables.PB_InternalBuild, 'true')",
       "timeoutInMinutes": 0,
       "task": {
         "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
@@ -122,6 +123,7 @@
       "continueOnError": false,
       "alwaysRun": false,
       "displayName": "Create CoreFX drop directory",
+      "condition": "ne(variables.PB_InternalBuild, 'true')",
       "timeoutInMinutes": 0,
       "task": {
         "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
@@ -140,6 +142,7 @@
       "continueOnError": false,
       "alwaysRun": false,
       "displayName": "Download Azure Internal drop",
+      "condition": "ne(variables.PB_InternalBuild, 'true')",
       "timeoutInMinutes": 0,
       "task": {
         "id": "e213ff0f-5d5c-4791-802d-52ea3e7be1f1",
@@ -160,6 +163,7 @@
       "continueOnError": false,
       "alwaysRun": false,
       "displayName": "Add CoreFX drop to NuGet.config",
+      "condition": "ne(variables.PB_InternalBuild, 'true')",
       "timeoutInMinutes": 0,
       "task": {
         "id": "e213ff0f-5d5c-4791-802d-52ea3e7be1f1",
@@ -180,6 +184,7 @@
       "continueOnError": false,
       "alwaysRun": false,
       "displayName": "Copy $(PB_SourcesDirectory)/AzureCoreFxDownload/Release/pkg (*.nupkg) -> $(PB_SourcesDirectory)/AzureCoreFxDownload/Release",
+      "condition": "ne(variables.PB_InternalBuild, 'true')",
       "timeoutInMinutes": 0,
       "task": {
         "id": "5bfb729a-a7c8-4a78-a7c3-8d717bb7c13c",
@@ -200,6 +205,7 @@
       "continueOnError": false,
       "alwaysRun": false,
       "displayName": "Add CoreCLR drop to NuGet.config (AzureCoreFxDownload/Release/pkg)",
+      "condition": "ne(variables.PB_InternalBuild, 'true')",
       "timeoutInMinutes": 0,
       "task": {
         "id": "e213ff0f-5d5c-4791-802d-52ea3e7be1f1",
@@ -441,6 +447,7 @@
       "continueOnError": true,
       "alwaysRun": true,
       "displayName": "Remove Release Tools directory",
+      "condition": "ne(variables.PB_InternalBuild, 'true')",
       "timeoutInMinutes": 0,
       "task": {
         "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
@@ -459,6 +466,7 @@
       "continueOnError": true,
       "alwaysRun": true,
       "displayName": "Remove Azure CoreFX drop directory",
+      "condition": "ne(variables.PB_InternalBuild, 'true')",
       "timeoutInMinutes": 0,
       "task": {
         "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
@@ -671,8 +679,8 @@
     "ReleaseToolsGitUrl": {
       "value": "https://dn-bot:$(PB_VsoPassword)@devdiv.visualstudio.com/DevDiv/_git/DotNet-Core-Release-Tools"
     },
-    "OverridePackageSource": {
-      "value": "$(PB_SourcesDirectory)\\AzureCoreFxDownload\\Release"
+    "PB_InternalBuild": {
+      "value": "false"
     }
   },
   "demands": [

--- a/buildpipeline/Core-Setup-Windows-BT.json
+++ b/buildpipeline/Core-Setup-Windows-BT.json
@@ -26,6 +26,26 @@
     {
       "enabled": true,
       "continueOnError": true,
+      "alwaysRun": true,
+      "displayName": "Remove Release Tools directory",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "e213ff0f-5d5c-4791-802d-52ea3e7be1f1",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "scriptType": "inlineScript",
+        "scriptName": "",
+        "arguments": "",
+        "workingFolder": "",
+        "inlineScript": "rm -Recurse -Force -ErrorAction Ignore DotNet-Core-Release-Tools",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": true,
       "alwaysRun": false,
       "displayName": "Cleanup previous build if present",
       "timeoutInMinutes": 0,
@@ -77,6 +97,122 @@
         "arguments": "checkout $(SourceVersion)",
         "workingFolder": "$(PB_SourcesDirectory)",
         "failOnStandardError": "false"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Clone release tools",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "filename": "git",
+        "arguments": "clone $(ReleaseToolsGitUrl)",
+        "workingFolder": "",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Create CoreFX drop directory",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "filename": "mkdir",
+        "arguments": "$(PB_SourcesDirectory)\\AzureCoreFxDownload",
+        "workingFolder": "",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Download Azure Internal drop",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "e213ff0f-5d5c-4791-802d-52ea3e7be1f1",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "scriptType": "filePath",
+        "scriptName": "DotNet-Core-Release-Tools/msbuildrun.ps1",
+        "arguments": "-RepositoryRoot $(Build.SourcesDirectory)\\DotNet-Core-Release-Tools -Target DownloadFromAzure -Properties ContainerName=$(Internal_CoreFX_AzureContainer),DownloadDirectory=$(PB_SourcesDirectory)\\AzureCoreFxDownload,AccountName=$(Internal_CoreFX_AzureAccountName),AccessToken=$(Internal_CoreFX_AzureAccessToken),FilterBlobNames=Release/",
+        "inlineScript": "# You can write your powershell scripts inline here. \n# You can also pass predefined and custom variables to this scripts using arguments\n\n Write-Host \"Hello World\"",
+        "workingFolder": "",
+        "failOnStandardError": "true"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Add CoreFX drop to NuGet.config",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "e213ff0f-5d5c-4791-802d-52ea3e7be1f1",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "scriptType": "filePath",
+        "scriptName": "DotNet-Core-Release-Tools/msbuildrun.ps1",
+        "arguments": "-RepositoryRoot $(Build.SourcesDirectory)\\DotNet-Core-Release-Tools -Target AddSourceToNuGetConfig -Properties NuGetConfigFile=$(PB_SourcesDirectory)\\NuGet.config,SourceName=LocalDownload,SourcePath=$(PB_SourcesDirectory)\\AzureCoreFxDownload\\Release",
+        "inlineScript": "# You can write your powershell scripts inline here. \n# You can also pass predefined and custom variables to this scripts using arguments\n\n Write-Host \"Hello World\"",
+        "workingFolder": "",
+        "failOnStandardError": "true"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Copy $(PB_SourcesDirectory)/AzureCoreFxDownload/Release/pkg (*.nupkg) -> $(PB_SourcesDirectory)/AzureCoreFxDownload/Release",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "5bfb729a-a7c8-4a78-a7c3-8d717bb7c13c",
+        "versionSpec": "2.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "SourceFolder": "$(PB_SourcesDirectory)\\AzureCoreFxDownload\\Release\\pkg",
+        "Contents": "*.nupkg",
+        "TargetFolder": "$(PB_SourcesDirectory)\\AzureCoreFxDownload\\Release",
+        "CleanTargetFolder": "false",
+        "OverWrite": "false",
+        "flattenFolders": "true"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Add CoreCLR drop to NuGet.config (AzureCoreFxDownload/Release/pkg)",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "e213ff0f-5d5c-4791-802d-52ea3e7be1f1",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "scriptType": "filePath",
+        "scriptName": "DotNet-Core-Release-Tools/msbuildrun.ps1",
+        "arguments": "-RepositoryRoot $(Build.SourcesDirectory)\\DotNet-Core-Release-Tools -Target AddSourceToNuGetConfig -Properties NuGetConfigFile=$(PB_SourcesDirectory)\\NuGet.config,SourceName=LocalDownload2,SourcePath=$(Build.SourcesDirectory)\\AzureCoreFxDownload\\Release\\pkg",
+        "inlineScript": "",
+        "workingFolder": "",
+        "failOnStandardError": "true"
       }
     },
     {
@@ -490,6 +626,42 @@
       }
     },
     {
+      "enabled": true,
+      "continueOnError": true,
+      "alwaysRun": true,
+      "displayName": "Remove Release Tools directory",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "filename": "rmdir",
+        "arguments": "/q /s DotNet-Core-Release-Tools",
+        "workingFolder": "",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": true,
+      "alwaysRun": true,
+      "displayName": "Remove Azure CoreFX drop directory",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "filename": "rmdir",
+        "arguments": "/q /s $(PB_SourcesDirectory)\\AzureCoreFxDownload",
+        "workingFolder": "",
+        "failOnStandardError": "false"
+      }
+    },
+    {
       "environment": {},
       "enabled": true,
       "continueOnError": true,
@@ -589,7 +761,7 @@
       "value": "true"
     },
     "NUGET_FEED_URL": {
-      "value": "https:%2F%2Fdotnet.myget.org/F/dotnet-core/api/v2/package"
+      "value": ""
     },
     "NUGET_API_KEY": {
       "value": "PassedViaPipeBuild"
@@ -620,7 +792,7 @@
       "allowOverride": true
     },
     "NUGET_SYMBOLS_FEED_URL": {
-      "value": "https:%2F%2Fdotnet.myget.org/F/dotnet-core/symbols/api/v2/package"
+      "value": ""
     },
     "PB_SourcesDirectory": {
       "value": "$(Build.SourcesDirectory)\\core-setup"
@@ -683,6 +855,22 @@
     },
     "PB_BuildFullPlatformManifest": {
       "value": "false"
+    },
+    "Internal_CoreFX_AzureContainer": {
+      "value": "PassedViaPipeBuild"
+    },
+    "Internal_CoreFX_AzureAccountName": {
+      "value": "PassedViaPipeBuild"
+    },
+    "Internal_CoreFX_AzureAccessToken": {
+      "value": null,
+      "isSecret": true
+    },
+    "ReleaseToolsGitUrl": {
+      "value": "https://dn-bot:$(PB_VsoPassword)@devdiv.visualstudio.com/DevDiv/_git/DotNet-Core-Release-Tools"
+    },
+    "OverridePackageSource": {
+      "value": "$(PB_SourcesDirectory)\\AzureCoreFxDownload\\Release"
     }
   },
   "demands": [

--- a/buildpipeline/Core-Setup-Windows-BT.json
+++ b/buildpipeline/Core-Setup-Windows-BT.json
@@ -104,6 +104,7 @@
       "continueOnError": false,
       "alwaysRun": false,
       "displayName": "Clone release tools",
+      "condition": "ne(variables.PB_InternalBuild, 'true')",
       "timeoutInMinutes": 0,
       "task": {
         "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
@@ -122,6 +123,7 @@
       "continueOnError": false,
       "alwaysRun": false,
       "displayName": "Create CoreFX drop directory",
+      "condition": "ne(variables.PB_InternalBuild, 'true')",
       "timeoutInMinutes": 0,
       "task": {
         "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
@@ -140,6 +142,7 @@
       "continueOnError": false,
       "alwaysRun": false,
       "displayName": "Download Azure Internal drop",
+      "condition": "ne(variables.PB_InternalBuild, 'true')",
       "timeoutInMinutes": 0,
       "task": {
         "id": "e213ff0f-5d5c-4791-802d-52ea3e7be1f1",
@@ -160,6 +163,7 @@
       "continueOnError": false,
       "alwaysRun": false,
       "displayName": "Add CoreFX drop to NuGet.config",
+      "condition": "ne(variables.PB_InternalBuild, 'true')",
       "timeoutInMinutes": 0,
       "task": {
         "id": "e213ff0f-5d5c-4791-802d-52ea3e7be1f1",
@@ -180,6 +184,7 @@
       "continueOnError": false,
       "alwaysRun": false,
       "displayName": "Copy $(PB_SourcesDirectory)/AzureCoreFxDownload/Release/pkg (*.nupkg) -> $(PB_SourcesDirectory)/AzureCoreFxDownload/Release",
+      "condition": "ne(variables.PB_InternalBuild, 'true')",
       "timeoutInMinutes": 0,
       "task": {
         "id": "5bfb729a-a7c8-4a78-a7c3-8d717bb7c13c",
@@ -200,6 +205,7 @@
       "continueOnError": false,
       "alwaysRun": false,
       "displayName": "Add CoreCLR drop to NuGet.config (AzureCoreFxDownload/Release/pkg)",
+      "condition": "ne(variables.PB_InternalBuild, 'true')",
       "timeoutInMinutes": 0,
       "task": {
         "id": "e213ff0f-5d5c-4791-802d-52ea3e7be1f1",
@@ -630,6 +636,7 @@
       "continueOnError": true,
       "alwaysRun": true,
       "displayName": "Remove Release Tools directory",
+      "condition": "ne(variables.PB_InternalBuild, 'true')",
       "timeoutInMinutes": 0,
       "task": {
         "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
@@ -648,6 +655,7 @@
       "continueOnError": true,
       "alwaysRun": true,
       "displayName": "Remove Azure CoreFX drop directory",
+      "condition": "ne(variables.PB_InternalBuild, 'true')",
       "timeoutInMinutes": 0,
       "task": {
         "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
@@ -869,8 +877,8 @@
     "ReleaseToolsGitUrl": {
       "value": "https://dn-bot:$(PB_VsoPassword)@devdiv.visualstudio.com/DevDiv/_git/DotNet-Core-Release-Tools"
     },
-    "OverridePackageSource": {
-      "value": "$(PB_SourcesDirectory)\\AzureCoreFxDownload\\Release"
+    "PB_InternalBuild": {
+      "value": "false"
     }
   },
   "demands": [


### PR DESCRIPTION
This ports the changes from the ReleaseTools branch into the open, allowing us to run our internal builds against the same definitions as our normal builds (rather than maintaining two separate sets of build definitions).

This will also require passing the following from the internal pipebuild:
 `PB_InternalBuild=true` 
`OverridePackageSource=/p:OverridePackageSource=$(PB_GitDirectory)/AzureCoreFxDownload/Release`
`PB_GitDirectory=/root/coresetup`

And the following from the non-internal pipebuild:
`CLI_NUGET_FEED_URL=https:%2F%2Fdotnet.myget.org/F/cli-deps/api/v2/package`
`NUGET_FEED_URL=https:%2F%2Fdotnet.myget.org/F/dotnet-core/api/v2/package`
`NUGET_SYMBOLS_FEED_URL=https:%2F%2Fdotnet.myget.org/F/dotnet-core/symbols/api/v2/package`

@dagood @weshaggard PTAL