### PR TITLE
Set PB_OverridePackageSource inside of each build's json

### DIFF
--- a/buildpipeline/Core-Setup-Linux-Arm-BT.json
+++ b/buildpipeline/Core-Setup-Linux-Arm-BT.json
@@ -610,6 +610,9 @@
     },
     "PB_InternalBuild": {
       "value": "false"
+    },
+    "PB_OverridePackageSource": {
+      "value": "/p:OverridePackageSource=$(PB_SourcesDirectory)/AzureCoreFxDownload/Release"
     }
   },
   "demands": [

--- a/buildpipeline/Core-Setup-Linux-Arm-BT.json
+++ b/buildpipeline/Core-Setup-Linux-Arm-BT.json
@@ -281,7 +281,7 @@
       },
       "inputs": {
         "filename": "docker",
-        "arguments": "run --rm $(PB_CrossBuildArgs)$(DockerCommonRunArgs) $(PB_GitDirectory)/build.sh -OfficialBuildId=$(OfficialBuildId) $(PB_BuildArguments) -- $(PB_AdditionalMSBuildArguments) $(PB_OverridePackageSource)",
+        "arguments": "run --rm $(PB_CrossBuildArgs)$(DockerCommonRunArgs) $(PB_GitDirectory)/build.sh -OfficialBuildId=$(OfficialBuildId) $(PB_BuildArguments) -- $(PB_AdditionalMSBuildArguments) $(PB_OverrideDockerPackageSource)",
         "workingFolder": "$(PB_SourcesDirectory)",
         "failOnStandardError": "false"
       }
@@ -610,9 +610,6 @@
     },
     "PB_InternalBuild": {
       "value": "false"
-    },
-    "PB_OverridePackageSource": {
-      "value": "/p:OverridePackageSource=$(PB_SourcesDirectory)/AzureCoreFxDownload/Release"
     }
   },
   "demands": [

--- a/buildpipeline/Core-Setup-Linux-BT.json
+++ b/buildpipeline/Core-Setup-Linux-BT.json
@@ -1300,6 +1300,9 @@
     },
     "PB_InternalBuild": {
       "value": "false"
+    },
+    "PB_OverridePackageSource": {
+      "value": "/p:OverridePackageSource=$(PB_SourcesDirectory)/AzureCoreFxDownload/Release"
     }
   },
   "demands": [

--- a/buildpipeline/Core-Setup-Linux-BT.json
+++ b/buildpipeline/Core-Setup-Linux-BT.json
@@ -281,7 +281,7 @@
       },
       "inputs": {
         "filename": "docker",
-        "arguments": "run --rm $(PB_CrossBuildArgs)$(DockerCommonRunArgs) $(PB_GitDirectory)/build.sh -OfficialBuildId=$(OfficialBuildId) $(PB_BuildArguments) -- $(PB_OverridePackageSource)",
+        "arguments": "run --rm $(PB_CrossBuildArgs)$(DockerCommonRunArgs) $(PB_GitDirectory)/build.sh -OfficialBuildId=$(OfficialBuildId) $(PB_BuildArguments) -- $(PB_OverrideDockerPackageSource)",
         "workingFolder": "$(PB_SourcesDirectory)",
         "failOnStandardError": "false"
       }
@@ -1300,9 +1300,6 @@
     },
     "PB_InternalBuild": {
       "value": "false"
-    },
-    "PB_OverridePackageSource": {
-      "value": "/p:OverridePackageSource=$(PB_SourcesDirectory)/AzureCoreFxDownload/Release"
     }
   },
   "demands": [

--- a/buildpipeline/Core-Setup-OSX-BT.json
+++ b/buildpipeline/Core-Setup-OSX-BT.json
@@ -453,6 +453,9 @@
     },
     "PB_InternalBuild": {
       "value": "false"
+    },
+    "PB_OverridePackageSource": {
+      "value": "/p:OverridePackageSource=$(PB_SourcesDirectory)/AzureCoreFxDownload/Release"
     }
   },
   "demands": [

--- a/buildpipeline/Core-Setup-OSX-BT.json
+++ b/buildpipeline/Core-Setup-OSX-BT.json
@@ -132,6 +132,28 @@
       }
     },
     {
+      "environment": {},
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Set PB_OverridePackageSource variable",
+      "condition": "eq(variables.PB_InternalBuild, 'true')",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "e213ff0f-5d5c-4791-802d-52ea3e7be1f1",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "scriptType": "inlineScript",
+        "scriptName": "",
+        "arguments": "-SourceDir $(PB_SourcesDirectory)",
+        "workingFolder": "",
+        "inlineScript": "param($SourceDir)\n\nWrite-Host (\"##vso[task.setvariable variable=PB_OverridePackageSource;]/p:OverridePackageSource=$SourceDir/AzureCoreFxDownload/Release\")",
+        "failOnStandardError": "true"
+      }
+    },
+    {
       "enabled": true,
       "continueOnError": false,
       "alwaysRun": false,
@@ -453,9 +475,6 @@
     },
     "PB_InternalBuild": {
       "value": "false"
-    },
-    "PB_OverridePackageSource": {
-      "value": "/p:OverridePackageSource=$(PB_SourcesDirectory)/AzureCoreFxDownload/Release"
     }
   },
   "demands": [

--- a/buildpipeline/Core-Setup-OSX-BT.json
+++ b/buildpipeline/Core-Setup-OSX-BT.json
@@ -132,28 +132,6 @@
       }
     },
     {
-      "environment": {},
-      "enabled": true,
-      "continueOnError": false,
-      "alwaysRun": false,
-      "displayName": "Set PB_OverridePackageSource variable",
-      "condition": "eq(variables.PB_InternalBuild, 'true')",
-      "timeoutInMinutes": 0,
-      "task": {
-        "id": "e213ff0f-5d5c-4791-802d-52ea3e7be1f1",
-        "versionSpec": "1.*",
-        "definitionType": "task"
-      },
-      "inputs": {
-        "scriptType": "inlineScript",
-        "scriptName": "",
-        "arguments": "-SourceDir $(PB_SourcesDirectory)",
-        "workingFolder": "",
-        "inlineScript": "param($SourceDir)\n\nWrite-Host (\"##vso[task.setvariable variable=PB_OverridePackageSource;]/p:OverridePackageSource=$SourceDir/AzureCoreFxDownload/Release\")",
-        "failOnStandardError": "true"
-      }
-    },
-    {
       "enabled": true,
       "continueOnError": false,
       "alwaysRun": false,
@@ -247,7 +225,7 @@
       },
       "inputs": {
         "filename": "$(PB_SourcesDirectory)/build.sh",
-        "arguments": "-OfficialBuildId=$(OfficialBuildId) $(PB_BuildArguments) -- $(PB_OverridePackageSource)",
+        "arguments": "-OfficialBuildId=$(OfficialBuildId) $(PB_BuildArguments) -- /p:InternalBuild=$(PB_InternalBuild)",
         "workingFolder": "$(PB_SourcesDirectory)",
         "failOnStandardError": "false"
       }

--- a/buildpipeline/Core-Setup-Windows-Arm-BT.json
+++ b/buildpipeline/Core-Setup-Windows-Arm-BT.json
@@ -681,6 +681,9 @@
     },
     "PB_InternalBuild": {
       "value": "false"
+    },
+    "PB_OverridePackageSource": {
+      "value": "/p:OverridePackageSource=$(PB_SourcesDirectory)/AzureCoreFxDownload/Release"
     }
   },
   "demands": [

--- a/buildpipeline/Core-Setup-Windows-Arm-BT.json
+++ b/buildpipeline/Core-Setup-Windows-Arm-BT.json
@@ -138,28 +138,6 @@
       }
     },
     {
-      "environment": {},
-      "enabled": true,
-      "continueOnError": false,
-      "alwaysRun": false,
-      "displayName": "Set PB_OverridePackageSource variable",
-      "condition": "eq(variables.PB_InternalBuild, 'true')",
-      "timeoutInMinutes": 0,
-      "task": {
-        "id": "e213ff0f-5d5c-4791-802d-52ea3e7be1f1",
-        "versionSpec": "1.*",
-        "definitionType": "task"
-      },
-      "inputs": {
-        "scriptType": "inlineScript",
-        "scriptName": "",
-        "arguments": "-SourceDir $(PB_SourcesDirectory)",
-        "workingFolder": "",
-        "inlineScript": "param($SourceDir)\n\nWrite-Host (\"##vso[task.setvariable variable=PB_OverridePackageSource;]/p:OverridePackageSource=$SourceDir/AzureCoreFxDownload/Release\")",
-        "failOnStandardError": "true"
-      }
-    },
-    {
       "enabled": true,
       "continueOnError": false,
       "alwaysRun": false,
@@ -274,7 +252,7 @@
       },
       "inputs": {
         "filename": "$(PB_SourcesDirectory)\\build.cmd",
-        "arguments": "-- $(PB_CommonMSBuildArgs) $(PB_OverridePackageSource) /t:BuildTraversalBuildDependencies /flp:v=diag",
+        "arguments": "-- $(PB_CommonMSBuildArgs) /p:InternalBuild=$(PB_InternalBuild) /t:BuildTraversalBuildDependencies /flp:v=diag",
         "workingFolder": "$(PB_SourcesDirectory)",
         "failOnStandardError": "false"
       }
@@ -292,7 +270,7 @@
       },
       "inputs": {
         "filename": "$(PB_SourcesDirectory)\\build.cmd",
-        "arguments": "-src-builds -- $(PB_CommonMSBuildArgs) $(PB_OverridePackageSource)",
+        "arguments": "-src-builds -- $(PB_CommonMSBuildArgs) /p:InternalBuild=$(PB_InternalBuild)",
         "workingFolder": "$(PB_SourcesDirectory)",
         "failOnStandardError": "false"
       }

--- a/buildpipeline/Core-Setup-Windows-Arm-BT.json
+++ b/buildpipeline/Core-Setup-Windows-Arm-BT.json
@@ -138,6 +138,28 @@
       }
     },
     {
+      "environment": {},
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Set PB_OverridePackageSource variable",
+      "condition": "eq(variables.PB_InternalBuild, 'true')",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "e213ff0f-5d5c-4791-802d-52ea3e7be1f1",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "scriptType": "inlineScript",
+        "scriptName": "",
+        "arguments": "-SourceDir $(PB_SourcesDirectory)",
+        "workingFolder": "",
+        "inlineScript": "param($SourceDir)\n\nWrite-Host (\"##vso[task.setvariable variable=PB_OverridePackageSource;]/p:OverridePackageSource=$SourceDir/AzureCoreFxDownload/Release\")",
+        "failOnStandardError": "true"
+      }
+    },
+    {
       "enabled": true,
       "continueOnError": false,
       "alwaysRun": false,
@@ -681,9 +703,6 @@
     },
     "PB_InternalBuild": {
       "value": "false"
-    },
-    "PB_OverridePackageSource": {
-      "value": "/p:OverridePackageSource=$(PB_SourcesDirectory)/AzureCoreFxDownload/Release"
     }
   },
   "demands": [

--- a/buildpipeline/Core-Setup-Windows-BT.json
+++ b/buildpipeline/Core-Setup-Windows-BT.json
@@ -138,28 +138,6 @@
       }
     },
     {
-      "environment": {},
-      "enabled": true,
-      "continueOnError": false,
-      "alwaysRun": false,
-      "displayName": "Set PB_OverridePackageSource variable",
-      "condition": "eq(variables.PB_InternalBuild, 'true')",
-      "timeoutInMinutes": 0,
-      "task": {
-        "id": "e213ff0f-5d5c-4791-802d-52ea3e7be1f1",
-        "versionSpec": "1.*",
-        "definitionType": "task"
-      },
-      "inputs": {
-        "scriptType": "inlineScript",
-        "scriptName": "",
-        "arguments": "-SourceDir $(PB_SourcesDirectory)",
-        "workingFolder": "",
-        "inlineScript": "param($SourceDir)\n\nWrite-Host (\"##vso[task.setvariable variable=PB_OverridePackageSource;]/p:OverridePackageSource=$SourceDir/AzureCoreFxDownload/Release\")",
-        "failOnStandardError": "true"
-      }
-    },
-    {
       "enabled": true,
       "continueOnError": false,
       "alwaysRun": false,
@@ -274,7 +252,7 @@
       },
       "inputs": {
         "filename": "$(PB_SourcesDirectory)\\build.cmd",
-        "arguments": "-- $(PB_CommonMSBuildArgs) $(PB_OverridePackageSource) /t:BuildTraversalBuildDependencies /flp:v=diag",
+        "arguments": "-- $(PB_CommonMSBuildArgs) /p:InternalBuild=$(PB_InternalBuild) /t:BuildTraversalBuildDependencies /flp:v=diag",
         "workingFolder": "$(PB_SourcesDirectory)",
         "failOnStandardError": "false"
       }
@@ -292,7 +270,7 @@
       },
       "inputs": {
         "filename": "$(PB_SourcesDirectory)\\build.cmd",
-        "arguments": "-src-builds -- $(PB_CommonMSBuildArgs) $(PB_OverridePackageSource)",
+        "arguments": "-src-builds -- $(PB_CommonMSBuildArgs) /p:InternalBuild=$(PB_InternalBuild)",
         "workingFolder": "$(PB_SourcesDirectory)",
         "failOnStandardError": "false"
       }

--- a/buildpipeline/Core-Setup-Windows-BT.json
+++ b/buildpipeline/Core-Setup-Windows-BT.json
@@ -879,6 +879,9 @@
     },
     "PB_InternalBuild": {
       "value": "false"
+    },
+    "PB_OverridePackageSource": {
+      "value": "/p:OverridePackageSource=$(PB_SourcesDirectory)/AzureCoreFxDownload/Release"
     }
   },
   "demands": [

--- a/buildpipeline/Core-Setup-Windows-BT.json
+++ b/buildpipeline/Core-Setup-Windows-BT.json
@@ -138,6 +138,28 @@
       }
     },
     {
+      "environment": {},
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Set PB_OverridePackageSource variable",
+      "condition": "eq(variables.PB_InternalBuild, 'true')",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "e213ff0f-5d5c-4791-802d-52ea3e7be1f1",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "scriptType": "inlineScript",
+        "scriptName": "",
+        "arguments": "-SourceDir $(PB_SourcesDirectory)",
+        "workingFolder": "",
+        "inlineScript": "param($SourceDir)\n\nWrite-Host (\"##vso[task.setvariable variable=PB_OverridePackageSource;]/p:OverridePackageSource=$SourceDir/AzureCoreFxDownload/Release\")",
+        "failOnStandardError": "true"
+      }
+    },
+    {
       "enabled": true,
       "continueOnError": false,
       "alwaysRun": false,
@@ -879,9 +901,6 @@
     },
     "PB_InternalBuild": {
       "value": "false"
-    },
-    "PB_OverridePackageSource": {
-      "value": "/p:OverridePackageSource=$(PB_SourcesDirectory)/AzureCoreFxDownload/Release"
     }
   },
   "demands": [

--- a/dir.props
+++ b/dir.props
@@ -31,6 +31,10 @@
 
   <Import Project="$(MSBuildThisFileDirectory)RepoDirectories.props" />
 
+  <PropertyGroup Condition="'$(InternalBuild)' == 'true'">
+    <OverridePackageSource>$(MSBuildThisFileDirectory)AzureCoreFxDownload/$(ConfigurationGroup)/</OverridePackageSource>
+  </PropertyGroup>
+
   <PropertyGroup Condition="'$(DotNetBuildOffline)' != 'true'">
     <!-- list of nuget package sources passed to NuGet -->
     <RestoreSources>


### PR DESCRIPTION
It turns out that if we want to pass an override directory relative to where the current build is happening, it needs to be set directly inside the .json corresponding to each individual build, rather than being passed from pipebuild (which, naturally, doesn't know what directories its child builds will be run out of).

This instead sets a velue for `OverridePackageSourc` in dir.props, given that we're running an internal build. It also changes `PB_OverridePackageSource` to `PB_OverrideDockerPackageSource` for Linux builds, as the value previously set for `PB_OverridePackageSource` is correct for the builds which run inside of Docker containers.

I should also change `PB_OverridePackageSource` to `PB_OverrideDockerPackageSource` in the VSTS pipebuild definition once this is merged.

@dagood @dseefeld PTAL