### PR TITLE
Implement SemVer 2.0.0

### DIFF
--- a/src/corehost/cli/CMakeLists.txt
+++ b/src/corehost/cli/CMakeLists.txt
@@ -2,6 +2,7 @@ add_subdirectory(apphost)
 add_subdirectory(dotnet)
 add_subdirectory(fxr)
 add_subdirectory(hostpolicy)
+add_subdirectory(test_fx_ver)
 
 add_subdirectory(test)
 

--- a/src/corehost/cli/fxr/fx_ver.cpp
+++ b/src/corehost/cli/fxr/fx_ver.cpp
@@ -6,6 +6,8 @@
 #include "utils.h"
 #include "fx_ver.h"
 
+static bool validIdentifiers(const pal::string_t& ids);
+
 fx_ver_t::fx_ver_t(int major, int minor, int patch, const pal::string_t& pre, const pal::string_t& build)
     : m_major(major)
     , m_minor(minor)
@@ -13,6 +15,12 @@ fx_ver_t::fx_ver_t(int major, int minor, int patch, const pal::string_t& pre, co
     , m_pre(pre)
     , m_build(build)
 {
+    // verify preconditions
+    assert(is_empty() || m_major >= 0);
+    assert(is_empty() || m_minor >= 0);
+    assert(is_empty() || m_patch >= 0);
+    assert(m_pre[0] == 0 || validIdentifiers(m_pre));
+    assert(m_build[0] == 0 || validIdentifiers(m_build));
 }
 
 fx_ver_t::fx_ver_t(int major, int minor, int patch, const pal::string_t& pre)
@@ -70,7 +78,7 @@ pal::string_t fx_ver_t::as_str() const
     }
     if (!m_build.empty())
     {
-        stream << _X("+") << m_build;
+        stream << m_build;
     }
     return stream.str();
 }
@@ -87,6 +95,13 @@ pal::string_t fx_ver_t::patch_glob() const
     pal::stringstream_t stream;
     stream << m_major << _X(".") << m_minor << _X(".*");
     return stream.str();
+}
+
+static pal::string_t getId(const pal::string_t &ids, size_t idStart)
+{
+    size_t next = ids.find(_X('.'), idStart);
+
+    return next == pal::string_t::npos ? ids.substr(idStart) : ids.substr(idStart, next - idStart);
 }
 
 /* static */
@@ -108,20 +123,163 @@ int fx_ver_t::compare(const fx_ver_t&a, const fx_ver_t& b)
         return (a.m_patch > b.m_patch) ? 1 : -1;
     }
 
-    if (a.m_pre.empty() != b.m_pre.empty())
+    if (a.m_pre.empty() || b.m_pre.empty())
     {
-        // Either a is empty or b is empty
-        return a.m_pre.empty() ? 1 : -1;
+        // Either a is empty or b is empty or both are empty
+        return a.m_pre.empty() ? !b.m_pre.empty() : -1;
     }
 
-    // Either both are empty or both are non-empty (may be equal)
-    int pre_cmp = a.m_pre.compare(b.m_pre);
-    if (pre_cmp != 0)
+    // Both are non-empty (may be equal)
+
+    // First character of pre is '-' when it is not empty
+    assert(a.m_pre[0] == _X('-'));
+    assert(b.m_pre[0] == _X('-'));
+
+    // First idenitifier starts at position 1
+    size_t idStart = 1;
+    for (size_t i = idStart; true; ++i)
     {
-        return pre_cmp;
+        if (a.m_pre[i] != b.m_pre[i])
+        {
+            // Found first character with a difference
+            if (a.m_pre[i] == 0 && b.m_pre[i] == _X('.'))
+            {
+                // identifiers both complete, b has an additional idenitifier
+                return -1;
+            }
+
+            if (b.m_pre[i] == 0 && a.m_pre[i] == _X('.'))
+            {
+                // identifiers both complete, a has an additional idenitifier
+                return 1;
+            }
+
+            // identifiers must not be empty
+            pal::string_t ida = getId(a.m_pre, idStart);
+            pal::string_t idb = getId(b.m_pre, idStart);
+
+            unsigned idanum = 0;
+            bool idaIsNum = try_stou(ida, &idanum);
+            unsigned idbnum = 0;
+            bool idbIsNum = try_stou(idb, &idbnum);
+
+            if (idaIsNum && idbIsNum)
+            {
+                // Numeric comparison
+                return (idanum > idbnum) ? 1 : -1;
+            }
+            else if (idaIsNum || idbIsNum)
+            {
+                // Mixed compare.  Spec: Number < Text
+                return idbIsNum ? 1 : -1;
+            }
+            // Ascii compare
+            return ida.compare(idb);
+        }
+        else
+        {
+            // a.m_pre[i] == b.m_pre[i]
+            if (a.m_pre[i] == 0)
+            {
+                break;
+            }
+            if (a.m_pre[i] == _X('.'))
+            {
+                idStart = i + 1;
+            }
+        }
     }
-    
-    return a.m_build.compare(b.m_build);
+
+    return 0;
+}
+
+static bool validIdentifierCharSet(const pal::string_t& id)
+{
+    // ids must be of the set [0-9a-zA-Z-]
+
+    // ASCII and Unicode ordering
+    static_assert(_X('-') < _X('0'), "Code assumes ordering - < 0 < 9 < A < Z < a < z");
+    static_assert(_X('0') < _X('9'), "Code assumes ordering - < 0 < 9 < A < Z < a < z");
+    static_assert(_X('9') < _X('A'), "Code assumes ordering - < 0 < 9 < A < Z < a < z");
+    static_assert(_X('A') < _X('Z'), "Code assumes ordering - < 0 < 9 < A < Z < a < z");
+    static_assert(_X('Z') < _X('a'), "Code assumes ordering - < 0 < 9 < A < Z < a < z");
+    static_assert(_X('a') < _X('z'), "Code assumes ordering - < 0 < 9 < A < Z < a < z");
+
+    for (size_t i = 0; id[i] != 0; ++i)
+    {
+        if (id[i] >= _X('A'))
+        {
+            if ((id[i] > _X('Z') && id[i] < _X('a')) || id[i] > _X('z'))
+            {
+                return false;
+            }
+        }
+        else
+        {
+            if ((id[i] < _X('0') && id[i] != _X('-')) || id[i] > _X('9'))
+            {
+                return false;
+            }
+        }
+    }
+    return true;
+}
+
+static bool validIdentifier(const pal::string_t& id, bool buildMeta)
+{
+    if (id.empty())
+    {
+        // Identifier must not be empty
+        return false;
+    }
+
+    if (!validIdentifierCharSet(id))
+    {
+        // ids must be of the set [0-9a-zA-Z-]
+        return false;
+    }
+
+    if (!buildMeta && id[0] == _X('0') && id[1] != 0 && index_of_non_numeric(id, 1) == pal::string_t::npos)
+    {
+        // numeric identifiers must not be padded with 0s
+        return false;
+    }
+    return true;
+}
+
+static bool validIdentifiers(const pal::string_t& ids)
+{
+    if (ids.empty())
+    {
+        return true;
+    }
+
+    bool prerelease = ids[0] == _X('-');
+    bool buildMeta = ids[0] == _X('+');
+
+    if (!(prerelease || buildMeta))
+    {
+        // ids must start with '-' or '+' for prerelease & build respectively
+        return false;
+    }
+
+    size_t idStart = 1;
+    size_t nextId;
+    while ((nextId = ids.find(_X('.'), idStart)) != pal::string_t::npos)
+    {
+        if (!validIdentifier(ids.substr(idStart, nextId - idStart), buildMeta))
+        {
+            return false;
+        }
+        idStart = nextId + 1;
+    }
+
+    if (!validIdentifier(ids.substr(idStart), buildMeta))
+    {
+        return false;
+    }
+
+    return true;
 }
 
 bool parse_internal(const pal::string_t& ver, fx_ver_t* fx_ver, bool parse_only_production)
@@ -137,6 +295,12 @@ bool parse_internal(const pal::string_t& ver, fx_ver_t* fx_ver, bool parse_only_
     {
         return false;
     }
+    if (maj_sep > 1 && ver[maj_start] == _X('0'))
+    {
+        // if leading character is 0, and strlen > 1
+        // then the numeric substring has leading zeroes which is prohibited by the specification.
+        return false;
+    }
 
     size_t min_start = maj_sep + 1;
     size_t min_sep = ver.find(_X('.'), min_start);
@@ -150,6 +314,12 @@ bool parse_internal(const pal::string_t& ver, fx_ver_t* fx_ver, bool parse_only_
     {
         return false;
     }
+    if (min_sep - min_start > 1 && ver[min_start] == _X('0'))
+    {
+        // if leading character is 0, and strlen > 1
+        // then the numeric substring has leading zeroes which is prohibited by the specification.
+        return false;
+    }
 
     unsigned patch = 0;
     size_t pat_start = min_sep + 1;
@@ -158,6 +328,12 @@ bool parse_internal(const pal::string_t& ver, fx_ver_t* fx_ver, bool parse_only_
     {
         if (!try_stou(ver.substr(pat_start), &patch))
         {
+            return false;
+        }
+        if (ver[pat_start + 1] != 0 && ver[pat_start] == _X('0'))
+        {
+            // if leading character is 0, and strlen != 1
+            // then the numeric substring has leading zeroes which is prohibited by the specification.
             return false;
         }
 
@@ -175,20 +351,35 @@ bool parse_internal(const pal::string_t& ver, fx_ver_t* fx_ver, bool parse_only_
     {
         return false;
     }
+    if (pat_sep - pat_start > 1 && ver[pat_start] == _X('0'))
+    {
+        return false;
+    }
 
     size_t pre_start = pat_sep;
-    size_t pre_sep = ver.find(_X('+'), pre_start);
-    if (pre_sep == pal::string_t::npos)
+    size_t pre_sep = ver.find(_X('+'), pat_sep);
+
+    pal::string_t pre = (pre_sep == pal::string_t::npos) ? ver.substr(pre_start) : ver.substr(pre_start, pre_sep - pre_start);
+
+    if (!validIdentifiers(pre))
     {
-        *fx_ver = fx_ver_t(major, minor, patch, ver.substr(pre_start));
-        return true;
+        return false;
     }
-    else
+
+    pal::string_t build;
+
+    if (pre_sep != pal::string_t::npos)
     {
-        size_t build_start = pre_sep + 1;
-        *fx_ver = fx_ver_t(major, minor, patch, ver.substr(pre_start, pre_sep - pre_start), ver.substr(build_start));
-        return true;
+        build = ver.substr(pre_sep);
+
+        if (!validIdentifiers(build))
+        {
+            return false;
+        }
     }
+
+    *fx_ver = fx_ver_t(major, minor, patch, pre, build);
+    return true;
 }
 
 /* static */

--- a/src/corehost/cli/fxr/fx_ver.h
+++ b/src/corehost/cli/fxr/fx_ver.h
@@ -6,13 +6,15 @@
 
 #include <pal.h>
 
-// Note: This is not SemVer (esp., in comparing pre-release part, fx_ver_t does not
-// compare multiple dot separated identifiers individually.) ex: 1.0.0-beta.2 vs. 1.0.0-beta.11
+// Note: This is intended to implement SemVer 2.0
 struct fx_ver_t
 {
     fx_ver_t();
     fx_ver_t(int major, int minor, int patch);
+    // if not empty pre contains valid prerelease label with leading '-'
     fx_ver_t(int major, int minor, int patch, const pal::string_t& pre);
+    // if not empty pre contains valid prerelease label with leading '-'
+    // if not empty build contains valid build label with leading '+'
     fx_ver_t(int major, int minor, int patch, const pal::string_t& pre, const pal::string_t& build);
 
     int get_major() const { return m_major; }

--- a/src/corehost/cli/test_fx_ver/CMakeLists.txt
+++ b/src/corehost/cli/test_fx_ver/CMakeLists.txt
@@ -1,0 +1,46 @@
+# Copyright (c) .NET Foundation and contributors. All rights reserved.
+# Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+cmake_minimum_required (VERSION 2.6)
+project(test_fx_ver)
+
+set(EXE_NAME "test_fx_ver")
+
+include_directories(../fxr)
+include_directories(../../common)
+
+set(SOURCES
+    test_fx_ver.cpp
+    ../fxr/fx_ver.cpp
+    ../../common/trace.cpp
+    ../../common/utils.cpp)
+
+if(WIN32)
+    list(APPEND SOURCES
+        ../../common/pal.windows.cpp
+        ../../common/longfile.windows.cpp)
+else()
+    list(APPEND SOURCES
+        ../../common/pal.unix.cpp)
+endif()
+
+if(WIN32)
+    add_compile_options($<$<CONFIG:RelWithDebInfo>:/MT>)
+    add_compile_options($<$<CONFIG:Release>:/MT>)
+    add_compile_options($<$<CONFIG:Debug>:/MTd>)
+else()
+    add_compile_options(-fPIE)
+    add_compile_options(-fvisibility=hidden)
+endif()
+
+add_executable(${EXE_NAME} ${SOURCES})
+
+install(TARGETS ${EXE_NAME} DESTINATION corehost_test)
+
+if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
+    target_link_libraries (${EXE_NAME} "dl")
+endif()
+
+if((${CMAKE_SYSTEM_NAME} MATCHES "Linux") AND CLI_CMAKE_PLATFORM_ARCH_ARM)
+    target_link_libraries (${EXE_NAME} "atomic")
+endif()

--- a/src/corehost/cli/test_fx_ver/test_fx_ver.cpp
+++ b/src/corehost/cli/test_fx_ver/test_fx_ver.cpp
@@ -1,0 +1,202 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#include "fx_ver.h"
+#include "pal.h"
+
+#define TEST_ASSERT(a) \
+  if (!(a)) \
+  { \
+    fprintf(stderr, "TEST_ASSERT failed '%s' at %d\n", #a, __LINE__); \
+    exit(1); \
+  }
+
+struct TestCase
+{
+    pal::string_t str;
+    struct
+    {
+        int major;
+        int minor;
+        int patch;
+        pal::string_t pre;
+        pal::string_t build;
+    } ver;
+    bool same;
+};
+
+const TestCase orderedCases[] =
+{
+    { _X("1.0.0-0.3.7"),                { 1, 0, 0,  _X("-0.3.7"),             _X("") }                 , false },
+    { _X("1.0.0-alpha"),                { 1, 0, 0,  _X("-alpha"),             _X("") }                 , false },
+    { _X("1.0.0-alpha+001"),            { 1, 0, 0,  _X("-alpha"),             _X("+001") }             , true  },
+    { _X("1.0.0-alpha.1"),              { 1, 0, 0,  _X("-alpha.1"),           _X("") }                 , false },
+    { _X("1.0.0-alpha.beta"),           { 1, 0, 0,  _X("-alpha.beta"),        _X("") }                 , false },
+    { _X("1.0.0-beta"),                 { 1, 0, 0,  _X("-beta"),              _X("") }                 , false },
+    { _X("1.0.0-beta+exp.sha.5114f85"), { 1, 0, 0,  _X("-beta"),              _X("+exp.sha.5114f85") } , true  },
+    { _X("1.0.0-beta.2"),               { 1, 0, 0,  _X("-beta.2"),            _X("") }                 , false },
+    { _X("1.0.0-beta.11"),              { 1, 0, 0,  _X("-beta.11"),           _X("") }                 , false },
+    { _X("1.0.0-rc.1"),                 { 1, 0, 0,  _X("-rc.1"),              _X("") }                 , false },
+    { _X("1.0.0-x.7.z.92"),             { 1, 0, 0,  _X("-x.7.z.92"),          _X("") }                 , false },
+    { _X("1.0.0"),                      { 1, 0, 0,  _X(""),                   _X("") }                 , false },
+    { _X("1.0.0+20130313144700"),       { 1, 0, 0,  _X(""),                   _X("+20130313144700") }  , true  },
+    { _X("1.9.0-9"),                    { 1, 9, 0,  _X("-9"),                 _X("") }                 , false },
+    { _X("1.9.0-10"),                   { 1, 9, 0,  _X("-10"),                _X("") }                 , false },
+    { _X("1.9.0-1A"),                   { 1, 9, 0,  _X("-1A"),                _X("") }                 , false },
+    { _X("1.9.0"),                      { 1, 9, 0,  _X(""),                   _X("") }                 , false },
+    { _X("1.10.0"),                     { 1, 10, 0, _X(""),                   _X("") }                 , false },
+    { _X("1.11.0"),                     { 1, 11, 0, _X(""),                   _X("") }                 , false },
+    { _X("2.0.0"),                      { 2, 0, 0,  _X(""),                   _X("") }                 , false },
+    { _X("2.1.0"),                      { 2, 1, 0,  _X(""),                   _X("") }                 , false },
+    { _X("2.1.1"),                      { 2, 1, 1,  _X(""),                   _X("") }                 , false },
+    { _X("4.6.0-preview.19064.1"),      { 4, 6, 0,  _X("-preview.19064.1"),   _X("") }                 , false },
+    { _X("4.6.0-preview1-27018-01"),    { 4, 6, 0,  _X("-preview1-27018-01"), _X("") }                 , false },
+};
+
+const size_t cases = sizeof(orderedCases)/sizeof(TestCase);
+
+void checkPrecedence(size_t iVal, const fx_ver_t &iVer, size_t jVal, const fx_ver_t &jVer)
+{
+    if (iVal == jVal)
+    {
+        TEST_ASSERT( (iVer == jVer));
+        TEST_ASSERT(!(iVer <  jVer));
+        TEST_ASSERT(!(iVer >  jVer));
+        TEST_ASSERT( (iVer <= jVer));
+        TEST_ASSERT( (iVer >= jVer));
+        TEST_ASSERT(!(iVer != jVer));
+    }
+    else if (iVal < jVal)
+    {
+        TEST_ASSERT(!(iVer == jVer));
+        TEST_ASSERT( (iVer <  jVer));
+        TEST_ASSERT(!(iVer >  jVer));
+        TEST_ASSERT( (iVer <= jVer));
+        TEST_ASSERT(!(iVer >= jVer));
+        TEST_ASSERT( (iVer != jVer));
+    }
+    else
+    {
+        TEST_ASSERT(iVal > jVal);
+
+        TEST_ASSERT(!(iVer == jVer));
+        TEST_ASSERT(!(iVer <  jVer));
+        TEST_ASSERT( (iVer >  jVer));
+        TEST_ASSERT(!(iVer <= jVer));
+        TEST_ASSERT( (iVer >= jVer));
+        TEST_ASSERT( (iVer != jVer));
+    }
+}
+
+void checkPrecedence()
+{
+    size_t isame = 0;
+
+    for (size_t i = 0; i < cases; ++i)
+    {
+        fx_ver_t iver;
+        bool ivalid = fx_ver_t::parse(orderedCases[i].str, &iver);
+
+        TEST_ASSERT(ivalid);
+
+        if (orderedCases[i].same) isame++;
+
+        size_t jsame = 0;
+
+        for (size_t j = 0; j < cases; ++j)
+        {
+            fx_ver_t jver;
+            bool jvalid = fx_ver_t::parse(orderedCases[j].str, &jver);
+
+            TEST_ASSERT(jvalid);
+
+            if (orderedCases[j].same) jsame++;
+
+            checkPrecedence(i - isame, iver, j - jsame, jver);
+        }
+    }
+}
+
+void checkParsing(const TestCase &myCase)
+{
+    fx_ver_t ver;
+    bool valid = fx_ver_t::parse(myCase.str, &ver);
+
+    TEST_ASSERT(valid);
+    TEST_ASSERT(ver.get_major() == myCase.ver.major);
+    TEST_ASSERT(ver.get_minor() == myCase.ver.minor);
+    TEST_ASSERT(ver.get_patch() == myCase.ver.patch);
+    TEST_ASSERT(ver.is_prerelease() == !myCase.ver.pre.empty());
+    TEST_ASSERT(ver.as_str() == myCase.str);
+}
+
+void checkParsing()
+{
+    for (size_t i = 0; i < cases; ++i)
+    {
+        checkParsing(orderedCases[i]);
+    }
+}
+
+void checkInvalidVersions()
+{
+    pal::string_t invalidVersions[] =
+    {
+        _X(""),
+        _X("1"),
+        _X("1.1"),
+        _X("A.1.1"),
+        _X("1.A.1"),
+        _X("1.1.A"),
+        _X("1A.1.1"),
+        _X("1.1A.1"),
+        _X("1.1.1A"),
+        _X("1.1.1-"),
+        _X("1.1.1-."),
+        _X("1.1.1-A."),
+        _X("1.1.1-A.B."),
+        _X("1.1.1-.+id"),
+        _X("1.1.1-A.+id"),
+        _X("1.1.1-A.B.+id"),
+        _X("1.1.1-A.B+id."),
+        _X("01.1.1"),
+        _X("1.01.1"),
+        _X("1.1.01"),
+        _X("1.1.1-01.B"),
+        _X("1.1.1-A.01"),
+        _X("00.1.1"),
+        _X("1.00.1"),
+        _X("1.1.00"),
+        _X("1.1.00-A"),
+        _X("1.1.1-00.B"),
+        _X("1.1.1-A.00"),
+        _X("1.1.1+"),
+        _X("1.1.1-A+"),
+        _X("1.1.1-A*B"),
+        _X("1.1.1-A/B"),
+        _X("1.1.1-A:B"),
+        _X("1.1.1-A^B"),
+        _X("1.1.1-A|B"),
+    };
+
+    const size_t cases = sizeof(invalidVersions)/sizeof(pal::string_t);
+
+    for (size_t i = 0; i < cases; ++i)
+    {
+        fx_ver_t ver;
+        bool valid = fx_ver_t::parse(invalidVersions[i], &ver);
+
+        TEST_ASSERT(!valid);
+    }
+}
+
+#if defined(_WIN32)
+int __cdecl wmain(const int argc, const pal::char_t* argv[])
+#else
+int main(const int argc, const pal::char_t* argv[])
+#endif
+{
+    checkInvalidVersions();
+    checkParsing();
+    checkPrecedence();
+}

--- a/src/test/HostActivationTests/GivenThatICareAboutNativeUnitTests.cs
+++ b/src/test/HostActivationTests/GivenThatICareAboutNativeUnitTests.cs
@@ -1,0 +1,29 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Xunit;
+using FluentAssertions;
+using System;
+using System.IO;
+using Microsoft.DotNet.CoreSetup.Test;
+using Microsoft.DotNet.Cli.Build.Framework;
+
+namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.NativeUnitTests
+{
+    public class GivenThatICareAboutNativeUnitTests
+    {
+        [Fact]
+        public void Native_Test_Fx_Ver()
+        {
+            RepoDirectoriesProvider repoDirectoriesProvider = new RepoDirectoriesProvider();
+
+            string testPath = Path.Combine(repoDirectoriesProvider.Artifacts, "corehost_test", RuntimeInformationExtensions.GetExeFileNameForCurrentPlatform("test_fx_ver"));
+
+            Command testCommand = Command.Create(testPath);
+            testCommand
+                .Execute()
+                .Should()
+                .Pass();
+        }
+    }
+}

--- a/src/test/HostActivationTests/SDKLookup.cs
+++ b/src/test/HostActivationTests/SDKLookup.cs
@@ -475,13 +475,13 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
             var dotnet = fixture.BuiltDotnet;
 
             // Add SDK versions
-            AddAvailableSdkVersions(_exeSdkBaseDir, "9999.0.0", "9999.0.3-dummy");
+            AddAvailableSdkVersions(_exeSdkBaseDir, "9999.0.0", "9999.0.3-dummy.9", "9999.0.3-dummy.10");
 
             // Specified SDK version: none
             // Cwd: empty
             // User: empty
-            // Exe: 9999.0.0, 9999.0.3-dummy
-            // Expected: 9999.0.3-dummy from exe dir
+            // Exe: 9999.0.0, 9999.0.3-dummy.9, 9999.0.3-dummy.10
+            // Expected: 9999.0.3-dummy.10 from exe dir
             dotnet.Exec("help")
                 .WorkingDirectory(_currentWorkingDir)
                 .WithUserProfile(_userDir)
@@ -491,7 +491,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
                 .CaptureStdErr()
                 .Execute()
                 .Should().Pass()
-                .And.HaveStdErrContaining(Path.Combine(_exeSelectedMessage, "9999.0.3-dummy", _dotnetSdkDllMessageTerminator));
+                .And.HaveStdErrContaining(Path.Combine(_exeSelectedMessage, "9999.0.3-dummy.10", _dotnetSdkDllMessageTerminator));
 
             // Add SDK versions
             AddAvailableSdkVersions(_exeSdkBaseDir, "9999.0.3");
@@ -499,7 +499,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
             // Specified SDK version: none
             // Cwd: empty
             // User: empty
-            // Exe: 9999.0.0, 9999.0.3-dummy, 9999.0.3
+            // Exe: 9999.0.0, 9999.0.3-dummy.9, 9999.0.3-dummy.10, 9999.0.3
             // Expected: 9999.0.3 from exe dir
             dotnet.Exec("help")
                 .WorkingDirectory(_currentWorkingDir)
@@ -520,7 +520,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
             // Specified SDK version: none
             // Cwd: 10000.0.0                 --> should not be picked
             // User: 9999.0.200               --> should not be picked
-            // Exe: 9999.0.0, 9999.0.3-dummy, 9999.0.3, 9999.0.100
+            // Exe: 9999.0.0, 9999.0.3-dummy.9, 9999.0.3-dummy.10, 9999.0.3, 9999.0.100
             // Expected: 9999.0.100 from exe dir
             dotnet.Exec("help")
                 .WorkingDirectory(_currentWorkingDir)
@@ -539,7 +539,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
             // Specified SDK version: none
             // Cwd: 10000.0.0                 --> should not be picked
             // User: 9999.0.200               --> should not be picked
-            // Exe: 9999.0.0, 9999.0.3-dummy, 9999.0.3, 9999.0.100, 9999.0.80
+            // Exe: 9999.0.0, 9999.0.3-dummy.9, 9999.0.3-dummy.10, 9999.0.3, 9999.0.100, 9999.0.80
             // Expected: 9999.0.100 from exe dir
             dotnet.Exec("help")
                 .WorkingDirectory(_currentWorkingDir)
@@ -558,7 +558,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
             // Specified SDK version: none
             // Cwd: 10000.0.0                 --> should not be picked
             // User: 9999.0.200               --> should not be picked
-            // Exe: 9999.0.0, 9999.0.3-dummy, 9999.0.3, 9999.0.100, 9999.0.80, 9999.0.5500000
+            // Exe: 9999.0.0, 9999.0.3-dummy.9, 9999.0.3-dummy.10, 9999.0.3, 9999.0.100, 9999.0.80, 9999.0.5500000
             // Expected: 9999.0.5500000 from exe dir
             dotnet.Exec("help")
                 .WorkingDirectory(_currentWorkingDir)
@@ -577,7 +577,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
             // Specified SDK version: none
             // Cwd: 10000.0.0                 --> should not be picked
             // User: 9999.0.200               --> should not be picked
-            // Exe: 9999.0.0, 9999.0.3-dummy, 9999.0.3, 9999.0.100, 9999.0.80, 9999.0.5500000, 9999.0.52000000
+            // Exe: 9999.0.0, 9999.0.3-dummy.9, 9999.0.3-dummy.10, 9999.0.3, 9999.0.100, 9999.0.80, 9999.0.5500000, 9999.0.52000000
             // Expected: 9999.0.52000000 from exe dir
             dotnet.Exec("help")
                 .WorkingDirectory(_currentWorkingDir)
@@ -600,7 +600,8 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
                 .Execute()
                 .Should().Pass()
                 .And.HaveStdOutContaining("9999.0.0")
-                .And.HaveStdOutContaining("9999.0.3-dummy")
+                .And.HaveStdOutContaining("9999.0.3-dummy.9")
+                .And.HaveStdOutContaining("9999.0.3-dummy.10")
                 .And.HaveStdOutContaining("9999.0.3")
                 .And.HaveStdOutContaining("9999.0.100")
                 .And.HaveStdOutContaining("9999.0.80")

--- a/src/test/HostActivationTests/SharedFxLookup.cs
+++ b/src/test/HostActivationTests/SharedFxLookup.cs
@@ -392,12 +392,12 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
             SharedFramework.SetRuntimeConfigJson(runtimeConfig, "9999.0.0");
 
             // Add preview version in the exe
-            SharedFramework.AddAvailableSharedFxVersions(_builtSharedFxDir, _exeSharedFxBaseDir, "9999.1.1-dummy1");
+            SharedFramework.AddAvailableSharedFxVersions(_builtSharedFxDir, _exeSharedFxBaseDir, "9999.1.1-dummy.9");
 
             // Version: 9999.0.0
             // 'Roll forward on no candidate fx' default value of 1 (minor)
-            // exe: 9999.1.1-dummy1
-            // Expected: 9999.1.1-dummy1 since there is no production version
+            // exe: 9999.1.1-dummy.9
+            // Expected: 9999.1.1-dummy.9 since there is no production version
             dotnet.Exec(appDll)
                 .WorkingDirectory(_currentWorkingDir)
                 .EnvironmentVariable("COREHOST_TRACE", "1")
@@ -405,7 +405,39 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
                 .CaptureStdErr()
                 .Execute()
                 .Should().Pass()
-                .And.HaveStdErrContaining(Path.Combine(_exeSelectedMessage, "9999.1.1-dummy1"));
+                .And.HaveStdErrContaining(Path.Combine(_exeSelectedMessage, "9999.1.1-dummy.9"));
+
+            // Add preview version in the exe
+            SharedFramework.AddAvailableSharedFxVersions(_builtSharedFxDir, _exeSharedFxBaseDir, "9999.1.1-dummy.8");
+
+            // Version: 9999.0.0
+            // 'Roll forward on no candidate fx' default value of 1 (minor)
+            // exe: 9999.1.1-dummy.8, 9999.1.1-dummy.9
+            // Expected: 9999.1.1-dummy.9 since there is no production version and latest preview should be selected
+            dotnet.Exec(appDll)
+                .WorkingDirectory(_currentWorkingDir)
+                .EnvironmentVariable("COREHOST_TRACE", "1")
+                .CaptureStdOut()
+                .CaptureStdErr()
+                .Execute()
+                .Should().Pass()
+                .And.HaveStdErrContaining(Path.Combine(_exeSelectedMessage, "9999.1.1-dummy.9"));
+
+            // Add preview version in the exe
+            SharedFramework.AddAvailableSharedFxVersions(_builtSharedFxDir, _exeSharedFxBaseDir, "9999.1.1-dummy.10");
+
+            // Version: 9999.0.0
+            // 'Roll forward on no candidate fx' default value of 1 (minor)
+            // exe: 9999.1.1-dummy.8, 9999.1.1-dummy.9, 9999.1.1-dummy.10
+            // Expected: 9999.1.1-dummy.10 since there is no production version and latest preview should be selected
+            dotnet.Exec(appDll)
+                .WorkingDirectory(_currentWorkingDir)
+                .EnvironmentVariable("COREHOST_TRACE", "1")
+                .CaptureStdOut()
+                .CaptureStdErr()
+                .Execute()
+                .Should().Pass()
+                .And.HaveStdErrContaining(Path.Combine(_exeSelectedMessage, "9999.1.1-dummy.10"));
 
             // Add a production version with higher value
             SharedFramework.AddAvailableSharedFxVersions(_builtSharedFxDir, _exeSharedFxBaseDir, "9999.2.1");
@@ -461,7 +493,9 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
                 .CaptureStdOut()
                 .Execute()
                 .Should().Pass()
-                .And.HaveStdOutContaining("Microsoft.NETCore.App 9999.1.1-dummy1")
+                .And.HaveStdOutContaining("Microsoft.NETCore.App 9999.1.1-dummy.8")
+                .And.HaveStdOutContaining("Microsoft.NETCore.App 9999.1.1-dummy.9")
+                .And.HaveStdOutContaining("Microsoft.NETCore.App 9999.1.1-dummy.10")
                 .And.HaveStdOutContaining("Microsoft.NETCore.App 9999.2.1")
                 .And.HaveStdOutContaining("Microsoft.NETCore.App 9999.2.1-dummy1")
                 .And.HaveStdOutContaining("Microsoft.NETCore.App 9999.2.2-dummy1");


### PR DESCRIPTION
Implement SemVer 2.0.0 https://semver.org/spec/v2.0.0.html
Add unit test code.

~~Manually tested on MacOS using command
`g++ --std=c++11 -D _TARGET_AMD64_ cli/fxr/test_fx_ver.cpp cli/fxr/fx_ver.cpp common/utils.cpp common/pal.unix.cpp common/trace.cpp -I common && ./a.out`
from the src/corehost directory.  Similar command should work for Linux.~~

Marked WIP until we resolve #4952.
Fixes #4795 
