### PR TITLE
Add option to build the corehost incrementally

### DIFF
--- a/config.json
+++ b/config.json
@@ -143,6 +143,12 @@
       "valueType": "property",
       "values": ["true", "false"],
       "defaultValue":false
+    },
+    "IncrementalNativeBuild": {
+      "description": "Enables/Disables incremental native build.",
+      "valueType": "property",
+      "values": ["true", "false"],
+      "defaultValue": false
     }
   },
   "commands": {
@@ -182,6 +188,12 @@
           "description": "Only build src\\src.builds project",
           "settings": {
             "Project": "src\\src.builds"
+          }
+        },
+        "corehost-build": {
+          "description": "Only build src\\corehost\\build.proj project",
+          "settings": {
+            "Project": "src\\corehost\\build.proj"
           }
         },
         "signing-validation": {

--- a/src/corehost/build.proj
+++ b/src/corehost/build.proj
@@ -26,8 +26,8 @@
       <BuildArgs Condition="'$(StripSymbols)' == 'true'">$(BuildArgs) --stripsymbols</BuildArgs>   
     </PropertyGroup>
 
-    <RemoveDir Directories="$(CMakeBuildDir)" Condition="Exists('$(CMakeBuildDir)')" />
-    <MakeDir Directories="$(CMakeBuildDir)" />
+    <RemoveDir Directories="$(CMakeBuildDir)" Condition="Exists('$(CMakeBuildDir)') And '$(IncrementalNativeBuild)' != 'true'" />
+    <MakeDir Directories="$(CMakeBuildDir)" Condition="!(Exists('$(CMakeBuildDir)'))" />
 
     <Message Text="$(MSBuildProjectDirectory)\build.sh $(BuildArgs)" Importance="High"/>
     <Exec Command="$(MSBuildProjectDirectory)\build.sh $(BuildArgs)"

--- a/src/corehost/build.proj
+++ b/src/corehost/build.proj
@@ -66,10 +66,12 @@
     
     <MSBuild Projects="$(MSBuildProjectFullPath)"
              Properties="GenerateNativeVersionInfo=true;FileDescription=%(HostFiles.FileDescription);NativeVersionFileDir=$(IntermediateOutputRootPath)hostResourceFiles\%(HostFiles.Identity);NativeVersionHeaderFile=$(IntermediateOutputRootPath)hostResourceFiles\%(HostFiles.Identity)\version_info.h"
-             Targets="GenerateVersionHeader" />
+             Targets="GenerateVersionHeader" 
+             Condition="'$(IncrementalNativeBuild)' != 'true'"/>
     <PropertyGroup>
       <BuildArgs>$(ConfigurationGroup) $(TargetArchitecture) apphostver $(AppHostVersion) hostver $(HostVersion) fxrver $(HostResolverVersion) policyver $(HostPolicyVersion) commit $(LatestCommit) rid $(OutputRid)</BuildArgs>
       <BuildArgs Condition="'$(PortableBuild)' == 'true'">$(BuildArgs) portable</BuildArgs>  
+      <BuildArgs Condition="'$(IncrementalNativeBuild)' == 'true'">$(BuildArgs) incremental-native-build</BuildArgs>
       <CustomNativeToolsetDir Condition="'$(TargetArchitecture)' == 'arm64'"> toolsetdir $(NativeToolsetDir)</CustomNativeToolsetDir>      
     </PropertyGroup>
 


### PR DESCRIPTION
Currently the build script hardcodes clean rebuild of the native components in corehost. This makes it pretty slow for inner dev loop.
The same script also always clears all the intermediates which makes cmake perform all of the detections again which is also very slow.
This change adds a new build option -IncrementalNativeBuild=true which disables these two behaviors (don't delete intermediates, don't force a rebuild).

Also add a build option to build just the corehost subtree since that's a common task for devs working on the hosting components.

With this change empty incremental build (no changes made) of the corehost components is now less than 10 seconds. Change to a single cpp file takes less than 20 seconds to rebuild (as oppose to couple of minutes before).