### PR TITLE
Generate xml docs for managed API

### DIFF
--- a/src/managed/CommonManaged.props
+++ b/src/managed/CommonManaged.props
@@ -13,6 +13,9 @@
     <Authors>Microsoft</Authors>
     <NugetLicenseFile>$(RepoRoot)LICENSE.TXT</NugetLicenseFile>
     <PackageThirdPartyNoticesFile>$(RepoRoot)THIRD-PARTY-NOTICES.TXT</PackageThirdPartyNoticesFile>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <!-- Managed API isn't completely documented yet. TODO: https://github.com/dotnet/core-setup/issues/5108 -->
+    <NoWarn>$(NoWarn);CS1591</NoWarn>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/managed/Microsoft.Extensions.DependencyModel/Microsoft.Extensions.DependencyModel.csproj
+++ b/src/managed/Microsoft.Extensions.DependencyModel/Microsoft.Extensions.DependencyModel.csproj
@@ -20,7 +20,7 @@
       <PropertyGroup>
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
         <!-- Suppress warnings for unnecessary CLSCompliance attributes -->
-        <NoWarn>3021</NoWarn>
+        <NoWarn>$(NoWarn);3021</NoWarn>
       </PropertyGroup>
       <ItemGroup>
         <PackageReference Include="Microsoft.Bcl.Json.Sources">


### PR DESCRIPTION
Even if the file is mostly empty, I'd still like to have it generated. These files will eventually end up in the Microsoft.AspNetCore.App.Ref targeting pack.