### PR TITLE
Avoid searching multilevel dir when same as dotnet root

### DIFF
--- a/src/corehost/cli/fxr/framework_info.cpp
+++ b/src/corehost/cli/fxr/framework_info.cpp
@@ -49,7 +49,7 @@ bool compare_by_name_and_version(const framework_info &a, const framework_info &
     {
         for (pal::string_t dir : global_dirs)
         {
-            if (dir != own_dir_temp)
+            if (!pal::are_paths_equal_with_normalized_casing(dir, own_dir_temp))
             {
                 hive_dir.push_back(dir);
             }

--- a/src/corehost/cli/fxr/fx_muxer.cpp
+++ b/src/corehost/cli/fxr/fx_muxer.cpp
@@ -509,7 +509,7 @@ fx_definition_t* fx_muxer_t::resolve_fx(
         for (pal::string_t dir : global_dirs)
         {
             // Avoid duplicate of dotnet_dir_temp
-            if (dir != dotnet_dir_temp)
+            if (!pal::are_paths_equal_with_normalized_casing(dir, dotnet_dir_temp))
             {
                 hive_dir.push_back(dir);
             }

--- a/src/corehost/cli/fxr/sdk_info.cpp
+++ b/src/corehost/cli/fxr/sdk_info.cpp
@@ -30,7 +30,7 @@ void sdk_info::get_all_sdk_infos(
     {
         for (pal::string_t dir : global_dirs)
         {
-            if (dir != own_dir_temp)
+            if (!pal::are_paths_equal_with_normalized_casing(dir, own_dir_temp))
             {
                 hive_dir.push_back(dir);
             }

--- a/src/corehost/cli/fxr/sdk_resolver.cpp
+++ b/src/corehost/cli/fxr/sdk_resolver.cpp
@@ -179,18 +179,20 @@ bool sdk_resolver_t::resolve_sdk_dotnet_path(const pal::string_t& dotnet_root, c
     std::vector<pal::string_t> global_dirs;
     bool multilevel_lookup = multilevel_lookup_enabled();
 
-    // dotnet_root contains DIR_SEPARATOR appended that we need to remove.
-    assert(!dotnet_root.empty());
-    pal::string_t dotnet_root_temp = dotnet_root;
-    remove_trailing_dir_seperator(&dotnet_root_temp);
-
-    hive_dir.push_back(dotnet_root_temp);
+    pal::string_t dotnet_root_temp;
+    if (!dotnet_root.empty())
+    {
+        // dotnet_root contains DIR_SEPARATOR appended that we need to remove.
+        dotnet_root_temp = dotnet_root;
+        remove_trailing_dir_seperator(&dotnet_root_temp);
+        hive_dir.push_back(dotnet_root_temp);
+    }
 
     if (multilevel_lookup && pal::get_global_dotnet_dirs(&global_dirs))
     {
         for (pal::string_t dir : global_dirs)
         {
-            // Avoid duplicate of dotnet_dir_temp
+            // Avoid duplicate of dotnet_root_temp
             if (!pal::are_paths_equal_with_normalized_casing(dir, dotnet_root_temp))
             {
                 hive_dir.push_back(dir);

--- a/src/corehost/cli/fxr/sdk_resolver.cpp
+++ b/src/corehost/cli/fxr/sdk_resolver.cpp
@@ -179,16 +179,22 @@ bool sdk_resolver_t::resolve_sdk_dotnet_path(const pal::string_t& dotnet_root, c
     std::vector<pal::string_t> global_dirs;
     bool multilevel_lookup = multilevel_lookup_enabled();
 
-    if (!dotnet_root.empty())
-    {
-        hive_dir.push_back(dotnet_root);
-    }
+    // dotnet_root contains DIR_SEPARATOR appended that we need to remove.
+    assert(!dotnet_root.empty());
+    pal::string_t dotnet_root_temp = dotnet_root;
+    remove_trailing_dir_seperator(&dotnet_root_temp);
+
+    hive_dir.push_back(dotnet_root_temp);
 
     if (multilevel_lookup && pal::get_global_dotnet_dirs(&global_dirs))
     {
         for (pal::string_t dir : global_dirs)
         {
-            hive_dir.push_back(dir);
+            // Avoid duplicate of dotnet_dir_temp
+            if (!pal::are_paths_equal_with_normalized_casing(dir, dotnet_root_temp))
+            {
+                hive_dir.push_back(dir);
+            }
         }
     }
 

--- a/src/corehost/common/pal.h
+++ b/src/corehost/common/pal.h
@@ -228,6 +228,8 @@ namespace pal
     void unload_library(dll_t library);
 
     bool is_running_in_wow64();
+
+    bool are_paths_equal_with_normalized_casing(const string_t& path1, const string_t& path2);
 }
 
 #endif // PAL_H

--- a/src/corehost/common/pal.unix.cpp
+++ b/src/corehost/common/pal.unix.cpp
@@ -644,6 +644,11 @@ bool pal::is_running_in_wow64()
 
 bool pal::are_paths_equal_with_normalized_casing(const string_t& path1, const string_t& path2)
 {
-    // On Unix paths are case-sensitive.
+#if defined(__APPLE__)
+    // On Mac, paths are case-insensitive
+    return (strcasecmp(path1.c_str(), path2.c_str()) == 0);
+#else
+    // On Linux, paths are case-sensitive
     return path1 == path2;
+#endif
 }

--- a/src/corehost/common/pal.unix.cpp
+++ b/src/corehost/common/pal.unix.cpp
@@ -641,3 +641,9 @@ bool pal::is_running_in_wow64()
 {
     return false;
 }
+
+bool pal::are_paths_equal_with_normalized_casing(const string_t& path1, const string_t& path2)
+{
+    // On Unix paths are case-sensitive.
+    return path1 == path2;
+}

--- a/src/corehost/common/pal.windows.cpp
+++ b/src/corehost/common/pal.windows.cpp
@@ -519,3 +519,9 @@ bool pal::is_running_in_wow64()
     }
     return (fWow64Process != FALSE);
 }
+
+bool pal::are_paths_equal_with_normalized_casing(const string_t& path1, const string_t& path2)
+{
+    // On Windows, paths are case-insensitive
+    return (strcasecmp(path1.c_str(), path2.c_str()) == 0);
+}


### PR DESCRIPTION
On Windows only, if an explicit path is specified when launching `dotnet.exe`, and that path is also the multilevel lookup location ('C:\Program Files\dotnet') it is possible for `--info`, `--list-runtimes`, `--list-sdks` and the actual probing for the runtime and SDK to return duplicate entries when there exists casing differences between the actual file system and the path specified with `dotnet.exe`.

This affects the output of the commands (duplicated information) plus adds an unnecessary probing pass when finding the SDK or runtime (performance).

The fix is to perform a case-insensitive compare on Windows.

Fixes https://github.com/dotnet/core-setup/issues/4236

Also found and detected is that the SDK would *always* perform an extra unnecessary probing pass when the path to `dotnet.exe` is also the multilevel location (irregardless of casing). It occurred because of a trailing slash that was checked in the other cases, but not for the core SDK probing. Fixing this should help SDK performance as it will remove a few I\O probing hits.

@nguerrera do you think this should be ported to 2.1.x\2.2? Mostly based on the SDK performance aspect.

No tests were added because it is not possible to change the multilevel location via %ProgramFiles% and %ProgramFiles(x86)% environment variables to a test location. Changing them in the current environment does not actually change the value obtained when reading them (they appear to be special). We could change our internal code to use an indirection (e.g. create a new environment variable) but that would be too intrusive just for this IMO.