### PR TITLE
Fix lookup of coreclr.dll in .deps.json to not rely on relative paths

### DIFF
--- a/src/corehost/cli/deps_resolver.cpp
+++ b/src/corehost/cli/deps_resolver.cpp
@@ -573,13 +573,15 @@ void deps_resolver_t::init_known_entry_path(const deps_entry_t& entry, const pal
     {
         return;
     }
-    if (m_coreclr_path.empty() && ends_with(entry.asset.relative_path, _X("/") + pal::string_t(LIBCORECLR_NAME), false))
+
+    assert(pal::is_path_rooted(path));
+    if (m_coreclr_path.empty() && ends_with(path, DIR_SEPARATOR + pal::string_t(LIBCORECLR_NAME), false))
     {
         m_coreclr_path = path;
         m_coreclr_library_version = entry.library_version;
         return;
     }
-    if (m_clrjit_path.empty() && ends_with(entry.asset.relative_path, _X("/") + pal::string_t(LIBCLRJIT_NAME), false))
+    if (m_clrjit_path.empty() && ends_with(path, DIR_SEPARATOR + pal::string_t(LIBCLRJIT_NAME), false))
     {
         m_clrjit_path = path;
         return;

--- a/src/test/HostActivationTests/GivenThatICareAboutSharedFxLookup.cs
+++ b/src/test/HostActivationTests/GivenThatICareAboutSharedFxLookup.cs
@@ -1068,14 +1068,14 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.SharedFxLookup
                 .Children().Children().OfType<JProperty>().Where(p => p.Name.Contains("runtime") && p.Name.Contains("Microsoft.NETCore.App"))
                 .Values()["native"].Children().OfType<JProperty>();
 
-            // Change the coreclr.dll asset to not specify only "coreclr.dll" as the relative path (no directories).
+            // Change the coreclr.dll asset to specify only "coreclr.dll" as the relative path (no directories).
             string coreClrLibraryName = $"{fixture.SharedLibraryPrefix}coreclr{fixture.SharedLibraryExtension}";
             JProperty coreClrProperty = netCoreAppNativeAssets.First(p => p.Name.Contains(coreClrLibraryName));
             JProperty newCoreClrProperty = new JProperty(coreClrProperty.Name.Substring(coreClrProperty.Name.LastIndexOf('/') + 1), coreClrProperty.Value);
             coreClrProperty.Parent.Add(newCoreClrProperty);
             coreClrProperty.Remove();
 
-            // Change the clrjit.dll asset to not specify only "clrjit.dll" as the relative path (no directories).
+            // Change the clrjit.dll asset to specify only "clrjit.dll" as the relative path (no directories).
             string clrJitLibraryName = $"{fixture.SharedLibraryPrefix}clrjit{fixture.SharedLibraryExtension}";
             JProperty clrJitProperty = netCoreAppNativeAssets.First(p => p.Name.Contains(clrJitLibraryName));
             JProperty newClrJitProperty = new JProperty(clrJitProperty.Name.Substring(clrJitProperty.Name.LastIndexOf('/') + 1), clrJitProperty.Value);

--- a/src/test/HostActivationTests/GivenThatICareAboutSharedFxLookup.cs
+++ b/src/test/HostActivationTests/GivenThatICareAboutSharedFxLookup.cs
@@ -1,10 +1,11 @@
-﻿using Microsoft.DotNet.InternalAbstractions;
-using Microsoft.DotNet.Cli.Build.Framework;
+﻿using Microsoft.DotNet.Cli.Build.Framework;
 using Newtonsoft.Json.Linq;
 using System;
+using System.Collections.Generic;
 using System.IO;
-using Xunit;
+using System.Linq;
 using System.Runtime.InteropServices;
+using Xunit;
 
 namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.SharedFxLookup
 {
@@ -1041,6 +1042,60 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.SharedFxLookup
                 .HaveStdErrContaining(Path.Combine("7777.0.0", "System.Collections.Immutable.dll"))
                 .And
                 .NotHaveStdErrContaining(Path.Combine("9999.1.0", "System.Collections.Immutable.dll"));
+        }
+
+        [Fact]
+        public void CoreClrLookup_WithNoDirectorySeparatorInDeps()
+        {
+            var fixture = PreviouslyBuiltAndRestoredPortableTestProjectFixture
+                .Copy();
+
+            var dotnet = fixture.BuiltDotnet;
+            var appDll = fixture.TestProject.AppDll;
+
+            string runtimeConfig = Path.Combine(fixture.TestProject.OutputDirectory, "SharedFxLookupPortableApp.runtimeconfig.json");
+            SharedFramework.SetRuntimeConfigJson(runtimeConfig, "9999.0.0", null);
+
+            // Add versions in the exe folders
+            SharedFramework.AddAvailableSharedFxVersions(_builtSharedFxDir, _exeSharedFxBaseDir, "9999.0.0");
+            string sharedFxPath = Path.Combine(_exeSharedFxBaseDir, "9999.0.0");
+            string sharedFxDepsJsonPath = Path.Combine(sharedFxPath, "Microsoft.NETCore.App.deps.json");
+
+            // Modify the .deps.json for Microsoft.NETCore.App FX
+            JObject root = JObject.Parse(File.ReadAllText(sharedFxDepsJsonPath));
+            IEnumerable<JProperty> netCoreAppNativeAssets = root["targets"]
+                .Children<JProperty>().Where(p => p.Name.Contains("/"))
+                .Children().Children().OfType<JProperty>().Where(p => p.Name.Contains("runtime") && p.Name.Contains("Microsoft.NETCore.App"))
+                .Values()["native"].Children().OfType<JProperty>();
+
+            // Change the coreclr.dll asset to not specify only "coreclr.dll" as the relative path (no directories).
+            string coreClrLibraryName = $"{fixture.SharedLibraryPrefix}coreclr{fixture.SharedLibraryExtension}";
+            JProperty coreClrProperty = netCoreAppNativeAssets.First(p => p.Name.Contains(coreClrLibraryName));
+            JProperty newCoreClrProperty = new JProperty(coreClrProperty.Name.Substring(coreClrProperty.Name.LastIndexOf('/') + 1), coreClrProperty.Value);
+            coreClrProperty.Parent.Add(newCoreClrProperty);
+            coreClrProperty.Remove();
+
+            // Change the clrjit.dll asset to not specify only "clrjit.dll" as the relative path (no directories).
+            string clrJitLibraryName = $"{fixture.SharedLibraryPrefix}clrjit{fixture.SharedLibraryExtension}";
+            JProperty clrJitProperty = netCoreAppNativeAssets.First(p => p.Name.Contains(clrJitLibraryName));
+            JProperty newClrJitProperty = new JProperty(clrJitProperty.Name.Substring(clrJitProperty.Name.LastIndexOf('/') + 1), clrJitProperty.Value);
+            clrJitProperty.Parent.Add(newClrJitProperty);
+            clrJitProperty.Remove();
+
+            File.WriteAllText(sharedFxDepsJsonPath, root.ToString());
+
+            dotnet.Exec(appDll)
+                .WorkingDirectory(_currentWorkingDir)
+                .EnvironmentVariable("COREHOST_TRACE", "1")
+                .CaptureStdOut()
+                .CaptureStdErr()
+                .Execute()
+                .Should()
+                .Pass()
+                .And
+                .HaveStdErrContaining($"CoreCLR path = '{Path.Combine(sharedFxPath, coreClrLibraryName)}'")
+                .And
+                .HaveStdErrContaining($"The resolved JIT path is '{Path.Combine(sharedFxPath, clrJitLibraryName)}'");
         }
 
         static private JObject GetAdditionalFramework(string fxName, string fxVersion, bool? applyPatches, int? rollForwardOnNoCandidateFx)

--- a/src/test/TestUtils/RuntimeInformationExtensions.cs
+++ b/src/test/TestUtils/RuntimeInformationExtensions.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Runtime.InteropServices;
-using System.Threading.Tasks;
+﻿using System.Runtime.InteropServices;
 
 namespace Microsoft.DotNet.CoreSetup.Test
 {


### PR DESCRIPTION
The existing code expects the .deps.json record for coreclr.dll (and clrjit.dll) to have at least one directory separator, since that was always the case up until now.
With recent changes to targeting packs, these records are just file names, and the above logic breaks.

Fix the logic by lookup at the resolved absolute path, which is guaranteed to have a directory separator before the library name (we need the separator to match whole file names).

Added a test which validates the new scenario.

Fixes #4978 .