### PR TITLE
Small SDK lookup fix

### DIFF
--- a/Documentation/design-docs/multilevel-sharedfx-lookup.md
+++ b/Documentation/design-docs/multilevel-sharedfx-lookup.md
@@ -41,7 +41,10 @@ There are two possibilities for a muxer: it can be a framework-dependent app or 
 
 In the first case the app file path should have been specified as an argument to the dotnet.exe.
 
-In the second case the dotnet.dll from SDK must be invoked as a framework-dependent app. At first the running program searches for the global.json file which may have specified a CLI version. It starts from the current working directory and looks for it inside all parent folder hierarchy. After that, it searches for the dotnet.dll file inside the sdk\CLI_version subfolder in the executable directory. If the version defined in the global.json file or the specified version folder cannot be found, then it must choose the most appropriate one. The most appropriate version is defined as the latest version according to the Semantic Versioning system.
+In the second case the `dotnet.dll` from SDK must be invoked as a framework-dependent app. At first the running program searches for the `global.json` file which may have specified a CLI version. It starts from the current working directory and looks for it inside all parent folder hierarchy. After that, it searches for the dotnet.dll file inside the `sdk\<CLI_version>` sub-folder in the executable directory.
+The exact algorithm how versions as matched is described (with some history) in the [docs](https://docs.microsoft.com/en-us/dotnet/core/tools/global-json#matching-rules)
+
+Note: if the SDK lookup is invoked through `hostfxr_resolve_sdk2` the algorithm is the same, expect that the function can disallow pre-release versions via the `hostfxr_resolve_sdk2_flags_t::disallow_prerelease` flag.
 
 ### Framework search and rolling forward
 

--- a/src/corehost/cli/fxr/sdk_resolver.cpp
+++ b/src/corehost/cli/fxr/sdk_resolver.cpp
@@ -111,14 +111,17 @@ pal::string_t resolve_sdk_version(pal::string_t sdk_path, bool disallow_prerelea
         }
     }
 
-    pal::string_t max_ver_str = max_ver.as_str();
-    append_path(&sdk_path, max_ver_str.c_str());
-
-    trace::verbose(_X("Checking if resolved SDK dir [%s] exists"), sdk_path.c_str());
-    if (pal::directory_exists(sdk_path))
+    if (!max_ver.is_empty())
     {
-        trace::verbose(_X("Resolved SDK dir is [%s]"), sdk_path.c_str());
-        retval = max_ver_str;
+        pal::string_t max_ver_str = max_ver.as_str();
+        append_path(&sdk_path, max_ver_str.c_str());
+
+        trace::verbose(_X("Checking if resolved SDK dir [%s] exists"), sdk_path.c_str());
+        if (pal::directory_exists(sdk_path))
+        {
+            trace::verbose(_X("Resolved SDK dir is [%s]"), sdk_path.c_str());
+            retval = max_ver_str;
+        }
     }
 
     return retval;

--- a/src/test/HostActivationTests/GivenThatICareAboutMultilevelSDKLookup.cs
+++ b/src/test/HostActivationTests/GivenThatICareAboutMultilevelSDKLookup.cs
@@ -140,7 +140,9 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.MultilevelSDKLookup
                 .And
                 .HaveStdErrContaining("A compatible installed dotnet SDK for global.json version")
                 .And
-                .HaveStdErrContaining("It was not possible to find any installed dotnet SDKs");
+                .HaveStdErrContaining("It was not possible to find any installed dotnet SDKs")
+                .And
+                .NotHaveStdErrContaining("Checking if resolved SDK dir");
 
             // Add some dummy versions
             AddAvailableSdkVersions(_exeSdkBaseDir, "9999.4.1", "9999.3.4-dummy");
@@ -674,7 +676,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.MultilevelSDKLookup
             // CWD: 10000.0.0                 --> should not be picked
             // User: 9999.0.200               --> should not be picked
             // Exe: 9999.0.0, 9999.0.3-dummy, 9999.0.3, 9999.0.100, 9999.0.80, 9999.0.5500000, 9999.0.52000000
-            // Expected: 9999.0.5500000 from exe dir
+            // Expected: 9999.0.52000000 from exe dir
             dotnet.Exec("help")
                 .WorkingDirectory(_currentWorkingDir)
                 .WithUserProfile(_userDir)


### PR DESCRIPTION
If the global.json specifies SDK version but we can't find that version in a given search location, the code would end up checking if a folder with name "-1.-1.-1" exist. This is because we're left with empty version structure which is represented as -1.-1.-1.
Not only this is a small perf issue (unnecessarily looking at disk), but if the folder existed by any chance we would have returned that version for use.

Also improves the doc describing the SDK version algorithm by linking to the public docs which have detailed description.