### PR TITLE
Disable node reuse in AzDO builds on persistent machines, add FreeBSD

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -71,15 +71,15 @@ jobs:
   ################################################################################
   # Build Bash legs (Linux and FreeBSD)
   ################################################################################
-# - ${{ if ne(variables['System.TeamProject'], 'public') }}:
-#   - template: /eng/jobs/bash-build.yml
-#     parameters:
-#       displayName: Build_FreeBSD_x64
-#       disableCrossgen: true
-#       osGroup: FreeBSD
-#       portableBuild: true
-#       skipTests: true
-#       targetArchitecture: x64
+- ${{ if ne(variables['System.TeamProject'], 'public') }}:
+  - template: /eng/jobs/bash-build.yml
+    parameters:
+      displayName: Build_FreeBSD_x64
+      disableCrossgen: true
+      osGroup: FreeBSD
+      portableBuild: true
+      skipTests: true
+      targetArchitecture: x64
 
 - template: /eng/jobs/bash-build.yml
   parameters:

--- a/eng/jobs/bash-build.yml
+++ b/eng/jobs/bash-build.yml
@@ -51,6 +51,7 @@ jobs:
         -SkipTests=${{ parameters.skipTests }}
         -TargetArchitecture=${{ parameters.targetArchitecture }}
         -- /p:StabilizePackageVersion=$(IsStable)
+        /nr:false
         ${{ parameters.additionalMSBuildArgs }}
 
       PublishArguments: /p:PublishType=$(_PublishType)
@@ -59,6 +60,7 @@ jobs:
         /p:PortableBuild=${{ parameters.portableBuild }}
         /p:StabilizePackageVersion=$(IsStable)
         /p:TargetArchitecture=${{ parameters.targetArchitecture }}
+        /nr:false
          ${{ parameters.additionalMSBuildArgs }}
 
       CommonMSBuildArgs: /bl
@@ -68,6 +70,7 @@ jobs:
         /p:PortableBuild=false
         /p:StabilizePackageVersion=$(IsStable)
         /p:TargetArchitecture=${{ parameters.targetArchitecture }}
+        /nr:false
 
       # Packaging related variables
       # Debian

--- a/eng/jobs/finalize-publish.yml
+++ b/eng/jobs/finalize-publish.yml
@@ -5,7 +5,7 @@ jobs:
     displayName: Finalize_Publish
     # Run only if all build legs succeeded
     condition: and(
-                  # succeeded('Build_FreeBSD_x64'),
+                  succeeded('Build_FreeBSD_x64'),
                   succeeded('Build_Linux_Arm'),
                   succeeded('Build_Linux_Arm64'),
                   succeeded('Build_Linux_x64_Alpine36'),
@@ -19,7 +19,7 @@ jobs:
                   ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest'))
     # Run after all dependent legs are executed
     dependsOn: 
-      # - Build_FreeBSD_x64
+      - Build_FreeBSD_x64
       - Build_Linux_Arm
       - Build_Linux_Arm64
       - Build_Linux_x64_Alpine36

--- a/eng/jobs/windows-build.yml
+++ b/eng/jobs/windows-build.yml
@@ -29,7 +29,8 @@ jobs:
                           /p:TargetArchitecture=${{ parameters.targetArchitecture }} 
                           /p:PortableBuild=true
                           /p:SkipTests=${{ parameters.skipTests }}
-                          /p:StabilizePackageVersion=$(IsStable)"
+                          /p:StabilizePackageVersion=$(IsStable)
+                          /nr:false"
       MsbuildSigningArguments: /p:CertificateId=400 /v:detailed /p:SignType=$(SignType)
     steps:
 


### PR DESCRIPTION
See https://github.com/dotnet/core-setup/issues/4949 for info about the issue/fix.

I wasn't able to repro the original issue--I'd bet it's because it had been too long since a build happened on the FreeBSD agent and the old MSBuild node disappeared.

I also applied the fix to Windows because we use persistent machines there, too. In the future we'll be on Arcade and use the `-ci`/`--ci` flag to apply generally known tweaks we need for CI.

Working on running a testing build with this fix.