### PR TITLE
Revert "Publish to dotnet/versions during official builds"

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -39,15 +39,6 @@ variables:
         /p:SymbolPackagesUrl=$(_PublishBlobFeedUrl)
         /p:TransportFeedAccessToken=$(dotnetfeed-storage-access-key-1)
 
-    - name: _DotNetVersionsArgs
-      value: >-
-        /p:GitHubUser=dotnet-build-bot
-        /p:GitHubEmail=dotnet-build-bot@microsoft.com
-        /p:GitHubAuthToken=$(AccessToken-dotnet-build-bot-public-repo)
-        /p:VersionsRepoOwner=dotnet
-        /p:VersionsRepo=versions
-        /p:VersionsRepoPath=build-info/dotnet/core-setup/$(FullBranchName)
-
     # Symbol Server update
     - name: _SymbolServerPath
       value: https://microsoftpublicsymbols.artifacts.visualstudio.com/DefaultCollection

--- a/eng/jobs/finalize-publish.yml
+++ b/eng/jobs/finalize-publish.yml
@@ -58,18 +58,6 @@ jobs:
       continueOnError: false
       condition: and(succeeded(), in(variables['SignType'], 'real', 'test'))
 
-    - powershell: |
-        $prefix = "refs/heads/"
-        $branch = "$(Build.SourceBranch)"
-        $branchName = $branch
-        if ($branchName.StartsWith($prefix))
-        {
-          $branchName = $branchName.Substring($prefix.Length)
-        }
-        Write-Host "For Build.SourceBranch $branch, FullBranchName is $branchName"
-        Write-Host "##vso[task.setvariable variable=FullBranchName;]$branchName"
-      displayName: Find true SourceBranchName
-
     - task: MSBuild@1
       displayName: Publish (no PublishType)
       inputs: 
@@ -85,7 +73,6 @@ jobs:
         /p:StabilizePackageVersion=$(IsStable) 
         /p:TargetArchitecture=x64
         $(_BlobFeedArgs) 
-        $(_DotNetVersionsArgs)
         $(_CommonPublishArgs) 
         $(_NugetFeedArgs) 
         $(_SymbolServerArgs) 

--- a/publish/publish.proj
+++ b/publish/publish.proj
@@ -32,7 +32,7 @@
 
   <Target Name="PublishFinalOutput"
           Condition="'$(Finalize)' == 'true'"
-          DependsOnTargets="PublishCoreHostPackages;SetupPublishSymbols;PublishSymbols;FinalizeBuildInAzure;UpdateVersionsRepo" />
+          DependsOnTargets="PublishCoreHostPackages;SetupPublishSymbols;PublishSymbols;FinalizeBuildInAzure" />
     
   <Target Name="GetPackagesToSign" DependsOnTargets="GatherShippingPackages">
     <ItemGroup>


### PR DESCRIPTION
Reverts dotnet/core-setup#5003

The official build ran into the exact issue https://github.com/dotnet/core-setup/pull/5000 was meant to fix. I'm going to try to repro locally to figure out why this happened during the official build but not my testing build. Until then, revert to unblock the build.