### PR TITLE
disable tests on FreeBSD

### DIFF
--- a/buildpipeline/Core-Setup-FreeBSD-BT.json
+++ b/buildpipeline/Core-Setup-FreeBSD-BT.json
@@ -200,6 +200,9 @@
     "PB_PackageVersionPropsUrl": {
       "value": ""
     },
+    "PB_SkipTests": {
+      "value": "true"
+    },
     "PACKAGEVERSIONPROPSURL": {
       "value": "$(PB_PackageVersionPropsUrl)"
     }

--- a/buildpipeline/Core-Setup-FreeBSD-BT.json
+++ b/buildpipeline/Core-Setup-FreeBSD-BT.json
@@ -200,9 +200,6 @@
     "PB_PackageVersionPropsUrl": {
       "value": ""
     },
-    "PB_SkipTests": {
-      "value": "true"
-    },
     "PACKAGEVERSIONPROPSURL": {
       "value": "$(PB_PackageVersionPropsUrl)"
     }

--- a/buildpipeline/Core-Setup-FreeBSD-BT.json
+++ b/buildpipeline/Core-Setup-FreeBSD-BT.json
@@ -71,7 +71,7 @@
       },
       "inputs": {
         "filename": "bash",
-        "arguments": "-c \"export DotNetBootstrapCliTarPath=/dotnet-sdk-freebsd-x64.tar && $(PB_SourcesDirectory)/build.sh -OfficialBuildId=$(OfficialBuildId) $(PB_BuildArguments) -- $(PB_AdditionalMSBuildArguments) \"",
+        "arguments": "-c \"export DotNetBootstrapCliTarPath=/dotnet-sdk-freebsd-x64.tar && $(PB_SourcesDirectory)/build.sh -OfficialBuildId=$(OfficialBuildId) -ConfigurationGroup=$(BuildConfiguration) -PortableBuild=true -strip-symbols -SkipTests=true -- $(PB_AdditionalMSBuildArguments) \"",
         "workingFolder": "$(PB_SourcesDirectory)",
         "failOnStandardError": "false"
       }


### PR DESCRIPTION
The previous change did not work. I was watching tests crawling SLOWLY and timed out at 2H.
They did not hang - there were just super slow. Something we should investigate next week.
On my D4 VM it takes 35 minutes to build & test and it takes ~ 20 minutes on my old desktop. 

I was trying to set BP_SkipTest=false or pass in -SkipTest=True but that conflicted with value passed in down from general section and build did no like same value set twice with different values. 

Here is global run https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=2198702&view=logs

Linux with test: https://devdiv.visualstudio.com/DefaultCollection/DevDiv/_build?_a=summary&buildId=2198703

BSD without: https://devdiv.visualstudio.com/DefaultCollection/DevDiv/_build/results?buildId=2198709&view=logs