### PR TITLE
Publish signed packages to myget in 1.1.0 pipeline

### DIFF
--- a/build_projects/dotnet-host-build/PublishTargets.cs
+++ b/build_projects/dotnet-host-build/PublishTargets.cs
@@ -214,7 +214,7 @@ namespace Microsoft.DotNet.Host.Build
             string nugetFeedUrl = EnvVars.EnsureVariable("NUGET_FEED_URL");
             string apiKey = EnvVars.EnsureVariable("NUGET_API_KEY");
 
-            NuGetUtil.PushPackages(Dirs.PackagesNoRID, nugetFeedUrl, apiKey, IncludeSymbolPackages);
+            NuGetUtil.PushPackages(Dirs.DownloadedPackagesForFinalPublish, nugetFeedUrl, apiKey, IncludeSymbolPackages);
 
             return c.Success();
         }
@@ -225,7 +225,7 @@ namespace Microsoft.DotNet.Host.Build
             string githubAuthToken = EnvVars.EnsureVariable("GITHUB_PASSWORD");
             VersionRepoUpdater repoUpdater = new VersionRepoUpdater(githubAuthToken);
 
-            repoUpdater.UpdatePublishedVersions(Dirs.PackagesNoRID, $"build-info/dotnet/core-setup/{Channel}/Latest").Wait();
+            repoUpdater.UpdatePublishedVersions(Dirs.DownloadedPackagesForFinalPublish, $"build-info/dotnet/core-setup/{Channel}/Latest").Wait();
 
             return c.Success();
         }

--- a/build_projects/dotnet-host-build/PublishTargets.cs
+++ b/build_projects/dotnet-host-build/PublishTargets.cs
@@ -50,7 +50,7 @@ namespace Microsoft.DotNet.Host.Build
 
         [Target(nameof(PrepareTargets.Init),
         nameof(PublishTargets.InitPublish),
-        nameof(PublishTargets.PublishArtifacts),
+        nameof(PublishTargets.PublishArtifacts))]
         [Environment("PUBLISH_TO_AZURE_BLOB", "1", "true")] // This is set by CI systems
         public static BuildTargetResult Publish(BuildTargetContext c)
         {

--- a/build_projects/dotnet-host-build/PublishTargets.cs
+++ b/build_projects/dotnet-host-build/PublishTargets.cs
@@ -51,9 +51,17 @@ namespace Microsoft.DotNet.Host.Build
         [Target(nameof(PrepareTargets.Init),
         nameof(PublishTargets.InitPublish),
         nameof(PublishTargets.PublishArtifacts),
-        nameof(PublishTargets.FinalizeBuild))]
         [Environment("PUBLISH_TO_AZURE_BLOB", "1", "true")] // This is set by CI systems
         public static BuildTargetResult Publish(BuildTargetContext c)
+        {
+            return c.Success();
+        }
+
+        [Target(nameof(PrepareTargets.Init),
+        nameof(PublishTargets.InitPublish),
+        nameof(PublishTargets.FinalizeBuild))]
+        [Environment("PUBLISH_TO_AZURE_BLOB", "1", "true")] // This is set by CI systems
+        public static BuildTargetResult FinalSignAndPublish(BuildTargetContext c)
         {
             return c.Success();
         }
@@ -201,18 +209,6 @@ namespace Microsoft.DotNet.Host.Build
             }
         }
 
-        [Target]
-        public static BuildTargetResult DownloadCoreHostPackagesToBuildDirectory(BuildTargetContext c)
-        {
-            var hostBlob = $"{Channel}/Binaries/{SharedFrameworkNugetVersion}";
-
-            Directory.CreateDirectory(Dirs.PackagesNoRID);
-            AzurePublisherTool.DownloadFilesWithExtension(hostBlob, ".nupkg", Dirs.PackagesNoRID);
-
-            return c.Success();
-        }
-
-        [Target(nameof(PublishTargets.DownloadCoreHostPackagesToBuildDirectory))]
         [Environment("NUGET_FEED_URL")]
         public static BuildTargetResult PublishCoreHostPackagesToFeed(BuildTargetContext c)
         {
@@ -224,7 +220,6 @@ namespace Microsoft.DotNet.Host.Build
             return c.Success();
         }
 
-        [Target(nameof(PublishTargets.DownloadCoreHostPackagesToBuildDirectory))]
         [Environment("GITHUB_PASSWORD")]
         public static BuildTargetResult PublishCoreHostPackageVersionsToVersionsRepo(BuildTargetContext c)
         {

--- a/build_projects/dotnet-host-build/PublishTargets.cs
+++ b/build_projects/dotnet-host-build/PublishTargets.cs
@@ -60,7 +60,6 @@ namespace Microsoft.DotNet.Host.Build
         [Target(nameof(PrepareTargets.Init),
         nameof(PublishTargets.InitPublish),
         nameof(PublishTargets.FinalizeBuild))]
-        [Environment("PUBLISH_TO_AZURE_BLOB", "1", "true")] // This is set by CI systems
         public static BuildTargetResult FinalSignAndPublish(BuildTargetContext c)
         {
             return c.Success();

--- a/build_projects/shared-build-targets-utils/Utils/Dirs.cs
+++ b/build_projects/shared-build-targets-utils/Utils/Dirs.cs
@@ -17,7 +17,7 @@ namespace Microsoft.DotNet.Cli.Build
 
         public static readonly string Intermediate = Path.Combine(Output, "intermediate");
         public static readonly string PackagesIntermediate = Path.Combine(Output, "packages/intermediate");
-        public static readonly string PackagesNoRID = Path.Combine(RepoRoot, "artifacts", "packages");
+        public static readonly string PackagesNoRID = Path.Combine(RepoRoot, "pkg", "packages", "AzureTransfer", "pkg");
         public static readonly string Packages = Path.Combine(Output, "packages");
         public static readonly string Stage1 = Path.Combine(Output, "stage1");
         public static readonly string Stage1Compilation = Path.Combine(Output, "stage1compilation");

--- a/build_projects/shared-build-targets-utils/Utils/Dirs.cs
+++ b/build_projects/shared-build-targets-utils/Utils/Dirs.cs
@@ -17,7 +17,7 @@ namespace Microsoft.DotNet.Cli.Build
 
         public static readonly string Intermediate = Path.Combine(Output, "intermediate");
         public static readonly string PackagesIntermediate = Path.Combine(Output, "packages/intermediate");
-        public static readonly string PackagesNoRID = Path.Combine(RepoRoot, "pkg", "packages", "AzureTransfer", "pkg");
+        public static readonly string DownloadedPackagesForFinalPublish = Path.Combine(RepoRoot, "pkg", "packages", "AzureTransfer", "pkg");
         public static readonly string Packages = Path.Combine(Output, "packages");
         public static readonly string Stage1 = Path.Combine(Output, "stage1");
         public static readonly string Stage1Compilation = Path.Combine(Output, "stage1compilation");

--- a/buildpipeline/Core-Setup-Sign-And-Publish.json
+++ b/buildpipeline/Core-Setup-Sign-And-Publish.json
@@ -178,8 +178,8 @@
     },
     {
       "environment": {},
-      "enabled": false,
-      "continueOnError": true,
+      "enabled": true,
+      "continueOnError": false,
       "alwaysRun": false,
       "displayName": "Copy Signed Packages To Separate Directory For Publishing",
       "timeoutInMinutes": 0,

--- a/buildpipeline/Core-Setup-Sign-And-Publish.json
+++ b/buildpipeline/Core-Setup-Sign-And-Publish.json
@@ -63,45 +63,6 @@
       }
     },
     {
-      "environment": {},
-      "enabled": false,
-      "continueOnError": false,
-      "alwaysRun": false,
-      "displayName": "Fetch custom tooling (NuGet)",
-      "timeoutInMinutes": 0,
-      "task": {
-        "id": "e213ff0f-5d5c-4791-802d-52ea3e7be1f1",
-        "versionSpec": "1.*",
-        "definitionType": "task"
-      },
-      "inputs": {
-        "scriptType": "filePath",
-        "scriptName": "scripts/DotNet-Trusted-Publish/Fetch-Tools.ps1",
-        "arguments": "$(Build.StagingDirectory)\\ToolingDownload",
-        "workingFolder": "",
-        "inlineScript": "# You can write your powershell scripts inline here. \n# You can also pass predefined and custom variables to this scripts using arguments\n\n Write-Host \"Hello World\"",
-        "failOnStandardError": "true"
-      }
-    },
-    {
-      "enabled": true,
-      "continueOnError": false,
-      "alwaysRun": false,
-      "displayName": "git checkout",
-      "timeoutInMinutes": 0,
-      "task": {
-        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
-        "versionSpec": "1.*",
-        "definitionType": "task"
-      },
-      "inputs": {
-        "filename": "git",
-        "arguments": "checkout $(SourceVersion)",
-        "workingFolder": "",
-        "failOnStandardError": "false"
-      }
-    },
-    {
       "enabled": true,
       "continueOnError": false,
       "alwaysRun": false,
@@ -218,7 +179,7 @@
     {
       "environment": {},
       "enabled": false,
-      "continueOnError": false,
+      "continueOnError": true,
       "alwaysRun": false,
       "displayName": "Copy Signed Packages To Separate Directory For Publishing",
       "timeoutInMinutes": 0,
@@ -235,25 +196,22 @@
       }
     },
     {
-      "environment": {},
-      "enabled": false,
+      "enabled": true,
       "continueOnError": false,
       "alwaysRun": false,
       "displayName": "Publish Signed Packages To MyGet",
       "timeoutInMinutes": 0,
-      "condition": "and(succeeded(), contains(variables.PB_PublishType, 'myget'), eq(variables.BuildConfiguration, 'Release'))",
       "task": {
-        "id": "e213ff0f-5d5c-4791-802d-52ea3e7be1f1",
+        "id": "bfc8bf76-e7ac-4a8c-9a55-a944a9f632fd",
         "versionSpec": "1.*",
         "definitionType": "task"
       },
       "inputs": {
-        "scriptType": "inlineScript",
-        "scriptName": "",
-        "arguments": "-ApiKey $(NUGET_API_KEY) -ConfigurationGroup $(BuildConfiguration) -PackagesGlob $(AzureContainerPackageDirectory)$(AzureContainerPackageGlob) -MyGetFeedUrl $(NUGET_FEED_URL)",
+        "filename": "build.cmd",
+        "arguments": "-Targets FinalSignAndPublish $(BuildArguments)",
+        "modifyEnvironment": "false",
         "workingFolder": "",
-        "inlineScript": "param($ApiKey, $ConfigurationGroup, $PackagesGlob, $MyGetFeedUrl)\n\nif ($ConfigurationGroup.ToLower() -ne \"release\") { Write-host \"Chose not to publish\"; exit }\n\nmsbuild /t:NuGetPush /v:Normal `\n/p:NuGetExePath=$env:CustomNuGetPath `\n/p:NuGetApiKey=$ApiKey `\n/p:NuGetSource=$MyGetFeedUrl `\n/p:PackagesGlob=$PackagesGlob",
-        "failOnStandardError": "true"
+        "failOnStandardError": "false"
       }
     },
     {
@@ -327,7 +285,7 @@
       "allowOverride": true
     },
     "BuildArguments": {
-      "value": "-envVars 'CONNECTION_STRING=$(CONNECTION_STRING)'"
+      "value": "-envVars 'NUGET_API_KEY=$(NUGET_API_KEY)','GITHUB_PASSWORD=$(GITHUB_PASSWORD)','REPO_PASS=$(REPO_PASS)','CONNECTION_STRING=$(CONNECTION_STRING)'"
     },
     "CloudDropAccountName": {
       "value": "dotnetcli",

--- a/buildpipeline/Core-Setup-Sign-And-Publish.json
+++ b/buildpipeline/Core-Setup-Sign-And-Publish.json
@@ -273,13 +273,6 @@
     }
   ],
   "variables": {
-    "AzureContainerPackageDirectory": {
-      "value": "$(Pipeline.SourcesDirectory)\\pkg\\packages\\AzureTransfer\\",
-      "allowOverride": true
-    },
-    "AzureContainerPackageGlob": {
-      "value": "pkg\\*.nupkg",
-    },
     "BuildConfiguration": {
       "value": "Release",
       "allowOverride": true


### PR DESCRIPTION
This attempts to change the workflow for finalizing/publishing in Core-Setup 1.1.0.

Old workflow:

1. Run all build legs - whoever finishes last, runs `finalize`
    - copy published blobs into `latest` container
    - publish packages to myget
    - update versions repo
2. Run `sign-and-publish` leg
    - download unsigned packages from blob storage
    - sign packages
    - reupload them to blob storage

New workflow:

1. Run all build legs
2. Run `sign-and-publish` leg
    - download unsigned packages from blob storage
    - sign packages
    - reupload them to blob storage
    - run `finalize` as above

For https://github.com/dotnet/core-setup/issues/4249

@eerhardt @dagood PTAL - also needs to be ported to 1.0.0