### PR TITLE
Enable building Tizen leg for PR builds using Azure Devops

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -67,7 +67,6 @@ variables:
         /p:NuGetSymbolsFeedUrl=$(MyGetSymbolsFeedUrl)
         /p:NuGetApiKey=$(MyGetApiKey)
 
-    # ******* End Dev testing Configuration ********
 jobs:
   ################################################################################
   # Build Linux legs
@@ -116,6 +115,20 @@ jobs:
     dockerImage: microsoft/dotnet-buildtools-prereqs:centos-6-376e1a3-20174311014331
     portableBuild: false
     targetArchitecture: x64
+
+# Tizen build only for PR build
+- ${{ if eq(variables['Build.Reason'], 'PullRequest') }}:
+  - template: /eng/jobs/linux-build.yml
+    parameters:
+      additionalMSBuildArgs: /p:OverridePackageSource=https:%2F%2Ftizen.myget.org/F/dotnet-core/api/v3/index.json /p:OutputRid=tizen.5.0.0-armel
+      additionalRunArgs: -e ROOTFS_DIR=/crossrootfs/armel.tizen.build
+      crossBuild: true
+      displayName: Build_Linux_ArmRel_Tizen
+      disableCrossgen: true
+      dockerImage: tizendotnet/dotnet-buildtools-prereqs:ubuntu-16.04-cross-e435274-20180426002255-tizen-rootfs-5.0m1
+      portableBuild: false
+      skipTests: true
+      targetArchitecture: armel
 
 # - template: /eng/jobs/linux-build.yml
 #   parameters:

--- a/eng/jobs/linux-build.yml
+++ b/eng/jobs/linux-build.yml
@@ -1,7 +1,8 @@
 parameters:
   additionalMSBuildArgs: ''
   additionalRunArgs: ''
-  crossBuild: false 
+  crossBuild: false
+  disableCrossgen: false
   displayName: null
   dockerImage: null
   osGroup: Linux
@@ -41,13 +42,14 @@ jobs:
       BuildArguments: -OfficialBuildId=$(OfficialBuildId)
         -ConfigurationGroup=$(_BuildConfig)
         -CrossBuild=${{ parameters.crossBuild }}
+        -DisableCrossgen=${{ parameters.disableCrossgen }}
         -PortableBuild=${{ parameters.portableBuild }}
         -strip-symbols
         -SkipTests=${{ parameters.skipTests }}
         -TargetArchitecture=${{ parameters.targetArchitecture }}
         -- /p:StabilizePackageVersion=$(IsStable)
         ${{ parameters.additionalMSBuildArgs }}
-      
+
       PublishArguments: /p:PublishType=$(_PublishType)
         /p:ConfigurationGroup=$(_BuildConfig)
         /p:OSGroup=${{ parameters.osGroup }}


### PR DESCRIPTION
As of today, Jenkins builds Tizen leg for PR. Enabling this leg in Azure devops. This will bring Jenkins PR builds in parity with Azure devops and will help retire Jenkins for core-setup master branch.