### PR TITLE
Publish to dotnet/versions during official builds

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -39,6 +39,15 @@ variables:
         /p:SymbolPackagesUrl=$(_PublishBlobFeedUrl)
         /p:TransportFeedAccessToken=$(dotnetfeed-storage-access-key-1)
 
+    - name: _DotNetVersionsArgs
+      value: >-
+        /p:GitHubUser=dotnet-build-bot
+        /p:GitHubEmail=dotnet-build-bot@microsoft.com
+        /p:GitHubAuthToken=$(AccessToken-dotnet-build-bot-public-repo)
+        /p:VersionsRepoOwner=dotnet
+        /p:VersionsRepo=versions
+        /p:VersionsRepoPath=build-info/dotnet/core-setup/$(FullBranchName)
+
     # Symbol Server update
     - name: _SymbolServerPath
       value: https://microsoftpublicsymbols.artifacts.visualstudio.com/DefaultCollection

--- a/eng/jobs/finalize-publish.yml
+++ b/eng/jobs/finalize-publish.yml
@@ -58,6 +58,18 @@ jobs:
       continueOnError: false
       condition: and(succeeded(), in(variables['SignType'], 'real', 'test'))
 
+    - powershell: |
+        $prefix = "refs/heads/"
+        $branch = "$(Build.SourceBranch)"
+        $branchName = $branch
+        if ($branchName.StartsWith($prefix))
+        {
+          $branchName = $branchName.Substring($prefix.Length)
+        }
+        Write-Host "For Build.SourceBranch $branch, FullBranchName is $branchName"
+        Write-Host "##vso[task.setvariable variable=FullBranchName;]$branchName"
+      displayName: Find true SourceBranchName
+
     - task: MSBuild@1
       displayName: Publish (no PublishType)
       inputs: 
@@ -73,10 +85,12 @@ jobs:
         /p:StabilizePackageVersion=$(IsStable) 
         /p:TargetArchitecture=x64
         $(_BlobFeedArgs) 
+        $(_DotNetVersionsArgs)
         $(_CommonPublishArgs) 
         $(_NugetFeedArgs) 
         $(_SymbolServerArgs) 
-        /bl:$(Build.SourcesDirectory)\finalizepublish.binlog'
+        /bl:$(Build.SourcesDirectory)\finalizepublish.binlog
+        /nr:false'
       condition: and(succeeded(), eq(variables._PublishType, 'nopublishtype'))
 
     - task: CopyFiles@2

--- a/publish/publish.proj
+++ b/publish/publish.proj
@@ -32,7 +32,7 @@
 
   <Target Name="PublishFinalOutput"
           Condition="'$(Finalize)' == 'true'"
-          DependsOnTargets="PublishCoreHostPackages;SetupPublishSymbols;PublishSymbols;FinalizeBuildInAzure" />
+          DependsOnTargets="PublishCoreHostPackages;SetupPublishSymbols;PublishSymbols;FinalizeBuildInAzure;UpdateVersionsRepo" />
     
   <Target Name="GetPackagesToSign" DependsOnTargets="GatherShippingPackages">
     <ItemGroup>


### PR DESCRIPTION
This reapplies https://github.com/dotnet/core-setup/pull/5003 after it was reverted and disables MSBuild node reuse in the finalize step. This turns dotnet/versions publish back on and avoids a reused node having an old version of VersionTools loaded.

---

I can't repro the failure that caused me to revert this (in https://github.com/dotnet/core-setup/pull/5004). I recently fixed some "DLL already loaded" errors by turning off node reuse in other build legs, and I figure node reuse could similarly cause an old version of VersionTools.dll without the fix to still be loaded.

After merging, I'm keeping an eye on the build to finish up https://github.com/dotnet/core-setup/issues/4987.