### PR TITLE
Upgrade runtime-deps OpenSSL dependency to 1.1

### DIFF
--- a/src/pkg/packaging/deb/dotnet-runtime-deps-debian_config_debian.9-x64.json
+++ b/src/pkg/packaging/deb/dotnet-runtime-deps-debian_config_debian.9-x64.json
@@ -34,7 +34,7 @@
         "libgssapi-krb5-2":{},
         "libstdc++6":{},
         "zlib1g":{},
-        "libssl1.0.2" : {},
+        "libssl1.1" : {},
         "libicu57": {} 
     },
 

--- a/src/pkg/packaging/deb/dotnet-runtime-deps-debian_config_ubuntu.18.04-x64.json
+++ b/src/pkg/packaging/deb/dotnet-runtime-deps-debian_config_ubuntu.18.04-x64.json
@@ -34,7 +34,7 @@
         "libgssapi-krb5-2":{},
         "libstdc++6":{},
         "zlib1g":{},
-        "libssl1.0.0" : {},
+        "libssl1.1" : {},
         "libicu60": {} 
     },
 

--- a/src/pkg/packaging/rpm/dotnet-runtime-deps-rpm_config_fedora.27-x64.json
+++ b/src/pkg/packaging/rpm/dotnet-runtime-deps-rpm_config_fedora.27-x64.json
@@ -30,7 +30,7 @@
     },
     
     "rpm_dependencies":[{
-        "package_name": "compat-openssl10",
+        "package_name": "openssl",
         "package_version": ""
     },
     {


### PR DESCRIPTION
In distro versions where it's available in default repositories, upgrade to OpenSSL 1.1.

This is for https://github.com/dotnet/core-setup/issues/4731.