### PR TITLE
Disable UpdateVersionsRepo: unblock official build

### DIFF
--- a/publish/publish.proj
+++ b/publish/publish.proj
@@ -32,7 +32,7 @@
 
   <Target Name="PublishFinalOutput"
           Condition="'$(Finalize)' == 'true'"
-          DependsOnTargets="PublishCoreHostPackages;SetupPublishSymbols;PublishSymbols;FinalizeBuildInAzure;UpdateVersionsRepo" />
+          DependsOnTargets="PublishCoreHostPackages;SetupPublishSymbols;PublishSymbols;FinalizeBuildInAzure" />
     
   <Target Name="GetPackagesToSign" DependsOnTargets="GatherShippingPackages">
     <ItemGroup>


### PR DESCRIPTION
It's unknown at this point what's causing dotnet/versions publish to fail, and it only fails in the official build definition. Removing the target for now to get a build through. I will likely add this target back later with additional clean steps depending on the results of https://github.com/dotnet/core-setup/pull/5032.