### PR TITLE
Fix channel for feature/utf8string

### DIFF
--- a/BranchInfo.props
+++ b/BranchInfo.props
@@ -13,7 +13,7 @@
 
     <ReleaseSuffix>$(PreReleaseLabel)</ReleaseSuffix>
     <ReleaseBrandSuffix>Alpha Feature Utf8String</ReleaseBrandSuffix>
-    <Channel>master</Channel>
+    <Channel>feature/utf8string</Channel>
     <ContainerName>dotnet</ContainerName>
     <ChecksumContainerName>$(ContainerName)</ChecksumContainerName>
     <NETCoreAppMaximumVersion>$(MajorVersion).$(MinorVersion)</NETCoreAppMaximumVersion>


### PR DESCRIPTION
This should prevent builds from publishing to 'latest'