### PR TITLE
Download internal drop in sign-and-publish job

### DIFF
--- a/buildpipeline/Core-Setup-Sign-And-Publish.json
+++ b/buildpipeline/Core-Setup-Sign-And-Publish.json
@@ -25,6 +25,26 @@
     },
     {
       "enabled": true,
+      "continueOnError": true,
+      "alwaysRun": true,
+      "displayName": "Remove Release Tools directory",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "e213ff0f-5d5c-4791-802d-52ea3e7be1f1",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "scriptType": "inlineScript",
+        "scriptName": "",
+        "arguments": "",
+        "workingFolder": "",
+        "inlineScript": "rm -Recurse -Force -ErrorAction Ignore DotNet-Core-Release-Tools",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "enabled": true,
       "continueOnError": false,
       "alwaysRun": false,
       "displayName": "Run script $(VS140COMNTOOLS)\\VsDevCmd.bat",
@@ -38,6 +58,44 @@
         "filename": "$(VS140COMNTOOLS)\\VsDevCmd.bat",
         "arguments": "",
         "modifyEnvironment": "true",
+        "workingFolder": "",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Clone release tools",
+      "condition": "eq(variables.PB_InternalBuild, 'true')",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "filename": "git",
+        "arguments": "clone $(ReleaseToolsGitUrl)",
+        "workingFolder": "",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Create Internal drop directory",
+      "condition": "eq(variables.PB_InternalBuild, 'true')",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "filename": "mkdir",
+        "arguments": "$(Build.SourcesDirectory)\\AzureCoreFxDownload",
         "workingFolder": "",
         "failOnStandardError": "false"
       }
@@ -60,6 +118,69 @@
         "version": "",
         "feedSource": "https://devdiv.pkgs.visualstudio.com/DefaultCollection/_packaging/MicroBuildToolset/nuget/v3/index.json",
         "esrpSigning": "$(PB_UseEsrpSigning)"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Download Azure Internal drop",
+      "condition": "eq(variables.PB_InternalBuild, 'true')",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "e213ff0f-5d5c-4791-802d-52ea3e7be1f1",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "scriptType": "filePath",
+        "scriptName": "DotNet-Core-Release-Tools/msbuildrun.ps1",
+        "arguments": "-RepositoryRoot $(Build.SourcesDirectory)\\DotNet-Core-Release-Tools -Target DownloadFromAzure -Properties ContainerName=$(CoreFxAzureContainer),DownloadDirectory=$(Build.SourcesDirectory)\\AzureCoreFxDownload,AccountName=$(AzureAccountName),AccessToken=$(AzureAccessToken),FilterBlobNames=Release/",
+        "inlineScript": "# You can write your powershell scripts inline here. \n# You can also pass predefined and custom variables to this scripts using arguments\n\n Write-Host \"Hello World\"",
+        "workingFolder": "",
+        "failOnStandardError": "true"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Add CoreFX drop to NuGet.Config",
+      "condition": "eq(variables.PB_InternalBuild, 'true')",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "e213ff0f-5d5c-4791-802d-52ea3e7be1f1",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "scriptType": "filePath",
+        "scriptName": "DotNet-Core-Release-Tools/msbuildrun.ps1",
+        "arguments": "-RepositoryRoot $(Build.SourcesDirectory)\\DotNet-Core-Release-Tools -Target AddSourceToNuGetConfig -Properties NuGetConfigFile=$(Build.SourcesDirectory)\\NuGet.Config,SourceName=LocalDownload,SourcePath=$(Build.SourcesDirectory)\\AzureCoreFxDownload\\Release",
+        "inlineScript": "# You can write your powershell scripts inline here. \n# You can also pass predefined and custom variables to this scripts using arguments\n\n Write-Host \"Hello World\"",
+        "workingFolder": "",
+        "failOnStandardError": "true"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Add CoreCLR drop to NuGet.Config (AzureCoreFxDownload/Release/pkg)",
+      "condition": "eq(variables.PB_InternalBuild, 'true')",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "e213ff0f-5d5c-4791-802d-52ea3e7be1f1",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "scriptType": "filePath",
+        "scriptName": "DotNet-Core-Release-Tools/msbuildrun.ps1",
+        "arguments": "-RepositoryRoot $(Build.SourcesDirectory)\\DotNet-Core-Release-Tools -Target AddSourceToNuGetConfig -Properties NuGetConfigFile=$(Build.SourcesDirectory)\\NuGet.Config,SourceName=LocalDownload2,SourcePath=$(Build.SourcesDirectory)\\AzureCoreFxDownload\\Release\\pkg",
+        "inlineScript": "",
+        "workingFolder": "",
+        "failOnStandardError": "true"
       }
     },
     {
@@ -217,6 +338,44 @@
       }
     },
     {
+      "enabled": true,
+      "continueOnError": true,
+      "alwaysRun": true,
+      "displayName": "Remove Release Tools directory",
+      "condition": "eq(variables.PB_InternalBuild, 'true')",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "filename": "rmdir",
+        "arguments": "/q /s DotNet-Core-Release-Tools",
+        "workingFolder": "",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": true,
+      "alwaysRun": true,
+      "displayName": "Remove Azure CoreFX drop directory",
+      "condition": "eq(variables.PB_InternalBuild, 'true')",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "filename": "rmdir",
+        "arguments": "/q /s AzureCoreFxDownload",
+        "workingFolder": "",
+        "failOnStandardError": "false"
+      }
+    },
+    {
       "environment": {},
       "enabled": true,
       "continueOnError": true,
@@ -306,6 +465,27 @@
     },
     "TeamName": {
       "value": "DotNetCore"
+    },
+    "CoreFxAzureContainer": {
+      "value": "ENV_VAR_EMPTY_WORKAROUND",
+      "allowOverride": true
+    },
+    "AzureAccountName": {
+      "value": "ENV_VAR_EMPTY_WORKAROUND"
+    },
+    "AzureAccessToken": {
+      "value": null,
+      "isSecret": true
+    },
+    "VsoPassword": {
+      "value": null,
+      "isSecret": true
+    },
+    "ReleaseToolsGitUrl": {
+      "value": "https://dn-bot:$(VsoPassword)@devdiv.visualstudio.com/DevDiv/_git/DotNet-Core-Release-Tools"
+    },
+    "PB_InternalBuild": {
+      "value": "false"
     },
     "system.debug": {
       "value": "false"


### PR DESCRIPTION
For the product build during internal builds, we download the internal Azure drops & restore packages from that local store. It turns out we also need to do this during the sign-and-publish job, since that job runs build.cmd. I hadn't caught this before since this is the first time we've run an internal build for a full release - I guess the test builds I ran a while back were not depending on any packages that only existed in internal drops. This will fix the failures in https://devdiv.visualstudio.com/DefaultCollection/DevDiv/_build/results?buildId=2021716&view=logs

@weshaggard @MattGal PTAL

Port of https://github.com/dotnet/core-setup/pull/4563 for 1.1.0