### PR TITLE
Use MSBuildDisableNodeReuse=1 in official builds

### DIFF
--- a/eng/jobs/bash-build.yml
+++ b/eng/jobs/bash-build.yml
@@ -98,6 +98,11 @@ jobs:
         /p:UsePrebuiltPortableBinariesForInstallers=true
         /p:SharedFrameworkPublishDir=/root/sharedFrameworkPublish/
         $(CommonMSBuildArgs)
+
+      # Disable MSBuild node reuse in case this build is running on a persistent agent.
+      # Use environment variable rather than /nr:false to make sure internal Execs that run MSBuild
+      # commands also disable node reuse.
+      MSBUILDDISABLENODEREUSE: 1
     steps:
 
     - script: df -h

--- a/eng/jobs/finalize-publish.yml
+++ b/eng/jobs/finalize-publish.yml
@@ -41,6 +41,11 @@ jobs:
     timeoutInMinutes: 120
     variables:
       _PublishType: ${{ parameters._PublishType}}
+
+      # Disable MSBuild node reuse in case this build is running on a persistent agent.
+      # Use environment variable rather than /nr:false to make sure internal Execs that run MSBuild
+      # commands also disable node reuse.
+      MSBUILDDISABLENODEREUSE: 1
     steps:
 
     # Initialize tooling

--- a/eng/jobs/windows-build.yml
+++ b/eng/jobs/windows-build.yml
@@ -32,6 +32,11 @@ jobs:
                           /p:StabilizePackageVersion=$(IsStable)
                           /nr:false"
       MsbuildSigningArguments: /p:CertificateId=400 /v:detailed /p:SignType=$(SignType)
+
+      # Disable MSBuild node reuse in case this build is running on a persistent agent.
+      # Use environment variable rather than /nr:false to make sure internal Execs that run MSBuild
+      # commands also disable node reuse.
+      MSBUILDDISABLENODEREUSE: 1
     steps:
 
     - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:


### PR DESCRIPTION
I think this will help https://github.com/dotnet/core-setup/issues/4949. I haven't set up a consistent repro.

See https://github.com/dotnet/core-setup/issues/4949#issuecomment-456611580 for info on a new build failure and why I don't think `/nr:false` was sufficient. (PR that added `/nr:false`: https://github.com/dotnet/core-setup/pull/4950.)

AzDO automatically injects variables as env vars.