### PR TITLE
Fix FreeBSD leg removal

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -80,16 +80,6 @@ jobs:
   ################################################################################
   # Build Bash legs (Linux and FreeBSD)
   ################################################################################
-# - ${{ if ne(variables['System.TeamProject'], 'public') }}:
-#   - template: /eng/jobs/bash-build.yml
-#     parameters:
-#       displayName: Build_FreeBSD_x64
-#       disableCrossgen: true
-#       osGroup: FreeBSD
-#       portableBuild: true
-#       skipTests: true
-#       targetArchitecture: x64
-
 - template: /eng/jobs/bash-build.yml
   parameters:
     crossBuild: true

--- a/eng/jobs/finalize-publish.yml
+++ b/eng/jobs/finalize-publish.yml
@@ -5,7 +5,6 @@ jobs:
     displayName: Finalize_Publish
     # Run only if all build legs succeeded
     condition: and(
-                  # succeeded('Build_FreeBSD_x64'),
                   succeeded('Build_Linux_Arm'),
                   succeeded('Build_Linux_Arm64'),
                   succeeded('Build_Linux_x64_Alpine36'),
@@ -19,7 +18,6 @@ jobs:
                   ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest'))
     # Run after all dependent legs are executed
     dependsOn: 
-      # - Build_FreeBSD_x64
       - Build_Linux_Arm
       - Build_Linux_Arm64
       - Build_Linux_x64_Alpine36


### PR DESCRIPTION
Delete lines rather than commenting to fix AzDO yaml parsing.

https://github.com/dotnet/core-setup/pull/5035 caused a syntax error starting at the `#` here:

```yaml
    condition: and(
                  # succeeded('Build_FreeBSD_x64'),
                  succeeded('Build_Linux_Arm'),
                  succeeded('Build_Linux_Arm64'),
                  succeeded('Build_Linux_x64_Alpine36'),
                  succeeded('Build_Linux_x64_glibc'),
                  succeeded('Build_Linux_x64_Rhel6'),
                  succeeded('Build_OSX'),
                  succeeded('Build_Windows_Arm'),
                  succeeded('Build_Windows_Arm64'),
                  succeeded('Build_Windows_x64'),
                  succeeded('Build_Windows_x86'),
                  ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest'))
```