### PR TITLE
Remove FreeBSD temporarily: unblock official build

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -80,15 +80,15 @@ jobs:
   ################################################################################
   # Build Bash legs (Linux and FreeBSD)
   ################################################################################
-- ${{ if ne(variables['System.TeamProject'], 'public') }}:
-  - template: /eng/jobs/bash-build.yml
-    parameters:
-      displayName: Build_FreeBSD_x64
-      disableCrossgen: true
-      osGroup: FreeBSD
-      portableBuild: true
-      skipTests: true
-      targetArchitecture: x64
+# - ${{ if ne(variables['System.TeamProject'], 'public') }}:
+#   - template: /eng/jobs/bash-build.yml
+#     parameters:
+#       displayName: Build_FreeBSD_x64
+#       disableCrossgen: true
+#       osGroup: FreeBSD
+#       portableBuild: true
+#       skipTests: true
+#       targetArchitecture: x64
 
 - template: /eng/jobs/bash-build.yml
   parameters:

--- a/eng/jobs/finalize-publish.yml
+++ b/eng/jobs/finalize-publish.yml
@@ -5,7 +5,7 @@ jobs:
     displayName: Finalize_Publish
     # Run only if all build legs succeeded
     condition: and(
-                  succeeded('Build_FreeBSD_x64'),
+                  # succeeded('Build_FreeBSD_x64'),
                   succeeded('Build_Linux_Arm'),
                   succeeded('Build_Linux_Arm64'),
                   succeeded('Build_Linux_x64_Alpine36'),
@@ -19,7 +19,7 @@ jobs:
                   ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest'))
     # Run after all dependent legs are executed
     dependsOn: 
-      - Build_FreeBSD_x64
+      # - Build_FreeBSD_x64
       - Build_Linux_Arm
       - Build_Linux_Arm64
       - Build_Linux_x64_Alpine36


### PR DESCRIPTION
The FreeBSD agent is currently not available. This PR unblocks build flow for 3.0 preview2.

(Cherry-picked https://github.com/dotnet/core-setup/pull/4948.)