### PR TITLE
Use self-hosted pool for Windows arm/arm64 CI to unblock PR validation

### DIFF
--- a/eng/jobs/windows-build.yml
+++ b/eng/jobs/windows-build.yml
@@ -13,7 +13,10 @@ jobs:
       # For public or PR jobs, use the hosted pool.  For internal jobs use the internal pool.
       # Will eventually change this to two BYOC pools.
       ${{ if eq(variables['System.TeamProject'], 'public') }}:
-        name: Hosted VS2017
+        ${{ if contains(parameters.targetArchitecture, 'arm') }}:
+          name: dotnet-external-temp
+        ${{ if not(contains(parameters.targetArchitecture, 'arm')) }}:
+          name: Hosted VS2017
       ${{ if ne(variables['System.TeamProject'], 'public') }}:
         name: dotnet-internal-temp
     strategy:


### PR DESCRIPTION
I noticed our ARM official builds are still working, even though our public CI is failing (https://github.com/dotnet/core-setup/issues/5052). This is because the public CI uses hosted agents, but internal builds use core-eng hosted agents.

There's an email thread about getting the hosted agents back into working condition. For now, we can unblock PR CI by switching pools.