### PR TITLE
Revert and pin NETStandard.Library, Microsoft.NETCore.Targets dependencies

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -9,14 +9,12 @@
       <Uri>https://github.com/dotnet/corefx</Uri>
       <Sha>77096755443730962810662501f82550fdb4656d</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.Targets" Version="3.0.0-preview.19064.1">
+    <PinnedDependency Name="Microsoft.NETCore.Targets" Version="2.0.0">
       <Uri>https://github.com/dotnet/corefx</Uri>
-      <Sha>77096755443730962810662501f82550fdb4656d</Sha>
-    </Dependency>
-    <Dependency Name="NETStandard.Library" Version="2.1.0-prerelease.19054.1">
+    </PinnedDependency>
+    <PinnedDependency Name="NETStandard.Library" Version="2.0.3">
       <Uri>https://github.com/dotnet/standard</Uri>
-      <Sha>5a403159021b1871eef8fe30a86ddf4e64688a37</Sha>
-    </Dependency>
+    </PinnedDependency>
     <Dependency Name="Microsoft.NETCore.Runtime.CoreCLR" Version="3.0.0-preview-27219-72">
       <Uri>https://github.com/dotnet/coreclr</Uri>
       <Sha>c0c51f83e56eb37bb5a257c0e82ca6676894d6c1</Sha>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -9,8 +9,8 @@
   <PropertyGroup>
     <MicrosoftPrivateCoreFxNETCoreAppPackageVersion>4.6.0-preview.19064.1</MicrosoftPrivateCoreFxNETCoreAppPackageVersion>
     <MicrosoftNETCorePlatformsPackageVersion>3.0.0-preview.19064.1</MicrosoftNETCorePlatformsPackageVersion>
-    <MicrosoftNETCoreTargetsPackageVersion>3.0.0-preview.19064.1</MicrosoftNETCoreTargetsPackageVersion>
-    <NETStandardLibraryPackageVersion>2.1.0-prerelease.19054.1</NETStandardLibraryPackageVersion>
+    <MicrosoftNETCoreTargetsPackageVersion>2.0.0</MicrosoftNETCoreTargetsPackageVersion>
+    <NETStandardLibraryPackageVersion>2.0.3</NETStandardLibraryPackageVersion>
     <MicrosoftNETCoreRuntimeCoreCLRPackageVersion>3.0.0-preview-27220-01</MicrosoftNETCoreRuntimeCoreCLRPackageVersion>
   </PropertyGroup>
   <!--Package names-->


### PR DESCRIPTION
These packages got dev channel auto-upgrade config when switching from VersionTools to Darc (https://github.com/dotnet/core-setup/commit/0dedb91315f0df16f6e243c449aca4d134143948), but these dependencies are expected to be more stable.

Work around current lack of "pinning" feature in Darc (https://github.com/dotnet/arcade/issues/1656) by changing `Dependency` to `PinnedDependency`, which Darc doesn't find. (Tested with `darc update-dependencies -c '.NET Core 3 Dev'` which still does a CoreCLR upgrade fine.)

Once there's a stable branch of `NETStandard.Library` that publishes to a stable BAR channel, we can unpin this and point our dependency there. https://github.com/dotnet/core-setup/issues/4973