### PR TITLE
Add new RIDs for DotNetHostPolicy in stable.packages.props

### DIFF
--- a/pkg/stable.packages.props
+++ b/pkg/stable.packages.props
@@ -577,10 +577,22 @@
     <StablePackage Include="runtime.debian.8-x64.Microsoft.NETCore.DotNetHostPolicy">
       <Version>1.1.10</Version>
     </StablePackage>
+    <StablePackage Include="runtime.debian.9-x64.Microsoft.NETCore.DotNetHostPolicy">
+      <Version>1.1.10</Version>
+    </StablePackage>
     <StablePackage Include="runtime.fedora.24-x64.Microsoft.NETCore.DotNetHostPolicy">
       <Version>1.1.10</Version>
     </StablePackage>
+    <StablePackage Include="runtime.fedora.27-x64.Microsoft.NETCore.DotNetHostPolicy">
+      <Version>1.1.10</Version>
+    </StablePackage>
+    <StablePackage Include="runtime.fedora.28-x64.Microsoft.NETCore.DotNetHostPolicy">
+      <Version>1.1.10</Version>
+    </StablePackage>
     <StablePackage Include="runtime.opensuse.42.1-x64.Microsoft.NETCore.DotNetHostPolicy">
+      <Version>1.1.10</Version>
+    </StablePackage>
+    <StablePackage Include="runtime.opensuse.42.3-x64.Microsoft.NETCore.DotNetHostPolicy">
       <Version>1.1.10</Version>
     </StablePackage>
     <StablePackage Include="runtime.osx.10.10-x64.Microsoft.NETCore.DotNetHostPolicy">
@@ -593,6 +605,9 @@
       <Version>1.1.10</Version>
     </StablePackage>
     <StablePackage Include="runtime.ubuntu.16.04-x64.Microsoft.NETCore.DotNetHostPolicy">
+      <Version>1.1.10</Version>
+    </StablePackage>
+    <StablePackage Include="runtime.ubuntu.18.04-x64.Microsoft.NETCore.DotNetHostPolicy">
       <Version>1.1.10</Version>
     </StablePackage>
     <StablePackage Include="runtime.win10-arm64.Microsoft.NETCore.DotNetHostPolicy">

--- a/pkg/stable.packages.props
+++ b/pkg/stable.packages.props
@@ -568,12 +568,6 @@
     </StablePackage>
 
     <!-- NETCore 1.1.10 core-setup -->
-    <StablePackage Include="Microsoft.DotNet.PlatformAbstractions">
-      <Version>1.1.10</Version>
-    </StablePackage>
-    <StablePackage Include="Microsoft.Extensions.DependencyModel">
-      <Version>1.1.10</Version>
-    </StablePackage>
     <StablePackage Include="Microsoft.NETCore.App">
       <Version>1.1.10</Version>
     </StablePackage>

--- a/pkg/stable.packages.props
+++ b/pkg/stable.packages.props
@@ -568,55 +568,157 @@
     </StablePackage>
 
     <!-- NETCore 1.1.10 core-setup -->
+    <StablePackage Include="Microsoft.DotNet.PlatformAbstractions">
+      <Version>1.1.10</Version>
+    </StablePackage>
+    <StablePackage Include="Microsoft.Extensions.DependencyModel">
+      <Version>1.1.10</Version>
+    </StablePackage>
     <StablePackage Include="Microsoft.NETCore.App">
+      <Version>1.1.10</Version>
+    </StablePackage>
+    <StablePackage Include="Microsoft.NETCore.DotNetHost">
       <Version>1.1.10</Version>
     </StablePackage>
     <StablePackage Include="Microsoft.NETCore.DotNetHostPolicy">
       <Version>1.1.10</Version>
     </StablePackage>
+    <StablePackage Include="Microsoft.NETCore.DotNetHostResolver">
+      <Version>1.1.10</Version>
+    </StablePackage>
+    <StablePackage Include="runtime.debian.8-x64.Microsoft.NETCore.DotNetHost">
+      <Version>1.1.10</Version>
+    </StablePackage>
     <StablePackage Include="runtime.debian.8-x64.Microsoft.NETCore.DotNetHostPolicy">
+      <Version>1.1.10</Version>
+    </StablePackage>
+    <StablePackage Include="runtime.debian.8-x64.Microsoft.NETCore.DotNetHostResolver">
+      <Version>1.1.10</Version>
+    </StablePackage>
+    <StablePackage Include="runtime.debian.9-x64.Microsoft.NETCore.DotNetHost">
       <Version>1.1.10</Version>
     </StablePackage>
     <StablePackage Include="runtime.debian.9-x64.Microsoft.NETCore.DotNetHostPolicy">
       <Version>1.1.10</Version>
     </StablePackage>
+    <StablePackage Include="runtime.debian.9-x64.Microsoft.NETCore.DotNetHostResolver">
+      <Version>1.1.10</Version>
+    </StablePackage>
+    <StablePackage Include="runtime.fedora.24-x64.Microsoft.NETCore.DotNetHost">
+      <Version>1.1.10</Version>
+    </StablePackage>
     <StablePackage Include="runtime.fedora.24-x64.Microsoft.NETCore.DotNetHostPolicy">
+      <Version>1.1.10</Version>
+    </StablePackage>
+    <StablePackage Include="runtime.fedora.24-x64.Microsoft.NETCore.DotNetHostResolver">
+      <Version>1.1.10</Version>
+    </StablePackage>
+    <StablePackage Include="runtime.fedora.27-x64.Microsoft.NETCore.DotNetHost">
       <Version>1.1.10</Version>
     </StablePackage>
     <StablePackage Include="runtime.fedora.27-x64.Microsoft.NETCore.DotNetHostPolicy">
       <Version>1.1.10</Version>
     </StablePackage>
+    <StablePackage Include="runtime.fedora.27-x64.Microsoft.NETCore.DotNetHostResolver">
+      <Version>1.1.10</Version>
+    </StablePackage>
+    <StablePackage Include="runtime.fedora.28-x64.Microsoft.NETCore.DotNetHost">
+      <Version>1.1.10</Version>
+    </StablePackage>
     <StablePackage Include="runtime.fedora.28-x64.Microsoft.NETCore.DotNetHostPolicy">
+      <Version>1.1.10</Version>
+    </StablePackage>
+    <StablePackage Include="runtime.fedora.28-x64.Microsoft.NETCore.DotNetHostResolver">
+      <Version>1.1.10</Version>
+    </StablePackage>
+    <StablePackage Include="runtime.opensuse.42.1-x64.Microsoft.NETCore.DotNetHost">
       <Version>1.1.10</Version>
     </StablePackage>
     <StablePackage Include="runtime.opensuse.42.1-x64.Microsoft.NETCore.DotNetHostPolicy">
       <Version>1.1.10</Version>
     </StablePackage>
+    <StablePackage Include="runtime.opensuse.42.1-x64.Microsoft.NETCore.DotNetHostResolver">
+      <Version>1.1.10</Version>
+    </StablePackage>
+    <StablePackage Include="runtime.opensuse.42.3-x64.Microsoft.NETCore.DotNetHost">
+      <Version>1.1.10</Version>
+    </StablePackage>
     <StablePackage Include="runtime.opensuse.42.3-x64.Microsoft.NETCore.DotNetHostPolicy">
+      <Version>1.1.10</Version>
+    </StablePackage>
+    <StablePackage Include="runtime.opensuse.42.3-x64.Microsoft.NETCore.DotNetHostResolver">
+      <Version>1.1.10</Version>
+    </StablePackage>
+    <StablePackage Include="runtime.osx.10.10-x64.Microsoft.NETCore.DotNetHost">
       <Version>1.1.10</Version>
     </StablePackage>
     <StablePackage Include="runtime.osx.10.10-x64.Microsoft.NETCore.DotNetHostPolicy">
       <Version>1.1.10</Version>
     </StablePackage>
+    <StablePackage Include="runtime.osx.10.10-x64.Microsoft.NETCore.DotNetHostResolver">
+      <Version>1.1.10</Version>
+    </StablePackage>
+    <StablePackage Include="runtime.rhel.7-x64.Microsoft.NETCore.DotNetHost">
+      <Version>1.1.10</Version>
+    </StablePackage>
     <StablePackage Include="runtime.rhel.7-x64.Microsoft.NETCore.DotNetHostPolicy">
+      <Version>1.1.10</Version>
+    </StablePackage>
+    <StablePackage Include="runtime.rhel.7-x64.Microsoft.NETCore.DotNetHostResolver">
+      <Version>1.1.10</Version>
+    </StablePackage>
+    <StablePackage Include="runtime.ubuntu.14.04-x64.Microsoft.NETCore.DotNetHost">
       <Version>1.1.10</Version>
     </StablePackage>
     <StablePackage Include="runtime.ubuntu.14.04-x64.Microsoft.NETCore.DotNetHostPolicy">
       <Version>1.1.10</Version>
     </StablePackage>
+    <StablePackage Include="runtime.ubuntu.14.04-x64.Microsoft.NETCore.DotNetHostResolver">
+      <Version>1.1.10</Version>
+    </StablePackage>
+    <StablePackage Include="runtime.ubuntu.16.04-x64.Microsoft.NETCore.DotNetHost">
+      <Version>1.1.10</Version>
+    </StablePackage>
     <StablePackage Include="runtime.ubuntu.16.04-x64.Microsoft.NETCore.DotNetHostPolicy">
+      <Version>1.1.10</Version>
+    </StablePackage>
+    <StablePackage Include="runtime.ubuntu.16.04-x64.Microsoft.NETCore.DotNetHostResolver">
+      <Version>1.1.10</Version>
+    </StablePackage>
+    <StablePackage Include="runtime.ubuntu.18.04-x64.Microsoft.NETCore.DotNetHost">
       <Version>1.1.10</Version>
     </StablePackage>
     <StablePackage Include="runtime.ubuntu.18.04-x64.Microsoft.NETCore.DotNetHostPolicy">
       <Version>1.1.10</Version>
     </StablePackage>
+    <StablePackage Include="runtime.ubuntu.18.04-x64.Microsoft.NETCore.DotNetHostResolver">
+      <Version>1.1.10</Version>
+    </StablePackage>
+    <StablePackage Include="runtime.win10-arm64.Microsoft.NETCore.DotNetHost">
+      <Version>1.1.10</Version>
+    </StablePackage>
     <StablePackage Include="runtime.win10-arm64.Microsoft.NETCore.DotNetHostPolicy">
+      <Version>1.1.10</Version>
+    </StablePackage>
+    <StablePackage Include="runtime.win10-arm64.Microsoft.NETCore.DotNetHostResolver">
+      <Version>1.1.10</Version>
+    </StablePackage>
+    <StablePackage Include="runtime.win7-x64.Microsoft.NETCore.DotNetHost">
       <Version>1.1.10</Version>
     </StablePackage>
     <StablePackage Include="runtime.win7-x64.Microsoft.NETCore.DotNetHostPolicy">
       <Version>1.1.10</Version>
     </StablePackage>
+    <StablePackage Include="runtime.win7-x64.Microsoft.NETCore.DotNetHostResolver">
+      <Version>1.1.10</Version>
+    </StablePackage>
+    <StablePackage Include="runtime.win7-x86.Microsoft.NETCore.DotNetHost">
+      <Version>1.1.10</Version>
+    </StablePackage>
     <StablePackage Include="runtime.win7-x86.Microsoft.NETCore.DotNetHostPolicy">
+      <Version>1.1.10</Version>
+    </StablePackage>
+    <StablePackage Include="runtime.win7-x86.Microsoft.NETCore.DotNetHostResolver">
       <Version>1.1.10</Version>
     </StablePackage>
   </ItemGroup>


### PR DESCRIPTION
Some builds were failing because I missed adding entries for the new RIDs. We also need to build DotNetHost & DotNetHostResolver since Debian9 was introduced in this release.

@weshaggard @safern @eerhardt PTAL