### PR TITLE
Fix the timestamp timezone in tracing in Windows

### DIFF
--- a/src/corehost/common/pal.windows.cpp
+++ b/src/corehost/common/pal.windows.cpp
@@ -50,7 +50,7 @@ pal::string_t pal::get_timestamp()
     std::time_t t = std::time(0);
     const std::size_t elems = 100;
     char_t buf[elems];
-    std::wcsftime(buf, elems, _X("%c %Z"), std::gmtime(&t));
+    std::wcsftime(buf, elems, _X("%c GMT"), std::gmtime(&t));
 
     return pal::string_t(buf);
 }


### PR DESCRIPTION
It seems that printing out timezone information for a tm structure on Windows always shows the local timezone, even if the tm is returned by gmtime.
The simplest fix seems to be to simply print out GMT always, after all gmtime always returns GMT time.
This also makes the output match Linux formating as Windows otherwise uses verbose zone names, while Linux uses abbreviations.

Fixes #5048 