### PR TITLE
disable crossgen on FreeBSD for now

### DIFF
--- a/dir.props
+++ b/dir.props
@@ -273,6 +273,8 @@
 
   <PropertyGroup>
     <DisableCrossgen>false</DisableCrossgen>
+    <!-- Disable cross-gen on FreeBSD for now. This can be revisited when we have full support. -->
+    <DisableCrossgen Condition="'$(OSGroup)'=='FreeBSD'">true</DisableCrossgen>
     <OutputVersionBadge>$(BaseOutputRootPath)sharedfx_$(OutputRid)_$(ConfigurationGroup)_version_badge.svg</OutputVersionBadge>
   </PropertyGroup>
 


### PR DESCRIPTION
This is basic port of https://github.com/dotnet/source-build/pull/631 allowing official CI runs to function as well. 

#4698 is still open to track the investigation. 
