### PR TITLE
Publish cross-bitness cross-architecture tools on Linux/arm32

### DIFF
--- a/src/pkg/projects/Microsoft.NETCore.App/src/Microsoft.NETCore.App.depproj
+++ b/src/pkg/projects/Microsoft.NETCore.App/src/Microsoft.NETCore.App.depproj
@@ -167,6 +167,10 @@
         <TargetPath>runtimes$(_crossDir)/native</TargetPath>
         <IsNative>true</IsNative>
       </FilesToPackage>
+      <FilesToPackage Condition="'$(TargetArchitecture)' == 'arm'" Include="$(_jitPackagePath)/runtimes$(_obsoleteCrossDir)/native/*.*">
+        <TargetPath>runtimes$(_obsoleteCrossDir)/native</TargetPath>
+        <IsNative>true</IsNative>
+      </FilesToPackage>
     </ItemGroup>
 
     <ItemGroup Condition="'$(NuGetRuntimeIdentifier)' == ''">

--- a/src/pkg/projects/Microsoft.NETCore.App/src/Microsoft.NETCore.App.depproj
+++ b/src/pkg/projects/Microsoft.NETCore.App/src/Microsoft.NETCore.App.depproj
@@ -67,8 +67,9 @@
     </ItemGroup>
 
     <PropertyGroup>
-      <_obsoleteCrossDir Condition="'$(TargetArchitecture)' == 'arm'">/x86_arm</_obsoleteCrossDir>
-      <_crossDir Condition="'$(TargetArchitecture)' == 'arm'">/x64_arm</_crossDir>
+      <_crossDir Condition="'$(TargetArchitecture)' == 'arm' AND '$(OS)' == 'Windows_NT'">/x86_arm</_crossDir>
+      <_crossDir Condition="'$(TargetArchitecture)' == 'arm' AND '$(OS)' != 'Windows_NT'">/x64_arm</_crossDir>
+      <_obsoleteCrossDir Condition="'$(TargetArchitecture)' == 'arm' AND '$(OS)' != 'Windows_NT'">/x86_arm</_obsoleteCrossDir>
       <_crossDir Condition="'$(TargetArchitecture)' == 'arm64'">/x64_arm64</_crossDir>
     </PropertyGroup>
 
@@ -78,7 +79,6 @@
       <_runtimePackagePath>$(PackagesDir)/$(_runtimePackageId.ToLowerInvariant())/$(_runtimePackageVersion)</_runtimePackagePath>
 
       <_crossGenPath>$(_runtimePackagePath)/tools$(_crossDir)/crossgen$(ApplicationFileExtension)</_crossGenPath>
-      <_crossGenPath Condition="'$(TargetArchitecture)' == 'arm' AND '$(OS)' == 'Windows_NT'">$(_runtimePackagePath)/tools$(_obsoleteCrossDir)/crossgen$(ApplicationFileExtension)</_crossGenPath>
       <_runtimeDirectory>%(_runtimeCLR.RootDir)%(_runtimeCLR.Directory)</_runtimeDirectory>
     </PropertyGroup>
 
@@ -92,7 +92,6 @@
       <_jitPackagePath>$(PackagesDir)/$(_jitPackageId.ToLowerInvariant())/$(_jitPackageVersion)</_jitPackagePath>
       <_jitPath>%(_runtimeJIT.FullPath)</_jitPath>
       <_jitPath Condition="'$(_crossDir)' != ''">$(_jitPackagePath)/runtimes$(_crossDir)/native/$(LibraryFilePrefix)clrjit$(LibraryFileExtension)</_jitPath>
-      <_jitPath Condition="'$(TargetArchitecture)' == 'arm' AND '$(OS)' == 'Windows_NT'">$(_jitPackagePath)/runtimes$(_obsoleteCrossDir)/native/$(LibraryFilePrefix)clrjit$(LibraryFileExtension)</_jitPath>
     </PropertyGroup>
 
     <PropertyGroup Condition="'@(_fxSystemRuntime)' != ''">
@@ -167,7 +166,7 @@
         <TargetPath>runtimes$(_crossDir)/native</TargetPath>
         <IsNative>true</IsNative>
       </FilesToPackage>
-      <FilesToPackage Condition="'$(TargetArchitecture)' == 'arm'" Include="$(_jitPackagePath)/runtimes$(_obsoleteCrossDir)/native/*.*">
+      <FilesToPackage Condition="'$(_obsoleteCrossDir)' != ''" Include="$(_jitPackagePath)/runtimes$(_obsoleteCrossDir)/native/*.*">
         <TargetPath>runtimes$(_obsoleteCrossDir)/native</TargetPath>
         <IsNative>true</IsNative>
       </FilesToPackage>

--- a/src/pkg/projects/Microsoft.NETCore.App/src/Microsoft.NETCore.App.depproj
+++ b/src/pkg/projects/Microsoft.NETCore.App/src/Microsoft.NETCore.App.depproj
@@ -67,7 +67,8 @@
     </ItemGroup>
 
     <PropertyGroup>
-      <_crossDir Condition="'$(TargetArchitecture)' == 'arm'">/x86_arm</_crossDir>
+      <_obsoleteCrossDir Condition="'$(TargetArchitecture)' == 'arm'">/x86_arm</_obsoleteCrossDir>
+      <_crossDir Condition="'$(TargetArchitecture)' == 'arm'">/x64_arm</_crossDir>
       <_crossDir Condition="'$(TargetArchitecture)' == 'arm64'">/x64_arm64</_crossDir>
     </PropertyGroup>
 
@@ -77,6 +78,7 @@
       <_runtimePackagePath>$(PackagesDir)/$(_runtimePackageId.ToLowerInvariant())/$(_runtimePackageVersion)</_runtimePackagePath>
 
       <_crossGenPath>$(_runtimePackagePath)/tools$(_crossDir)/crossgen$(ApplicationFileExtension)</_crossGenPath>
+      <_crossGenPath Condition="'$(TargetArchitecture)' == 'arm' AND '$(OS)' == 'Windows_NT'">$(_runtimePackagePath)/tools$(_obsoleteCrossDir)/crossgen$(ApplicationFileExtension)</_crossGenPath>
       <_runtimeDirectory>%(_runtimeCLR.RootDir)%(_runtimeCLR.Directory)</_runtimeDirectory>
     </PropertyGroup>
 
@@ -90,6 +92,7 @@
       <_jitPackagePath>$(PackagesDir)/$(_jitPackageId.ToLowerInvariant())/$(_jitPackageVersion)</_jitPackagePath>
       <_jitPath>%(_runtimeJIT.FullPath)</_jitPath>
       <_jitPath Condition="'$(_crossDir)' != ''">$(_jitPackagePath)/runtimes$(_crossDir)/native/$(LibraryFilePrefix)clrjit$(LibraryFileExtension)</_jitPath>
+      <_jitPath Condition="'$(TargetArchitecture)' == 'arm' AND '$(OS)' == 'Windows_NT'">$(_jitPackagePath)/runtimes$(_obsoleteCrossDir)/native/$(LibraryFilePrefix)clrjit$(LibraryFileExtension)</_jitPath>
     </PropertyGroup>
 
     <PropertyGroup Condition="'@(_fxSystemRuntime)' != ''">


### PR DESCRIPTION
**dotnet/coreclr** now builds and publishes Hostx64/arm32 CrossGen (https://github.com/dotnet/coreclr/pull/19933) as well as *obsolete* Hostx86/arm32 CrossGen during Linux/arm32 official build.

This PR:
1. switches from using Hostx86/arm32 to Hostx64/arm32 CrossGen for producing native images and debugging files (i.e. perfmap files) in core-setup on Linux **and**
2. includes both Hostx86/arm32 and Hostx64/arm32 cross-architecture tools in *runtime.linux-arm64.Microsoft.NETCore.App\*.nupkg* produced by core-setup

These changes would allow up-stack components to use x64 CrossGen during their Linux/arm32 builds without requiring to run under the Docker (this was needed to be able to run a Linux x86 CrossGen application on Linux/x64 build machine).

@eerhardt Please take a look.
/cc @RussKeldorph

skip_ci_please 