### PR TITLE
Fix usage message for `--roll-forward-on-no-candidate-fx`

### DIFF
--- a/src/corehost/cli/fxr/fx_muxer.cpp
+++ b/src/corehost/cli/fxr/fx_muxer.cpp
@@ -710,7 +710,7 @@ std::vector<host_option> fx_muxer_t::get_known_opts(bool exec_mode, host_mode_t 
         // If mode=host_mode_t::apphost, these are only used when the app is framework-dependent.
         known_opts.push_back({ _X("--fx-version"), _X("<version>"), _X("Version of the installed Shared Framework to use to run the application.")});
         known_opts.push_back({ _X("--roll-forward-on-no-candidate-fx"), _X("<n>"), _X("Set roll forward on no candidate shared framework behavior.")});
-        known_opts.push_back({ _X("--additional-deps"), _X("<path>"), _X("Path to additonal deps.json file.")});
+        known_opts.push_back({ _X("--additional-deps"), _X("<path>"), _X("Path to additional deps.json file.")});
     }
 
     return known_opts;

--- a/src/corehost/cli/fxr/fx_muxer.cpp
+++ b/src/corehost/cli/fxr/fx_muxer.cpp
@@ -638,10 +638,10 @@ void fx_muxer_t::muxer_usage(bool is_sdk_present)
 
     for (const auto& arg : known_opts)
     {
-        trace::println(_X("  %-38s  %s"), (arg.option + _X(" ") + arg.argument).c_str(), arg.description.c_str());
+        trace::println(_X("  %-37s  %s"), (arg.option + _X(" ") + arg.argument).c_str(), arg.description.c_str());
     }
-    trace::println(_X("  --list-runtimes                         Display the installed runtimes"));
-    trace::println(_X("  --list-sdks                             Display the installed SDKs"));
+    trace::println(_X("  --list-runtimes                        Display the installed runtimes"));
+    trace::println(_X("  --list-sdks                            Display the installed SDKs"));
 
     if (!is_sdk_present)
     {
@@ -709,7 +709,7 @@ std::vector<host_option> fx_muxer_t::get_known_opts(bool exec_mode, host_mode_t 
     {
         // If mode=host_mode_t::apphost, these are only used when the app is framework-dependent.
         known_opts.push_back({ _X("--fx-version"), _X("<version>"), _X("Version of the installed Shared Framework to use to run the application.")});
-        known_opts.push_back({ _X("--roll-forward-on-no-candidate-fx"), _X("<n>"), _X("Set roll forward on no candidate shared framework behavior.")});
+        known_opts.push_back({ _X("--roll-forward-on-no-candidate-fx"), _X("<n>"), _X("Roll forward on no candidate framework (0=off, 1=roll minor, 2=roll major & minor).")});
         known_opts.push_back({ _X("--additional-deps"), _X("<path>"), _X("Path to additional deps.json file.")});
     }
 
@@ -737,7 +737,7 @@ int fx_muxer_t::parse_args(
         trace::error(_X("Failed to parse supported options or their values:"));
         for (const auto& arg : known_opts)
         {
-            trace::error(_X("  %-38s  %s"), (arg.option + _X(" ") + arg.argument).c_str(), arg.description.c_str());
+            trace::error(_X("  %-37s  %s"), (arg.option + _X(" ") + arg.argument).c_str(), arg.description.c_str());
         }
         return InvalidArgFailure;
     }

--- a/src/corehost/cli/fxr/fx_muxer.cpp
+++ b/src/corehost/cli/fxr/fx_muxer.cpp
@@ -638,10 +638,10 @@ void fx_muxer_t::muxer_usage(bool is_sdk_present)
 
     for (const auto& arg : known_opts)
     {
-        trace::println(_X("  %-34s  %s"), (arg.option + _X(" ") + arg.argument).c_str(), arg.description.c_str());
+        trace::println(_X("  %-38s  %s"), (arg.option + _X(" ") + arg.argument).c_str(), arg.description.c_str());
     }
-    trace::println(_X("  --list-runtimes                     Display the installed runtimes"));
-    trace::println(_X("  --list-sdks                         Display the installed SDKs"));
+    trace::println(_X("  --list-runtimes                         Display the installed runtimes"));
+    trace::println(_X("  --list-sdks                             Display the installed SDKs"));
 
     if (!is_sdk_present)
     {
@@ -698,19 +698,19 @@ void append_probe_realpath(const pal::string_t& path, std::vector<pal::string_t>
 
 std::vector<host_option> fx_muxer_t::get_known_opts(bool exec_mode, host_mode_t mode, bool get_all_options)
 {
-    std::vector<host_option> known_opts = { { _X("--additionalprobingpath"), _X("<path>"), _X("Path containing probing policy and assemblies to probe for") } };
+    std::vector<host_option> known_opts = { { _X("--additionalprobingpath"), _X("<path>"), _X("Path containing probing policy and assemblies to probe for.") } };
     if (get_all_options || exec_mode || mode == host_mode_t::split_fx || mode == host_mode_t::apphost)
     {
-        known_opts.push_back({ _X("--depsfile"), _X("<path>"), _X("Path to <application>.deps.json file")});
-        known_opts.push_back({ _X("--runtimeconfig"), _X("<path>"), _X("Path to <application>.runtimeconfig.json file")});
+        known_opts.push_back({ _X("--depsfile"), _X("<path>"), _X("Path to <application>.deps.json file.")});
+        known_opts.push_back({ _X("--runtimeconfig"), _X("<path>"), _X("Path to <application>.runtimeconfig.json file.")});
     }
 
     if (get_all_options || mode == host_mode_t::muxer || mode == host_mode_t::apphost)
     {
         // If mode=host_mode_t::apphost, these are only used when the app is framework-dependent.
         known_opts.push_back({ _X("--fx-version"), _X("<version>"), _X("Version of the installed Shared Framework to use to run the application.")});
-        known_opts.push_back({ _X("--roll-forward-on-no-candidate-fx"), _X(""), _X("Roll forward on no candidate shared framework is enabled")});
-        known_opts.push_back({ _X("--additional-deps"), _X("<path>"), _X("Path to additonal deps.json file")});
+        known_opts.push_back({ _X("--roll-forward-on-no-candidate-fx"), _X("<n>"), _X("Set roll forward on no candidate shared framework behavior.")});
+        known_opts.push_back({ _X("--additional-deps"), _X("<path>"), _X("Path to additonal deps.json file.")});
     }
 
     return known_opts;
@@ -737,7 +737,7 @@ int fx_muxer_t::parse_args(
         trace::error(_X("Failed to parse supported options or their values:"));
         for (const auto& arg : known_opts)
         {
-            trace::error(_X("  %s"), (arg.option + _X(" ") + arg.argument).c_str());
+            trace::error(_X("  %-38s  %s"), (arg.option + _X(" ") + arg.argument).c_str(), arg.description.c_str());
         }
         return InvalidArgFailure;
     }


### PR DESCRIPTION
Explicitly state that the `--roll-forward-on-no-candidate-fx` command line argument requires a value.

Made the descriptions consistent with those reported by CLI (dots at the end).

In case of parsing error, show the argument descriptions as well, not just the names and values.

- Please add a description for changes you are making.
- If there is an issue related to this PR, please add a reference to it.
- If this PR should not run tests please add say skip_ci_please in this description replacing the underscores with spaces.

Related to #4873 