### PR TITLE
Fix dotnet exe on FreeBSD 12

### DIFF
--- a/src/corehost/cli/exe.cmake
+++ b/src/corehost/cli/exe.cmake
@@ -56,8 +56,13 @@ if (WIN32 AND CLI_CMAKE_PLATFORM_ARCH_ARM)
     target_link_libraries(${DOTNET_HOST_EXE_NAME} shell32.lib)
 endif()
 
-if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
-    target_link_libraries (${DOTNET_HOST_EXE_NAME} "dl" "pthread")
+if(${CMAKE_SYSTEM_NAME} MATCHES "Linux|FreeBSD")
+    target_link_libraries (${DOTNET_HOST_EXE_NAME} "pthread")
 endif()
+
+if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
+    target_link_libraries (${DOTNET_HOST_EXE_NAME} "dl")
+endif()
+
 
 


### PR DESCRIPTION
As mentioned in [this comment](https://github.com/dotnet/corefx/issues/1626#issuecomment-459842620), the dotnet exe-file does not work on FreeBSD 12 unless provided explicit linker help at runtime.

Linking pthread when building the binary (like we do on Linux) should probably help fix this issue.