### PR TITLE
Add startup hook design document

### DIFF
--- a/Documentation/design-docs/host-startup-hook.md
+++ b/Documentation/design-docs/host-startup-hook.md
@@ -198,7 +198,8 @@ method, so thread state will persist between startup hooks. The
 threading apartment state will be set based on any attributes present
 in the `Main` method of the app, before startup hooks execute. As a
 result, attemps to explicitly set the thread apartment state in a
-startup hook will likely fail.
+startup hook will fail if the requested state is incompatible with the
+app's threading state.
 
 While it may make sense to set global behavior in startup hooks, it is
 not recommended to use the thread state as a communication mechanism

--- a/Documentation/design-docs/host-startup-hook.md
+++ b/Documentation/design-docs/host-startup-hook.md
@@ -72,7 +72,7 @@ assemblies that are on the TPA list from a different location. Future
 changes to `AssemblyLoadContext` could make this easier to use by
 making the default load context or TPA list modifiable.
 
-```
+```c#
 namespace SharedHostPolicy
 {
     class SharedHostInitializer
@@ -106,36 +106,26 @@ trace. They fall into the following categories:
 - Errors detected eagerly, with exceptions thrown before the execution
   of any startup hook.
 
--- Invalid syntax. This will throw an `ArgumentException` with "The
-  syntax of the startup hook variable was invalid.".
+  - Invalid syntax throws an `ArgumentException`.
 
--- Partially qualified path in the startup hook. This will throw an
-   `ArgumentException` with "Absolute path information is required.".
+  - Partially qualified paths in the startup hook throw an
+    `ArgumentException`.
 
 - Exceptions thrown during the call to a given startup hook. Previous
   hooks may have run successfully.
 
--- Missing startup hook assembly. This will throw a
-   `FileNotFoundException` with "Could not load file or assembly
-   '<assemblyPath>'".
+  - Missing startup hook assemblies throw a `FileNotFoundException`.
 
--- Invalid startup hook assembly. This will throw a
-   `BadImageFormatException` with the startup hook path on the stack
-   trace.
+  - Invalid startup hook assemblies throw a `BadImageFormatException`.
 
--- Missing startup hook type. This will throw a `TypeLoadException`
-   with "Could not load type '<specifiedType>' from assembly
-   '<assemblyName>'".
+  - Missing startup hook types throw a `TypeLoadException`.
 
--- Missing `Initialize` method in startup hook. This will throw a
-   `MissingMethodException` with "Method '<specifiedType>.Initialize'
-   not found.".
+  - Missing `Initialize` methods in startup hooks throw a
+    `MissingMethodException`.
 
--- Invalid `Initialize` method (with an incorrect signature - one that
-   takes parameters, has a non-void return type, is not public, or is
-   not static). This will throw an `ArgumentException` with "The
-   signature of the startup hook '<specifiedType>.Initialize was
-   invalid. It must be 'public static void Initialize()'.
+  - Invalid `Initialize` methods (with an incorrect signature - that
+    take parameters, have a non-void return type, are not public, or
+    are not static) throw an `ArgumentException`.
 
 ## Guidance and caveats
 
@@ -145,12 +135,11 @@ need for this kind of power. It should only be used in situations
 where modifying application code is not an option and there is not an
 existing structured dependency injection framework in place. An
 example of such a use case is a hook that injects logging, telemetry,
-or profiling into an existing deployed application at run tim.e
+or profiling into an existing deployed application at runtime.
 
 It is prone to ordering issues when multiple hooks are used, and does
 nothing to attempt to make dependencies of hooks easy to
-manage. Multiple hooks, if used, should be fairly independent of each
-other.
+manage. Multiple hooks should be independent of each other.
 
 ### No built-in solution to ordering issues
 
@@ -163,9 +152,9 @@ framework that gives independently-owned components access to shared
 resources - often dependency injection frameworks will have a
 dependency manager that loads components in a specific order. If this
 kind of behavior is required, a proper dependency injection framework
-should be used instead of multpile startup hooks.
+should be used instead of multiple startup hooks.
 
-## No dependency resolution for non-app assemblies
+### No dependency resolution for non-app assemblies
 
 Another example regarding hook dependencies: the startup hook dll must
 not depend on any assemblies outside of the app's TPA list. If a
@@ -176,7 +165,7 @@ startup hooks. Any startup hook that wants to modify load behavior
 will have to use framework APIs like AssemblyLoadContexts to do this
 manually.
 
-## No conflict resolution for dependencies shared by hooks or the app
+### No conflict resolution for dependencies shared by hooks or the app
 
 If a startup hook decides to do something dangerous like force the
 load of a particular assembly, any later hooks (or the entry point)
@@ -184,7 +173,7 @@ that run in the same AssemblyLoadContext and depend on that assembly
 will use the version that was forcefully loaded, even if they were
 compiled against a different version.
 
-## Threading behavior
+### Threading behavior
 
 Each startup hook with run on the same managed thread as the `Main`
 method, so thread state will persist between startup hooks. While it

--- a/Documentation/design-docs/host-startup-hook.md
+++ b/Documentation/design-docs/host-startup-hook.md
@@ -7,7 +7,7 @@ to run before the main application's entry point.
 
 This would allow hosting providers to put configuration and policy in
 a single location, including settings that potentially influence load
-behavior of the main entry point such as the AssemblyLoadContext
+behavior of the main entry point such as the `AssemblyLoadContext`
 behavior. This could be used to set up callbacks for handling
 Debug.Assert (if we make such an API available), or other
 environment-dependent behavior. The hook needs to be separate from the
@@ -16,8 +16,8 @@ entry point, so that user code doesn't need to be modified.
 ## Proposed behavior
 
 Environment variables or `<appname>.runtimeconfig.json` can be used to
-specify a managed assembly and type that contains an `Initialize`
-method.
+specify a managed assembly and type that contains a `public void
+Initialize()` method.
 
 ```
 DOTNET_MANAGED_HOST_ASSEMBLY=/path/to/ManagedHost.dll
@@ -45,7 +45,7 @@ globally, if desired.
 Specifically, hostpolicy starts up coreclr and sets up a new AppDomain
 with `ManagedHost.dll` on the TPA list. It then invokes
 `ManagedHost.Initialize()`. This gives `ManagedHost` a chance to set
-up new AssemblyLoadContexts, or register other callbacks. After
+up new `AssemblyLoadContext`s, or register other callbacks. After
 `Initialize()` returns, hostpolicy starts up the main entry point of
 the app like usual.
 
@@ -63,9 +63,9 @@ same or lower version of .NET Core than the app.
 
 ## Example
 
-This could be used with AssemblyLoadContext APIs to resolve
+This could be used with `AssemblyLoadContext` APIs to resolve
 non-framework dependencies from a shared location, similar to the GAC
-on full framework. Future changes to AssemblyLoadContext could make
+on full framework. Future changes to `AssemblyLoadContext` could make
 this easier to use by making the default load context modifiable.
 
 ```

--- a/Documentation/design-docs/host-startup-hook.md
+++ b/Documentation/design-docs/host-startup-hook.md
@@ -36,12 +36,14 @@ DOTNET_MANAGED_HOST_TYPE=ManagedHostNamespace.ManagedHostType
 The environment variables, if set, take precedence over the
 `<appname>.runtimeconfig.json` settings. These settings result in
 `ManagedHostType.Initialize()` being called in hostpolicy, before the
-main assembly is loaded.
+main assembly is loaded. If it read these settings from environment
+variables, they will be inherited by child processes by default. It is
+up to the ManagedHost.dll and user code to decide what to do about
+this - ManagedHost.dll may clear them to prevent this behavior
+globally, if desired.
 
 Specifically, hostpolicy starts up coreclr and sets up a new AppDomain
-with `ManagedHost.dll` on the TPA list. If it read these settings from
-environment variables, it clears them so that child processes do not
-inherit these settings. It then invokes
+with `ManagedHost.dll` on the TPA list. It then invokes
 `ManagedHost.Initialize()`. This gives `ManagedHost` a chance to set
 up new AssemblyLoadContexts, or register other callbacks. After
 `Initialize()` returns, hostpolicy starts up the main entry point of
@@ -55,7 +57,9 @@ so desires.
 The producer of `ManagedHost.dll` needs to ensure that
 `ManagedHost.dll` is compatible with the dependencies specified in the
 main application's deps.json, since those dependencies are put on the
-TPA list when the runtime is started.
+TPA list during the runtime startup, before `ManagedHost.dll` is
+loaded. This means that `ManagedHost.dll` needs to built against the
+same or lower version of .NET Core than the app.
 
 ## Example
 

--- a/Documentation/design-docs/host-startup-hook.md
+++ b/Documentation/design-docs/host-startup-hook.md
@@ -1,0 +1,89 @@
+# Host startup hook
+
+For .NET Core 3+, we want to provide a hook that allows managed code
+to run before the main application's entry point.
+
+## Motivation
+
+This would allow hosting providers to put configuration and policy in
+a single location, including settings that potentially influence load
+behavior of the main entry point such as the AssemblyLoadContext
+behavior. This could be used to set up callbacks for handling
+Debug.Assert (if we make such an API available), or other
+environment-dependent behavior. The hook needs to be separate from the
+entry point, so that user code doesn't need to be modified.
+
+## Proposed behavior
+
+Environment variables or `<appname>.runtimeconfig.json` can be used to
+specify a managed assembly and type that contains an `Initialize`
+method.
+
+```
+DOTNET_MANAGED_HOST_ASSEMBLY=/path/to/ManagedHost.dll
+DOTNET_MANAGED_HOST_TYPE=ManagedHostNamespace.ManagedHostType
+```
+
+```
+{
+    "runtimeOptions": {
+        "managedHostAssembly": "/path/to/ManagedHost.dll",
+        "managedHostType": "ManagedHostNamespace.ManagedHostType"
+    }
+}
+```
+
+The environment variables, if set, take precedence over the
+`<appname>.runtimeconfig.json` settings. These settings result in
+`ManagedHostType.Initialize()` being called in hostpolicy, before the
+main assembly is loaded.
+
+Specifically, hostpolicy starts up coreclr and sets up a new AppDomain
+with `ManagedHost.dll` on the TPA list. If it read these settings from
+environment variables, it clears them so that child processes do not
+inherit these settings. It then invokes
+`ManagedHost.Initialize()`. This gives `ManagedHost` a chance to set
+up new AssemblyLoadContexts, or register other callbacks. After
+`Initialize()` returns, hostpolicy starts up the main entry point of
+the app like usual.
+
+Rather than forcing all configuration to be done through a single
+predefined API, this creates a place where such configuration could be
+centralized, while still allowing user code to do its own thing if it
+so desires.
+
+The producer of `ManagedHost.dll` needs to ensure that
+`ManagedHost.dll` is compatible with the dependencies specified in the
+main application's deps.json, since those dependencies are put on the
+TPA list when the runtime is started.
+
+## Example
+
+This could be used with AssemblyLoadContext APIs to resolve
+non-framework dependencies from a shared location, similar to the GAC
+on full framework. Future changes to AssemblyLoadContext could make
+this easier to use by making the default load context modifiable.
+
+```
+namespace SharedHostPolicy
+{
+    class SharedHostInitializer
+    {
+        public static void Initialize()
+        {
+            AssemblyLoadContext.Default.Resolving += SharedAssemblyResolver.LoadAssemblyFromSharedLocation;
+        }
+    }
+
+    class SharedAssemblyResolver
+    {
+        public static Assembly LoadAssemblyFromSharedLocation(AssemblyLoadContext context, AssemblyName assemblyName)
+        {
+            string sharedAssemblyPath = // find assemblyName in shared location...
+            if (sharedAssemblyPath != null)
+                return AssemblyLoadContext.Default.LoadFromAssemblyPath(sharedAssemblyPath)
+            return null;
+        }
+    }
+}
+```

--- a/Documentation/design-docs/host-startup-hook.md
+++ b/Documentation/design-docs/host-startup-hook.md
@@ -28,9 +28,10 @@ specified, before the `Main` entry point:
 DOTNET_STARTUP_HOOKS=/path/to/StartupHook1.dll!StartupHookNamespace.StartupHookType1;/path/to/StartupHook2.dll!StartupHookNamespace.StartupHookType2
 ```
 
-The list is a semicolon-delimited list of assembly paths (absolute, or
-relative to the working directory), each with a type name following an
-exclamation mark.
+This variable is a list of absolute assembly paths, each with a type
+name following an exclamation mark. The list is delimited by the
+platform-specific path separator (`;` on Windows and `:` on Unix). It
+may not contain any empty entries or a trailing path separator.
 
 Setting this environment variable will cause each of the specified
 types' `public static void Initialize()` methods to be called in
@@ -40,9 +41,9 @@ default. It is up to the `StartupHook.dll`s and user code to decide
 what to do about this - `StartupHook.dll` may clear them to prevent
 this behavior globally, if desired.
 
-Specifically, hostpolicy starts up coreclr and sets up a new AppDomain
-with each `StartupHook.dll` on the TPA list. It then invokes a private
-method in `System.Private.CoreLib`, which will call each
+Specifically, hostpolicy starts up coreclr and sets up a new
+AppDomain. It then invokes a private method in
+`System.Private.CoreLib`, which will call each
 `StartupHookType.Initialize()` in turn synchronously. This gives
 `StartupHookType` a chance to set up new `AssemblyLoadContext`s, or
 register other callbacks. After all of the `Initialize()` methods

--- a/Documentation/design-docs/host-startup-hook.md
+++ b/Documentation/design-docs/host-startup-hook.md
@@ -51,10 +51,12 @@ will be inherited by child processes by default. It is up to the
 desired.
 
 Specifically, hostpolicy starts up coreclr and sets up a new
-AppDomain, passing in the startup hook variable if it was
-set. Hostpolicy then asks the runtime to execute the main method.
-Just before the main method is called, the runtime will call a private
-method in `System.Private.CoreLib`, which will call each
+AppDomain, passing in the startup hook variable as the property
+`STARTUP_HOOKS` if it was set. This variable can be retrieved using
+`AppContext.GetData("STARTUP_HOOKS")`. Hostpolicy then asks the
+runtime to execute the main method.  Just before the main method is
+called, the runtime will call a private method in
+`System.Private.CoreLib`, which will call each
 `StartupHook.Initialize()` in turn synchronously. This gives
 `StartupHook` a chance to set up new `AssemblyLoadContext`s, or
 register other callbacks. After all of the `Initialize()` methods


### PR DESCRIPTION
This adds a proposal for an early startup hook that allows managed
code to run before the entry point.

@jeffschwMSFT @vitek-karas @swaroop-sridhar @AaronRobinsonMSFT @richlander @jkotas 