### PR TITLE
Allow setting the commit id using /p:LatestCommit

### DIFF
--- a/dir.targets
+++ b/dir.targets
@@ -17,7 +17,8 @@
     <Exec Command="$(DotnetToolCommand) build $(MSBuildThisFileDirectory)tools-local/tasks/core-setup.tasks.csproj" />
   </Target>
 
-  <Target Name="GetLatestCommitHash">
+  <Target Name="GetLatestCommitHash"
+          Condition="'$(LatestCommit)' == ''">
     <!-- Get the latest commit hash -->
     <Exec Command="git rev-parse HEAD 2>&amp;1" StandardOutputImportance="Low" IgnoreExitCode="true" IgnoreStandardErrorWarningFormat="true" ConsoleToMSBuild="true">
       <Output TaskParameter="ConsoleOutput" PropertyName="LatestCommit" />
@@ -29,13 +30,13 @@
     </PropertyGroup>
   </Target>
 
-  <Target Name="GetCommitCount">
+  <Target Name="GetCommitCount"
+          Condition="'$(CommitCount)' == ''">
     <Exec Command="git rev-list --count HEAD"
           StandardOutputImportance="Low"
           IgnoreExitCode="true"
           IgnoreStandardErrorWarningFormat="true"
-          ConsoleToMSBuild="true"
-          Condition="'$(CommitCount)' == ''">
+          ConsoleToMSBuild="true">
      <Output TaskParameter="ConsoleOutput" PropertyName="CommitCount" />
      <Output TaskParameter="ExitCode" PropertyName="CommitCountExitCode" />
     </Exec>


### PR DESCRIPTION
This is similar to how CommitCount is already supported.

This lets consumers who are building outside a git repo, such as source-build, set a commit id which is displayed by `dotnet --info` and `strings dotnet | grep '@(#)'`.

See: https://github.com/dotnet/source-build/issues/651
See: https://github.com/dotnet/cli/pull/5945