### PR TITLE
Fix registry access on legacy windows

### DIFF
--- a/src/corehost/common/pal.windows.cpp
+++ b/src/corehost/common/pal.windows.cpp
@@ -12,10 +12,6 @@
 #include <ShlObj.h>
 #include <ctime>
 
-#if !defined(RRF_SUBKEY_WOW6432KEY)
-#define RRF_SUBKEY_WOW6432KEY  0x00020000
-#endif
-
 bool GetModuleFileNameWrapper(HMODULE hModule, pal::string_t* recv)
 {
     pal::string_t path;
@@ -240,9 +236,8 @@ bool get_sdk_self_registered_dir(pal::string_t* recv)
     //  ***************************
 
     DWORD size = 0;
-    HKEY hkey = HKEY_LOCAL_MACHINE;
+    HKEY hkeyHive = HKEY_LOCAL_MACHINE;
     // The registry search occurs in the 32-bit registry in all cases.
-    const DWORD flags = RRF_RT_REG_SZ | RRF_SUBKEY_WOW6432KEY;
     pal::string_t dotnet_key_path = pal::string_t(_X("SOFTWARE\\dotnet"));
 
     pal::string_t environmentRegistryPathOverride;
@@ -251,7 +246,7 @@ bool get_sdk_self_registered_dir(pal::string_t* recv)
         pal::string_t hkcuPrefix = _X("HKEY_CURRENT_USER\\");
         if (environmentRegistryPathOverride.substr(0, hkcuPrefix.length()) == hkcuPrefix)
         {
-            hkey = HKEY_CURRENT_USER;
+            hkeyHive = HKEY_CURRENT_USER;
             environmentRegistryPathOverride = environmentRegistryPathOverride.substr(hkcuPrefix.length());
         }
 
@@ -261,18 +256,30 @@ bool get_sdk_self_registered_dir(pal::string_t* recv)
     pal::string_t sub_key = dotnet_key_path + pal::string_t(_X("\\Setup\\InstalledVersions\\")) + get_arch() + pal::string_t(_X("\\sdk"));
     pal::char_t* value = _X("InstallLocation");
 
+    // Must use RegOpenKeyEx to be able to specify KEY_WOW64_32KEY to access the 32-bit registry in all cases.
+    // The RegGetValue has this option available only on Win10.
+    HKEY hkey = NULL;
+    LSTATUS result = ::RegOpenKeyExW(hkeyHive, sub_key.c_str(), 0, KEY_READ | KEY_WOW64_32KEY, &hkey);
+    if (result != ERROR_SUCCESS)
+    {
+        trace::verbose(_X("Can't open the SDK installed location registry key, result: 0x%X"), result);
+        return false;
+    }
+
     // Determine the size of the buffer
-    LONG result = ::RegGetValueW(hkey, sub_key.c_str(), value, flags, nullptr, nullptr, &size);
+    result = ::RegGetValueW(hkey, nullptr, value, RRF_RT_REG_SZ, nullptr, nullptr, &size);
     if (result != ERROR_SUCCESS || size == 0)
     {
+        trace::verbose(_X("Can't get the size of the SDK location registry value or it's empty, result: 0x%X"), result);
         return false;
     }
 
     // Get the key's value
     std::vector<pal::char_t> buffer(size/sizeof(pal::char_t));
-    result = ::RegGetValueW(hkey, sub_key.c_str(), value, flags, nullptr, &buffer[0], &size);
+    result = ::RegGetValueW(hkey, nullptr, value, RRF_RT_REG_SZ, nullptr, &buffer[0], &size);
     if (result != ERROR_SUCCESS)
     {
+        trace::verbose(_X("Can't get the value of the SDK location registry value, result: 0x%X"), result);
         return false;
     }
 

--- a/src/corehost/common/pal.windows.cpp
+++ b/src/corehost/common/pal.windows.cpp
@@ -240,10 +240,25 @@ bool get_sdk_self_registered_dir(pal::string_t* recv)
     //  ***************************
 
     DWORD size = 0;
-    const HKEY hkey = HKEY_LOCAL_MACHINE;
+    HKEY hkey = HKEY_LOCAL_MACHINE;
     // The registry search occurs in the 32-bit registry in all cases.
     const DWORD flags = RRF_RT_REG_SZ | RRF_SUBKEY_WOW6432KEY;
-    pal::string_t sub_key = pal::string_t(_X("SOFTWARE\\dotnet\\Setup\\InstalledVersions\\")) + get_arch() + pal::string_t(_X("\\sdk"));
+    pal::string_t dotnet_key_path = pal::string_t(_X("SOFTWARE\\dotnet"));
+
+    pal::string_t environmentRegistryPathOverride;
+    if (pal::getenv(_X("_DOTNET_TEST_SDK_REGISTRY_PATH"), &environmentRegistryPathOverride))
+    {
+        pal::string_t hkcuPrefix = _X("HKEY_CURRENT_USER\\");
+        if (environmentRegistryPathOverride.substr(0, hkcuPrefix.length()) == hkcuPrefix)
+        {
+            hkey = HKEY_CURRENT_USER;
+            environmentRegistryPathOverride = environmentRegistryPathOverride.substr(hkcuPrefix.length());
+        }
+
+        dotnet_key_path = environmentRegistryPathOverride;
+    }
+
+    pal::string_t sub_key = dotnet_key_path + pal::string_t(_X("\\Setup\\InstalledVersions\\")) + get_arch() + pal::string_t(_X("\\sdk"));
     pal::char_t* value = _X("InstallLocation");
 
     // Determine the size of the buffer

--- a/src/test/HostActivationTests/GivenThatICareAboutMultilevelSDKLookup.cs
+++ b/src/test/HostActivationTests/GivenThatICareAboutMultilevelSDKLookup.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
 using Microsoft.DotNet.InternalAbstractions;
+using Microsoft.Win32;
 using Xunit;
 
 namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.MultilevelSDKLookup
@@ -592,7 +593,89 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.MultilevelSDKLookup
                 .And
                 .HaveStdErrContaining(Path.Combine(_exeSelectedMessage, "9999.0.4", _dotnetSdkDllMessageTerminator));
         }
-   
+
+        [Fact]
+        public void SdkMultilevelLookup_RegistryAccess()
+        {
+            // The purpose of this test is to verify that the product uses correct code to access
+            // the registry to extract the path to search for SDKs.
+            // Most of our tests rely on a shortcut which is to set _DOTNET_TEST_SDK_SELF_REGISTERED_DIR env variable
+            // which will skip the registry reading code in the product and simply use the specified value.
+            // This test is different since it actually runs the registry reading code.
+            // Normally the reg key the product uses is in HKEY_LOCAL_MACHINE which is only writable as admin
+            // so we would require the tests to run as admin to modify that key (and it may introduce races with other code running on the machine).
+            // So instead the tests use _DOTENT_TEST_SDK_REGISTRY_PATH env variable to point to the produce to use
+            // different registry key, inside the HKEY_CURRENT_USER hive which is writable without admin.
+            // Note that the test creates a unique key (based on PID) for every run, to avoid collisions between parallel running tests.
+
+            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                // Multi-level lookup is only supported on Windows.
+                return;
+            }
+
+            var fixture = PreviouslyBuiltAndRestoredPortableTestProjectFixture
+                .Copy();
+
+            var dotnet = fixture.BuiltDotnet;
+
+            // To correctly test the product we need a registry key which is
+            // - writable without admin access (so that the tests don't require admin to run)
+            // - redirected in WOW64 - so that there are both 32bit and 64bit versions of the key
+            //   this is because the product stores the info in the 32bit version only and even 64bit
+            //   product must look into the 32bit version.
+            //   Without the redirection we would not be able to test that the product always looks
+            //   into 32bit only.
+            // Per this page https://docs.microsoft.com/en-us/windows/desktop/WinProg64/shared-registry-keys
+            // a user writable redirected key is for example HKCU\Software\Classes\Interface
+            // so we're going to use that one - it's not super clean as they key stored COM interfaces
+            // but we should not corrupt anything by adding a special subkey even if it's left behind.
+            //
+            // Note: If you want to inspect the values written by the test and/or modify them manually
+            //   normal regedit.exe will not show these anywhere, as it's running as 64bit process
+            //   and there's no SysWOW6432 symbolic link for the Interface key (unlike the one for Software).
+            //   You can however run C:\Windows\SysWOW64\regedt32.exe which will launch a 32bit regedit
+            //   which will see these keys.
+
+            RegistryKey hkcu = RegistryKey.OpenBaseKey(RegistryHive.CurrentUser, RegistryView.Registry32);
+            RegistryKey interfaceKey = hkcu.OpenSubKey(@"Software\Classes\Interface", writable: true);
+            string testKeyName = "_DOTNET_Test" + System.Diagnostics.Process.GetCurrentProcess().Id.ToString();
+            RegistryKey testKey = interfaceKey.CreateSubKey(testKeyName);
+            try
+            {
+                string architecture = fixture.CurrentRid.Split('-')[1];
+                RegistryKey sdkKey = testKey.CreateSubKey($@"Setup\InstalledVersions\{architecture}\sdk");
+                sdkKey.SetValue("InstallLocation", _regDir);
+
+                // Add SDK versions
+                AddAvailableSdkVersions(_regSdkBaseDir, "9999.0.4");
+
+                // Specified SDK version: none
+                // Cwd: empty
+                // User: empty
+                // Exe: empty
+                // Reg: 9999.0.4
+                // Expected: 9999.0.4 from reg dir
+                dotnet.Exec("help")
+                    .WorkingDirectory(_currentWorkingDir)
+                    .WithUserProfile(_userDir)
+                    .Environment(s_DefaultEnvironment)
+                    .EnvironmentVariable("DOTNET_MULTILEVEL_LOOKUP", "1")
+                    .EnvironmentVariable("_DOTNET_TEST_SDK_REGISTRY_PATH", testKey.Name)
+                    .CaptureStdOut()
+                    .CaptureStdErr()
+                    .Execute()
+                    .Should()
+                    .Pass()
+                    .And
+                    .HaveStdErrContaining(Path.Combine(_regSelectedMessage, "9999.0.4", _dotnetSdkDllMessageTerminator));
+            }
+            finally
+            {
+                interfaceKey.DeleteSubKeyTree(testKeyName);
+            }
+        }
+
         [Fact]
         public void SdkMultilevelLookup_Must_Pick_The_Highest_Semantic_Version()
         {

--- a/src/test/HostActivationTests/GivenThatICareAboutMultilevelSDKLookup.cs
+++ b/src/test/HostActivationTests/GivenThatICareAboutMultilevelSDKLookup.cs
@@ -632,13 +632,10 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.MultilevelSDKLookup
             // but we should not corrupt anything by adding a special subkey even if it's left behind.
             //
             // Note: If you want to inspect the values written by the test and/or modify them manually
-            //   normal regedit.exe will not show these anywhere, as it's running as 64bit process
-            //   and there's no SysWOW6432 symbolic link for the Interface key (unlike the one for Software).
-            //   You can however run C:\Windows\SysWOW64\regedt32.exe which will launch a 32bit regedit
-            //   which will see these keys.
+            //   you have to navigate to HKCU\Software\Classes\Wow6432Node\Interface on a 64bit OS.
 
             RegistryKey hkcu = RegistryKey.OpenBaseKey(RegistryHive.CurrentUser, RegistryView.Registry32);
-            RegistryKey interfaceKey = hkcu.OpenSubKey(@"Software\Classes\Interface", writable: true);
+            RegistryKey interfaceKey = hkcu.CreateSubKey(@"Software\Classes\Interface");
             string testKeyName = "_DOTNET_Test" + System.Diagnostics.Process.GetCurrentProcess().Id.ToString();
             RegistryKey testKey = interfaceKey.CreateSubKey(testKeyName);
             try

--- a/src/test/HostActivationTests/HostActivationTests.csproj
+++ b/src/test/HostActivationTests/HostActivationTests.csproj
@@ -19,6 +19,7 @@
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
     <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="2.1.0" />
     <PackageReference Include="Microsoft.DotNet.PlatformAbstractions" Version="2.1.0" />
+    <PackageReference Include="Microsoft.Win32.Registry" Version="4.3.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Fix registry access on legacy Windows

The bug was that `RRF_SUBKEY_WOW6432KEY` is only supported on Win10. On legacy Windows it has no effect and 64bit registry is accessed.

The fix is to use `RegOpenKeyEx` which takes the access right parameter which can specify `KEY_WOW64_32KEY`. This makes 64bit app access the 32bit registry and this one is supported on anything above Windows 2000 (excluded).

Fixes #5028 