### PR TITLE
[release/2.2] Startup hook host functionality

### DIFF
--- a/Documentation/design-docs/host-startup-hook.md
+++ b/Documentation/design-docs/host-startup-hook.md
@@ -1,0 +1,233 @@
+# Host startup hook
+
+For .NET Core 3+, we want to provide a low-level hook that allows
+injecting managed code to run before the main application's entry
+point. This hook will make it possible for the host to customize the
+behavior of managed applications during process launch, after they
+have been deployed.
+
+## Motivation
+
+This would allow hosting providers to define custom configuration and
+policy in managed code, including settings that potentially influence
+load behavior of the main entry point such as the
+`AssemblyLoadContext` behavior. The hook could be used to set up
+tracing or telemetry injection, to set up callbacks for handling
+Debug.Assert (if we make such an API available), or other
+environment-dependent behavior. The hook is separate from the entry
+point, so that user code doesn't need to be modified.
+
+## Proposed behavior
+
+The `DOTNET_STARTUP_HOOKS` environment variable can be used to specify
+a list of managed assemblies that contain a `StartupHook` type with a
+`public static void Initialize()` method, each of which will be called
+in the order specified, before the `Main` entry point
+
+Unix:
+```
+DOTNET_STARTUP_HOOKS=/path/to/StartupHook1.dll:/path/to/StartupHook2.dll
+```
+
+Windows:
+```
+DOTNET_STARTUP_HOOKS=D:\path\to\StartupHook1.dll;D:\path\to\StartupHook2.dll
+```
+
+This variable is a list of absolute assembly paths, delimited by the
+platform-specific path separator (`;` on Windows and `:` on Unix). It
+may not contain any empty entries or a trailing path separator. The
+type must be named `StartupHook` without any namespace, and should be
+`internal`.
+
+Setting this environment variable will cause the `public static void
+Initialize()` method of the `StartupHook` type in each of the
+specified assemblies to be called in order, synchronously, before the
+main assembly is loaded. The hooks are all called on the same managed
+thread (the same thread that calls `Main`). The environment variable
+will be inherited by child processes by default. It is up to the
+`StartupHook.dll`s and user code to decide what to do about this -
+`StartupHook.dll` may clear them to prevent this behavior globally, if
+desired.
+
+Specifically, hostpolicy starts up coreclr and sets up a new
+AppDomain, passing in the startup hook variable as the property
+`STARTUP_HOOKS` if it was set. This variable can be retrieved using
+`AppContext.GetData("STARTUP_HOOKS")`. Hostpolicy then asks the
+runtime to execute the main method.  Just before the main method is
+called, the runtime will call a private method in
+`System.Private.CoreLib`, which will call each
+`StartupHook.Initialize()` in turn synchronously. This gives
+`StartupHook` a chance to set up new `AssemblyLoadContext`s, or
+register other callbacks. After all of the `Initialize()` methods
+return, the runtime calls the main entry point of the app like usual.
+
+Rather than forcing all configuration to be done through a single
+predefined API, this creates a place where such configuration could be
+centralized, while still allowing user code to do its own thing if it
+so desires.
+
+The producer of `StartupHook.dll` needs to ensure that
+`StartupHook.dll` is compatible with the dependencies specified in the
+main application's deps.json, since those dependencies are put on the
+TPA list during the runtime startup, before `StartupHook.dll` is
+loaded. This means that `StartupHook.dll` needs to built against the
+same or lower version of .NET Core than the app.
+
+## Example
+
+This could be used with `AssemblyLoadContext` APIs to resolve
+dependencies not on the TPA list from a shared location, similar to
+the GAC on full framework. It could also be used to forcibly preload
+assemblies that are on the TPA list from a different location. Future
+changes to `AssemblyLoadContext` could make this easier to use by
+making the default load context or TPA list modifiable.
+
+Note that the `StartupHook` type is internal and in the global
+namespace, and the signature of the `Initialize` method is `public
+static void Initialize()`.
+
+```c#
+internal class StartupHook
+{
+    public static void Initialize()
+    {
+        AssemblyLoadContext.Default.Resolving += SharedHostPolicy.SharedAssemblyResolver.LoadAssemblyFromSharedLocation;
+    }
+}
+
+namespace SharedHostPolicy
+{
+    class SharedAssemblyResolver
+    {
+        public static Assembly LoadAssemblyFromSharedLocation(AssemblyLoadContext context, AssemblyName assemblyName)
+        {
+            string sharedAssemblyPath = // find assemblyName in shared location...
+            if (sharedAssemblyPath != null)
+                return AssemblyLoadContext.Default.LoadFromAssemblyPath(sharedAssemblyPath)
+            return null;
+        }
+    }
+}
+```
+
+## Error handling details
+
+Problems with the startup hook should be fairly straightforward to
+diagnose. All of these exceptions will contain the startup hook path
+(`System.StartupHookProvider.ProcessStartupHooks`) on the stack
+trace. They fall into the following categories:
+
+- Errors detected eagerly, with exceptions thrown before the execution
+  of any startup hook.
+
+  - Invalid syntax throws an `ArgumentException`.
+
+  - Partially qualified paths in the startup hook throw an
+    `ArgumentException`.
+
+- Exceptions thrown during the call to a given startup hook. Previous
+  hooks may have run successfully.
+
+  - Missing startup hook assemblies throw a `FileNotFoundException`.
+
+  - Invalid startup hook assemblies throw a `BadImageFormatException`.
+
+  - Missing startup hook types throw a `TypeLoadException`.
+
+  - Missing `Initialize` methods in startup hooks throw a
+    `MissingMethodException`.
+
+  - Invalid `Initialize` methods (with an incorrect signature - that
+    take parameters, have a non-void return type, are not public, or
+    are not static) throw an `ArgumentException`.
+
+  - Unhandled exceptions thrown from a startup hook will have the same
+    exception behavior as any other managed exception thrown from
+    `Main` - by default, they will terminate the process and show a
+    stack trace.
+
+## Guidance and caveats
+
+This hook is meant as a low-level, powerful way to inject code into
+the process at runtime, for use by tool developers who truly have a
+need for this kind of power. It should only be used in situations
+where modifying application code is not an option and there is not an
+existing structured dependency injection framework in place. An
+example of such a use case is a hook that injects logging, telemetry,
+or profiling into an existing deployed application at runtime.
+
+It is prone to ordering issues when multiple hooks are used, and does
+nothing to attempt to make dependencies of hooks easy to
+manage. Multiple hooks should be independent of each other.
+
+### No built-in solution to ordering issues
+
+For example, if one hook sets global state that introduces logging in
+the process, the new behavior will affect all subsequent hooks in the
+process and the `Main` entry point. Subsequent hooks may attempt to
+modify logging behavior in a way that conflicts with the first hook,
+leading to unexpected results. This kind of problem exists for any
+framework that gives independently-owned components access to shared
+resources - often dependency injection frameworks will have a
+dependency manager that loads components in a specific order. If this
+kind of behavior is required, a proper dependency injection framework
+should be used instead of multiple startup hooks.
+
+### No dependency resolution for non-app assemblies
+
+Another example regarding hook dependencies: the startup hook dll must
+not depend on any assemblies outside of the app's TPA list. If a
+startup hook has a static dependency on an assembly like
+'Newtonsoft.Json' but the app does not, executing the hook will throw
+a `FileNotFoundException`. There is no extra resolution logic for
+startup hooks. Any startup hook that wants to modify load behavior
+will have to use framework APIs like AssemblyLoadContexts to do this
+manually.
+
+### No conflict resolution for dependencies shared by hooks or the app
+
+If a startup hook decides to do something dangerous like force the
+load of a particular assembly, any later hooks (or the entry point)
+that run in the same AssemblyLoadContext and depend on that assembly
+will use the version that was forcefully loaded, even if they were
+compiled against a different version.
+
+### Threading behavior
+
+Each startup hook will run on the same managed thread as the `Main`
+method, so thread state will persist between startup hooks. The
+threading apartment state will be set based on any attributes present
+in the `Main` method of the app, before startup hooks execute. As a
+result, attemps to explicitly set the thread apartment state in a
+startup hook will fail if the requested state is incompatible with the
+app's threading state.
+
+While it may make sense to set global behavior in startup hooks, it is
+not recommended to use the thread state as a communication mechanism
+between startup hooks. Any setup that requires multiple communicating
+hooks should consider using a plugin system instead.
+
+In order to use `ThreadStatic` storage, for example, the class
+containing the shared thread state needs to be a common dependency of
+the hooks that use it. Because hooks can not depend on assemblies
+outside of the app's TPA list, this requires the shared state class to
+be defined either in the app or within the first hook that uses it:
+
+- If defined in the app, the shared state used by startup hooks would
+  need to be compiled into the app. In that case, consider explicitly
+  activating the desired behavior by modifying the app code, instead
+  of using startup hooks.
+
+- If defined in the first startup hook, all subsequent hooks that
+  access the `ThreadStatic` need to be compiled with references to the
+  first. In a situation like this, consider making the components that
+  need to communicate with each other part of a common plugin
+  framework. If necessary, the plugin host could be injected into the
+  process with a single startup hook.
+
+### Visibility of `StartupHook` type
+
+The type should be made `internal` to prevent exposing it as API
+surface to any managed code that happens to have access to the startup
+hook dll. However, the feature will also work if the type is `public`.

--- a/src/corehost/cli/hostpolicy.cpp
+++ b/src/corehost/cli/hostpolicy.cpp
@@ -107,7 +107,7 @@ int run(const arguments_t& args, pal::string_t* out_host_command_result = nullpt
     };
 
     // Note: these variables' lifetime should be longer than coreclr_initialize.
-    std::vector<char> tpa_paths_cstr, app_base_cstr, native_dirs_cstr, resources_dirs_cstr, fx_deps, deps, clrjit_path_cstr, probe_directories;
+    std::vector<char> tpa_paths_cstr, app_base_cstr, native_dirs_cstr, resources_dirs_cstr, fx_deps, deps, clrjit_path_cstr, probe_directories, startup_hooks_cstr;
     pal::pal_clrstring(probe_paths.tpa, &tpa_paths_cstr);
     pal::pal_clrstring(args.app_root, &app_base_cstr);
     pal::pal_clrstring(probe_paths.native, &native_dirs_cstr);
@@ -183,6 +183,15 @@ int run(const arguments_t& args, pal::string_t* out_host_command_result = nullpt
         property_keys.push_back("APP_NI_PATHS");
         property_values.push_back(app_base_cstr.data());
         property_values.push_back(app_base_cstr.data());
+    }
+
+    // Startup hooks
+    pal::string_t startup_hooks;
+    if (pal::getenv(_X("DOTNET_STARTUP_HOOKS"), &startup_hooks))
+    {
+        pal::pal_clrstring(startup_hooks, &startup_hooks_cstr);
+        property_keys.push_back("STARTUP_HOOKS");
+        property_values.push_back(startup_hooks_cstr.data());
     }
 
     size_t property_size = property_keys.size();

--- a/src/test/Assets/TestProjects/LightupLib/Program.cs
+++ b/src/test/Assets/TestProjects/LightupLib/Program.cs
@@ -8,7 +8,7 @@ namespace LightupLib
         public static string Hello(string name)
         {
             // Load a dependency of LightupLib
-             var t = typeof(Newtonsoft.Json.JsonReader);
+            var t = typeof(Newtonsoft.Json.JsonReader);
             if (t != null)
                 return "Hello "+name;
             else 

--- a/src/test/Assets/TestProjects/PortableAppWithMissingRef/PortableAppWithMissingRef.csproj
+++ b/src/test/Assets/TestProjects/PortableAppWithMissingRef/PortableAppWithMissingRef.csproj
@@ -1,0 +1,23 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>$(NETCoreAppFramework)</TargetFramework>
+    <OutputType>Exe</OutputType>
+    <RuntimeFrameworkVersion>$(MNAVersion)</RuntimeFrameworkVersion>
+    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="Program.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="./SharedLibrary/ReferenceLibrary.csproj">
+      <!-- This ensures that ResolveAssemblyReferences sets CopyLocal
+           to False, so that the referenced assembly doesn't get
+           published with this application. -->
+      <Private>False</Private>
+    </ProjectReference>
+  </ItemGroup>
+
+</Project>

--- a/src/test/Assets/TestProjects/PortableAppWithMissingRef/Program.cs
+++ b/src/test/Assets/TestProjects/PortableAppWithMissingRef/Program.cs
@@ -1,0 +1,17 @@
+using System;
+using SharedLibrary;
+
+namespace PortableApp
+{
+    public static class Program
+    {
+        public static int Main(string[] args)
+        {
+            // Returns 1 if using the reference assembly, and 2 if
+            // using the assembly injected by the startup hook. This
+            // should never actually use the reference assembly, which
+            // is not published with the app.
+            return SharedType.Value;
+        }
+    }
+}

--- a/src/test/Assets/TestProjects/PortableAppWithMissingRef/SharedLibrary/ReferenceLibrary.csproj
+++ b/src/test/Assets/TestProjects/PortableAppWithMissingRef/SharedLibrary/ReferenceLibrary.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>$(NETCoreAppFramework)</TargetFramework>
+    <OutputType>Library</OutputType>
+    <RuntimeFrameworkVersion>$(MNAVersion)</RuntimeFrameworkVersion>
+    <AssemblyName>SharedLibrary</AssemblyName>
+  </PropertyGroup>
+
+</Project>

--- a/src/test/Assets/TestProjects/PortableAppWithMissingRef/SharedLibrary/SharedLibrary.cs
+++ b/src/test/Assets/TestProjects/PortableAppWithMissingRef/SharedLibrary/SharedLibrary.cs
@@ -1,0 +1,11 @@
+﻿using System;
+
+namespace SharedLibrary
+{
+    public class SharedType
+    {
+        // This is only used as a reference library for a portable
+        // app. It will never be called.
+        public static int Value = 1;
+    }
+}

--- a/src/test/Assets/TestProjects/StartupHook/StartupHook.cs
+++ b/src/test/Assets/TestProjects/StartupHook/StartupHook.cs
@@ -1,0 +1,10 @@
+using System;
+
+internal class StartupHook
+{
+    public static void Initialize()
+    {
+        // Normal success case with a simple startup hook.
+        Console.WriteLine("Hello from startup hook!");
+    }
+}

--- a/src/test/Assets/TestProjects/StartupHook/StartupHook.csproj
+++ b/src/test/Assets/TestProjects/StartupHook/StartupHook.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>$(NETCoreAppFramework)</TargetFramework>
+    <RuntimeFrameworkVersion>$(MNAVersion)</RuntimeFrameworkVersion>
+  </PropertyGroup>
+
+</Project>

--- a/src/test/Assets/TestProjects/StartupHookFake/StartupHookFake.csproj
+++ b/src/test/Assets/TestProjects/StartupHookFake/StartupHookFake.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>$(NETCoreAppFramework)</TargetFramework>
+    <RuntimeFrameworkVersion>$(MNAVersion)</RuntimeFrameworkVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Content Include="StartupHookInvalidAssembly.dll" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
+
+</Project>

--- a/src/test/Assets/TestProjects/StartupHookFake/StartupHookInvalidAssembly.dll
+++ b/src/test/Assets/TestProjects/StartupHookFake/StartupHookInvalidAssembly.dll
@@ -1,0 +1,1 @@
+Used to test assembly load failure in startup hook path.

--- a/src/test/Assets/TestProjects/StartupHookWithAssemblyResolver/SharedLibrary/SharedLibrary.cs
+++ b/src/test/Assets/TestProjects/StartupHookWithAssemblyResolver/SharedLibrary/SharedLibrary.cs
@@ -1,0 +1,9 @@
+namespace SharedLibrary
+{
+    public class SharedType
+    {
+        // This is injected into a portable application by a startup
+        // hook.
+        public static int Value = 2;
+    }
+}

--- a/src/test/Assets/TestProjects/StartupHookWithAssemblyResolver/SharedLibrary/SharedLibrary.csproj
+++ b/src/test/Assets/TestProjects/StartupHookWithAssemblyResolver/SharedLibrary/SharedLibrary.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>$(NETCoreAppFramework)</TargetFramework>
+    <OutputType>Library</OutputType>
+    <RuntimeFrameworkVersion>$(MNAVersion)</RuntimeFrameworkVersion>
+  </PropertyGroup>
+
+</Project>

--- a/src/test/Assets/TestProjects/StartupHookWithAssemblyResolver/StartupHookWithAssemblyResolver.cs
+++ b/src/test/Assets/TestProjects/StartupHookWithAssemblyResolver/StartupHookWithAssemblyResolver.cs
@@ -1,0 +1,29 @@
+using System;
+using System.IO;
+using System.Reflection;
+using System.Runtime.Loader;
+
+internal class StartupHook
+{
+    public static void Initialize()
+    {
+        AssemblyLoadContext.Default.Resolving += SharedHostPolicy.SharedAssemblyResolver.Resolve;
+    }
+}
+
+namespace SharedHostPolicy
+{
+    public class SharedAssemblyResolver
+    {
+        public static Assembly Resolve(AssemblyLoadContext context, AssemblyName assemblyName)
+        {
+            if (assemblyName.Name == "SharedLibrary")
+            {
+                string startupHookDirectory = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
+                string sharedLibrary = Path.GetFullPath(Path.Combine(startupHookDirectory, "SharedLibrary.dll"));
+                return AssemblyLoadContext.Default.LoadFromAssemblyPath(sharedLibrary);
+            }
+            return null;
+        }
+    }
+}

--- a/src/test/Assets/TestProjects/StartupHookWithAssemblyResolver/StartupHookWithAssemblyResolver.csproj
+++ b/src/test/Assets/TestProjects/StartupHookWithAssemblyResolver/StartupHookWithAssemblyResolver.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>$(NETCoreAppFramework)</TargetFramework>
+    <RuntimeFrameworkVersion>$(MNAVersion)</RuntimeFrameworkVersion>
+    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="StartupHookWithAssemblyResolver.cs" />
+  </ItemGroup>
+
+  <!-- Copy the preloaded base type to the startup hook's output
+       directory to make it easy to find. -->
+  <ItemGroup>
+    <ProjectReference Include="./SharedLibrary/SharedLibrary.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/test/Assets/TestProjects/StartupHookWithDependency/StartupHookWithDependency.cs
+++ b/src/test/Assets/TestProjects/StartupHookWithDependency/StartupHookWithDependency.cs
@@ -1,0 +1,14 @@
+using System;
+
+internal class StartupHook
+{
+    public static void Initialize()
+    {
+        // This startup hook can pass or fail depending on whether the
+        // app comes with Newtonsoft.Json.
+        Console.WriteLine("Hello from startup hook with dependency!");
+
+        // A small operation involving NewtonSoft.Json to ensure the assembly is loaded properly
+        var t = typeof(Newtonsoft.Json.JsonReader);
+    }
+}

--- a/src/test/Assets/TestProjects/StartupHookWithDependency/StartupHookWithDependency.csproj
+++ b/src/test/Assets/TestProjects/StartupHookWithDependency/StartupHookWithDependency.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>$(NETCoreAppFramework)</TargetFramework>
+    <RuntimeFrameworkVersion>$(MNAVersion)</RuntimeFrameworkVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
+  </ItemGroup>
+
+</Project>

--- a/src/test/Assets/TestProjects/StartupHookWithInstanceMethod/StartupHookWithInstanceMethod.cs
+++ b/src/test/Assets/TestProjects/StartupHookWithInstanceMethod/StartupHookWithInstanceMethod.cs
@@ -1,0 +1,12 @@
+using System;
+
+internal class StartupHook
+{
+    public void Initialize()
+    {
+        // This hook should not be called because it's an instance
+        // method. Instead, the startup hook provider code should
+        // throw an exception.
+        Console.WriteLine("Hello from startup hook with instance method!");
+    }
+}

--- a/src/test/Assets/TestProjects/StartupHookWithInstanceMethod/StartupHookWithInstanceMethod.csproj
+++ b/src/test/Assets/TestProjects/StartupHookWithInstanceMethod/StartupHookWithInstanceMethod.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>$(NETCoreAppFramework)</TargetFramework>
+    <RuntimeFrameworkVersion>$(MNAVersion)</RuntimeFrameworkVersion>
+  </PropertyGroup>
+
+</Project>

--- a/src/test/Assets/TestProjects/StartupHookWithMultipleIncorrectSignatures/StartupHookWithMultipleIncorrectSignatures.cs
+++ b/src/test/Assets/TestProjects/StartupHookWithMultipleIncorrectSignatures/StartupHookWithMultipleIncorrectSignatures.cs
@@ -1,0 +1,22 @@
+using System;
+
+internal class StartupHook
+{
+    // Neither of these hooks should be called, because they have the
+    // wrong signature (it should be static void Initialize()). This
+    // is used to check that the provider code properly detects the
+    // case where there are multiple incorrect Initialize
+    // methods. Instead, the startup hook provider code should throw
+    // an exception.
+ 
+    public static int Initialize()
+    {
+        Console.WriteLine("Hello from startup hook returning int!");
+        return 10;
+    }
+
+    public static void Initialize(int input)
+    {
+        Console.WriteLine("Hello from startup hook taking int! Input: " + input);
+    }
+}

--- a/src/test/Assets/TestProjects/StartupHookWithMultipleIncorrectSignatures/StartupHookWithMultipleIncorrectSignatures.csproj
+++ b/src/test/Assets/TestProjects/StartupHookWithMultipleIncorrectSignatures/StartupHookWithMultipleIncorrectSignatures.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>$(NETCoreAppFramework)</TargetFramework>
+    <RuntimeFrameworkVersion>$(MNAVersion)</RuntimeFrameworkVersion>
+  </PropertyGroup>
+
+</Project>

--- a/src/test/Assets/TestProjects/StartupHookWithNonPublicMethod/StartupHookWithNonPublicMethod.cs
+++ b/src/test/Assets/TestProjects/StartupHookWithNonPublicMethod/StartupHookWithNonPublicMethod.cs
@@ -1,0 +1,10 @@
+using System;
+
+internal class StartupHook
+{
+    static void Initialize()
+    {
+        // Success case with a startup hook that is a private method.
+        Console.WriteLine("Hello from startup hook with non-public method!");
+    }
+}

--- a/src/test/Assets/TestProjects/StartupHookWithNonPublicMethod/StartupHookWithNonPublicMethod.csproj
+++ b/src/test/Assets/TestProjects/StartupHookWithNonPublicMethod/StartupHookWithNonPublicMethod.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>$(NETCoreAppFramework)</TargetFramework>
+    <RuntimeFrameworkVersion>$(MNAVersion)</RuntimeFrameworkVersion>
+  </PropertyGroup>
+
+</Project>

--- a/src/test/Assets/TestProjects/StartupHookWithOverload/StartupHookWithOverload.cs
+++ b/src/test/Assets/TestProjects/StartupHookWithOverload/StartupHookWithOverload.cs
@@ -1,0 +1,18 @@
+using System;
+
+internal class StartupHook
+{
+    public static void Initialize()
+    {
+        // Success case with a startup hook that contains multiple
+        // Initialize methods. This is used to check that the startup
+        // hook provider doesn't get confused by the presence of an
+        // extra Initialize method with an incorrect signature.
+        Initialize(123);
+    }
+
+    public static void Initialize(int input)
+    {
+        Console.WriteLine("Hello from startup hook with overload! Input: " + input);
+    }
+}

--- a/src/test/Assets/TestProjects/StartupHookWithOverload/StartupHookWithOverload.csproj
+++ b/src/test/Assets/TestProjects/StartupHookWithOverload/StartupHookWithOverload.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>$(NETCoreAppFramework)</TargetFramework>
+    <RuntimeFrameworkVersion>$(MNAVersion)</RuntimeFrameworkVersion>
+  </PropertyGroup>
+
+</Project>

--- a/src/test/Assets/TestProjects/StartupHookWithParameter/StartupHookWithParameter.cs
+++ b/src/test/Assets/TestProjects/StartupHookWithParameter/StartupHookWithParameter.cs
@@ -1,0 +1,12 @@
+using System;
+
+internal class StartupHook
+{
+    public static void Initialize(int input)
+    {
+        // This hook should not be called because it takes a
+        // parameter. Instead, the startup hook provider code should
+        // throw an exception.
+        Console.WriteLine("Hello from startup hook taking int! Input: " + input);
+    }
+}

--- a/src/test/Assets/TestProjects/StartupHookWithParameter/StartupHookWithParameter.csproj
+++ b/src/test/Assets/TestProjects/StartupHookWithParameter/StartupHookWithParameter.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>$(NETCoreAppFramework)</TargetFramework>
+    <RuntimeFrameworkVersion>$(MNAVersion)</RuntimeFrameworkVersion>
+  </PropertyGroup>
+
+</Project>

--- a/src/test/Assets/TestProjects/StartupHookWithReturnType/StartupHookWithReturnType.cs
+++ b/src/test/Assets/TestProjects/StartupHookWithReturnType/StartupHookWithReturnType.cs
@@ -1,0 +1,13 @@
+using System;
+
+internal class StartupHook
+{
+    public static int Initialize()
+    {
+        // This hook should not be called because it doesn't have a
+        // void return type. Instead, the startup hook provider code
+        // should throw an exception.
+        Console.WriteLine("Hello from startup hook returning int!");
+        return 10;
+    }
+}

--- a/src/test/Assets/TestProjects/StartupHookWithReturnType/StartupHookWithReturnType.csproj
+++ b/src/test/Assets/TestProjects/StartupHookWithReturnType/StartupHookWithReturnType.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>$(NETCoreAppFramework)</TargetFramework>
+    <RuntimeFrameworkVersion>$(MNAVersion)</RuntimeFrameworkVersion>
+  </PropertyGroup>
+
+</Project>

--- a/src/test/Assets/TestProjects/StartupHookWithoutInitializeMethod/StartupHookWithoutInitializeMethod.cs
+++ b/src/test/Assets/TestProjects/StartupHookWithoutInitializeMethod/StartupHookWithoutInitializeMethod.cs
@@ -1,0 +1,12 @@
+using System;
+
+internal class StartupHook
+{
+    public static void Init()
+    {
+        // This hook should not be called because it doesn't have the
+        // correct name (Initialize). Instead, the startup hook
+        // provider code should throw an exception.
+        Console.WriteLine("Hello from startup hook!");
+    }
+}

--- a/src/test/Assets/TestProjects/StartupHookWithoutInitializeMethod/StartupHookWithoutInitializeMethod.csproj
+++ b/src/test/Assets/TestProjects/StartupHookWithoutInitializeMethod/StartupHookWithoutInitializeMethod.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>$(NETCoreAppFramework)</TargetFramework>
+    <RuntimeFrameworkVersion>$(MNAVersion)</RuntimeFrameworkVersion>
+  </PropertyGroup>
+
+</Project>

--- a/src/test/Assets/TestProjects/StartupHookWithoutStartupHookType/StartupHookWithoutStartupHookType.cs
+++ b/src/test/Assets/TestProjects/StartupHookWithoutStartupHookType/StartupHookWithoutStartupHookType.cs
@@ -1,0 +1,12 @@
+using System;
+
+internal class StartupHookWrongType
+{
+    public static void Initialize()
+    {
+        // This hook should not be called because it doesn't have the
+        // correct type name (StartupHook). Instead, the startup hook
+        // provider code should throw an exception.
+        Console.WriteLine("Hello from startup hook!");
+    }
+}

--- a/src/test/Assets/TestProjects/StartupHookWithoutStartupHookType/StartupHookWithoutStartupHookType.csproj
+++ b/src/test/Assets/TestProjects/StartupHookWithoutStartupHookType/StartupHookWithoutStartupHookType.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>$(NETCoreAppFramework)</TargetFramework>
+    <RuntimeFrameworkVersion>$(MNAVersion)</RuntimeFrameworkVersion>
+  </PropertyGroup>
+
+</Project>

--- a/src/test/HostActivationTests/GivenThatICareAboutStartupHooks.cs
+++ b/src/test/HostActivationTests/GivenThatICareAboutStartupHooks.cs
@@ -1,0 +1,717 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.IO;
+using System.Linq;
+using Xunit;
+using Microsoft.Extensions.DependencyModel;
+
+namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.StartupHooks
+{
+    public class GivenThatICareAboutStartupHooks : IClassFixture<GivenThatICareAboutStartupHooks.SharedTestState>
+    {
+        private SharedTestState sharedTestState;
+        private string startupHookVarName = "DOTNET_STARTUP_HOOKS";
+
+        public GivenThatICareAboutStartupHooks(GivenThatICareAboutStartupHooks.SharedTestState fixture)
+        {
+            sharedTestState = fixture;
+        }
+
+        // Run the app with a startup hook
+        [Fact]
+        public void Muxer_activation_of_StartupHook_Succeeds()
+        {
+            var fixture = sharedTestState.PreviouslyPublishedAndRestoredPortableAppProjectFixture.Copy();
+            var dotnet = fixture.BuiltDotnet;
+            var appDll = fixture.TestProject.AppDll;
+
+            var startupHookFixture = sharedTestState.PreviouslyPublishedAndRestoredStartupHookProjectFixture.Copy();
+            var startupHookDll = startupHookFixture.TestProject.AppDll;
+
+            var startupHookWithNonPublicMethodFixture = sharedTestState.PreviouslyPublishedAndRestoredStartupHookWithNonPublicMethodProjectFixture.Copy();
+            var startupHookWithNonPublicMethodDll = startupHookWithNonPublicMethodFixture.TestProject.AppDll;
+
+            // Simple startup hook
+            dotnet.Exec(appDll)
+                .EnvironmentVariable(startupHookVarName, startupHookDll)
+                .CaptureStdOut()
+                .CaptureStdErr()
+                .Execute()
+                .Should()
+                .Pass()
+                .And
+                .HaveStdOutContaining("Hello from startup hook!")
+                .And
+                .HaveStdOutContaining("Hello World");
+
+            // Non-public Initialize method
+            dotnet.Exec(appDll)
+                .EnvironmentVariable(startupHookVarName, startupHookWithNonPublicMethodDll)
+                .CaptureStdOut()
+                .CaptureStdErr()
+                .Execute()
+                .Should()
+                .Pass()
+                .And
+                .HaveStdOutContaining("Hello from startup hook with non-public method");
+
+            // Ensure startup hook tracing works
+            dotnet.Exec(appDll)
+                .EnvironmentVariable("COREHOST_TRACE", "1")
+                .EnvironmentVariable(startupHookVarName, startupHookDll)
+                .CaptureStdOut()
+                .CaptureStdErr()
+                .Execute()
+                .Should()
+                .Pass()
+                .And
+                .HaveStdErrContaining("Property STARTUP_HOOKS = " + startupHookDll)
+                .And
+                .HaveStdOutContaining("Hello from startup hook!")
+                .And
+                .HaveStdOutContaining("Hello World");
+
+            // Startup hook in type that has an additional overload of Initialize with a different signature
+            startupHookFixture = sharedTestState.PreviouslyPublishedAndRestoredStartupHookWithOverloadProjectFixture.Copy();
+            startupHookDll = startupHookFixture.TestProject.AppDll;
+            dotnet.Exec(appDll)
+                .EnvironmentVariable(startupHookVarName, startupHookDll)
+                .CaptureStdOut()
+                .CaptureStdErr()
+                .Execute()
+                .Should()
+                .Pass()
+                .And
+                .HaveStdOutContaining("Hello from startup hook with overload! Input: 123")
+                .And
+                .HaveStdOutContaining("Hello World");
+        }
+
+        // Run the app with multiple startup hooks
+        [Fact]
+        public void Muxer_activation_of_Multiple_StartupHooks_Succeeds()
+        {
+            var fixture = sharedTestState.PreviouslyPublishedAndRestoredPortableAppProjectFixture.Copy();
+            var dotnet = fixture.BuiltDotnet;
+            var appDll = fixture.TestProject.AppDll;
+
+            var startupHookFixture = sharedTestState.PreviouslyPublishedAndRestoredStartupHookProjectFixture.Copy();
+            var startupHookDll = startupHookFixture.TestProject.AppDll;
+
+            var startupHook2Fixture = sharedTestState.PreviouslyPublishedAndRestoredStartupHookWithDependencyProjectFixture.Copy();
+            var startupHook2Dll = startupHook2Fixture.TestProject.AppDll;
+
+            // Multiple startup hooks
+            var startupHookVar = startupHookDll + Path.PathSeparator + startupHook2Dll;
+            dotnet.Exec(appDll)
+                .EnvironmentVariable(startupHookVarName, startupHookVar)
+                .CaptureStdOut()
+                .CaptureStdErr()
+                .Execute()
+                .Should()
+                .Pass()
+                .And
+                .HaveStdOutContaining("Hello from startup hook!")
+                .And
+                .HaveStdOutContaining("Hello from startup hook with dependency!")
+                .And
+                .HaveStdOutContaining("Hello World");
+        }
+
+        // Empty startup hook variable
+        [Fact]
+        public void Muxer_activation_of_Empty_StartupHook_Variable_Succeeds()
+        {
+            var fixture = sharedTestState.PreviouslyPublishedAndRestoredPortableAppProjectFixture.Copy();
+            var dotnet = fixture.BuiltDotnet;
+            var appDll = fixture.TestProject.AppDll;
+
+            var startupHookVar = "";
+            dotnet.Exec(appDll)
+                .EnvironmentVariable(startupHookVarName, startupHookVar)
+                .CaptureStdOut()
+                .CaptureStdErr()
+                .Execute()
+                .Should()
+                .Pass()
+                .And
+                .HaveStdOutContaining("Hello World");
+        }
+
+        // Run the app with a startup hook assembly that depends on assemblies not on the TPA list
+        [Fact]
+        public void Muxer_activation_of_StartupHook_With_Missing_Dependencies_Fails()
+        {
+            var fixture = sharedTestState.PreviouslyPublishedAndRestoredPortableAppWithExceptionProjectFixture.Copy();
+            var dotnet = fixture.BuiltDotnet;
+            var appDll = fixture.TestProject.AppDll;
+
+            var startupHookFixture = sharedTestState.PreviouslyPublishedAndRestoredStartupHookWithDependencyProjectFixture.Copy();
+            var startupHookDll = startupHookFixture.TestProject.AppDll;
+
+            // Startup hook has a dependency not on the TPA list
+            dotnet.Exec(appDll)
+                .EnvironmentVariable(startupHookVarName, startupHookDll)
+                .CaptureStdOut()
+                .CaptureStdErr()
+                .Execute(fExpectedToFail: true)
+                .Should()
+                .Fail()
+                .And
+                .HaveStdErrContaining("System.IO.FileNotFoundException: Could not load file or assembly 'Newtonsoft.Json");
+        }
+
+        // Run the app with an invalid syntax in startup hook variable
+        [Fact]
+        public void Muxer_activation_of_Invalid_StartupHook_Fails()
+        {
+            var fixture = sharedTestState.PreviouslyPublishedAndRestoredPortableAppProjectFixture.Copy();
+            var dotnet = fixture.BuiltDotnet;
+            var appDll = fixture.TestProject.AppDll;
+
+            var startupHookFixture = sharedTestState.PreviouslyPublishedAndRestoredStartupHookProjectFixture.Copy();
+            var startupHookDll = startupHookFixture.TestProject.AppDll;
+
+            var fakeAssembly = Path.GetFullPath("Assembly.dll");
+            var fakeAssembly2 = Path.GetFullPath("Assembly2.dll");
+
+            var expectedError = "System.ArgumentException: The syntax of the startup hook variable was invalid.";
+
+            // Missing entries in the hook
+            var startupHookVar = fakeAssembly + Path.PathSeparator + Path.PathSeparator + fakeAssembly2;
+            dotnet.Exec(appDll)
+                .EnvironmentVariable(startupHookVarName, startupHookVar)
+                .CaptureStdOut()
+                .CaptureStdErr()
+                .Execute(fExpectedToFail: true)
+                .Should()
+                .Fail()
+                .And
+                .HaveStdErrContaining(expectedError);
+
+            // Leading separator
+            startupHookVar = Path.PathSeparator + startupHookDll;
+            dotnet.Exec(appDll)
+                .EnvironmentVariable(startupHookVarName, startupHookVar)
+                .CaptureStdOut()
+                .CaptureStdErr()
+                .Execute(fExpectedToFail: true)
+                .Should()
+                .Fail()
+                .And
+                .HaveStdErrContaining(expectedError);
+
+            // Trailing separator
+            startupHookVar = fakeAssembly + Path.PathSeparator + fakeAssembly2 + Path.PathSeparator;
+            dotnet.Exec(appDll)
+                .EnvironmentVariable(startupHookVarName, startupHookVar)
+                .CaptureStdOut()
+                .CaptureStdErr()
+                .Execute(fExpectedToFail: true)
+                .Should()
+                .Fail()
+                .And
+                .HaveStdErrContaining(expectedError);
+
+            // Syntax errors are caught before any hooks run
+            startupHookVar = startupHookDll + Path.PathSeparator;
+            dotnet.Exec(appDll)
+                .EnvironmentVariable(startupHookVarName, startupHookVar)
+                .CaptureStdOut()
+                .CaptureStdErr()
+                .Execute(fExpectedToFail: true)
+                .Should()
+                .Fail()
+                .And
+                .HaveStdErrContaining(expectedError)
+                .And
+                .NotHaveStdOutContaining("Hello from startup hook!");
+        }
+
+        // Run the app with a relative path to the startup hook assembly
+        [Fact]
+        public void Muxer_activation_of_StartupHook_With_Relative_Path_Fails()
+        {
+            var fixture = sharedTestState.PreviouslyPublishedAndRestoredPortableAppProjectFixture.Copy();
+            var dotnet = fixture.BuiltDotnet;
+            var appDll = fixture.TestProject.AppDll;
+
+            var startupHookFixture = sharedTestState.PreviouslyPublishedAndRestoredStartupHookProjectFixture.Copy();
+            var startupHookDll = startupHookFixture.TestProject.AppDll;
+
+            var relativeAssemblyPath = "Assembly.dll";
+
+            var expectedError = "System.ArgumentException: Absolute path information is required.";
+
+            // Relative path
+            var startupHookVar = relativeAssemblyPath;
+            dotnet.Exec(appDll)
+                .EnvironmentVariable(startupHookVarName, startupHookVar)
+                .CaptureStdOut()
+                .CaptureStdErr()
+                .Execute(fExpectedToFail: true)
+                .Should()
+                .Fail()
+                .And
+                .HaveStdErrContaining(expectedError);
+
+            // Relative path error is caught before any hooks run
+            startupHookVar = startupHookDll + Path.PathSeparator + "Assembly.dll";
+            dotnet.Exec(appDll)
+                .EnvironmentVariable(startupHookVarName, startupHookVar)
+                .CaptureStdOut()
+                .CaptureStdErr()
+                .Execute(fExpectedToFail: true)
+                .Should()
+                .Fail()
+                .And
+                .HaveStdErrContaining(expectedError)
+                .And
+                .NotHaveStdOutContaining("Hello from startup hook!");
+        }
+
+        // Run the app with missing startup hook assembly
+        [Fact]
+        public void Muxer_activation_of_Missing_StartupHook_Assembly_Fails()
+        {
+            var fixture = sharedTestState.PreviouslyPublishedAndRestoredPortableAppProjectFixture.Copy();
+            var dotnet = fixture.BuiltDotnet;
+            var appDll = fixture.TestProject.AppDll;
+
+            var startupHookFixture = sharedTestState.PreviouslyPublishedAndRestoredStartupHookProjectFixture.Copy();
+            var startupHookDll = startupHookFixture.TestProject.AppDll;
+            var startupHookMissingDll = Path.Combine(Path.GetDirectoryName(startupHookDll), "StartupHookMissing.dll");
+
+            var expectedError = "System.IO.FileNotFoundException: Could not load file or assembly '{0}'.";
+
+            // Missing dll is detected with appropriate error
+            var startupHookVar = startupHookMissingDll;
+            dotnet.Exec(appDll)
+                .EnvironmentVariable(startupHookVarName, startupHookVar)
+                .CaptureStdOut()
+                .CaptureStdErr()
+                .Execute(fExpectedToFail: true)
+                .Should()
+                .Fail()
+                .And
+                .HaveStdErrContaining(String.Format(expectedError, Path.GetFullPath(startupHookMissingDll)));
+
+            // Missing dll is detected after previous hooks run
+            startupHookVar = startupHookDll + Path.PathSeparator + startupHookMissingDll;
+            dotnet.Exec(appDll)
+                .EnvironmentVariable(startupHookVarName, startupHookVar)
+                .CaptureStdOut()
+                .CaptureStdErr()
+                .Execute(fExpectedToFail: true)
+                .Should()
+                .Fail()
+                .And
+                .HaveStdOutContaining("Hello from startup hook!")
+                .And
+                .HaveStdErrContaining(String.Format(expectedError, Path.GetFullPath((startupHookMissingDll))));
+        }
+
+        // Run the app with an invalid startup hook assembly
+        [Fact]
+        public void Muxer_activation_of_Invalid_StartupHook_Assembly_Fails()
+        {
+            var fixture = sharedTestState.PreviouslyPublishedAndRestoredPortableAppProjectFixture.Copy();
+            var dotnet = fixture.BuiltDotnet;
+            var appDll = fixture.TestProject.AppDll;
+
+            var startupHookFixture = sharedTestState.PreviouslyPublishedAndRestoredStartupHookProjectFixture.Copy();
+            var startupHookDll = startupHookFixture.TestProject.AppDll;
+
+            var startupHookInvalidAssembly = sharedTestState.PreviouslyPublishedAndRestoredStartupHookWithInvalidAssembly.Copy();
+            var startupHookInvalidAssemblyDll = Path.Combine(Path.GetDirectoryName(startupHookInvalidAssembly.TestProject.AppDll), "StartupHookInvalidAssembly.dll");
+
+            var expectedError = "System.BadImageFormatException";
+
+            // Dll load gives meaningful error message
+            dotnet.Exec(appDll)
+                .EnvironmentVariable(startupHookVarName, startupHookInvalidAssemblyDll)
+                .CaptureStdOut()
+                .CaptureStdErr()
+                .Execute(fExpectedToFail: true)
+                .Should()
+                .Fail()
+                .And
+                .HaveStdErrContaining(expectedError);
+
+            // Dll load error happens after previous hooks run
+            var startupHookVar = startupHookDll + Path.PathSeparator + startupHookInvalidAssemblyDll;
+            dotnet.Exec(appDll)
+                .EnvironmentVariable(startupHookVarName, startupHookVar)
+                .CaptureStdOut()
+                .CaptureStdErr()
+                .Execute(fExpectedToFail: true)
+                .Should()
+                .Fail()
+                .And
+                .HaveStdErrContaining(expectedError);
+        }
+
+        // Run the app with the startup hook type missing
+        [Fact]
+        public void Muxer_activation_of_Missing_StartupHook_Type_Fails()
+        {
+            var fixture = sharedTestState.PreviouslyPublishedAndRestoredPortableAppProjectFixture.Copy();
+            var dotnet = fixture.BuiltDotnet;
+            var appDll = fixture.TestProject.AppDll;
+
+            var startupHookFixture = sharedTestState.PreviouslyPublishedAndRestoredStartupHookProjectFixture.Copy();
+            var startupHookDll = startupHookFixture.TestProject.AppDll;
+
+            var startupHookMissingTypeFixture = sharedTestState.PreviouslyPublishedAndRestoredStartupHookWithoutStartupHookTypeProjectFixture.Copy();
+            var startupHookMissingTypeDll = startupHookMissingTypeFixture.TestProject.AppDll;
+
+            // Missing type is detected
+            dotnet.Exec(appDll)
+                .EnvironmentVariable(startupHookVarName, startupHookMissingTypeDll)
+                .CaptureStdOut()
+                .CaptureStdErr()
+                .Execute(fExpectedToFail: true)
+                .Should()
+                .Fail()
+                .And
+                .HaveStdErrContaining("System.TypeLoadException: Could not load type 'StartupHook' from assembly 'StartupHook");
+
+            // Missing type is detected after previous hooks have run
+            var startupHookVar = startupHookDll + Path.PathSeparator + startupHookMissingTypeDll;
+            dotnet.Exec(appDll)
+                .EnvironmentVariable(startupHookVarName, startupHookVar)
+                .CaptureStdOut()
+                .CaptureStdErr()
+                .Execute(fExpectedToFail: true)
+                .Should()
+                .Fail()
+                .And
+                .HaveStdOutContaining("Hello from startup hook!")
+                .And
+                .HaveStdErrContaining("System.TypeLoadException: Could not load type 'StartupHook' from assembly 'StartupHookWithoutStartupHookType");
+        }
+
+
+        // Run the app with a startup hook that doesn't have any Initialize method
+        [Fact]
+        public void Muxer_activation_of_StartupHook_With_Missing_Method()
+        {
+            var fixture = sharedTestState.PreviouslyPublishedAndRestoredPortableAppProjectFixture.Copy();
+            var dotnet = fixture.BuiltDotnet;
+            var appDll = fixture.TestProject.AppDll;
+
+            var startupHookFixture = sharedTestState.PreviouslyPublishedAndRestoredStartupHookProjectFixture.Copy();
+            var startupHookDll = startupHookFixture.TestProject.AppDll;
+
+            var startupHookMissingMethodFixture = sharedTestState.PreviouslyPublishedAndRestoredStartupHookWithoutInitializeMethodProjectFixture.Copy();
+            var startupHookMissingMethodDll = startupHookMissingMethodFixture.TestProject.AppDll;
+
+            var expectedError = "System.MissingMethodException: Method 'StartupHook.Initialize' not found.";
+
+            // No Initialize method
+            dotnet.Exec(appDll)
+                .EnvironmentVariable(startupHookVarName, startupHookMissingMethodDll)
+                .CaptureStdOut()
+                .CaptureStdErr()
+                .Execute(fExpectedToFail: true)
+                .Should()
+                .Fail()
+                .And
+                .HaveStdErrContaining(expectedError);
+
+            // Missing Initialize method is caught after previous hooks have run
+            var startupHookVar = startupHookDll + Path.PathSeparator + startupHookMissingMethodDll;
+            dotnet.Exec(appDll)
+                .EnvironmentVariable(startupHookVarName, startupHookVar)
+                .CaptureStdOut()
+                .CaptureStdErr()
+                .Execute(fExpectedToFail: true)
+                .Should()
+                .Fail()
+                .And
+                .HaveStdOutContaining("Hello from startup hook!")
+                .And
+                .HaveStdErrContaining(expectedError);
+        }
+
+        // Run the app with startup hook that has no static void Initialize() method
+        [Fact]
+        public void Muxer_activation_of_StartupHook_With_Incorrect_Method_Signature_Fails()
+        {
+            var fixture = sharedTestState.PreviouslyPublishedAndRestoredPortableAppProjectFixture.Copy();
+            var dotnet = fixture.BuiltDotnet;
+            var appDll = fixture.TestProject.AppDll;
+
+            var startupHookFixture = sharedTestState.PreviouslyPublishedAndRestoredStartupHookProjectFixture.Copy();
+            var startupHookDll = startupHookFixture.TestProject.AppDll;
+
+            var expectedError = "System.ArgumentException: The signature of the startup hook 'StartupHook.Initialize' in assembly '{0}' was invalid. It must be 'public static void Initialize()'.";
+
+            // Initialize is an instance method
+            var startupHookWithInstanceMethodFixture = sharedTestState.PreviouslyPublishedAndRestoredStartupHookWithInstanceMethodProjectFixture.Copy();
+            var startupHookWithInstanceMethodDll = startupHookWithInstanceMethodFixture.TestProject.AppDll;
+            dotnet.Exec(appDll)
+                .EnvironmentVariable(startupHookVarName, startupHookWithInstanceMethodDll)
+                .CaptureStdOut()
+                .CaptureStdErr()
+                .Execute(fExpectedToFail: true)
+                .Should()
+                .Fail()
+                .And
+                .HaveStdErrContaining(String.Format(expectedError, startupHookWithInstanceMethodDll));
+
+            // Initialize method takes parameters
+            var startupHookWithParameterFixture = sharedTestState.PreviouslyPublishedAndRestoredStartupHookWithParameterProjectFixture.Copy();
+            var startupHookWithParameterDll = startupHookWithParameterFixture.TestProject.AppDll;
+            dotnet.Exec(appDll)
+                .EnvironmentVariable(startupHookVarName, startupHookWithParameterDll)
+                .CaptureStdOut()
+                .CaptureStdErr()
+                .Execute(fExpectedToFail: true)
+                .Should()
+                .Fail()
+                .And
+                .HaveStdErrContaining(String.Format(expectedError, startupHookWithParameterDll));
+
+            // Initialize method has non-void return type
+            var startupHookWithReturnTypeFixture = sharedTestState.PreviouslyPublishedAndRestoredStartupHookWithReturnTypeProjectFixture.Copy();
+            var startupHookWithReturnTypeDll = startupHookWithReturnTypeFixture.TestProject.AppDll;
+            dotnet.Exec(appDll)
+                .EnvironmentVariable(startupHookVarName, startupHookWithReturnTypeDll)
+                .CaptureStdOut()
+                .CaptureStdErr()
+                .Execute(fExpectedToFail: true)
+                .Should()
+                .Fail()
+                .And
+                .HaveStdErrContaining(String.Format(expectedError, startupHookWithReturnTypeDll));
+
+            // Initialize method that has multiple methods with an incorrect signature
+            var startupHookWithMultipleIncorrectSignaturesFixture = sharedTestState.PreviouslyPublishedAndRestoredStartupHookWithMultipleIncorrectSignaturesProjectFixture.Copy();
+            var startupHookWithMultipleIncorrectSignaturesDll = startupHookWithMultipleIncorrectSignaturesFixture.TestProject.AppDll;
+            dotnet.Exec(appDll)
+                .EnvironmentVariable(startupHookVarName, startupHookWithMultipleIncorrectSignaturesDll)
+                .CaptureStdOut()
+                .CaptureStdErr()
+                .Execute(fExpectedToFail: true)
+                .Should()
+                .Fail()
+                .And
+                .HaveStdErrContaining(String.Format(expectedError, startupHookWithMultipleIncorrectSignaturesDll));
+
+            // Signature problem is caught after previous hooks have run
+            var startupHookVar = startupHookDll + Path.PathSeparator + startupHookWithMultipleIncorrectSignaturesDll;
+            dotnet.Exec(appDll)
+                .EnvironmentVariable(startupHookVarName, startupHookVar)
+                .CaptureStdOut()
+                .CaptureStdErr()
+                .Execute(fExpectedToFail: true)
+                .Should()
+                .Fail()
+                .And
+                .HaveStdOutContaining("Hello from startup hook!")
+                .And
+                .HaveStdErrContaining(String.Format(expectedError, startupHookWithMultipleIncorrectSignaturesDll));
+        }
+
+        private static void RemoveLibraryFromDepsJson(string depsJsonPath, string libraryName)
+        {
+            DependencyContext context;
+            using (FileStream fileStream = File.Open(depsJsonPath, FileMode.Open))
+            {
+                using (DependencyContextJsonReader reader = new DependencyContextJsonReader())
+                {
+                    context = reader.Read(fileStream);
+                }
+            }
+
+            context = new DependencyContext(context.Target,
+                context.CompilationOptions,
+                context.CompileLibraries,
+                context.RuntimeLibraries.Select(lib => new RuntimeLibrary(
+                    lib.Type,
+                    lib.Name,
+                    lib.Version,
+                    lib.Hash,
+                    lib.RuntimeAssemblyGroups.Select(assemblyGroup => new RuntimeAssetGroup(
+                        assemblyGroup.Runtime,
+                        assemblyGroup.RuntimeFiles.Where(f => !f.Path.EndsWith("SharedLibrary.dll")))).ToList().AsReadOnly(),
+                    lib.NativeLibraryGroups,
+                    lib.ResourceAssemblies,
+                    lib.Dependencies,
+                    lib.Serviceable,
+                    lib.Path,
+                    lib.HashPath,
+                    lib.RuntimeStoreManifestName)),
+                context.RuntimeGraph);
+
+            using (FileStream fileStream = File.Open(depsJsonPath, FileMode.Truncate, FileAccess.Write))
+            {
+                DependencyContextWriter writer = new DependencyContextWriter();
+                writer.Write(context, fileStream);
+            }
+        }
+
+        // Run startup hook that adds an assembly resolver
+        [Fact]
+        public void Muxer_activation_of_StartupHook_With_Assembly_Resolver()
+        {
+            var fixture = sharedTestState.PreviouslyPublishedAndRestoredPortableAppWithMissingRefProjectFixture.Copy();
+            var dotnet = fixture.BuiltDotnet;
+            var appDll = fixture.TestProject.AppDll;
+            var appDepsJson = Path.Combine(Path.GetDirectoryName(appDll), Path.GetFileNameWithoutExtension(appDll) + ".deps.json");
+            RemoveLibraryFromDepsJson(appDepsJson, "SharedLibrary.dll");
+
+            var startupHookFixture = sharedTestState.PreviouslyPublishedAndRestoredStartupHookWithAssemblyResolver.Copy();
+            var startupHookDll = startupHookFixture.TestProject.AppDll;
+
+            // No startup hook results in failure due to missing app dependency
+            dotnet.Exec(appDll)
+                .CaptureStdOut()
+                .CaptureStdErr()
+                .Execute(fExpectedToFail: true)
+                .Should()
+                .Fail()
+                .And
+                .HaveStdErrContaining("FileNotFoundException: Could not load file or assembly 'SharedLibrary");
+
+            // Startup hook with assembly resolver results in use of injected dependency (which has value 2)
+            dotnet.Exec(appDll)
+                .EnvironmentVariable(startupHookVarName, startupHookDll)
+                .CaptureStdOut()
+                .CaptureStdErr()
+                .Execute(fExpectedToFail: true)
+                .Should()
+                .Fail()
+                .And
+                .ExitWith(2);
+        }
+
+        public class SharedTestState : IDisposable
+        {
+            // Entry point projects
+            public TestProjectFixture PreviouslyPublishedAndRestoredPortableAppProjectFixture { get; set; }
+            public TestProjectFixture PreviouslyPublishedAndRestoredPortableAppWithExceptionProjectFixture { get; set; }
+            // Entry point with missing reference assembly
+            public TestProjectFixture PreviouslyPublishedAndRestoredPortableAppWithMissingRefProjectFixture { get; set; }
+
+            // Correct startup hooks
+            public TestProjectFixture PreviouslyPublishedAndRestoredStartupHookProjectFixture { get; set; }
+            public TestProjectFixture PreviouslyPublishedAndRestoredStartupHookWithOverloadProjectFixture { get; set; }
+            // Missing startup hook type (no StartupHook type defined)
+            public TestProjectFixture PreviouslyPublishedAndRestoredStartupHookWithoutStartupHookTypeProjectFixture { get; set; }
+            // Missing startup hook method (no Initialize method defined)
+            public TestProjectFixture PreviouslyPublishedAndRestoredStartupHookWithoutInitializeMethodProjectFixture { get; set; }
+            // Invalid startup hook assembly
+            public TestProjectFixture PreviouslyPublishedAndRestoredStartupHookWithInvalidAssembly { get; set; }
+            // Invalid startup hooks (incorrect signatures)
+            public TestProjectFixture PreviouslyPublishedAndRestoredStartupHookWithNonPublicMethodProjectFixture { get; set; }
+            public TestProjectFixture PreviouslyPublishedAndRestoredStartupHookWithInstanceMethodProjectFixture { get; set; }
+            public TestProjectFixture PreviouslyPublishedAndRestoredStartupHookWithParameterProjectFixture { get; set; }
+            public TestProjectFixture PreviouslyPublishedAndRestoredStartupHookWithReturnTypeProjectFixture { get; set; }
+            public TestProjectFixture PreviouslyPublishedAndRestoredStartupHookWithMultipleIncorrectSignaturesProjectFixture { get; set; }
+            // Valid startup hooks with incorrect behavior
+            public TestProjectFixture PreviouslyPublishedAndRestoredStartupHookWithDependencyProjectFixture { get; set; }
+
+            // Startup hook with an assembly resolver
+            public TestProjectFixture PreviouslyPublishedAndRestoredStartupHookWithAssemblyResolver { get; set; }
+
+            public RepoDirectoriesProvider RepoDirectories { get; set; }
+
+            public SharedTestState()
+            {
+                RepoDirectories = new RepoDirectoriesProvider();
+
+                // Entry point projects
+                PreviouslyPublishedAndRestoredPortableAppProjectFixture = new TestProjectFixture("PortableApp", RepoDirectories)
+                    .EnsureRestored(RepoDirectories.CorehostPackages)
+                    .PublishProject();
+
+                PreviouslyPublishedAndRestoredPortableAppWithExceptionProjectFixture = new TestProjectFixture("PortableAppWithException", RepoDirectories)
+                    .EnsureRestored(RepoDirectories.CorehostPackages)
+                    .PublishProject();
+                // Entry point with missing reference assembly
+                PreviouslyPublishedAndRestoredPortableAppWithMissingRefProjectFixture = new TestProjectFixture("PortableAppWithMissingRef", RepoDirectories)
+                    .EnsureRestored(RepoDirectories.CorehostPackages)
+                    .PublishProject();
+
+                // Correct startup hooks
+                PreviouslyPublishedAndRestoredStartupHookProjectFixture = new TestProjectFixture("StartupHook", RepoDirectories)
+                    .EnsureRestored(RepoDirectories.CorehostPackages)
+                    .PublishProject();
+                PreviouslyPublishedAndRestoredStartupHookWithOverloadProjectFixture = new TestProjectFixture("StartupHookWithOverload", RepoDirectories)
+                    .EnsureRestored(RepoDirectories.CorehostPackages)
+                    .PublishProject();
+                // Missing startup hook type (no StartupHook type defined)
+                PreviouslyPublishedAndRestoredStartupHookWithoutStartupHookTypeProjectFixture = new TestProjectFixture("StartupHookWithoutStartupHookType", RepoDirectories)
+                    .EnsureRestored(RepoDirectories.CorehostPackages)
+                    .PublishProject();
+                // Missing startup hook method (no Initialize method defined)
+                PreviouslyPublishedAndRestoredStartupHookWithoutInitializeMethodProjectFixture = new TestProjectFixture("StartupHookWithoutInitializeMethod", RepoDirectories)
+                    .EnsureRestored(RepoDirectories.CorehostPackages)
+                    .PublishProject();
+                // Invalid startup hook assembly
+                PreviouslyPublishedAndRestoredStartupHookWithInvalidAssembly = new TestProjectFixture("StartupHookFake", RepoDirectories)
+                    .EnsureRestored(RepoDirectories.CorehostPackages)
+                    .PublishProject();
+                // Invalid startup hooks (incorrect signatures)
+                PreviouslyPublishedAndRestoredStartupHookWithNonPublicMethodProjectFixture = new TestProjectFixture("StartupHookWithNonPublicMethod", RepoDirectories)
+                    .EnsureRestored(RepoDirectories.CorehostPackages)
+                    .PublishProject();
+                PreviouslyPublishedAndRestoredStartupHookWithInstanceMethodProjectFixture = new TestProjectFixture("StartupHookWithInstanceMethod", RepoDirectories)
+                    .EnsureRestored(RepoDirectories.CorehostPackages)
+                    .PublishProject();
+                PreviouslyPublishedAndRestoredStartupHookWithParameterProjectFixture = new TestProjectFixture("StartupHookWithParameter", RepoDirectories)
+                    .EnsureRestored(RepoDirectories.CorehostPackages)
+                    .PublishProject();
+                PreviouslyPublishedAndRestoredStartupHookWithReturnTypeProjectFixture = new TestProjectFixture("StartupHookWithReturnType", RepoDirectories)
+                    .EnsureRestored(RepoDirectories.CorehostPackages)
+                    .PublishProject();
+                PreviouslyPublishedAndRestoredStartupHookWithMultipleIncorrectSignaturesProjectFixture = new TestProjectFixture("StartupHookWithMultipleIncorrectSignatures", RepoDirectories)
+                    .EnsureRestored(RepoDirectories.CorehostPackages)
+                    .PublishProject();
+                // Valid startup hooks with incorrect behavior
+                PreviouslyPublishedAndRestoredStartupHookWithDependencyProjectFixture = new TestProjectFixture("StartupHookWithDependency", RepoDirectories)
+                    .EnsureRestored(RepoDirectories.CorehostPackages)
+                    .PublishProject();
+
+                // Startup hook with an assembly resolver
+                PreviouslyPublishedAndRestoredStartupHookWithAssemblyResolver = new TestProjectFixture("StartupHookWithAssemblyResolver", RepoDirectories)
+                    .EnsureRestored(RepoDirectories.CorehostPackages)
+                    .PublishProject();
+            }
+
+            public void Dispose()
+            {
+                // Entry point projects
+                PreviouslyPublishedAndRestoredPortableAppProjectFixture.Dispose();
+                PreviouslyPublishedAndRestoredPortableAppWithExceptionProjectFixture.Dispose();
+                // Entry point with missing reference assembly
+                PreviouslyPublishedAndRestoredPortableAppWithMissingRefProjectFixture.Dispose();
+
+                // Correct startup hooks
+                PreviouslyPublishedAndRestoredStartupHookProjectFixture.Dispose();
+                PreviouslyPublishedAndRestoredStartupHookWithOverloadProjectFixture.Dispose();
+                // Missing startup hook type (no StartupHook type defined)
+                PreviouslyPublishedAndRestoredStartupHookWithoutStartupHookTypeProjectFixture.Dispose();
+                // Missing startup hook method (no Initialize method defined)
+                PreviouslyPublishedAndRestoredStartupHookWithoutInitializeMethodProjectFixture.Dispose();
+                // Invalid startup hook assembly
+                PreviouslyPublishedAndRestoredStartupHookWithInvalidAssembly.Dispose();
+                // Invalid startup hooks (incorrect signatures)
+                PreviouslyPublishedAndRestoredStartupHookWithNonPublicMethodProjectFixture.Dispose();
+                PreviouslyPublishedAndRestoredStartupHookWithInstanceMethodProjectFixture.Dispose();
+                PreviouslyPublishedAndRestoredStartupHookWithParameterProjectFixture.Dispose();
+                PreviouslyPublishedAndRestoredStartupHookWithReturnTypeProjectFixture.Dispose();
+                PreviouslyPublishedAndRestoredStartupHookWithMultipleIncorrectSignaturesProjectFixture.Dispose();
+                // Valid startup hooks with incorrect behavior
+                PreviouslyPublishedAndRestoredStartupHookWithDependencyProjectFixture.Dispose();
+
+                // Startup hook with an assembly resolver
+                PreviouslyPublishedAndRestoredStartupHookWithAssemblyResolver.Dispose();
+            }
+        }
+    }
+}

--- a/src/test/HostActivationTests/HostActivationTests.csproj
+++ b/src/test/HostActivationTests/HostActivationTests.csproj
@@ -16,6 +16,7 @@
     <PackageReference Include="xunit" Version="2.2.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
+    <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="2.1.0" />
   </ItemGroup>
 
 </Project>

--- a/src/test/TestUtils/Assertions/CommandResultAssertions.cs
+++ b/src/test/TestUtils/Assertions/CommandResultAssertions.cs
@@ -60,6 +60,13 @@ namespace Microsoft.DotNet.CoreSetup.Test
             return new AndConstraint<CommandResultAssertions>(this);
         }
 
+        public AndConstraint<CommandResultAssertions> NotHaveStdOutContaining(string pattern)
+        {
+            Execute.Assertion.ForCondition(!_commandResult.StdErr.Contains(pattern))
+                .FailWith("The command output contained a result it should not have contained: {0}{1}", pattern, GetDiagnosticsInfo());
+            return new AndConstraint<CommandResultAssertions>(this);
+        }
+
         public AndConstraint<CommandResultAssertions> HaveStdOutMatching(string pattern, RegexOptions options = RegexOptions.None)
         {
             Execute.Assertion.ForCondition(Regex.Match(_commandResult.StdOut, pattern, options).Success)

--- a/src/test/TestUtils/TestProjectFixture.cs
+++ b/src/test/TestUtils/TestProjectFixture.cs
@@ -375,6 +375,7 @@ namespace Microsoft.DotNet.CoreSetup.Test
             {
                 publishArgs.Add("--framework");
                 publishArgs.Add(framework);
+                publishArgs.Add($"/p:NETCoreAppFramework={framework}");
             }
 
             if (outputDirectory != null)


### PR DESCRIPTION
#### Description
This adds a hook that lets an environment variable specify managed code to be run before `Main`, allowing early customization in managed code.
Tracking issue: https://github.com/dotnet/core-setup/issues/4573
#### Customer Impact
This feature will enable Service Fabric to ship updates to their shared assemblies. They intend to use the startup hook to handle resolution for these shared assemblies.
#### Regression?
Not a regression.
#### Risk
Low. This shouldn't impact any old functionality.
**NOTE**: The tests will fail until they get the change from coreclr: https://github.com/dotnet/coreclr/pull/20005. Don't merge until this happens (or I can remove the tests from the port - let me know if I should do so).