### PR TITLE
Fix official build

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -57,7 +57,7 @@ variables:
         /p:ChecksumAzureAccessToken=$(dotnetclichecksums-storage-key)
     # Used for publishing to dotnet myget account
     - name: MyGetApiKey
-      value: $(dotnet-myget-org-api-key )
+      value: $(dotnet-myget-org-api-key)
     - name: MyGetFeedUrl
       value: https://dotnet.myget.org/F/dotnet-core/api/v2/package
     - name: MyGetSymbolsFeedUrl


### PR DESCRIPTION
Official build is failing at finalize-publish step , complaining about the variable name passed to the build command. This is excercised only during the official build, thus, encountered this issue now. 