### PR TITLE
Replace MIT License with .NET Library EULA in setup bundle

### DIFF
--- a/src/pkg/packaging/windows/sharedframework/bundle.thm
+++ b/src/pkg/packaging/windows/sharedframework/bundle.thm
@@ -28,7 +28,7 @@
         <Text Name="LearnMoreTitle" X="160" Y="200" Width="460" Height="30" TabStop="yes" FontId="2">#(loc.LearnMoreTitle)</Text>
         <Hypertext Name="WelcomeDocumentationLink" X="185" Y="238" Width="400" Height="22" FontId="3" HideWhenDisabled="yes" DisablePrefix="yes">#(loc.DocumentationLink)</Hypertext>
         <Hypertext Name="PrivacyStatementLink" X="185" Y="259" Width="400" Height="22" FontId="3" HideWhenDisabled="yes" DisablePrefix="yes">#(loc.PrivacyStatementLink)</Hypertext>
-        <Hypertext Name="MITLicenseLink" X="185" Y="281" Width="400" Height="22" FontId="3" HideWhenDisabled="yes" DisablePrefix="yes">#(loc.MITLicenseLink)</Hypertext>
+        <Hypertext Name="EulaLink" X="185" Y="281" Width="400" Height="22" FontId="3" HideWhenDisabled="yes" DisablePrefix="yes">#(loc.EulaLink)</Hypertext>
         <Button Name="InstallButton" X="-91" Y="-11" Width="75" Height="23" TabStop="yes" FontId="0">#(loc.InstallInstallButton)</Button>
         <Button Name="WelcomeCancelButton" X="-11" Y="-11" Width="75" Height="23" TabStop="yes" FontId="0">#(loc.InstallCloseButton)</Button>
     </Page>

--- a/src/pkg/packaging/windows/sharedframework/bundle.wxl
+++ b/src/pkg/packaging/windows/sharedframework/bundle.wxl
@@ -67,6 +67,6 @@ Ready? Set? Let's go!</String>
   <String Id="TutorialLink">&lt;A HREF=&quot;https://aka.ms/dotnet-tutorials&quot;&gt;Tutorials&lt;/A&gt;</String>
   <String Id="TelemetryLink">&lt;A HREF=&quot;https://aka.ms/dotnet-cli-telemetry&quot;&gt;.NET Core Telemetry&lt;/A&gt;</String>
   <String Id="PrivacyStatementLink">&lt;A HREF=&quot;https://aka.ms/dev-privacy&quot;&gt;Privacy Statement&lt;/A&gt;</String>
-  <String Id="MITLicenseLink">&lt;A HREF=&quot;https://aka.ms/dotnet-license&quot;&gt;MIT License&lt;/A&gt;</String>
+  <String Id="EulaLink">&lt;A HREF=&quot;http://go.microsoft.com/fwlink/?LinkId=329770&quot;&gt;.NET Library EULA&lt;/A&gt;</String>
   
 </WixLocalization>


### PR DESCRIPTION
#### Description 
As per guidance , MIT License does not apply for Windows. MIT License link is exposed in Windows setup. Replacing the license with .NET Library Eula.
 
#### Regression? 
No
 
