### PR TITLE
Improves the URLs reported in errors from the host

### DIFF
--- a/src/corehost/cli/fxr/fx_muxer.cpp
+++ b/src/corehost/cli/fxr/fx_muxer.cpp
@@ -56,8 +56,6 @@ void fx_muxer_t::display_missing_framework_error(
 
     trace::error(_X("  - Check application dependencies and target a framework version installed at:"));
     trace::error(_X("      %s"), fx_ver_dirs.c_str());
-    trace::error(_X("  - Installing .NET Core prerequisites might help resolve this problem:"));
-    trace::error(_X("      %s"), DOTNET_CORE_INSTALL_PREREQUISITES_URL);
     trace::error(_X("  - The .NET Core framework and SDK can be installed from:"));
     trace::error(_X("      %s"), DOTNET_CORE_DOWNLOAD_URL);
 
@@ -75,6 +73,9 @@ void fx_muxer_t::display_missing_framework_error(
 
         trace::error(_X("      %s at [%s]"), info.version.as_str().c_str(), info.path.c_str());
     }
+
+    trace::error(_X("  - Installing .NET Core prerequisites might help resolve this problem:"));
+    trace::error(_X("      %s"), DOTNET_CORE_INSTALL_PREREQUISITES_URL);
 }
 
 /**

--- a/src/corehost/cli/fxr/fx_muxer.cpp
+++ b/src/corehost/cli/fxr/fx_muxer.cpp
@@ -57,7 +57,7 @@ void fx_muxer_t::display_missing_framework_error(
     trace::error(_X("  - Check application dependencies and target a framework version installed at:"));
     trace::error(_X("      %s"), fx_ver_dirs.c_str());
     trace::error(_X("  - Installing .NET Core prerequisites might help resolve this problem:"));
-    trace::error(_X("      %s"), DOTNET_CORE_GETTING_STARTED_URL);
+    trace::error(_X("      %s"), DOTNET_CORE_INSTALL_PREREQUISITES_URL);
     trace::error(_X("  - The .NET Core framework and SDK can be installed from:"));
     trace::error(_X("      %s"), DOTNET_CORE_DOWNLOAD_URL);
 

--- a/src/corehost/cli/fxr/sdk_resolver.cpp
+++ b/src/corehost/cli/fxr/sdk_resolver.cpp
@@ -285,7 +285,7 @@ bool sdk_resolver_t::resolve_sdk_dotnet_path(
     {
         trace::error(_X("  It was not possible to find any installed dotnet SDKs"));
         trace::error(_X("  Did you mean to run dotnet SDK commands? Please install dotnet SDK from:"));
-        trace::error(_X("      %s"), DOTNET_CORE_GETTING_STARTED_URL);
+        trace::error(_X("      %s"), DOTNET_CORE_DOWNLOAD_URL);
     }
     return false;
 }

--- a/src/corehost/common/utils.h
+++ b/src/corehost/common/utils.h
@@ -15,7 +15,13 @@ struct host_option
 };
 
 #define _STRINGIFY(s) _X(s)
-#define DOTNET_CORE_GETTING_STARTED_URL _X("https://go.microsoft.com/fwlink/?LinkID=798306&clcid=0x409")
+#if defined(_WIN32)
+#define DOTNET_CORE_INSTALL_PREREQUISITES_URL _X("https://go.microsoft.com/fwlink/?linkid=798306")
+#elif defined(__APPLE__)
+#define DOTNET_CORE_INSTALL_PREREQUISITES_URL _X("https://go.microsoft.com/fwlink/?linkid=2063366")
+#else
+#define DOTNET_CORE_INSTALL_PREREQUISITES_URL _X("https://go.microsoft.com/fwlink/?linkid=2063370")
+#endif
 #define DOTNET_CORE_DOWNLOAD_RUNTIME_URL _X("https://aka.ms/dotnet-download-runtime")
 #define DOTNET_CORE_DOWNLOAD_URL _X("https://aka.ms/dotnet-download")
 

--- a/src/corehost/corehost.cpp
+++ b/src/corehost/corehost.cpp
@@ -266,7 +266,7 @@ int run(const int argc, const pal::char_t* argv[])
     {
         trace::error(_X("The library %s was found, but loading it from %s failed"), LIBFXR_NAME, fxr_path.c_str());
         trace::error(_X("  - Installing .NET Core prerequisites might help resolve this problem."));
-        trace::error(_X("     %s"), DOTNET_CORE_GETTING_STARTED_URL);
+        trace::error(_X("     %s"), DOTNET_CORE_INSTALL_PREREQUISITES_URL);
         return StatusCode::CoreHostLibLoadFailure;
     }
 

--- a/src/test/HostActivationTests/GivenThatICareAboutSDKLookup.cs
+++ b/src/test/HostActivationTests/GivenThatICareAboutSDKLookup.cs
@@ -140,6 +140,8 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.SDKLookup
                 .And
                 .HaveStdErrContaining("It was not possible to find any installed dotnet SDKs")
                 .And
+                .HaveStdErrContaining("aka.ms/dotnet-download")
+                .And
                 .NotHaveStdErrContaining("Checking if resolved SDK dir");
 
             // Add SDK versions

--- a/src/test/HostActivationTests/GivenThatICareAboutSharedFxLookup.cs
+++ b/src/test/HostActivationTests/GivenThatICareAboutSharedFxLookup.cs
@@ -4,6 +4,7 @@ using Newtonsoft.Json.Linq;
 using System;
 using System.IO;
 using Xunit;
+using System.Runtime.InteropServices;
 
 namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.SharedFxLookup
 {
@@ -356,6 +357,20 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.SharedFxLookup
             // Add some dummy versions in the exe
             SharedFramework.AddAvailableSharedFxVersions(_builtSharedFxDir, _exeSharedFxBaseDir, "10000.1.1");
 
+            string expectedPrereqInstallUrl;
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                expectedPrereqInstallUrl = "https://go.microsoft.com/fwlink/?linkid=798306";
+            }
+            else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            {
+                expectedPrereqInstallUrl = "https://go.microsoft.com/fwlink/?linkid=2063366";
+            }
+            else
+            {
+                expectedPrereqInstallUrl = "https://go.microsoft.com/fwlink/?linkid=2063370";
+            }
+
             // Version: 9999.0.0
             // 'Roll forward on no candidate fx' default value of 1 (minor)
             // exe: 10000.1.1
@@ -369,7 +384,11 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.SharedFxLookup
                 .Should()
                 .Fail()
                 .And
-                .HaveStdErrContaining("It was not possible to find any compatible framework version");
+                .HaveStdErrContaining("It was not possible to find any compatible framework version")
+                .And
+                .HaveStdErrContaining(expectedPrereqInstallUrl)
+                .And
+                .HaveStdErrContaining("aka.ms/dotnet-download");
 
             // Add a dummy version in the exe dir 
             SharedFramework.AddAvailableSharedFxVersions(_builtSharedFxDir, _exeSharedFxBaseDir, "9999.1.1");


### PR DESCRIPTION
Fixed the URL used when SDK commands fail to find SDK - this should point to the main download page.
Errors which talk about installing prerequisites now include platform specific URLs which point to the respective docs article for the correct platform.

The existing fwlink is now redirected to point to the Windows prereq page. Two new fwlinks were added to point to OSX and Linux pages.

Added simplistic tests for these changes.

Fixes #4868 