### PR TITLE
Host UI errors

### DIFF
--- a/src/corehost/common/pal.h
+++ b/src/corehost/common/pal.h
@@ -125,7 +125,7 @@ namespace pal
     inline size_t strlen(const char_t* str) { return ::wcslen(str); }
     inline FILE * file_open(const pal::string_t& path, const char_t* mode) { return ::_wfopen(path.c_str(), mode); }
     inline void file_vprintf(FILE* f, const char_t* format, va_list vl) { ::vfwprintf(f, format, vl); ::fputwc(_X('\n'), f); }
-    inline void err_vprintf(const char_t* format, va_list vl) { ::vfwprintf(stderr, format, vl); ::fputwc(_X('\n'), stderr); }
+    inline void err_fputs(const char_t* message) { ::fputws(message, stderr); ::fputwc(_X('\n'), stderr); }
     inline void out_vprintf(const char_t* format, va_list vl) { ::vfwprintf(stdout, format, vl); ::fputwc(_X('\n'), stdout); }
     inline int str_vprintf(char_t* buffer, size_t count, const char_t* format, va_list vl) { return ::_vsnwprintf(buffer, count, format, vl); }
 
@@ -172,7 +172,7 @@ namespace pal
     inline size_t strlen(const char_t* str) { return ::strlen(str); }
     inline FILE * file_open(const pal::string_t& path, const char_t* mode) { return fopen(path.c_str(), mode); }
     inline void file_vprintf(FILE* f, const char_t* format, va_list vl) { ::vfprintf(f, format, vl); ::fputc('\n', f); }
-    inline void err_vprintf(const char_t* format, va_list vl) { ::vfprintf(stderr, format, vl); ::fputc('\n', stderr); }
+    inline void err_fputs(const char_t* message) { ::fputs(message, stderr); ::fputc(_X('\n'), stderr); }
     inline void out_vprintf(const char_t* format, va_list vl) { ::vfprintf(stdout, format, vl); ::fputc('\n', stdout); }
     inline int str_vprintf(char_t* str, size_t size, const char_t* format, va_list vl) { return ::vsnprintf(str, size, format, vl); }
 

--- a/src/corehost/corehost.cpp
+++ b/src/corehost/corehost.cpp
@@ -284,12 +284,12 @@ int run(const int argc, const pal::char_t* argv[])
         trace::info(_X("Dotnet path: [%s]"), dotnet_root.c_str());
         trace::info(_X("App path: [%s]"), app_path.c_str());
 
-		hostfxr_set_error_writer_fn set_error_writer_fn = (hostfxr_set_error_writer_fn)pal::get_symbol(fxr, "hostfxr_set_error_writer");
+        hostfxr_set_error_writer_fn set_error_writer_fn = (hostfxr_set_error_writer_fn)pal::get_symbol(fxr, "hostfxr_set_error_writer");
 
         // Previous corehost trace messages must be printed before calling trace::setup in hostfxr
         trace::flush();
 
-		propagate_error_writer_t propagate_error_writer_to_hostfxr(set_error_writer_fn);
+        propagate_error_writer_t propagate_error_writer_to_hostfxr(set_error_writer_fn);
 
         rc = main_fn_v2(argc, argv, host_path_cstr, dotnet_root_cstr, app_path_cstr);
     }
@@ -331,7 +331,7 @@ pal::string_t g_buffered_errors;
 
 void buffering_trace_writer(const pal::char_t* message)
 {
-	g_buffered_errors.append(message).append(_X("\n"));
+    g_buffered_errors.append(message).append(_X("\n"));
 }
 #endif
 
@@ -354,34 +354,38 @@ int main(const int argc, const pal::char_t* argv[])
     }
 
 #if defined(_WIN32) && defined(FEATURE_APPHOST)
-	// Detect if the process has console
-	// Note that this will fail even if a GUI process has STDOUT redirected. So this pretty effectively detects
-	// if the process is a GUI process without a console window.
-	HANDLE con_out = ::CreateFileW(L"CONOUT$", GENERIC_READ, FILE_SHARE_READ | FILE_SHARE_WRITE, NULL, OPEN_EXISTING, 0, 0);
-	if (con_out == INVALID_HANDLE_VALUE)
-	{
-		// If there's no console, buffer errors to display them later. Without this any errors are effectively lost
-		// unless the caller explicitly redirects stderr. This leads to bad experience of running the GUI app and nothing happening.
-		trace::set_error_writer(buffering_trace_writer);
-	}
+    // Detect if the process has console
+    // Note that this will fail even if a GUI process has STDOUT redirected. So this pretty effectively detects
+    // if the process is a GUI process without a console window.
+    HANDLE con_out = ::CreateFileW(L"CONOUT$", GENERIC_READ, FILE_SHARE_READ | FILE_SHARE_WRITE, NULL, OPEN_EXISTING, 0, 0);
+    if (con_out == INVALID_HANDLE_VALUE)
+    {
+        // If there's no console, buffer errors to display them later. Without this any errors are effectively lost
+        // unless the caller explicitly redirects stderr. This leads to bad experience of running the GUI app and nothing happening.
+        trace::set_error_writer(buffering_trace_writer);
+    }
 #endif
 
     int exit_code = run(argc, argv);
 
-#if defined(_WIN32) && defined(FEATURE_APPHOST)
-	// No need to unregister the error writer since we're exiting anyway.
-	if (!g_buffered_errors.empty())
-	{
-		// If there are errors buffered, display them as a dialog. We only buffer if there's no console attached.
-		pal::string_t executable_name;
-		if (pal::get_own_executable_path(&executable_name))
-		{
-			executable_name = get_filename(executable_name);
-		}
+    // Flush traces before exit - just to be sure, and also if we're showing a popup below the error should show up in traces
+    // by the time the popup is displayed.
+    trace::flush();
 
-		::MessageBoxW(NULL, g_buffered_errors.c_str(), executable_name.c_str(), MB_OK);
-	}
+#if defined(_WIN32) && defined(FEATURE_APPHOST)
+    // No need to unregister the error writer since we're exiting anyway.
+    if (!g_buffered_errors.empty())
+    {
+        // If there are errors buffered, display them as a dialog. We only buffer if there's no console attached.
+        pal::string_t executable_name;
+        if (pal::get_own_executable_path(&executable_name))
+        {
+            executable_name = get_filename(executable_name);
+        }
+
+        ::MessageBoxW(NULL, g_buffered_errors.c_str(), executable_name.c_str(), MB_OK);
+    }
 #endif
 
-	return exit_code;
+    return exit_code;
 }

--- a/src/test/HostActivationTests/HostActivationTests.csproj
+++ b/src/test/HostActivationTests/HostActivationTests.csproj
@@ -5,6 +5,7 @@
     <AssemblyName>HostActivationTests</AssemblyName>
     <PackageId>HostActivationTests</PackageId>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
+    <DefineConstants Condition="'$(OSGroup)' == 'Windows_NT'">$(DefineConstants);WINDOWS</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/test/TestUtils/AppHostExtensions.cs
+++ b/src/test/TestUtils/AppHostExtensions.cs
@@ -113,6 +113,94 @@ namespace Microsoft.DotNet.CoreSetup.Test
                 }
             }
         }
+
+        /// <summary>
+        /// The first two bytes of a PE file are a constant signature.
+        /// </summary>
+        private const UInt16 PEFileSignature = 0x5A4D;
+
+        /// <summary>
+        /// The offset of the PE header pointer in the DOS header.
+        /// </summary>
+        private const int PEHeaderPointerOffset = 0x3C;
+
+        /// <summary>
+        /// The offset of the Subsystem field in the PE header.
+        /// </summary>
+        private const int SubsystemOffset = 0x5C;
+
+        /// <summary>
+        /// The value of the sybsystem field which indicates Windows GUI (Graphical UI)
+        /// </summary>
+        private const UInt16 WindowsGUISubsystem = 0x2;
+
+        /// <summary>
+        /// The value of the subsystem field which indicates Windows CUI (Console)
+        /// </summary>
+        private const UInt16 WindowsCUISubsystem = 0x3;
+
+        public static void SetWindowsGraphicalUserInterfaceBit(string appHostPath)
+        {
+            // Re-write ModifiedAppHostPath with the proper contents.
+            using (var memoryMappedFile = MemoryMappedFile.CreateFromFile(appHostPath))
+            {
+                using (MemoryMappedViewAccessor accessor = memoryMappedFile.CreateViewAccessor())
+                {
+                    SetWindowsGraphicalUserInterfaceBit(accessor);
+                }
+            }
+        }
+
+        /// <summary>
+        /// If the apphost file is a windows PE file (checked by looking at the first few bytes)
+        /// this method will set its subsystem to GUI.
+        /// </summary>
+        /// <param name="accessor">The memory accessor which has the apphost file opened.</param>
+        /// <param name="appHostSourcePath">The path to the source apphost.</param>
+        private static unsafe void SetWindowsGraphicalUserInterfaceBit(
+            MemoryMappedViewAccessor accessor)
+        {
+            byte* pointer = null;
+
+            try
+            {
+                accessor.SafeMemoryMappedViewHandle.AcquirePointer(ref pointer);
+                byte* bytes = pointer + accessor.PointerOffset;
+
+                // https://en.wikipedia.org/wiki/Portable_Executable
+                // Validate that we're looking at Windows PE file
+                if (((UInt16*)bytes)[0] != PEFileSignature || accessor.Capacity < PEHeaderPointerOffset + sizeof(UInt32))
+                {
+                    throw new Exception("apphost is not a Windows exe.");
+                }
+
+                UInt32 peHeaderOffset = ((UInt32*)(bytes + PEHeaderPointerOffset))[0];
+
+                if (accessor.Capacity < peHeaderOffset + SubsystemOffset + sizeof(UInt16))
+                {
+                    throw new Exception("apphost is not a Windows exe.");
+                }
+
+                UInt16* subsystem = ((UInt16*)(bytes + peHeaderOffset + SubsystemOffset));
+
+                // https://docs.microsoft.com/en-us/windows/desktop/Debug/pe-format#windows-subsystem
+                // The subsystem of the prebuilt apphost should be set to CUI
+                if (subsystem[0] != WindowsCUISubsystem)
+                {
+                    throw new Exception("apphost is not a Windows CLI.");
+                }
+
+                // Set the subsystem to GUI
+                subsystem[0] = WindowsGUISubsystem;
+            }
+            finally
+            {
+                if (pointer != null)
+                {
+                    accessor.SafeMemoryMappedViewHandle.ReleasePointer();
+                }
+            }
+        }
     }
 }
 

--- a/src/test/TestUtils/Assertions/CommandResultAssertions.cs
+++ b/src/test/TestUtils/Assertions/CommandResultAssertions.cs
@@ -126,7 +126,7 @@ namespace Microsoft.DotNet.CoreSetup.Test
         public AndConstraint<CommandResultAssertions> FileContains(string path, string pattern)
         {
             Execute.Assertion.ForCondition(System.IO.File.ReadAllText(path).Contains(pattern))
-                .FailWith("The command did not write the expected result '{1}' to the file: {1}{2}", pattern, path, GetDiagnosticsInfo());
+                .FailWith("The command did not write the expected result '{0}' to the file: {1}{2}", pattern, path, GetDiagnosticsInfo());
             return new AndConstraint<CommandResultAssertions>(this);
         }
 


### PR DESCRIPTION
Implements reporting errors with message box for Windows GUI apps in `apphost`.

In `apphost`, if there's no console detected, error writing will be redirected to a buffer. Upon exit, if the error buffer is not empty, it will be showed on screen as a message box.
The error writer is propagated from `apphost` to `hostfxr` and thus to `hostpolicy`.

This solves the problem that GUI apps which don't have console die silently without reporting any errors if there are issus during host execution.