### PR TITLE
Exclude Windows.winmd into NetCoreApp distro

### DIFF
--- a/src/pkg/projects/Microsoft.NETCore.App/src/Microsoft.NETCore.App.depproj
+++ b/src/pkg/projects/Microsoft.NETCore.App/src/Microsoft.NETCore.App.depproj
@@ -144,8 +144,8 @@
   <!-- Fetches all the file items from the packages that we want to redist -->
   <Target Name="GetFilesFromPackages" DependsOnTargets="GetPackagePaths">
     <ItemGroup Condition="'$(NuGetRuntimeIdentifier)' != ''">
-      <!-- RID-specific: include all runtime files except Windows.winmd -->
-      <FilesToPackage Include="@(ReferenceCopyLocalPaths)" Condition="'%(ReferenceCopyLocalPaths.FileName)%(ReferenceCopyLocalPaths.Extension)' != 'Windows.winmd'">
+      <!-- RID-specific: include all runtime files except files in Microsoft.TargetingPack.Private.WinRT -->
+      <FilesToPackage Include="@(ReferenceCopyLocalPaths)" Condition="'%(ReferenceCopyLocalPaths.NuGetPackageId)' != 'Microsoft.TargetingPack.Private.WinRT'">
         <!-- ResolveNugetPackageAssets doesn't preserve the asset type (native),
              calculate it by looking for native in the path -->
         <IsNative Condition="$([System.String]::new('%(Identity)').ToLowerInvariant().Replace('\', '/').Contains('/native/'))">true</IsNative>

--- a/src/pkg/projects/Microsoft.NETCore.App/src/Microsoft.NETCore.App.depproj
+++ b/src/pkg/projects/Microsoft.NETCore.App/src/Microsoft.NETCore.App.depproj
@@ -144,8 +144,8 @@
   <!-- Fetches all the file items from the packages that we want to redist -->
   <Target Name="GetFilesFromPackages" DependsOnTargets="GetPackagePaths">
     <ItemGroup Condition="'$(NuGetRuntimeIdentifier)' != ''">
-      <!-- RID-specific: include all runtime files -->
-      <FilesToPackage Include="@(ReferenceCopyLocalPaths)">
+      <!-- RID-specific: include all runtime files except Windows.winmd -->
+      <FilesToPackage Include="@(ReferenceCopyLocalPaths)" Condition="'%(ReferenceCopyLocalPaths.FileName)%(ReferenceCopyLocalPaths.Extension)' != 'Windows.winmd'">
         <!-- ResolveNugetPackageAssets doesn't preserve the asset type (native),
              calculate it by looking for native in the path -->
         <IsNative Condition="$([System.String]::new('%(Identity)').ToLowerInvariant().Replace('\', '/').Contains('/native/'))">true</IsNative>


### PR DESCRIPTION
Fix https://github.com/dotnet/core-setup/issues/4472

One of my previous change(enable crossgen on S.R.WindowsRuntime) accidentally includes windows.winmd into netcoreapp distro.

