### PR TITLE
Remove LTTng dependency from runtime-deps packages

### DIFF
--- a/src/pkg/packaging/deb/dotnet-runtime-deps-debian_config_debian.8-x64.json
+++ b/src/pkg/packaging/deb/dotnet-runtime-deps-debian_config_debian.8-x64.json
@@ -32,7 +32,6 @@
         "libc6":{},
         "libgcc1":{},
         "libgssapi-krb5-2":{},
-        "liblttng-ust0":{},
         "libstdc++6":{},
         "zlib1g":{},
         "libssl1.0.0" : {},

--- a/src/pkg/packaging/deb/dotnet-runtime-deps-debian_config_debian.9-x64.json
+++ b/src/pkg/packaging/deb/dotnet-runtime-deps-debian_config_debian.9-x64.json
@@ -32,7 +32,6 @@
         "libc6":{},
         "libgcc1":{},
         "libgssapi-krb5-2":{},
-        "liblttng-ust0":{},
         "libstdc++6":{},
         "zlib1g":{},
         "libssl1.0.2" : {},

--- a/src/pkg/packaging/deb/dotnet-runtime-deps-debian_config_ubuntu.14.04-x64.json
+++ b/src/pkg/packaging/deb/dotnet-runtime-deps-debian_config_ubuntu.14.04-x64.json
@@ -32,7 +32,6 @@
         "libc6":{},
         "libgcc1":{},
         "libgssapi-krb5-2":{},
-        "liblttng-ust0":{},
         "libstdc++6":{},
         "zlib1g":{},
         "libssl1.0.0" : {},

--- a/src/pkg/packaging/deb/dotnet-runtime-deps-debian_config_ubuntu.16.04-x64.json
+++ b/src/pkg/packaging/deb/dotnet-runtime-deps-debian_config_ubuntu.16.04-x64.json
@@ -32,7 +32,6 @@
         "libc6":{},
         "libgcc1":{},
         "libgssapi-krb5-2":{},
-        "liblttng-ust0":{},
         "libstdc++6":{},
         "zlib1g":{},
         "libssl1.0.0" : {},

--- a/src/pkg/packaging/deb/dotnet-runtime-deps-debian_config_ubuntu.18.04-x64.json
+++ b/src/pkg/packaging/deb/dotnet-runtime-deps-debian_config_ubuntu.18.04-x64.json
@@ -32,7 +32,6 @@
         "libc6":{},
         "libgcc1":{},
         "libgssapi-krb5-2":{},
-        "liblttng-ust0":{},
         "libstdc++6":{},
         "zlib1g":{},
         "libssl1.0.0" : {},


### PR DESCRIPTION
Removes the `liblttng-ust0` dependency from runtime-deps packages to reduce size. I tried out a dev build's Debian 9 deb package in a container, and a self-contained app started working after installing the updated package.

My test was a simple console app, so it doesn't rule out more complex dependencies. However, https://github.com/dotnet/core-setup/issues/4944 goes into more detail about how this dependency isn't needed. The change has also already been rolled out to the runtime deps and sdk Docker images.

/cc @brianrob @rakeshsinghranchi 