### PR TITLE
Add dotnet/versions publish as hosted job

### DIFF
--- a/eng/jobs/finalize-publish.yml
+++ b/eng/jobs/finalize-publish.yml
@@ -18,16 +18,16 @@ jobs:
                   ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest'))
     # Run after all dependent legs are executed
     dependsOn: 
-      - Build_Linux_Arm
-      - Build_Linux_Arm64
-      - Build_Linux_x64_Alpine36
-      - Build_Linux_x64_glibc
-      - Build_Linux_x64_Rhel6
-      - Build_OSX
-      - Build_Windows_Arm
-      - Build_Windows_Arm64
-      - Build_Windows_x64
-      - Build_Windows_x86
+    - Build_Linux_Arm
+    - Build_Linux_Arm64
+    - Build_Linux_x64_Alpine36
+    - Build_Linux_x64_glibc
+    - Build_Linux_x64_Rhel6
+    - Build_OSX
+    - Build_Windows_Arm
+    - Build_Windows_Arm64
+    - Build_Windows_x64
+    - Build_Windows_x86
     pool:
       # For public or PR jobs, use the hosted pool.  For internal jobs use the internal pool.
       # Will eventually change this to two BYOC pools.
@@ -61,18 +61,6 @@ jobs:
       continueOnError: false
       condition: and(succeeded(), in(variables['SignType'], 'real', 'test'))
 
-    - powershell: |
-        $prefix = "refs/heads/"
-        $branch = "$(Build.SourceBranch)"
-        $branchName = $branch
-        if ($branchName.StartsWith($prefix))
-        {
-          $branchName = $branchName.Substring($prefix.Length)
-        }
-        Write-Host "For Build.SourceBranch $branch, FullBranchName is $branchName"
-        Write-Host "##vso[task.setvariable variable=FullBranchName;]$branchName"
-      displayName: Find true SourceBranchName
-
     - task: MSBuild@1
       displayName: Publish (no PublishType)
       inputs: 
@@ -88,7 +76,6 @@ jobs:
         /p:StabilizePackageVersion=$(IsStable) 
         /p:TargetArchitecture=x64
         $(_BlobFeedArgs) 
-        $(_DotNetVersionsArgs)
         $(_CommonPublishArgs) 
         $(_NugetFeedArgs) 
         $(_SymbolServerArgs) 
@@ -129,4 +116,59 @@ jobs:
         PublishLocation: Container
         ArtifactName: AssetManifests
       continueOnError: true
+      condition: succeededOrFailed()
+
+  - job: Finalize_Publish_Versions
+    displayName: Finalize_Publish_Versions
+    dependsOn: 
+    - Finalize_Publish
+    pool:
+      name: Hosted VS2017
+    steps:
+    # Initialize tooling
+    - script: build.cmd -- /t:BuildTraversalBuildDependencies
+      displayName: Initialize tooling
+
+    - powershell: |
+        $prefix = "refs/heads/"
+        $branch = "$(Build.SourceBranch)"
+        $branchName = $branch
+        if ($branchName.StartsWith($prefix))
+        {
+          $branchName = $branchName.Substring($prefix.Length)
+        }
+        Write-Host "For Build.SourceBranch $branch, FullBranchName is $branchName"
+        Write-Host "##vso[task.setvariable variable=FullBranchName;]$branchName"
+      displayName: Find true SourceBranchName
+
+    - task: MSBuild@1
+      displayName: Publish (versions)
+      inputs: 
+        solution: $(Build.SourcesDirectory)\publish\publish-type.proj
+        platform: x64
+        configuration: Release
+        msbuildVersion: 15.0
+        msbuildArchitecture: x64
+        msbuildArguments: >-
+          /p:PublishType=versions
+          $(_DotNetVersionsArgs)
+          $(_CommonPublishArgs)
+          /bl:$(Build.SourcesDirectory)\publishversions.binlog
+
+    - task: CopyFiles@2
+      displayName: Copy Files to $(Build.StagingDirectory)\BuildLogs
+      inputs:
+        SourceFolder: '$(Build.SourcesDirectory)'
+        Contents: |
+          *.log
+          *.binlog
+        TargetFolder: '$(Build.StagingDirectory)\BuildLogs'
+      continueOnError: true
+      condition: succeededOrFailed()
+
+    - task: PublishBuildArtifacts@1
+      displayName: Publish Artifact BuildLogs
+      inputs:
+        PathtoPublish: '$(Build.StagingDirectory)\BuildLogs'
+        ArtifactName: Finalize_Publish_Versions
       condition: succeededOrFailed()


### PR DESCRIPTION
If dotnet/versions publish is enabled in the main finalize/publish job, it fails because VersionTools is an old version. The reason for the old VersionTools is unknown. To narrow it down or work around it, use a hosted agent to ensure machine state isn't a factor, such as previous builds' tooling carrying over somehow.

For https://github.com/dotnet/core-setup/issues/4987. This will likely work around the issue. If it still repros in the official build, it will show that agent environment isn't a factor which would be extremely strange.