### PR TITLE
Exclude SVG files from BAR manifest

### DIFF
--- a/publish/publish.proj
+++ b/publish/publish.proj
@@ -231,6 +231,11 @@
       <_DownloadedStandardPackages Include="@(_DownloadedPackages)"
                                   Exclude="@(_DownloadedSymbolsPackages)"
                                   Condition="$([System.String]::new('%(_DownloadedPackages.Identity)').EndsWith('.nupkg'))" />
+
+      <!-- Exclude SVG files from BAR manifest: https://github.com/dotnet/arcade/issues/1842. -->
+      <_DownloadedAssets Condition="$([System.String]::new('%(_DownloadedAssets.Identity)').EndsWith('.svg'))">
+        <ExcludeFromManifest>true</ExcludeFromManifest>
+      </_DownloadedAssets>
     </ItemGroup>
   </Target>
 


### PR DESCRIPTION
Fixes error in "Publish to Build Asset Registry Job" in official build. The error doesn't seem to block dependency uptake, but marks the build failed. (Example: https://dev.azure.com/dnceng/internal/_build/results?buildId=78895.)

See https://github.com/dotnet/arcade/issues/1842.

I ran a test build, and it applies the metadata correctly according to the binlog. I don't know if it actually flows through to make the BAR publish work. @chcosta, @mmitche, does this seem like it should be needed in core-setup too?