### PR TITLE
Fixed typo

### DIFF
--- a/src/pkg/projects/descriptions.json
+++ b/src/pkg/projects/descriptions.json
@@ -36,7 +36,7 @@
     },
     {
         "Name": "Microsoft.NETCore.App",
-        "Description": "A set of .NET API's that are included in the default .NET Core application model.",
+        "Description": "A set of .NET APIs that are included in the default .NET Core application model.",
         "CommonTypes": [ ]
     }
 ]


### PR DESCRIPTION
The plural of API should be APIs, not API's.
This description appears in a few places like below and it should be fixed.

![image](https://user-images.githubusercontent.com/1867877/51121925-8451af80-1810-11e9-9166-fa2ce81d0a33.png)


skip ci please

