### PR TITLE
Mark Connection String as secret in pipeline

### DIFF
--- a/buildpipeline/Core-Setup-Sign-And-Publish.json
+++ b/buildpipeline/Core-Setup-Sign-And-Publish.json
@@ -339,7 +339,8 @@
       "isSecret": true
     },
     "CONNECTION_STRING": {
-      "value": "ENV_VAR_EMPTY_WORKAROUND"
+      "value": "ENV_VAR_EMPTY_WORKAROUND",
+      "isSecret": true
     },
     "NUGET_FEED_URL": {
       "value": "ENV_VAR_EMPTY_WORKAROUND"


### PR DESCRIPTION
This variable is passed as a secret from pipebuild, so should be marked as a secret in the .json blob

CC @MattGal 