### PR TITLE
Lowercase bin dir name to align with corefx and others

### DIFF
--- a/RepoDirectories.props
+++ b/RepoDirectories.props
@@ -6,7 +6,7 @@
     <SourceDir>$(RepoRoot)src/</SourceDir>
 
     <!-- Output directories -->
-    <BinDir Condition="'$(BinDir)'==''">$(RepoRoot)Bin/</BinDir>
+    <BinDir Condition="'$(BinDir)'==''">$(RepoRoot)bin/</BinDir>
     <BaseOutputPath Condition="'$(BaseOutputPath)'==''">$(BinDir)</BaseOutputPath>
     <ObjDir Condition="'$(ObjDir)'==''">$(BinDir)obj/</ObjDir>
     <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'==''">$(ObjDir)</BaseIntermediateOutputPath>

--- a/buildpipeline/Core-Setup-Linux-BT.json
+++ b/buildpipeline/Core-Setup-Linux-BT.json
@@ -188,7 +188,7 @@
         "definitionType": "task"
       },
       "inputs": {
-        "SourceFolder": "$(PB_SourcesDirectory)/Bin/obj/linux-x64.$(BuildConfiguration)/sharedFrameworkPublish",
+        "SourceFolder": "$(PB_SourcesDirectory)/bin/obj/linux-x64.$(BuildConfiguration)/sharedFrameworkPublish",
         "Contents": "**",
         "TargetFolder": "$(Build.StagingDirectory)/sharedFrameworkPublish",
         "CleanTargetFolder": "false",

--- a/netci.groovy
+++ b/netci.groovy
@@ -112,7 +112,7 @@ platformList.each { platform ->
     Utilities.addGithubPRTriggerForBranch(newJob, branch, "${osForGHTrigger} ${architecture} ${configuration} Build")
     
     ArchivalSettings settings = new ArchivalSettings();
-    def archiveString = ["tar.gz", "zip", "deb", "msi", "pkg", "exe", "nupkg"].collect { "Bin/*/packages/*.${it},Bin/*/corehost/*.${it}" }.join(",")
+    def archiveString = ["tar.gz", "zip", "deb", "msi", "pkg", "exe", "nupkg"].collect { "bin/*/packages/*.${it},bin/*/corehost/*.${it}" }.join(",")
     settings.addFiles(archiveString)
     settings.setArchiveOnSuccess()
     settings.setFailIfNothingArchived()

--- a/src/corehost/build.cmd
+++ b/src/corehost/build.cmd
@@ -4,7 +4,7 @@ setlocal
 :SetupArgs
 :: Initialize the args that will be passed to cmake
 set __nativeWindowsDir=%~dp0Windows
-set __binDir=%~dp0..\..\Bin
+set __binDir=%~dp0..\..\bin
 set __rootDir=%~dp0..\..
 set __CMakeBinDir=""
 set __IntermediatesDir=""

--- a/src/corehost/build.sh
+++ b/src/corehost/build.sh
@@ -98,7 +98,7 @@ __portableBuildArgs=
 __configuration=Debug
 __linkPortable=0
 __cmake_defines=
-__baseIntermediateOutputPath="$RootRepo/Bin/obj"
+__baseIntermediateOutputPath="$RootRepo/bin/obj"
 __versionSourceFile="$__baseIntermediateOutputPath/version.cpp"
 
 while [ "$1" != "" ]; do


### PR DESCRIPTION
Fixes failures in https://github.com/dotnet/core-setup/pull/4489

We are using a property in buildtools that point to the obj directory in the repo (https://github.com/dotnet/buildtools/blob/0fa455c550abb4f49f4830a7f2fa78609f373fd0/src/Microsoft.DotNet.Build.Tasks/PackageFiles/Build.Common.props#L40). CI fails on Unix because the path is case-sensitive which it isn't on Windows. Lower-casing the bin directory here in core-setup to align with corefx and buildtools.

