### PR TITLE
Add new export to hostpolicy and hostfxr to redirect error output

### DIFF
--- a/src/corehost/cli/hostpolicy.cpp
+++ b/src/corehost/cli/hostpolicy.cpp
@@ -580,3 +580,30 @@ SHARED_API int corehost_resolve_component_dependencies(
     
     return 0;
 }
+
+
+typedef void(*corehost_error_writer_fn)(const pal::char_t* message);
+
+//
+// Sets a callback which is to be used to write errors to.
+//
+// Parameters:
+//     error_writer 
+//         A callback function which will be invoked every time an error is to be reported.
+//         Or nullptr to unregister previously registered callback and return to the default behavior.
+// Return value:
+//     The previously registered callback (which is now unregistered), or nullptr if no previous callback
+//     was registered
+// 
+// The error writer is registered per-thread, so the registration is thread-local. On each thread
+// only one callback can be registered. Subsequent registrations overwrite the previous ones.
+// 
+// By default no callback is registered in which case the errors are written to stderr.
+// 
+// Each call to the error writer is sort of like writing a single line (the EOL character is omitted).
+// Multiple calls to the error writer may occure for one failure.
+//
+SHARED_API corehost_error_writer_fn corehost_set_error_writer(corehost_error_writer_fn error_writer)
+{
+    return trace::set_error_writer(error_writer);
+}

--- a/src/corehost/common/pal.h
+++ b/src/corehost/common/pal.h
@@ -127,6 +127,7 @@ namespace pal
     inline void file_vprintf(FILE* f, const char_t* format, va_list vl) { ::vfwprintf(f, format, vl); ::fputwc(_X('\n'), f); }
     inline void err_vprintf(const char_t* format, va_list vl) { ::vfwprintf(stderr, format, vl); ::fputwc(_X('\n'), stderr); }
     inline void out_vprintf(const char_t* format, va_list vl) { ::vfwprintf(stdout, format, vl); ::fputwc(_X('\n'), stdout); }
+    inline void str_vprintf(char_t* str, size_t size, const char_t* format, va_list vl) { ::_vsnwprintf_s(str, size, _TRUNCATE, format, vl); }
 
     bool pal_utf8string(const pal::string_t& str, std::vector<char>* out);
     bool utf8_palstring(const std::string& str, pal::string_t* out);
@@ -173,6 +174,8 @@ namespace pal
     inline void file_vprintf(FILE* f, const char_t* format, va_list vl) { ::vfprintf(f, format, vl); ::fputc('\n', f); }
     inline void err_vprintf(const char_t* format, va_list vl) { ::vfprintf(stderr, format, vl); ::fputc('\n', stderr); }
     inline void out_vprintf(const char_t* format, va_list vl) { ::vfprintf(stdout, format, vl); ::fputc('\n', stdout); }
+    inline void str_vprintf(char_t* str, size_t size, const char_t* format, va_list vl) { ::vsnprintf(str, size, format, vl); }
+
     inline bool pal_utf8string(const pal::string_t& str, std::vector<char>* out) { out->assign(str.begin(), str.end()); out->push_back('\0'); return true; }
     inline bool utf8_palstring(const std::string& str, pal::string_t* out) { out->assign(str); return true; }
     inline bool pal_clrstring(const pal::string_t& str, std::vector<char>* out) { return pal_utf8string(str, out); }

--- a/src/corehost/common/trace.h
+++ b/src/corehost/common/trace.h
@@ -18,6 +18,18 @@ namespace trace
     void println(const pal::char_t* format, ...);
     void println();
     void flush();
+
+    typedef void (*error_writer_fn)(const pal::char_t* message);
+
+    // Sets a callback which is called whenever error is to be written
+    // The setting is per-thread (thread local). If no error writer is set for a given thread
+    // the error is written to stderr.
+    // The callback is set for the current thread which calls this function.
+    // The function returns the previously registered writer for the current thread (or null)
+    error_writer_fn set_error_writer(error_writer_fn error_writer);
+
+    // Returns the currently set callback for error writing
+    error_writer_fn get_error_writer();
 };
 
 #endif // TRACE_H

--- a/src/test/Assets/TestProjects/HostApiInvokerApp/HostPolicy.cs
+++ b/src/test/Assets/TestProjects/HostApiInvokerApp/HostPolicy.cs
@@ -1,8 +1,10 @@
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
 using System.Text;
+using System.Threading;
 
 namespace HostApiInvokerApp
 {
@@ -20,6 +22,71 @@ namespace HostApiInvokerApp
             internal static extern int corehost_resolve_component_dependencies(
                 string component_main_assembly_path, 
                 corehost_resolve_component_dependencies_result_fn result);
+
+            [UnmanagedFunctionPointer(CallingConvention.Cdecl, CharSet = Utils.OSCharSet)]
+            internal delegate void corehost_error_writer_fn(
+                string message);
+
+            [DllImport(nameof(hostpolicy), CharSet = Utils.OSCharSet, ExactSpelling = true, CallingConvention = CallingConvention.Cdecl)]
+            internal static extern IntPtr corehost_set_error_writer(
+                corehost_error_writer_fn error_writer);
+        }
+
+        static void Test_corehost_resolve_component_dependencies_internal(string prefix, string assemblyPath)
+        {
+            StringBuilder errorBuilder = new StringBuilder();
+
+            hostpolicy.corehost_set_error_writer((message) =>
+            {
+                errorBuilder.AppendLine(message);
+            });
+
+            string assemblies = null;
+            string nativeSearchPaths = null;
+            string resourceSearcPaths = null;
+            int rc;
+            try
+            {
+                rc = hostpolicy.corehost_resolve_component_dependencies(
+                    assemblyPath,
+                    (assembly_paths, native_search_paths, resource_search_paths) => 
+                    {
+                        assemblies = assembly_paths;
+                        nativeSearchPaths = native_search_paths;
+                        resourceSearcPaths = resource_search_paths;
+                    });
+            }
+            finally
+            {
+                hostpolicy.corehost_set_error_writer(null);
+            }
+
+            if (assemblies != null)
+            {
+                // Sort the assemblies since in the native code we store it in a hash table
+                // which gives random order. The native code always adds the separator at the end
+                // so mimic that behavior as well.
+                assemblies = string.Join(Path.PathSeparator, assemblies.Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries).OrderBy(a => a)) + Path.PathSeparator;
+            }
+
+            if (rc == 0)
+            {
+                Console.WriteLine($"{prefix}corehost_resolve_component_dependencies:Success");
+                Console.WriteLine($"{prefix}corehost_resolve_component_dependencies assemblies:[{assemblies}]");
+                Console.WriteLine($"{prefix}corehost_resolve_component_dependencies native_search_paths:[{nativeSearchPaths}]");
+                Console.WriteLine($"{prefix}corehost_resolve_component_dependencies resource_search_paths:[{resourceSearcPaths}]");
+            }
+            else
+            {
+                Console.WriteLine($"{prefix}corehost_resolve_component_dependencies:Fail[0x{rc.ToString("X8")}]");
+            }
+
+            if (errorBuilder.Length > 0)
+            {
+                IEnumerable<string> errorLines = errorBuilder.ToString().Split(new string[] { Environment.NewLine }, StringSplitOptions.None)
+                    .Select(line => prefix + line);
+                Console.WriteLine($"{prefix}corehost reported errors:{Environment.NewLine}{string.Join(Environment.NewLine, errorLines)}");
+            }
         }
 
         static void Test_corehost_resolve_component_dependencies(string[] args)
@@ -29,36 +96,67 @@ namespace HostApiInvokerApp
                 throw new ArgumentException("Invalid number of arguments passed");
             }
 
-            string assemblies = null;
-            string nativeSearchPaths = null;
-            string resourceSearcPaths = null;
-            int rc = hostpolicy.corehost_resolve_component_dependencies(
-                args[1],
-                (assembly_paths, native_search_paths, resource_search_paths) => 
+            Test_corehost_resolve_component_dependencies_internal("", args[1]);
+        }
+
+        static void Test_corehost_resolve_component_dependencies_multithreaded(string[] args)
+        {
+            if (args.Length != 3)
+            {
+                throw new ArgumentException("Invalid number of arguments passed");
+            }
+
+            Func<string, Thread> createThread = (string assemblyPath) =>
+            {
+                return new Thread(() =>
                 {
-                    assemblies = assembly_paths;
-                    nativeSearchPaths = native_search_paths;
-                    resourceSearcPaths = resource_search_paths;
+                    Test_corehost_resolve_component_dependencies_internal(
+                        Path.GetFileNameWithoutExtension(assemblyPath) + ": ",
+                        assemblyPath
+                    );
                 });
+            };
 
-            if (assemblies != null)
+            Thread t1 = createThread(args[1]);
+            Thread t2 = createThread(args[2]);
+
+            t1.Start();
+            t2.Start();
+
+            if (!t1.Join(TimeSpan.FromSeconds(30)))
             {
-                // Sort the assemblies since in the native code we store it in a hash table
-                // which gives random order. The native code always adds the separator at the end
-                // so mimic that behavior as well.
-                assemblies = string.Join(System.IO.Path.PathSeparator, assemblies.Split(System.IO.Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries).OrderBy(a => a)) + System.IO.Path.PathSeparator;
+                throw new ApplicationException("Thread 1 didn't finish in time.");
             }
 
-            if (rc == 0)
+            if (!t2.Join(TimeSpan.FromSeconds(30)))
             {
-                Console.WriteLine("corehost_resolve_component_dependencies:Success");
-                Console.WriteLine($"corehost_resolve_component_dependencies assemblies:[{assemblies}]");
-                Console.WriteLine($"corehost_resolve_component_dependencies native_search_paths:[{nativeSearchPaths}]");
-                Console.WriteLine($"corehost_resolve_component_dependencies resource_search_paths:[{resourceSearcPaths}]");
+                throw new ApplicationException("Thread 1 didn't finish in time.");
             }
-            else
+        }
+
+        static void Test_corehost_set_error_writer(string[] args)
+        {
+            hostpolicy.corehost_error_writer_fn writer1 = (message) => { Console.WriteLine(nameof(writer1)); };
+            IntPtr writer1Ptr = Marshal.GetFunctionPointerForDelegate(writer1);
+
+            if (hostpolicy.corehost_set_error_writer(writer1) != IntPtr.Zero)
             {
-                Console.WriteLine($"corehost_resolve_component_dependencies:Fail[0x{rc.ToString("X8")}]");
+                throw new ApplicationException("Error writer should be null by default.");
+            }
+
+            hostpolicy.corehost_error_writer_fn writer2 = (message) => { Console.WriteLine(nameof(writer2)); };
+            IntPtr writer2Ptr = Marshal.GetFunctionPointerForDelegate(writer2);
+            IntPtr previousWriterPtr = hostpolicy.corehost_set_error_writer(writer2);
+
+            if (previousWriterPtr != writer1Ptr)
+            {
+                throw new ApplicationException("First: The previous writer returned is not the one expected.");
+            }
+
+            previousWriterPtr = hostpolicy.corehost_set_error_writer(null);
+            if (previousWriterPtr != writer2Ptr)
+            {
+                throw new ApplicationException("Second: The previous writer returned is not the one expected.");
             }
         }
 
@@ -68,6 +166,12 @@ namespace HostApiInvokerApp
             {
                 case nameof(hostpolicy.corehost_resolve_component_dependencies):
                     Test_corehost_resolve_component_dependencies(args);
+                    break;
+                case nameof(hostpolicy.corehost_resolve_component_dependencies) + "_multithreaded":
+                    Test_corehost_resolve_component_dependencies_multithreaded(args);
+                    break;
+                case nameof(Test_corehost_set_error_writer):
+                    Test_corehost_set_error_writer(args);
                     break;
                 default:
                     return false;


### PR DESCRIPTION
This introduces corehost_set_error_writer and hostfxr_set_error_writer exports.
If set, all errors will be written to the error writer instead of the default stderr.
Tracing is unaffected by this change.
The error writer is set per-thread (thread local).
Only one error writer can be set on a given thread. Subsequent calls to set error
writer will overwrite the previous writer.

hostfxr propagates the custom error writer (if any) to the hostpolicy
for the duration of the calls it makes to hostpolicy.

Added tests to validate the new behavior.

- Please add a description for changes you are making.
- If there is an issue related to this PR, please add a reference to it.
- If this PR should not run tests please add say skip_ci_please in this description replacing the underscores with spaces.