### PR TITLE
Remove code duplication when enumerating framework locations

### DIFF
--- a/src/corehost/cli/fxr/framework_info.cpp
+++ b/src/corehost/cli/fxr/framework_info.cpp
@@ -27,26 +27,8 @@ bool compare_by_name_and_version(const framework_info &a, const framework_info &
     const pal::string_t& fx_name,
     std::vector<framework_info>* framework_infos)
 {
-    std::vector<pal::string_t> global_dirs;
-    bool multilevel_lookup = multilevel_lookup_enabled();
-
-    // own_dir contains DIR_SEPARATOR appended that we need to remove.
-    pal::string_t own_dir_temp = own_dir;
-    remove_trailing_dir_seperator(&own_dir_temp);
-
     std::vector<pal::string_t> hive_dir;
-    hive_dir.push_back(own_dir_temp);
-
-    if (multilevel_lookup && pal::get_global_dotnet_dirs(&global_dirs))
-    {
-        for (pal::string_t dir : global_dirs)
-        {
-            if (!pal::are_paths_equal_with_normalized_casing(dir, own_dir_temp))
-            {
-                hive_dir.push_back(dir);
-            }
-        }
-    }
+    get_framework_and_sdk_locations(own_dir, &hive_dir);
 
     for (pal::string_t dir : hive_dir)
     {

--- a/src/corehost/cli/fxr/fx_muxer.cpp
+++ b/src/corehost/cli/fxr/fx_muxer.cpp
@@ -472,25 +472,7 @@ fx_definition_t* fx_muxer_t::resolve_fx(
     // If it is not activated, then only .exe directory will be considered
 
     std::vector<pal::string_t> hive_dir;
-    std::vector<pal::string_t> global_dirs;
-    bool multilevel_lookup = multilevel_lookup_enabled();
-
-    // dotnet_dir contains DIR_SEPARATOR appended that we need to remove.
-    pal::string_t dotnet_dir_temp = dotnet_dir;
-    remove_trailing_dir_seperator(&dotnet_dir_temp);
-
-    hive_dir.push_back(dotnet_dir_temp);
-    if (multilevel_lookup && pal::get_global_dotnet_dirs(&global_dirs))
-    {
-        for (pal::string_t dir : global_dirs)
-        {
-            // Avoid duplicate of dotnet_dir_temp
-            if (!pal::are_paths_equal_with_normalized_casing(dir, dotnet_dir_temp))
-            {
-                hive_dir.push_back(dir);
-            }
-        }
-    }
+    get_framework_and_sdk_locations(dotnet_dir, &hive_dir);
 
     pal::string_t selected_fx_dir;
     pal::string_t selected_fx_version;

--- a/src/corehost/cli/fxr/sdk_info.cpp
+++ b/src/corehost/cli/fxr/sdk_info.cpp
@@ -44,26 +44,8 @@ void sdk_info::get_all_sdk_infos(
     const pal::string_t& own_dir,
     std::vector<sdk_info>* sdk_infos)
 {
-    std::vector<pal::string_t> global_dirs;
-    bool multilevel_lookup = multilevel_lookup_enabled();
-
-    // own_dir contains DIR_SEPARATOR appended that we need to remove.
-    pal::string_t own_dir_temp = own_dir;
-    remove_trailing_dir_seperator(&own_dir_temp);
-
     std::vector<pal::string_t> hive_dir;
-    hive_dir.push_back(own_dir_temp);
-
-    if (multilevel_lookup && pal::get_global_dotnet_dirs(&global_dirs))
-    {
-        for (pal::string_t dir : global_dirs)
-        {
-            if (!pal::are_paths_equal_with_normalized_casing(dir, own_dir_temp))
-            {
-                hive_dir.push_back(dir);
-            }
-        }
-    }
+    get_framework_and_sdk_locations(own_dir, &hive_dir);
 
     int32_t hive_depth = 0;
 

--- a/src/corehost/cli/fxr/sdk_resolver.cpp
+++ b/src/corehost/cli/fxr/sdk_resolver.cpp
@@ -192,29 +192,7 @@ bool sdk_resolver_t::resolve_sdk_dotnet_path(
     }
 
     std::vector<pal::string_t> hive_dir;
-    std::vector<pal::string_t> global_dirs;
-    bool multilevel_lookup = multilevel_lookup_enabled();
-
-    pal::string_t dotnet_root_temp;
-    if (!dotnet_root.empty())
-    {
-        // dotnet_root contains DIR_SEPARATOR appended that we need to remove.
-        dotnet_root_temp = dotnet_root;
-        remove_trailing_dir_seperator(&dotnet_root_temp);
-        hive_dir.push_back(dotnet_root_temp);
-    }
-
-    if (multilevel_lookup && pal::get_global_dotnet_dirs(&global_dirs))
-    {
-        for (pal::string_t dir : global_dirs)
-        {
-            // Avoid duplicate of dotnet_root_temp
-            if (!pal::are_paths_equal_with_normalized_casing(dir, dotnet_root_temp))
-            {
-                hive_dir.push_back(dir);
-            }
-        }
-    }
+    get_framework_and_sdk_locations(dotnet_root, &hive_dir);
 
     pal::string_t cli_version;
     pal::string_t sdk_path;

--- a/src/corehost/common/utils.cpp
+++ b/src/corehost/common/utils.cpp
@@ -337,6 +337,34 @@ bool multilevel_lookup_enabled()
     return multilevel_lookup;
 }
 
+void get_framework_and_sdk_locations(const pal::string_t& dotnet_dir, std::vector<pal::string_t>* locations)
+{
+    bool multilevel_lookup = multilevel_lookup_enabled();
+
+    pal::string_t dotnet_dir_temp;
+    if (!dotnet_dir.empty())
+    {
+        // own_dir contains DIR_SEPARATOR appended that we need to remove.
+        dotnet_dir_temp = dotnet_dir;
+        remove_trailing_dir_seperator(&dotnet_dir_temp);
+
+        locations->push_back(dotnet_dir_temp);
+    }
+
+    std::vector<pal::string_t> global_dirs;
+    if (multilevel_lookup && pal::get_global_dotnet_dirs(&global_dirs))
+    {
+        for (pal::string_t dir : global_dirs)
+        {
+            // avoid duplicate paths
+            if (!pal::are_paths_equal_with_normalized_casing(dir, dotnet_dir_temp))
+            {
+                locations->push_back(dir);
+            }
+        }
+    }
+}
+
 bool get_file_path_from_env(const pal::char_t* env_key, pal::string_t* recv)
 {
     recv->clear();

--- a/src/corehost/common/utils.h
+++ b/src/corehost/common/utils.h
@@ -57,6 +57,7 @@ bool skip_utf8_bom(pal::ifstream_t* stream);
 bool get_env_shared_store_dirs(std::vector<pal::string_t>* dirs, const pal::string_t& arch, const pal::string_t& tfm);
 bool get_global_shared_store_dirs(std::vector<pal::string_t>* dirs, const pal::string_t& arch, const pal::string_t& tfm);
 bool multilevel_lookup_enabled();
+void get_framework_and_sdk_locations(const pal::string_t& dotnet_dir, std::vector<pal::string_t>* locations);
 bool get_file_path_from_env(const pal::char_t* env_key, pal::string_t* recv);
 size_t index_of_non_numeric(const pal::string_t& str, unsigned i);
 bool try_stou(const pal::string_t& str, unsigned* num);


### PR DESCRIPTION
Simple refactoring to reuse the same code in all places where we enumerate framework and SDK locations.
