### PR TITLE
Add script to start Visual Studio

### DIFF
--- a/Documentation/building/Running-Tests-In-VisualStudio-IDE.md
+++ b/Documentation/building/Running-Tests-In-VisualStudio-IDE.md
@@ -6,14 +6,14 @@ There are several environment variables which must be set to get this to work co
 
 ## Steps
 
-1 `build.cmd`
-2 `visual-studio-devenv.cmd`
-3 Open the test explorer window within the Visual Studio IDE
-4 Select tests and run and/or debug.
+1. `build.cmd`
+2. `visual-studio-devenv.cmd`
+3. Open the test explorer window within the Visual Studio IDE
+4. Select tests and run and/or debug.
 
 ## Limitations
 
-* The script is not yet designed to be a robust solution.  As test configurastions change this file could get out of date.  The required configuration can be discovered by carefully examining the logs generated when running the tests with `build.cmd -MsBuildLogging=/bl`.  The script can then be updated.
+* The script is not yet designed to be a robust solution.  As test configurations change this file could get out of date.  The required configuration can be discovered by carefully examining the logs generated when running the tests with `build.cmd -MsBuildLogging=/bl`.  The script can then be updated.
 * The script is hardcoded to use the x64 debug build
 
 

--- a/Documentation/building/Running-Tests-In-VisualStudio-IDE.md
+++ b/Documentation/building/Running-Tests-In-VisualStudio-IDE.md
@@ -1,0 +1,19 @@
+# Running unit tests within Visual Studio
+
+Sometimes it is convenient to run individual unit tests within the Visual Studio IDE
+
+There are several environment variables which must be set to get this to work correctly.  To make things easier there is a convenience script `visual-studio-devenv.cmd` provided.  This script will set the necessary environment variables.
+
+## Steps
+
+1 `build.cmd`
+2 `visual-studio-devenv.cmd`
+3 Open the test explorer window within the Visual Studio IDE
+4 Select tests and run and/or debug.
+
+## Limitations
+
+* The script is not yet designed to be a robust solution.  As test configurastions change this file could get out of date.  The required configuration can be discovered by carefully examining the logs generated when running the tests with `build.cmd -MsBuildLogging=/bl`.  The script can then be updated.
+* The script is hardcoded to use the x64 debug build
+
+

--- a/run.cmd
+++ b/run.cmd
@@ -10,7 +10,7 @@ if exist %_VSWHERE% (
 if not exist "%_VSCOMNTOOLS%" set _VSCOMNTOOLS=%VS140COMNTOOLS%
 if not exist "%_VSCOMNTOOLS%" (
     echo Error: Visual Studio 2015 or 2017 required.
-    echo        Please see https://github.com/dotnet/corefx/blob/master/Documentation/project-docs/developer-guide.md for build instructions.
+    echo        Please see https://github.com/dotnet/core-setup/blob/master/Documentation/building/windows-instructions.md for build instructions.
     exit /b 1
 )
 

--- a/visual-studio-devenv.cmd
+++ b/visual-studio-devenv.cmd
@@ -1,0 +1,47 @@
+@if "%_echo%" neq "on" echo off
+setlocal
+setlocal enableextensions
+setlocal enabledelayedexpansion
+
+if defined VisualStudioVersion goto :Run
+
+set _VSWHERE="%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe"
+if exist %_VSWHERE% (
+  for /f "usebackq tokens=*" %%i in (`%_VSWHERE% -latest -prerelease -property installationPath`) do set _VSCOMNTOOLS=%%i\Common7\Tools
+)
+if not exist "%_VSCOMNTOOLS%" set _VSCOMNTOOLS=%VS140COMNTOOLS%
+if not exist "%_VSCOMNTOOLS%" (
+    echo Error: Visual Studio 2015 or 2017 required.
+    echo        Please see https://github.com/dotnet/corefx/blob/master/Documentation/project-docs/developer-guide.md for build instructions.
+    exit /b 1
+)
+
+set VSCMD_START_DIR="%~dp0"
+call "%_VSCOMNTOOLS%\VsDevCmd.bat"
+
+:Run
+
+:: this makes test explorer work in Visual Studio
+:: Found the env vars by running build -MsBuildLogging=/bl, then look at the Exec task in RunTest target
+
+set CMD_START_DIR=%~dp0
+set NUGET_PACKAGES=%CMD_START_DIR%packages\
+set DOTNET_SDK_PATH=%CMD_START_DIR%Tools\dotnetcli\
+
+set TEST_TARGETRID=win-x64
+set BUILDRID=win-x64
+set BUILD_ARCHITECTURE=x64
+set BUILD_CONFIGURATION=Debug
+
+set TEST_ARTIFACTS=%CMD_START_DIR%Bin\tests\%TEST_TARGETRID%.%BUILD_CONFIGURATION%\
+set MNA_TFM=netcoreapp3.0
+set MNA_SEARCH=%CMD_START_DIR%Bin\obj\%TEST_TARGETRID%.%BUILD_CONFIGURATION%\hostFxr\host\fxr\*
+
+:: We expect one hostfxr version directory in the MNA_SEARCH path
+for /d  %%i in (%MNA_SEARCH%) do (
+  set MNA_PATH=%%i
+  )
+
+set MNA_VERSION=%MNA_PATH:*host\fxr\=%
+
+devenv %CMD_START_DIR%\Microsoft.DotNet.CoreSetup.sln

--- a/visual-studio-devenv.cmd
+++ b/visual-studio-devenv.cmd
@@ -12,7 +12,7 @@ if exist %_VSWHERE% (
 if not exist "%_VSCOMNTOOLS%" set _VSCOMNTOOLS=%VS140COMNTOOLS%
 if not exist "%_VSCOMNTOOLS%" (
     echo Error: Visual Studio 2015 or 2017 required.
-    echo        Please see https://github.com/dotnet/corefx/blob/master/Documentation/project-docs/developer-guide.md for build instructions.
+    echo        Please see https://github.com/dotnet/core-setup/blob/master/Documentation/building/windows-instructions.md for build instructions.
     exit /b 1
 )
 
@@ -21,7 +21,8 @@ call "%_VSCOMNTOOLS%\VsDevCmd.bat"
 
 :Run
 
-:: this makes test explorer work in Visual Studio
+:: Makes test explorer work in Visual Studio by setting up environment variables for tests
+:: See EnvironmentVariables around https://github.com/dotnet/core-setup/blob/master/src/test/dir.proj#L93
 :: Found the env vars by running build -MsBuildLogging=/bl, then look at the Exec task in RunTest target
 
 set CMD_START_DIR=%~dp0
@@ -33,15 +34,15 @@ set BUILDRID=win-x64
 set BUILD_ARCHITECTURE=x64
 set BUILD_CONFIGURATION=Debug
 
-set TEST_ARTIFACTS=%CMD_START_DIR%Bin\tests\%TEST_TARGETRID%.%BUILD_CONFIGURATION%\
+set TEST_ARTIFACTS=%CMD_START_DIR%bin\tests\%TEST_TARGETRID%.%BUILD_CONFIGURATION%\
 set MNA_TFM=netcoreapp3.0
-set MNA_SEARCH=%CMD_START_DIR%Bin\obj\%TEST_TARGETRID%.%BUILD_CONFIGURATION%\hostFxr\host\fxr\*
+set MNA_SEARCH=%CMD_START_DIR%bin\obj\%TEST_TARGETRID%.%BUILD_CONFIGURATION%\sharedFrameworkPublish\shared\Microsoft.NETCore.App\*
 
 :: We expect one hostfxr version directory in the MNA_SEARCH path
 for /d  %%i in (%MNA_SEARCH%) do (
   set MNA_PATH=%%i
   )
 
-set MNA_VERSION=%MNA_PATH:*host\fxr\=%
+set MNA_VERSION=%MNA_PATH:*sharedFrameworkPublish\shared\Microsoft.NETCore.App\=%
 
 devenv %CMD_START_DIR%\Microsoft.DotNet.CoreSetup.sln


### PR DESCRIPTION
Add script to properly set the environment variables to run tests
within the Visual Studio IDE test explorer

Add brief documentation

This is based on the gist sample provided by @nguerrera 
@eerhardt @weshaggard @vitek-karas 

skip ci please
