### PR TITLE
Port fix for custom host

### DIFF
--- a/src/corehost/cli/breadcrumbs.h
+++ b/src/corehost/cli/breadcrumbs.h
@@ -9,18 +9,20 @@
 class breadcrumb_writer_t
 {
 public:
-    breadcrumb_writer_t(const std::unordered_set<pal::string_t>* files);
+    breadcrumb_writer_t(bool enabled, const std::unordered_set<pal::string_t>* files);
+    ~breadcrumb_writer_t();
 
     void begin_write();
-    bool end_write();
 
 private:
     void write_callback();
+    bool end_write();
     static void write_worker_callback(breadcrumb_writer_t* p_this);
 
     pal::string_t m_breadcrumb_store;
     std::thread m_thread;
     const std::unordered_set<pal::string_t>* m_files;
+    bool m_enabled;
     volatile bool m_status;
 };
 

--- a/src/corehost/cli/hostpolicy.cpp
+++ b/src/corehost/cli/hostpolicy.cpp
@@ -209,7 +209,7 @@ int run(const arguments_t& args, pal::string_t* out_host_command_result = nullpt
         return exit_code;
     }
 
-   // Bind CoreCLR
+    // Bind CoreCLR
     trace::verbose(_X("CoreCLR path = '%s', CoreCLR dir = '%s'"), clr_path.c_str(), clr_dir.c_str());
     if (!coreclr::bind(clr_dir))
     {
@@ -275,12 +275,9 @@ int run(const arguments_t& args, pal::string_t* out_host_command_result = nullpt
     std::vector<char> managed_app;
     pal::pal_clrstring(args.managed_application, &managed_app);
 
-    breadcrumb_writer_t writer(&breadcrumbs);
-    if (breadcrumbs_enabled)
-    {
-        // Leave breadcrumbs for servicing.
-        writer.begin_write();
-    }
+    // Leave breadcrumbs for servicing.
+    breadcrumb_writer_t writer(breadcrumbs_enabled, &breadcrumbs);
+    writer.begin_write();
 
     // Previous hostpolicy trace messages must be printed before executing assembly
     trace::flush();
@@ -309,13 +306,9 @@ int run(const arguments_t& args, pal::string_t* out_host_command_result = nullpt
 
     coreclr::unload();
 
-    if (breadcrumbs_enabled)
-    {
-        // Finish breadcrumb writing
-        writer.end_write();
-    }
-
     return exit_code;
+
+    // The breadcrumb destructor will join to the background thread to finish writing
 }
 
 SHARED_API int corehost_load(host_interface_t* init)

--- a/src/test/Assets/TestProjects/PortableAppWithException/PortableAppWithException.csproj
+++ b/src/test/Assets/TestProjects/PortableAppWithException/PortableAppWithException.csproj
@@ -1,0 +1,9 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>$(NETCoreAppFramework)</TargetFramework>
+    <OutputType>Exe</OutputType>
+    <RuntimeFrameworkVersion>$(MNAVersion)</RuntimeFrameworkVersion>
+  </PropertyGroup>
+
+</Project>

--- a/src/test/Assets/TestProjects/PortableAppWithException/Program.cs
+++ b/src/test/Assets/TestProjects/PortableAppWithException/Program.cs
@@ -1,0 +1,15 @@
+using System;
+
+namespace PortableAppWithException
+{
+    public static class Program
+    {
+        public static void Main(string[] args)
+        {
+            Console.WriteLine("Hello World!");
+            Console.WriteLine(string.Join(Environment.NewLine, args));
+
+            throw new Exception("Goodbye World!");
+        }
+    }
+}

--- a/src/test/TestUtils/TestProject.cs
+++ b/src/test/TestUtils/TestProject.cs
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 
 namespace Microsoft.DotNet.CoreSetup.Test
 {
-    public class TestProject
+    public class TestProject : IDisposable
     {
         private string _projectDirectory;
         private string _projectName;
@@ -24,12 +24,14 @@ namespace Microsoft.DotNet.CoreSetup.Test
         private string _appExe;
         private string _hostPolicyDll;
         private string _hostFxrDll;
+        private string _assemblyName;
 
         public string ProjectDirectory => _projectDirectory;
         public string ProjectName => _projectName;
 
         public string OutputDirectory { get { return _outputDirectory; } set { _outputDirectory = value; } }
         public string ExeExtension { get { return _exeExtension; } set { _exeExtension = value; } }
+        public string AssemblyName { get { return _assemblyName; } set { _assemblyName = value; } }
         public string ProjectFile { get { return _projectFile; } set { _projectFile = value; } }
         public string ProjectAssetsJson { get { return _projectAssetsJson; } set { _projectAssetsJson = value; } }
         public string RuntimeConfigJson { get { return _runtimeConfigJson; } set { _runtimeConfigJson = value; } }
@@ -45,13 +47,15 @@ namespace Microsoft.DotNet.CoreSetup.Test
             string exeExtension,
             string sharedLibraryExtension,
             string sharedLibraryPrefix,
-            string outputDirectory = null)
+            string outputDirectory = null,
+            string assemblyName = null)
         {
             _projectDirectory = projectDirectory;
             _exeExtension = exeExtension;
             _sharedLibraryExtension = sharedLibraryExtension;
             _sharedLibraryPrefix = sharedLibraryPrefix;
             _projectName = Path.GetFileName(_projectDirectory);
+            _assemblyName = assemblyName ?? _projectName;
             _projectFile = Path.Combine(_projectDirectory, $"{_projectName}.csproj");
             _projectAssetsJson = Path.Combine(_projectDirectory, "obj", "project.assets.json");
 
@@ -62,6 +66,14 @@ namespace Microsoft.DotNet.CoreSetup.Test
             }
         }
 
+        public void Dispose()
+        {
+            if (!PreserveTestRuns())
+            {
+                Directory.Delete(_projectDirectory, true);
+            }
+        }
+
         public void CopyProjectFiles(string directory)
         {
             CopyRecursive(_projectDirectory, directory, overwrite: true);
@@ -69,11 +81,11 @@ namespace Microsoft.DotNet.CoreSetup.Test
 
         public void LoadOutputFiles()
         {
-            _appDll = Path.Combine(_outputDirectory, $"{_projectName}.dll");
-            _appExe = Path.Combine(_outputDirectory, $"{_projectName}{_exeExtension}");
-            _depsJson = Path.Combine(_outputDirectory, $"{_projectName}.deps.json");
-            _runtimeConfigJson = Path.Combine(_outputDirectory, $"{_projectName}.runtimeconfig.json");
-            _runtimeDevConfigJson = Path.Combine(_outputDirectory, $"{_projectName}.runtimeconfig.dev.json");
+            _appDll = Path.Combine(_outputDirectory, $"{_assemblyName}.dll");
+            _appExe = Path.Combine(_outputDirectory, $"{_assemblyName}{_exeExtension}");
+            _depsJson = Path.Combine(_outputDirectory, $"{_assemblyName}.deps.json");
+            _runtimeConfigJson = Path.Combine(_outputDirectory, $"{_assemblyName}.runtimeconfig.json");
+            _runtimeDevConfigJson = Path.Combine(_outputDirectory, $"{_assemblyName}.runtimeconfig.dev.json");
             _hostPolicyDll = Path.Combine(_outputDirectory, $"{_sharedLibraryPrefix}hostpolicy{_sharedLibraryExtension}");
             _hostFxrDll = Path.Combine(_outputDirectory, $"{_sharedLibraryPrefix}hostfxr{_sharedLibraryExtension}");
         }
@@ -90,7 +102,7 @@ namespace Microsoft.DotNet.CoreSetup.Test
 
         private void CopyRecursive(string sourceDirectory, string destinationDirectory, bool overwrite = false)
         {
-            if ( ! Directory.Exists(destinationDirectory))
+            if (!Directory.Exists(destinationDirectory))
             {
                 Directory.CreateDirectory(destinationDirectory);
             }
@@ -110,6 +122,11 @@ namespace Microsoft.DotNet.CoreSetup.Test
                     File.Copy(file, dest, overwrite: true);
                 }
             }
+        }
+
+        public static bool PreserveTestRuns()
+        {
+            return Environment.GetEnvironmentVariable("PRESERVE_TEST_RUNS") == "1";
         }
     }
 }

--- a/src/test/TestUtils/TestProjectFixture.cs
+++ b/src/test/TestUtils/TestProjectFixture.cs
@@ -11,7 +11,7 @@ namespace Microsoft.DotNet.CoreSetup.Test
      * setup of the TestProject, copying test projects for perf on build/restore,
      * and building/publishing/restoring test projects where necessary.
      */
-    public class TestProjectFixture
+    public class TestProjectFixture : IDisposable
     {
         private static readonly string s_testArtifactDirectoryEnvironmentVariable = "TEST_ARTIFACTS";
 
@@ -23,6 +23,7 @@ namespace Microsoft.DotNet.CoreSetup.Test
         private string _testArtifactDirectory;
         private string _currentRid;
         private string _framework;
+        private string _assemblyName;
 
         private RepoDirectoriesProvider _repoDirectoriesProvider;
 
@@ -31,6 +32,7 @@ namespace Microsoft.DotNet.CoreSetup.Test
 
         private TestProject _sourceTestProject;
         private TestProject _testProject;
+        private List<TestProject> _copiedTestProjects = new List<TestProject>();
 
         public DotNetCli SdkDotnet => _sdkDotnet;
         public DotNetCli BuiltDotnet => _builtDotnet;
@@ -41,19 +43,20 @@ namespace Microsoft.DotNet.CoreSetup.Test
         public string SharedLibraryExtension => _sharedLibraryExtension;
         public string SharedLibraryPrefix => _sharedLibraryPrefix;
         public string Framework => _framework;
-        public RepoDirectoriesProvider RepoDirProvider  => _repoDirectoriesProvider;
+        public RepoDirectoriesProvider RepoDirProvider => _repoDirectoriesProvider;
         public TestProjectFixture(
             string testProjectName,
             RepoDirectoriesProvider repoDirectoriesProvider,
             string exeExtension = null,
             string sharedLibraryExtension = null,
-            string sharedLibraryPrefix= null,
+            string sharedLibraryPrefix = null,
             string testProjectSourceDirectory = null,
             string testArtifactDirectory = null,
             string dotnetInstallPath = null,
             string currentRid = null,
             string builtDotnetOutputPath = null,
-            string framework = null)
+            string framework = null,
+            string assemblyName = null)
         {
             ValidateRequiredDirectories(repoDirectoriesProvider);
 
@@ -78,13 +81,17 @@ namespace Microsoft.DotNet.CoreSetup.Test
             _currentRid = currentRid ?? repoDirectoriesProvider.TargetRID;
 
             _builtDotnet = new DotNetCli(repoDirectoriesProvider.BuiltDotnet);
+
+            _assemblyName = assemblyName;
+
             InitializeTestProject(
                 _testProjectName,
                 _testProjectSourceDirectory,
                 _testArtifactDirectory,
                 _exeExtension,
                 _sharedLibraryExtension,
-                _sharedLibraryPrefix);
+                _sharedLibraryPrefix,
+                _assemblyName);
         }
 
         public TestProjectFixture(TestProjectFixture fixtureToCopy)
@@ -101,13 +108,33 @@ namespace Microsoft.DotNet.CoreSetup.Test
             _builtDotnet = fixtureToCopy._builtDotnet;
             _sourceTestProject = fixtureToCopy._sourceTestProject;
             _framework = fixtureToCopy._framework;
+            _assemblyName = fixtureToCopy._assemblyName;
 
             _testProject = CopyTestProject(
                 fixtureToCopy.TestProject,
                 _testArtifactDirectory,
                 _exeExtension,
                 _sharedLibraryExtension,
-                _sharedLibraryPrefix);
+                _sharedLibraryPrefix,
+                _assemblyName);
+
+            fixtureToCopy._copiedTestProjects.Add(_testProject);
+        }
+
+        public void Dispose()
+        {
+            if (_testProject != null)
+            {
+                _testProject.Dispose();
+                _testProject = null;
+            }
+
+            foreach (var project in _copiedTestProjects)
+            {
+                project.Dispose();
+            }
+
+            _copiedTestProjects.Clear();
         }
 
         private void InitializeTestProject(
@@ -116,21 +143,24 @@ namespace Microsoft.DotNet.CoreSetup.Test
             string testArtifactDirectory,
             string exeExtension,
             string sharedLibraryExtension,
-            string sharedLibraryPrefix)
+            string sharedLibraryPrefix,
+            string assemblyName)
         {
             var sourceTestProjectPath = Path.Combine(testProjectSourceDirectory, testProjectName);
             _sourceTestProject = new TestProject(
                 sourceTestProjectPath,
                 exeExtension,
                 sharedLibraryExtension,
-                sharedLibraryPrefix);
+                sharedLibraryPrefix,
+                assemblyName: assemblyName);
 
             _testProject = CopyTestProject(
                 _sourceTestProject,
                 testArtifactDirectory,
                 exeExtension,
                 sharedLibraryExtension,
-                sharedLibraryPrefix);
+                sharedLibraryPrefix,
+                assemblyName);
         }
 
         private TestProject CopyTestProject(
@@ -138,7 +168,8 @@ namespace Microsoft.DotNet.CoreSetup.Test
             string testArtifactDirectory,
             string exeExtension,
             string sharedLibraryExtension,
-            string sharedLibraryPrefix)
+            string sharedLibraryPrefix,
+            string assemblyName)
         {
             string copiedTestProjectDirectory = CalculateTestProjectDirectory(
                 sourceTestProject.ProjectName,
@@ -147,11 +178,13 @@ namespace Microsoft.DotNet.CoreSetup.Test
             EnsureDirectoryBuildProps(testArtifactDirectory);
 
             sourceTestProject.CopyProjectFiles(copiedTestProjectDirectory);
+
             return new TestProject(
                 copiedTestProjectDirectory,
                 exeExtension,
                 sharedLibraryExtension,
-                sharedLibraryPrefix);
+                sharedLibraryPrefix,
+                assemblyName: assemblyName);
         }
 
         private void EnsureDirectoryBuildProps(string testArtifactDirectory)
@@ -159,7 +192,7 @@ namespace Microsoft.DotNet.CoreSetup.Test
             string directoryBuildPropsPath = Path.Combine(testArtifactDirectory, "Directory.Build.props");
             Directory.CreateDirectory(testArtifactDirectory);
 
-            for(int i = 0; i < 3 && !File.Exists(directoryBuildPropsPath); i++)
+            for (int i = 0; i < 3 && !File.Exists(directoryBuildPropsPath); i++)
             {
                 try
                 {
@@ -174,7 +207,7 @@ namespace Microsoft.DotNet.CoreSetup.Test
                     File.WriteAllText(directoryBuildPropsPath, propsFile.ToString());
                 }
                 catch (IOException)
-                {}
+                { }
             }
         }
 
@@ -193,12 +226,12 @@ namespace Microsoft.DotNet.CoreSetup.Test
 
         private void ValidateRequiredDirectories(RepoDirectoriesProvider repoDirectoriesProvider)
         {
-            if ( ! Directory.Exists(repoDirectoriesProvider.BuiltDotnet))
+            if (!Directory.Exists(repoDirectoriesProvider.BuiltDotnet))
             {
                 throw new Exception($"Unable to find built host and sharedfx, please ensure the build has been run: {repoDirectoriesProvider.BuiltDotnet}");
             }
 
-            if ( ! Directory.Exists(repoDirectoriesProvider.CorehostPackages))
+            if (!Directory.Exists(repoDirectoriesProvider.CorehostPackages))
             {
                 throw new Exception($"Unable to find host packages directory, please ensure the build has been run: {repoDirectoriesProvider.CorehostPackages}");
             }
@@ -273,7 +306,7 @@ namespace Microsoft.DotNet.CoreSetup.Test
             }
             else
             {
-               storeArgs.Add(CurrentRid);
+                storeArgs.Add(CurrentRid);
             }
 
             if (framework != null)
@@ -282,14 +315,14 @@ namespace Microsoft.DotNet.CoreSetup.Test
                 storeArgs.Add(framework);
             }
 
-                storeArgs.Add("--manifest");
+            storeArgs.Add("--manifest");
             if (manifest != null)
             {
                 storeArgs.Add(manifest);
             }
             else
             {
-                 storeArgs.Add(_sourceTestProject.ProjectFile);
+                storeArgs.Add(_sourceTestProject.ProjectFile);
             }
 
             if (outputDirectory != null)
@@ -396,7 +429,7 @@ namespace Microsoft.DotNet.CoreSetup.Test
 
         public TestProjectFixture EnsureRestored(params string[] fallbackSources)
         {
-            if ( ! _testProject.IsRestored())
+            if (!_testProject.IsRestored())
             {
                 RestoreProject(fallbackSources);
             }
@@ -406,7 +439,7 @@ namespace Microsoft.DotNet.CoreSetup.Test
 
         public TestProjectFixture EnsureRestoredForRid(string rid, params string[] fallbackSources)
         {
-            if ( ! _testProject.IsRestored())
+            if (!_testProject.IsRestored())
             {
                 string extraMSBuildProperties = $"/p:TestTargetRid={rid}";
                 RestoreProject(fallbackSources, extraMSBuildProperties);


### PR DESCRIPTION
[original issue](https://github.com/dotnet/core-setup/issues/4315)

fixes	https://github.com/dotnet/core-setup/issues/4366 (2.2 port issue)

This is a direct port of https://github.com/dotnet/core-setup/commit/84fa44f892b42ad9235e4ecb756975d8c8f46f1f except for some additional test infrastructure that needed to be pulled in to merge the new test.

#### Description
The issue only applies when the CoreCLR is being hosted by ASP.NET (not the standard dotnet.exe or apphost.exe)

If managed code throws an unhandled exception before the host’s background “breadcrumb writer” thread is done writing breadcrumbs (for potential servicing scenarios) then an AV occurs in the breadcrumb code.

This issue does not need to be fixed in 2.1.x since ASP.NET did not use the custom host until 2.2

#### Customer Impact
Without the fix, the ASP.NET host cannot catch the AV exception and continue execution (or log the exception)

#### Regression?
No

#### Risk
Minimal.  The change occurs in native code in hostpolicy.dll that is executed after managed code has started, and the fix does not affect the user’s managed code.