### PR TITLE
Remove number from 3.0 Preview <number> branding

### DIFF
--- a/BranchInfo.props
+++ b/BranchInfo.props
@@ -12,7 +12,7 @@
     <IncludeBuildNumberInPackageVersion Condition="'$(StabilizePackageVersion)' != 'true'">true</IncludeBuildNumberInPackageVersion>
 
     <ReleaseSuffix>$(PreReleaseLabel)</ReleaseSuffix>
-    <ReleaseBrandSuffix>Preview 1</ReleaseBrandSuffix>
+    <ReleaseBrandSuffix>Preview</ReleaseBrandSuffix>
     <Channel>master</Channel>
     <ContainerName>dotnet</ContainerName>
     <ChecksumContainerName>$(ContainerName)</ChecksumContainerName>


### PR DESCRIPTION
Applies https://github.com/dotnet/core-setup/pull/4714's change from `preview1` to `preview` to installer branding. The preview number shouldn't be included in build outputs for 3.0 previews.

Fixes https://github.com/dotnet/core-setup/issues/5021. (The change will be reflected in the SDK installer once the dependencies flow.)

A local build produces an installer that looks like this:

![image](https://user-images.githubusercontent.com/12819531/51570473-b7292280-1e64-11e9-8fdd-bbfe9832709f.png)