### PR TITLE
Create targeting pack MSI installers

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -173,6 +173,7 @@ jobs:
 # Windows x86
 - template: /eng/jobs/windows-build.yml
   parameters:
+    buildFullPlatformManifest: true
     displayName: Build_Windows_x86
     targetArchitecture: x86
 

--- a/dir.props
+++ b/dir.props
@@ -285,7 +285,7 @@
     <DotnetHostString>dotnet-host-</DotnetHostString>
     <DotnetHostFxrString>dotnet-hostfxr-</DotnetHostFxrString>
     <DotnetRuntimeString>dotnet-runtime-</DotnetRuntimeString>
-    <DotnetTargetingPackString>dotnet-netcoreapp-targeting-pack-</DotnetTargetingPackString>
+    <DotnetTargetingPackString>dotnet-targeting-pack-</DotnetTargetingPackString>
     <DotnetRuntimeDependenciesPackageString>dotnet-runtime-deps-</DotnetRuntimeDependenciesPackageString>
 
     <CombinedInstallerStart>$(AssetOutputPath)$(DotnetRuntimeString)</CombinedInstallerStart>

--- a/dir.props
+++ b/dir.props
@@ -285,11 +285,14 @@
     <DotnetHostString>dotnet-host-</DotnetHostString>
     <DotnetHostFxrString>dotnet-hostfxr-</DotnetHostFxrString>
     <DotnetRuntimeString>dotnet-runtime-</DotnetRuntimeString>
+    <DotnetTargetingPackString>dotnet-netcoreapp-targeting-pack-</DotnetTargetingPackString>
     <DotnetRuntimeDependenciesPackageString>dotnet-runtime-deps-</DotnetRuntimeDependenciesPackageString>
+
     <CombinedInstallerStart>$(AssetOutputPath)$(DotnetRuntimeString)</CombinedInstallerStart>
     <SharedHostInstallerStart>$(AssetOutputPath)$(DotnetHostString)</SharedHostInstallerStart>
     <HostFxrInstallerStart>$(AssetOutputPath)$(DotnetHostFxrString)</HostFxrInstallerStart>
     <SharedFrameworkInstallerStart>$(AssetOutputPath)$(DotnetRuntimeString)</SharedFrameworkInstallerStart>
+    <TargetingPackInstallerStart>$(AssetOutputPath)$(DotnetTargetingPackString)</TargetingPackInstallerStart>
     <DotnetRuntimeDependenciesPackageInstallerStart>$(AssetOutputPath)$(DotnetRuntimeDependenciesPackageString)</DotnetRuntimeDependenciesPackageInstallerStart>
 
     <!-- OSX specific intermediate package suffix . OSX specific intermediate packages are suffixed with -internal to avoid name collision for bundle package (dotnet-runtime-*)
@@ -298,6 +301,7 @@
     <SharedHostInstallerStart Condition="'$(OSGroup)' == 'OSX'">$(SharedHostInstallerStart)$(InstallerStartSuffix)-</SharedHostInstallerStart>
     <HostFxrInstallerStart Condition="'$(OSGroup)' == 'OSX'">$(HostFxrInstallerStart)$(InstallerStartSuffix)-</HostFxrInstallerStart>
     <SharedFrameworkInstallerStart Condition="'$(OSGroup)' == 'OSX'">$(SharedFrameworkInstallerStart)$(InstallerStartSuffix)-</SharedFrameworkInstallerStart>
+    <TargetingPackInstallerStart Condition="'$(OSGroup)' == 'OSX'">$(TargetingPackInstallerStart)$(InstallerStartSuffix)-</TargetingPackInstallerStart>
 
   </PropertyGroup>
 
@@ -428,9 +432,12 @@
   <PropertyGroup>
     <CombinedInstallerFile>$(CombinedInstallerStart)$(ProductMoniker)$(CombinedInstallerExtension)</CombinedInstallerFile>
     <CombinedInstallerEngine>$(CombinedInstallerStart)$(ProductMoniker)-engine.exe</CombinedInstallerEngine>
+
     <SharedHostInstallerFile>$(SharedHostInstallerStart)$(ProductMoniker)$(InstallerExtension)</SharedHostInstallerFile>
     <HostFxrInstallerFile>$(HostFxrInstallerStart)$(HostResolverVersionMoniker)$(InstallerExtension)</HostFxrInstallerFile>
     <SharedFrameworkInstallerFile>$(SharedFrameworkInstallerStart)$(ProductMoniker)$(InstallerExtension)</SharedFrameworkInstallerFile>
+    <TargetingPackInstallerFile>$(TargetingPackInstallerStart)$(ProductMoniker)$(InstallerExtension)</TargetingPackInstallerFile>
+
     <!-- Runtime Deb and Rpm packages are distro version agnostic -->
     <SharedHostInstallerFile Condition="'$(InstallerExtension)' == '.deb' or '$(InstallerExtension)' == '.rpm' ">$(SharedHostInstallerStart)$(SharedFrameworkNugetVersion)-$(TargetArchitecture)$(InstallerExtension)</SharedHostInstallerFile>
     <HostFxrInstallerFile Condition="'$(InstallerExtension)' == '.deb' or '$(InstallerExtension)' == '.rpm'">$(HostFxrInstallerStart)$(HostResolverVersion)-$(TargetArchitecture)$(InstallerExtension)</HostFxrInstallerFile>

--- a/src/pkg/packaging/dir.props
+++ b/src/pkg/packaging/dir.props
@@ -8,10 +8,12 @@
     <!-- Package prebuilt binaries -->
     <UsePrebuiltPortableBinariesForInstallers>false</UsePrebuiltPortableBinariesForInstallers>
     
+    <!-- Use trailing '/'. Heat.exe doesn't accept a trailing '\'.-->
     <PackagesIntermediateDir>$(IntermediateOutputRootPath)packages/</PackagesIntermediateDir>
     <SharedHostPublishRoot>$(IntermediateOutputRootPath)sharedHost/</SharedHostPublishRoot>
     <HostFxrPublishRoot>$(IntermediateOutputRootPath)hostFxr/</HostFxrPublishRoot>
     <SharedFrameworkPublishRoot>$(IntermediateOutputRootPath)sharedFx/</SharedFrameworkPublishRoot>
+    <TargetingPackPublishRoot>$(IntermediateOutputRootPath)Microsoft.NETCore.App.Ref/layout/</TargetingPackPublishRoot>
     <CombinedPublishRoot>$(IntermediateOutputRootPath)combined-framework-host/</CombinedPublishRoot>
   </PropertyGroup>
 
@@ -28,6 +30,7 @@
     <ProductBrandSuffix Condition="'$(ReleaseBrandSuffix)'!=''">$(ProductionVersion) $(ReleaseBrandSuffix)</ProductBrandSuffix>
     <SharedHostBrandName>$(ProductBrandPrefix) Host - $(ProductBrandSuffix)</SharedHostBrandName>
     <HostFxrBrandName>$(ProductBrandPrefix) Host FX Resolver - $(ProductBrandSuffix)</HostFxrBrandName>
+    <TargetingPackBrandName>$(ProductBrandPrefix) App Targeting Pack - $(ProductBrandSuffix)</TargetingPackBrandName>
     <SharedFrameworkBrandName>$(ProductBrandPrefix) Runtime - $(ProductBrandSuffix)</SharedFrameworkBrandName>
   </PropertyGroup>
 </Project>

--- a/src/pkg/packaging/dir.props
+++ b/src/pkg/packaging/dir.props
@@ -30,7 +30,7 @@
     <ProductBrandSuffix Condition="'$(ReleaseBrandSuffix)'!=''">$(ProductionVersion) $(ReleaseBrandSuffix)</ProductBrandSuffix>
     <SharedHostBrandName>$(ProductBrandPrefix) Host - $(ProductBrandSuffix)</SharedHostBrandName>
     <HostFxrBrandName>$(ProductBrandPrefix) Host FX Resolver - $(ProductBrandSuffix)</HostFxrBrandName>
-    <TargetingPackBrandName>$(ProductBrandPrefix) App Targeting Pack - $(ProductBrandSuffix)</TargetingPackBrandName>
+    <TargetingPackBrandName>$(ProductBrandPrefix) Targeting Pack - $(ProductBrandSuffix)</TargetingPackBrandName>
     <SharedFrameworkBrandName>$(ProductBrandPrefix) Runtime - $(ProductBrandSuffix)</SharedFrameworkBrandName>
   </PropertyGroup>
 </Project>

--- a/src/pkg/packaging/windows/package.targets
+++ b/src/pkg/packaging/windows/package.targets
@@ -47,6 +47,10 @@
         <Output TaskParameter="GeneratedGui" PropertyName="HostFxrUpgradeCode" />
       </GenerateGuidFromName>
 
+      <GenerateGuidFromName Name="$(TargetingPackInstallerFile)">
+        <Output TaskParameter="GeneratedGui" PropertyName="TargetingPackUpgradeCode" />
+      </GenerateGuidFromName>
+
       <ItemGroup>
         <WixOutputs Include="$(WixObjRoot)host">
             <InputDir>$(SharedHostPublishRoot)</InputDir>
@@ -59,6 +63,12 @@
             <BrandName>$(HostFxrBrandName)</BrandName>
             <InstallerName>$(HostFxrInstallerFile)</InstallerName>
             <UpgradeCode>$(HostFxrUpgradeCode)</UpgradeCode>
+        </WixOutputs>
+        <WixOutputs Include="$(WixObjRoot)targetingpack">
+            <InputDir>$(TargetingPackPublishRoot)</InputDir>
+            <BrandName>$(TargetingPackBrandName)</BrandName>
+            <InstallerName>$(TargetingPackInstallerFile)</InstallerName>
+            <UpgradeCode>$(TargetingPackUpgradeCode)</UpgradeCode>
         </WixOutputs>
         <!-- shared framework has extra arguments so it needs to be in a separate group -->
         <WixOutputs2 Include="$(WixObjRoot)sharedframework">

--- a/src/pkg/packaging/windows/package.targets
+++ b/src/pkg/packaging/windows/package.targets
@@ -40,15 +40,15 @@
                                  OverwriteDestination="false" />
 
       <GenerateGuidFromName Name="$(SharedHostInstallerFile)">
-        <Output TaskParameter="GeneratedGui" PropertyName="SharedHostUpgradeCode" />
+        <Output TaskParameter="GeneratedGuid" PropertyName="SharedHostUpgradeCode" />
       </GenerateGuidFromName>
 
       <GenerateGuidFromName Name="$(HostFxrInstallerFile)">
-        <Output TaskParameter="GeneratedGui" PropertyName="HostFxrUpgradeCode" />
+        <Output TaskParameter="GeneratedGuid" PropertyName="HostFxrUpgradeCode" />
       </GenerateGuidFromName>
 
       <GenerateGuidFromName Name="$(TargetingPackInstallerFile)">
-        <Output TaskParameter="GeneratedGui" PropertyName="TargetingPackUpgradeCode" />
+        <Output TaskParameter="GeneratedGuid" PropertyName="TargetingPackUpgradeCode" />
       </GenerateGuidFromName>
 
       <ItemGroup>
@@ -82,7 +82,7 @@
       <MakeDir Directories="$(WixObjRoot);@(WixOutputs);@(WixOutputs2)" />
 
       <GenerateGuidFromName Name="$(SharedFrameworkInstallerFile)">
-        <Output TaskParameter="GeneratedGui" PropertyName="SharedFxUpgradeCode" />
+        <Output TaskParameter="GeneratedGuid" PropertyName="SharedFxUpgradeCode" />
       </GenerateGuidFromName>
 
       <PropertyGroup>
@@ -110,7 +110,7 @@
      </PropertyGroup>
 
      <GenerateGuidFromName Name="$(SharedBundle)">
-       <Output TaskParameter="GeneratedGui" PropertyName="SharedBundleCode" />
+       <Output TaskParameter="GeneratedGuid" PropertyName="SharedBundleCode" />
      </GenerateGuidFromName>
 
      <PropertyGroup>

--- a/src/pkg/packaging/windows/targetingpack/generatemsi.ps1
+++ b/src/pkg/packaging/windows/targetingpack/generatemsi.ps1
@@ -30,35 +30,35 @@ $InstallFilesWixobj = "$WixObjRoot\install-files.wixobj"
 
 function RunHeat
 {
-    $result = $true
+    $Result = $true
     pushd "$WixRoot"
 
     Write-Host Running heat.. to $InstallFileswsx
-    write-host "Root $TargetingPackPublishRoot"
+    Write-Host "Root $TargetingPackPublishRoot"
 
     .\heat.exe dir `"$TargetingPackPublishRoot`" `
-    -nologo `
-    -template fragment `
-    -sreg -gg `
-    -var var.TargetingPackSrc `
-    -cg InstallFiles `
-    -srd `
-    -dr DOTNETHOME `
-    -out $InstallFileswsx | Out-Host
+        -nologo `
+        -template fragment `
+        -sreg -gg `
+        -var var.TargetingPackSrc `
+        -cg InstallFiles `
+        -srd `
+        -dr DOTNETHOME `
+        -out $InstallFileswsx | Out-Host
 
     if($LastExitCode -ne 0)
     {
-        $result = $false
+        $Result = $false
         Write-Host "Heat failed with exit code $LastExitCode."
     }
 
     popd
-    return $result
+    return $Result
 }
 
 function RunCandle
 {
-    $result = $true
+    $Result = $true
     pushd "$WixRoot"
 
     Write-Host Running candle..
@@ -84,17 +84,17 @@ function RunCandle
 
     if($LastExitCode -ne 0)
     {
-        $result = $false
+        $Result = $false
         Write-Host "Candle failed with exit code $LastExitCode."
     }
 
     popd
-    return $result
+    return $Result
 }
 
 function RunLight
 {
-    $result = $true
+    $Result = $true
     pushd "$WixRoot"
 
     Write-Host Running light..
@@ -111,12 +111,12 @@ function RunLight
 
     if($LastExitCode -ne 0)
     {
-        $result = $false
+        $Result = $false
         Write-Host "Light failed with exit code $LastExitCode."
     }
 
     popd
-    return $result
+    return $Result
 }
 
 if(!(Test-Path $TargetingPackPublishRoot))
@@ -154,7 +154,6 @@ if(-Not (RunLight))
 if(!(Test-Path $TargetingPackMSIOutput))
 {
     throw "Unable to create the Targeting Pack MSI."
-    Exit -1
 }
 
 Write-Host -ForegroundColor Green "Successfully created Targeting Pack MSI - $TargetingPackMSIOutput"

--- a/src/pkg/packaging/windows/targetingpack/generatemsi.ps1
+++ b/src/pkg/packaging/windows/targetingpack/generatemsi.ps1
@@ -1,0 +1,162 @@
+# Copyright (c) .NET Foundation and contributors. All rights reserved.
+# Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+param(
+    [Parameter(Mandatory=$true)][string]$TargetingPackPublishRoot,
+    [Parameter(Mandatory=$true)][string]$TargetingPackMSIOutput,
+    [Parameter(Mandatory=$true)][string]$WixRoot,
+    [Parameter(Mandatory=$true)][string]$ProductMoniker,
+    [Parameter(Mandatory=$true)][string]$TargetingPackMSIVersion,
+    [Parameter(Mandatory=$true)][string]$TargetingPackNugetVersion,
+    [Parameter(Mandatory=$true)][string]$Architecture,
+    [Parameter(Mandatory=$true)][string]$TargetArchitecture,
+    [Parameter(Mandatory=$true)][string]$WixObjRoot,
+    [Parameter(Mandatory=$true)][string]$TargetingPackUpgradeCode
+)
+
+$RepoRoot = Convert-Path "$PSScriptRoot\..\..\..\..\.."
+$CommonScript = "$RepoRoot\tools-local\scripts\common\_common.ps1"
+
+if(-Not (Test-Path "$CommonScript"))
+{
+    Exit -1
+} 
+. "$CommonScript"
+
+$PackagingRoot = Join-Path $RepoRoot "src\pkg\packaging"
+
+$InstallFileswsx = "$WixObjRoot\install-files.wxs"
+$InstallFilesWixobj = "$WixObjRoot\install-files.wixobj"
+
+function RunHeat
+{
+    $result = $true
+    pushd "$WixRoot"
+
+    Write-Host Running heat.. to $InstallFileswsx
+    write-host "Root $TargetingPackPublishRoot"
+
+    .\heat.exe dir `"$TargetingPackPublishRoot`" `
+    -nologo `
+    -template fragment `
+    -sreg -gg `
+    -var var.TargetingPackSrc `
+    -cg InstallFiles `
+    -srd `
+    -dr DOTNETHOME `
+    -out $InstallFileswsx | Out-Host
+
+    if($LastExitCode -ne 0)
+    {
+        $result = $false
+        Write-Host "Heat failed with exit code $LastExitCode."
+    }
+
+    popd
+    return $result
+}
+
+function RunCandle
+{
+    $result = $true
+    pushd "$WixRoot"
+
+    Write-Host Running candle..
+    $AuthWsxRoot =  Join-Path $PackagingRoot "windows\targetingpack"
+
+    $ComponentVersion = $TargetingPackNugetVersion.Replace('-', '_');
+
+    .\candle.exe -nologo `
+        -out "$WixObjRoot\" `
+        -dTargetingPackSrc="$TargetingPackPublishRoot" `
+        -dMicrosoftEula="$PackagingRoot\windows\eula.rtf" `
+        -dProductMoniker="$ProductMoniker" `
+        -dBuildVersion="$TargetingPackMSIVersion" `
+        -dNugetVersion="$TargetingPackNugetVersion" `
+        -dComponentVersion="$ComponentVersion" `
+        -dTargetArchitecture="$TargetArchitecture" `
+        -dUpgradeCode="$TargetingPackUpgradeCode" `
+        -arch $Architecture `
+        -ext WixDependencyExtension.dll `
+        "$AuthWsxRoot\targetingpack.wxs" `
+        "$AuthWsxRoot\provider.wxs" `
+        $InstallFileswsx | Out-Host
+
+    if($LastExitCode -ne 0)
+    {
+        $result = $false
+        Write-Host "Candle failed with exit code $LastExitCode."
+    }
+
+    popd
+    return $result
+}
+
+function RunLight
+{
+    $result = $true
+    pushd "$WixRoot"
+
+    Write-Host Running light..
+
+    .\light.exe -nologo `
+        -ext WixUIExtension.dll `
+        -ext WixDependencyExtension.dll `
+        -ext WixUtilExtension.dll `
+        -cultures:en-us `
+        "$WixObjRoot\targetingpack.wixobj" `
+        "$WixObjRoot\provider.wixobj" `
+        "$InstallFilesWixobj" `
+        -out $TargetingPackMSIOutput | Out-Host
+
+    if($LastExitCode -ne 0)
+    {
+        $result = $false
+        Write-Host "Light failed with exit code $LastExitCode."
+    }
+
+    popd
+    return $result
+}
+
+if(!(Test-Path $TargetingPackPublishRoot))
+{
+    throw "$TargetingPackPublishRoot not found"
+}
+
+if(!(Test-Path $WixObjRoot))
+{
+    throw "$WixObjRoot not found"
+}
+
+Write-Host "Creating Targeting Pack MSI at $TargetingPackMSIOutput"
+
+if([string]::IsNullOrEmpty($WixRoot))
+{
+    Exit -1
+}
+
+if(-Not (RunHeat))
+{
+    Exit -1
+}
+
+if(-Not (RunCandle))
+{
+    Exit -1
+}
+
+if(-Not (RunLight))
+{
+    Exit -1
+}
+
+if(!(Test-Path $TargetingPackMSIOutput))
+{
+    throw "Unable to create the Targeting Pack MSI."
+    Exit -1
+}
+
+Write-Host -ForegroundColor Green "Successfully created Targeting Pack MSI - $TargetingPackMSIOutput"
+
+exit $LastExitCode

--- a/src/pkg/packaging/windows/targetingpack/provider.wxs
+++ b/src/pkg/packaging/windows/targetingpack/provider.wxs
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<Wix xmlns="http://schemas.microsoft.com/wix/2006/wi" xmlns:dep="http://schemas.microsoft.com/wix/DependencyExtension">
+  <?include "Variables.wxi" ?>
+  <Fragment>
+    <Component Id="$(var.DependencyKeyId)" Directory="TARGETDIR" Win64="no" Guid="117B1755-5027-4257-A1A9-7C37D81C3D5F">
+      <dep:Provides Key="$(var.DependencyKey)" />
+    </Component>
+  </Fragment>
+</Wix>

--- a/src/pkg/packaging/windows/targetingpack/targetingpack.wxs
+++ b/src/pkg/packaging/windows/targetingpack/targetingpack.wxs
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
+    <?include "Variables.wxi" ?>
+    <Product Id="*" Name="$(var.ProductName)" Language="$(var.ProductLanguage)" Version="$(var.ProductVersion)" Manufacturer="$(var.Manufacturer)" UpgradeCode="$(var.UpgradeCode)">
+        <Package Compressed="yes" InstallScope="perMachine" InstallerVersion="200" />
+
+        <MajorUpgrade DowngradeErrorMessage="$(var.DowngradeErrorMessage)" Schedule="afterInstallInitialize"/>
+
+        <MediaTemplate CompressionLevel="high" EmbedCab="yes" />
+
+        <Feature Id="MainFeature" Title="Main Feature" Level="1">
+            <ComponentGroupRef Id="InstallFiles" />
+        </Feature>
+        <Feature Id="Provider" Absent="disallow" AllowAdvertise="no" Description="Used for Ref Counting" Display="hidden" Level="1" InstallDefault="local" Title="RefCounting" TypicalDefault="install">
+            <ComponentRef Id="$(var.DependencyKeyId)" />
+        </Feature>
+        <Property Id="ProductCPU" Value="$(var.Platform)" />
+        <Property Id="RTM_ProductVersion" Value="$(var.Dotnet_ProductVersion)" />
+
+        <Property Id="MSIFASTINSTALL" Value="7" />
+
+        <WixVariable Id="WixUILicenseRtf" Value="$(var.MicrosoftEula)" />
+
+        <Property Id="WIXUI_INSTALLDIR" Value="DOTNETHOME"/>
+        <UIRef Id="WixUI_InstallDir" />
+
+        <CustomActionRef Id="WixBroadcastEnvironmentChange" />
+    </Product>
+    <Fragment>
+        <Directory Id="TARGETDIR" Name="SourceDir">
+            <Directory Id="$(var.Program_Files)">
+                <Directory Id="DOTNETHOME" Name="dotnet"/>
+            </Directory>
+        </Directory>
+    </Fragment>
+</Wix>

--- a/src/pkg/packaging/windows/targetingpack/variables.wxi
+++ b/src/pkg/packaging/windows/targetingpack/variables.wxi
@@ -1,0 +1,26 @@
+<?xml version="1.0"?>
+<Include xmlns="http://schemas.microsoft.com/wix/2006/wi">
+
+  <?define Dotnet_ProductVersion   =   "$(var.BuildVersion)" ?>
+  <?define Dotnet_BuildVersion   =   "$(var.BuildVersion)" ?>
+  <?define Manufacturer     =   "Microsoft Corporation" ?>
+  <?define ProductName      =   "$(var.ProductMoniker) ($(var.TargetArchitecture))" ?>
+  <?define ProductLanguage  =   "1033" ?>
+  <?define ProductVersion   =   "$(var.Dotnet_ProductVersion)" ?>
+  <?define LCID  = "$(var.ProductLanguage)"?>
+  <?define DowngradeErrorMessage  = "A newer version is already installed; please uninstall it and re-run setup."?>
+
+  <?define Platform   =   "$(sys.BUILDARCH)" ?>
+  <?if $(var.Platform)=x86?>
+  <?define Program_Files="ProgramFilesFolder"?>
+  <?define Win64AttributeValue=no?>
+  <?elseif $(var.Platform)=x64?>
+  <?define Program_Files="ProgramFiles64Folder"?>
+  <?define Win64AttributeValue=yes?>
+  <?else?>
+  <?error Invalid Platform ($(var.Platform))?>
+  <?endif?>
+
+  <?define DependencyKey   = "Dotnet_CLI_TargetingPack_$(var.BuildVersion)_$(var.Platform)"?>
+  <?define DependencyKeyId = "$(var.DependencyKey)" ?>
+</Include>

--- a/src/pkg/packaging/windows/targetingpack/variables.wxi
+++ b/src/pkg/packaging/windows/targetingpack/variables.wxi
@@ -21,6 +21,6 @@
   <?error Invalid Platform ($(var.Platform))?>
   <?endif?>
 
-  <?define DependencyKey   = "Dotnet_CLI_TargetingPack_$(var.BuildVersion)_$(var.Platform)"?>
+  <?define DependencyKey   = "Dotnet_Core_TargetingPack_$(var.BuildVersion)_$(var.Platform)"?>
   <?define DependencyKeyId = "$(var.DependencyKey)" ?>
 </Include>

--- a/src/pkg/projects/Microsoft.NETCore.App.Ref/Microsoft.NETCore.App.Ref.pkgproj
+++ b/src/pkg/projects/Microsoft.NETCore.App.Ref/Microsoft.NETCore.App.Ref.pkgproj
@@ -18,6 +18,9 @@
     <!-- Remove package dependencies. -->
     <ExcludeLineupReference>true</ExcludeLineupReference>
     <PackProjectDependencies>false</PackProjectDependencies>
+
+    <!-- Location to lay out data/ dir. Used later to create installers. -->
+    <DataLayoutDir>$(IntermediateOutputPath)layout/</DataLayoutDir>
   </PropertyGroup>
 
   <!-- Redistribute package content from other nuget packages. -->
@@ -37,6 +40,37 @@
         Condition="$([System.String]::new('%(File.TargetPath)').StartsWith('ref'))"
         TargetPath="data/" />
     </ItemGroup>
+  </Target>
+
+  <!--
+    Copy the files in the package's data/ dir to a layout directory. This is what the targeting pack
+    installer will place in the dotnet install dir.
+
+    This extracts from the nupkg (zip) directly. An alternative would be using the PackageFile
+    items, but there's some risk of handling TargetPath metadata differently than NuGet does. Using
+    the nupkg directly ensures results are identical.
+  -->
+  <Target Name="CreateTargetingPackLayout"
+          AfterTargets="CreatePackage">
+    <PropertyGroup>
+      <TargetingPackNupkgFile>$(PackageOutputPath)$(Id).$(PackageVersion).nupkg</TargetingPackNupkgFile>
+    </PropertyGroup>
+
+    <ZipFileGetEntries TargetArchive="$(TargetingPackNupkgFile)">
+      <Output TaskParameter="Entries" ItemName="TargetingPackNupkgEntries" />
+    </ZipFileGetEntries>
+
+    <ItemGroup>
+      <TargetingPackDataEntries
+        Include="@(TargetingPackNupkgEntries)"
+        Condition="$([System.String]::new('%(TargetingPackNupkgEntries.Identity)').StartsWith('data/'))" />
+    </ItemGroup>
+
+    <ZipFileExtractToDirectory
+      SourceArchive="$(TargetingPackNupkgFile)"
+      DestinationDirectory="$(DataLayoutDir)ref/$(Id)/$(Version)/"
+      OverwriteDestination="true"
+      Include="@(TargetingPackDataEntries)" />
   </Target>
 
 </Project>

--- a/src/pkg/projects/Microsoft.NETCore.App.Ref/Microsoft.NETCore.App.Ref.pkgproj
+++ b/src/pkg/projects/Microsoft.NETCore.App.Ref/Microsoft.NETCore.App.Ref.pkgproj
@@ -68,7 +68,7 @@
 
     <ZipFileExtractToDirectory
       SourceArchive="$(TargetingPackNupkgFile)"
-      DestinationDirectory="$(DataLayoutDir)ref/$(Id)/$(Version)/"
+      DestinationDirectory="$(DataLayoutDir)packs/$(Id)/$(Version)/"
       OverwriteDestination="true"
       Include="@(TargetingPackDataEntries)" />
   </Target>

--- a/tools-local/tasks/GenerateGuidFromName.cs
+++ b/tools-local/tasks/GenerateGuidFromName.cs
@@ -12,8 +12,9 @@ namespace Microsoft.DotNet.Build.Tasks
     {
         [Required]
         public string Name { get; set; }
+
         [Output]
-        public string GeneratedGui { get; set; }
+        public string GeneratedGuid { get; set; }
 
         // Generate a Version 5 (SHA1 Name Based) Guid from a name.
         public override bool Execute()
@@ -44,7 +45,7 @@ namespace Microsoft.DotNet.Build.Tasks
 
                 SwapGuidByteOrder(res);
 
-                GeneratedGui = (new Guid(res)).ToString();
+                GeneratedGuid = (new Guid(res)).ToString();
             }
 
             return true;


### PR DESCRIPTION
This change has the targeting pack pkgproj create an install layout based on the nupkg's data/ dir. That's picked up by the targeting pack installer project the same way it is for hostfxr and shared framework. In general, the targeting pack installer project is a copy of existing installers with very little changed.

In official builds, build the full platform manifest on win-x86, not just win-x64. Both platforms' installers need the full manifest.

---

A wrinkle about building on x64 and x86: the `Microsoft.NETCore.App.Ref` nupkg is built once on each, so there's a chance of differences. I diffed the installed bits, and everything's identical except ordering of the lines in the platform manifest.

Ultimately it would be safest to feed one targeting pack nupkg to all the legs to package up. For now I could sort the platform manifest if order affects how the file's used at all.

For https://github.com/dotnet/core-setup/issues/4772

---

The three installer projects in core-setup were very copy-paste heavy, and this PR adds a fourth. I plan to refactor this to remove a lot of the duplication, and I'm waiting to do that to get the MSI validated in the SDK ASAP. I mentioned this in a mail thread but missed it in the original PR description.

List of things I plan to do before I make another installer:

* Remove `generatemsi.ps1` powershell scripts, use msbuild projects with shared targets.
  * Peek at wixproj, but likely stick with `Exec`s for now.
* Consider unifying targeting pack installer creation with targeting pack pkgproj. This could make the targeting pack creation entry point cleaner.
  * I also want to look into merging `Microsoft.NETCore.App.Ref.pkgproj` into `Microsoft.NETCore.App.pkgproj`, and using it to drive other packs (Runtime, AppHost) as well. Same goal: cleaner entry point.
* Share WiX project files to avoid boilerplate.
