### PR TITLE
Simplify computation of oldest framework reference

### DIFF
--- a/src/corehost/cli/fxr/fx_muxer.h
+++ b/src/corehost/cli/fxr/fx_muxer.h
@@ -106,13 +106,11 @@ private:
         const fx_reference_t& newer,
         const fx_reference_t& older,
         bool older_is_hard_roll_forward,
-        fx_name_to_fx_reference_map_t& newest_references,
-        fx_name_to_fx_reference_map_t& oldest_references);
+        fx_name_to_fx_reference_map_t& newest_references);
     static int soft_roll_forward(
         const fx_reference_t existing_ref,
         bool current_is_hard_roll_forward,
-        fx_name_to_fx_reference_map_t& newest_references,
-        fx_name_to_fx_reference_map_t& oldest_references);
+        fx_name_to_fx_reference_map_t& newest_references);
     static void display_missing_framework_error(
         const pal::string_t& fx_name,
         const pal::string_t& fx_version,


### PR DESCRIPTION
Instead of passing the list of oldest references all the way down to the code which performs roll forwards, simply assign to it when we enumerate reerences for the first time.
The only difference is that in case of a failure the oldest reference will be filled while before it would not be fully up to date.

This is just a very minor refactoring.