### PR TITLE
Move to 2.1.1 stable version for M.N.Platforms package

### DIFF
--- a/dependencies.props
+++ b/dependencies.props
@@ -16,7 +16,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <MicrosoftNETCorePlatformsPackageVersion>2.1.1-servicing-26902-02</MicrosoftNETCorePlatformsPackageVersion>
+    <MicrosoftNETCorePlatformsPackageVersion>2.1.1</MicrosoftNETCorePlatformsPackageVersion>
     <MicrosoftNETCoreTargetsPackageVersion>2.0.0</MicrosoftNETCoreTargetsPackageVersion>
     <MicrosoftPrivateCoreFxNETCoreAppPackageVersion>4.5.0-servicing-26911-03</MicrosoftPrivateCoreFxNETCoreAppPackageVersion>
     <MicrosoftNETCoreRuntimeCoreCLRPackageVersion>2.1.5-servicing-26911-03</MicrosoftNETCoreRuntimeCoreCLRPackageVersion>


### PR DESCRIPTION
We should be referencing the stable version of 2.1.1 Platorms
package as we haven't made any changes since then even though
there have been a few unstable builds past that point which is
what cause this version update.

cc @mmitche 