### PR TITLE
Stop publishing obsolete Hostx86/arm CrossGen

### DIFF
--- a/src/pkg/projects/Microsoft.NETCore.App/src/Microsoft.NETCore.App.depproj
+++ b/src/pkg/projects/Microsoft.NETCore.App/src/Microsoft.NETCore.App.depproj
@@ -69,7 +69,6 @@
     <PropertyGroup>
       <_crossDir Condition="'$(TargetArchitecture)' == 'arm' AND '$(OS)' == 'Windows_NT'">/x86_arm</_crossDir>
       <_crossDir Condition="'$(TargetArchitecture)' == 'arm' AND '$(OS)' != 'Windows_NT'">/x64_arm</_crossDir>
-      <_obsoleteCrossDir Condition="'$(TargetArchitecture)' == 'arm' AND '$(OS)' != 'Windows_NT'">/x86_arm</_obsoleteCrossDir>
       <_crossDir Condition="'$(TargetArchitecture)' == 'arm64'">/x64_arm64</_crossDir>
     </PropertyGroup>
 
@@ -164,10 +163,6 @@
       </FilesToPackage>
       <FilesToPackage Condition="'$(_crossDir)' != ''" Include="$(_jitPackagePath)/runtimes$(_crossDir)/native/*.*">
         <TargetPath>runtimes$(_crossDir)/native</TargetPath>
-        <IsNative>true</IsNative>
-      </FilesToPackage>
-      <FilesToPackage Condition="'$(_obsoleteCrossDir)' != ''" Include="$(_jitPackagePath)/runtimes$(_obsoleteCrossDir)/native/*.*">
-        <TargetPath>runtimes$(_obsoleteCrossDir)/native</TargetPath>
         <IsNative>true</IsNative>
       </FilesToPackage>
     </ItemGroup>


### PR DESCRIPTION
This PR removes Hostx86/arm from publishing in core-setup as we tend to believe there should zero ref counts on Hostx86/arm CrossGen by now:

- As of https://github.com/dotnet/core-sdk/pull/108 core-sdk uses Hostx64/arm CrossGen on Linux/arm to produce native images for the rest of SDK (FSharp, Roslyn)

- https://github.com/aspnet/AspNetCore have yet to consume ARM-targeting Linux CrossGen in 3.0 (see https://github.com/aspnet/AspNetCore/issues/3652#issuecomment-435549292) and this should be Hostx64/arm CrossGen (/cc @JunTaoLuo)

@eerhardt @RussKeldorph PTAL

