### PR TITLE
Create framework assembly list file in .NET Core targeting pack

### DIFF
--- a/dir.props
+++ b/dir.props
@@ -33,8 +33,11 @@
 
   <PropertyGroup>
     <SharedFrameworkName>Microsoft.NETCore.App</SharedFrameworkName>
-    <NETCoreAppFrameworkMoniker>.NETCoreApp,Version=v$(MajorVersion).$(MinorVersion)</NETCoreAppFrameworkMoniker>
-    <NETCoreAppFramework>netcoreapp$(MajorVersion).$(MinorVersion)</NETCoreAppFramework>
+    <NETCoreAppFrameworkIdentifier>.NETCoreApp</NETCoreAppFrameworkIdentifier>
+    <NETCoreAppFrameworkVersion>$(MajorVersion).$(MinorVersion)</NETCoreAppFrameworkVersion>
+    <NETCoreAppFrameworkMoniker>$(NETCoreAppFrameworkIdentifier),Version=v$(NETCoreAppFrameworkVersion)</NETCoreAppFrameworkMoniker>
+    <NETCoreAppFramework>netcoreapp$(NETCoreAppFrameworkVersion)</NETCoreAppFramework>
+    <NETCoreAppFrameworkBrandName>.NET Core $(NETCoreAppFrameworkVersion)</NETCoreAppFrameworkBrandName>
   </PropertyGroup>
 
   <!--

--- a/src/pkg/projects/Microsoft.NETCore.App.Ref/Microsoft.NETCore.App.Ref.pkgproj
+++ b/src/pkg/projects/Microsoft.NETCore.App.Ref/Microsoft.NETCore.App.Ref.pkgproj
@@ -9,8 +9,8 @@
     <SkipValidatePackage>true</SkipValidatePackage>
 
     <!-- Include the platform manifest in the data dir. -->
-    <PlatformManifestTargetPath>data/</PlatformManifestTargetPath>
-    <FrameworkListTargetPath>$(PlatformManifestTargetPath)</FrameworkListTargetPath>
+    <PlatformManifestTargetPath>data/PlatformManifest.txt</PlatformManifestTargetPath>
+    <FrameworkListTargetPath>data/</FrameworkListTargetPath>
 
     <!-- Exclude runtime.json from the package. -->
     <IncludeRuntimeJson>false</IncludeRuntimeJson>

--- a/src/pkg/projects/Microsoft.NETCore.App.Ref/Microsoft.NETCore.App.Ref.pkgproj
+++ b/src/pkg/projects/Microsoft.NETCore.App.Ref/Microsoft.NETCore.App.Ref.pkgproj
@@ -10,6 +10,7 @@
 
     <!-- Include the platform manifest in the data dir. -->
     <PlatformManifestTargetPath>data/</PlatformManifestTargetPath>
+    <FrameworkListTargetPath>$(PlatformManifestTargetPath)</FrameworkListTargetPath>
 
     <!-- Exclude runtime.json from the package. -->
     <IncludeRuntimeJson>false</IncludeRuntimeJson>

--- a/src/pkg/projects/dir.props
+++ b/src/pkg/projects/dir.props
@@ -20,6 +20,13 @@
     <PackProjectDependencies>true</PackProjectDependencies>
   </PropertyGroup>
 
+  <ItemGroup>
+    <FrameworkListRootAttributes Include="Name" Value="$(NETCoreAppFrameworkBrandName)" />
+    <FrameworkListRootAttributes Include="TargetFrameworkIdentifier" Value="$(NETCoreAppFrameworkIdentifier)" />
+    <FrameworkListRootAttributes Include="TargetFrameworkVersion" Value="$(NETCoreAppFrameworkVersion)" />
+    <FrameworkListRootAttributes Include="FrameworkName" Value="$(SharedFrameworkName)" />
+  </ItemGroup>
+
   <PropertyGroup Condition="'$(PackageTargetRuntime)' == ''">
     <SkipValidatePackage>true</SkipValidatePackage>
     <IncludeRuntimeJson>true</IncludeRuntimeJson>

--- a/src/pkg/projects/dir.targets
+++ b/src/pkg/projects/dir.targets
@@ -1,6 +1,7 @@
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\dir.targets" />
 
+  <UsingTask TaskName="CreateFrameworkListFile" AssemblyFile="$(LocalBuildToolsTaskDir)core-setup.tasks.dll"/>
   <UsingTask TaskName="GenerateFileVersionProps" AssemblyFile="$(LocalBuildToolsTaskDir)core-setup.tasks.dll"/>
 
   <PropertyGroup>
@@ -176,6 +177,25 @@
     <ItemGroup>
       <File Include="$(PlatformManifestFile)">
         <TargetPath>$(PlatformManifestTargetPath)</TargetPath>
+      </File>
+    </ItemGroup>
+  </Target>
+
+  <Target Name="IncludeFrameworkListFile"
+          BeforeTargets="GetFiles"
+          Condition="'$(PackageTargetRuntime)' == '' AND '$(FrameworkListTargetPath)' != ''">
+    <PropertyGroup>
+      <FrameworkListFile>$(IntermediateOutputPath)FrameworkList.xml</FrameworkListFile>
+    </PropertyGroup>
+
+    <CreateFrameworkListFile
+      Files="@(File)"
+      TargetFile="$(FrameworkListFile)"
+      RootAttributes="@(FrameworkListRootAttributes)" />
+
+    <ItemGroup>
+      <File Include="$(FrameworkListFile)">
+        <TargetPath>$(FrameworkListTargetPath)</TargetPath>
       </File>
     </ItemGroup>
   </Target>

--- a/tools-local/tasks/CreateFrameworkListFile.cs
+++ b/tools-local/tasks/CreateFrameworkListFile.cs
@@ -1,0 +1,81 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Build.Framework;
+using System;
+using System.IO;
+using System.Linq;
+using System.Xml.Linq;
+
+namespace Microsoft.DotNet.Build.Tasks
+{
+    public class CreateFrameworkListFile : BuildTask
+    {
+        /// <summary>
+        /// Files to extract basic information from and include in the list.
+        /// </summary>
+        [Required]
+        public ITaskItem[] Files { get; set; }
+
+        [Required]
+        public string TargetFile { get; set; }
+
+        /// <summary>
+        /// Extra attributes to place on the root node.
+        /// 
+        /// %(Identity): Attribute name.
+        /// %(Value): Attribute value.
+        /// </summary>
+        public ITaskItem[] RootAttributes { get; set; }
+
+        public override bool Execute()
+        {
+            XAttribute[] rootAttributes = RootAttributes
+                ?.Select(item => new XAttribute(item.ItemSpec, item.GetMetadata("Value")))
+                .ToArray();
+
+            var frameworkManifest = new XElement("FileList", rootAttributes);
+
+            foreach (var f in Files
+                .Where(item =>
+                    item.GetMetadata("TargetPath")?.StartsWith("data/") == true &&
+                    item.ItemSpec.EndsWith(".dll", StringComparison.OrdinalIgnoreCase))
+                .Select(item => new
+                {
+                    Item = item,
+                    AssemblyName = FileUtilities.GetAssemblyName(item.ItemSpec),
+                    FileVersion = FileUtilities.GetFileVersion(item.ItemSpec)
+                })
+                .Where(f => f.AssemblyName != null)
+                .OrderBy(f => f.Item.ItemSpec, StringComparer.OrdinalIgnoreCase))
+            {
+                string publicKeyToken = ToLowercaseHexString(f.AssemblyName.GetPublicKeyToken());
+
+                frameworkManifest.Add(new XElement(
+                    "File",
+                    new XAttribute("AssemblyName", f.AssemblyName.Name),
+                    new XAttribute("PublicKeyToken", publicKeyToken),
+                    new XAttribute("AssemblyVersion", f.AssemblyName.Version),
+                    new XAttribute("FileVersion", f.FileVersion)));
+            }
+
+            Directory.CreateDirectory(Path.GetDirectoryName(TargetFile));
+            File.WriteAllText(TargetFile, frameworkManifest.ToString());
+
+            return !Log.HasLoggedErrors;
+        }
+
+        private static string ToLowercaseHexString(byte[] bytes)
+        {
+            if (bytes == null)
+            {
+                return null;
+            }
+
+            return BitConverter.ToString(bytes)
+                .ToLowerInvariant()
+                .Replace("-", "");
+        }
+    }
+}

--- a/tools-local/tasks/FileUtilities.cs
+++ b/tools-local/tasks/FileUtilities.cs
@@ -10,7 +10,7 @@ using System.Reflection;
 
 namespace Microsoft.DotNet.Build.Tasks
 {
-    static partial class FileUtilities
+    internal static partial class FileUtilities
     {
         public static Version GetFileVersion(string sourcePath)
         {
@@ -25,20 +25,21 @@ namespace Microsoft.DotNet.Build.Tasks
         }
 
         static readonly HashSet<string> s_assemblyExtensions = new HashSet<string>(new[] { ".dll", ".exe", ".winmd" }, StringComparer.OrdinalIgnoreCase);
-        public static Version TryGetAssemblyVersion(string sourcePath)
-        {
-            var extension = Path.GetExtension(sourcePath);
 
-            return s_assemblyExtensions.Contains(extension) ? GetAssemblyVersion(sourcePath) : null;
-        }
-        private static Version GetAssemblyVersion(string sourcePath)
+        public static AssemblyName GetAssemblyName(string path)
         {
+            if (!s_assemblyExtensions.Contains(Path.GetExtension(path)))
+            {
+                return null;
+            }
+
             try
             {
-                return AssemblyName.GetAssemblyName(sourcePath)?.Version;
+                return AssemblyName.GetAssemblyName(path);
             }
             catch (BadImageFormatException)
             {
+                // Not a valid assembly.
                 return null;
             }
         }

--- a/tools-local/tasks/FileUtilities.cs
+++ b/tools-local/tasks/FileUtilities.cs
@@ -12,6 +12,10 @@ namespace Microsoft.DotNet.Build.Tasks
 {
     internal static partial class FileUtilities
     {
+        private static readonly HashSet<string> s_assemblyExtensions = new HashSet<string>(
+            new[] { ".dll", ".exe", ".winmd" },
+            StringComparer.OrdinalIgnoreCase);
+
         public static Version GetFileVersion(string sourcePath)
         {
             var fvi = FileVersionInfo.GetVersionInfo(sourcePath);
@@ -23,8 +27,6 @@ namespace Microsoft.DotNet.Build.Tasks
 
             return null;
         }
-
-        static readonly HashSet<string> s_assemblyExtensions = new HashSet<string>(new[] { ".dll", ".exe", ".winmd" }, StringComparer.OrdinalIgnoreCase);
 
         public static AssemblyName GetAssemblyName(string path)
         {

--- a/tools-local/tasks/GenerateFileVersionProps.cs
+++ b/tools-local/tasks/GenerateFileVersionProps.cs
@@ -131,7 +131,7 @@ namespace Microsoft.DotNet.Build.Tasks
             {
                 return new FileVersionData()
                 {
-                    AssemblyVersion = FileUtilities.TryGetAssemblyVersion(filePath),
+                    AssemblyVersion = FileUtilities.GetAssemblyName(filePath)?.Version,
                     FileVersion = FileUtilities.GetFileVersion(filePath)
                 };
             }


### PR DESCRIPTION
This adds `data/FrameworkList.xml` to the targeting pack with contents like this:

```xml
<FileList Name=".NET Core 3.0" TargetFrameworkIdentifier=".NETCoreApp" TargetFrameworkVersion="3.0" FrameworkName="Microsoft.NETCore.App">
  <File AssemblyName="Microsoft.CSharp" PublicKeyToken="b03f5f7f11d50a3a" AssemblyVersion="4.0.0.0" FileVersion="4.7.19.11304" />
  <File AssemblyName="Microsoft.VisualBasic.Core" PublicKeyToken="b03f5f7f11d50a3a" AssemblyVersion="10.0.4.0" FileVersion="4.7.19.11304" />
  <File AssemblyName="Microsoft.VisualBasic" PublicKeyToken="b03f5f7f11d50a3a" AssemblyVersion="10.0.0.0" FileVersion="14.7.3060.0" />
  <File AssemblyName="Microsoft.Win32.Primitives" PublicKeyToken="b03f5f7f11d50a3a" AssemblyVersion="4.1.1.0" FileVersion="4.7.19.11304" />
  <File AssemblyName="mscorlib" PublicKeyToken="b77a5c561934e089" AssemblyVersion="4.0.0.0" FileVersion="4.7.3060.0" />
  <File AssemblyName="netstandard" PublicKeyToken="cc7b13ffcd2ddd51" AssemblyVersion="2.1.0.0" FileVersion="1.1.19.7403" />
...
```

This is for https://github.com/dotnet/core-setup/issues/5074.

It might make more sense to name it `Microsoft.NETCore.App.Ref.FrameworkList.txt`, like the platform manifest--just went with what I first heard since I don't think there's a spec for this yet.

@dsplaisted @nguerrera 