### PR TITLE
[release/2.1] Set createLogFile to false for msbuild steps, fix official build

### DIFF
--- a/buildpipeline/Core-Setup-Windows-Arm-BT.json
+++ b/buildpipeline/Core-Setup-Windows-Arm-BT.json
@@ -261,7 +261,7 @@
         "maximumCpuCount": "false",
         "restoreNugetPackages": "false",
         "logProjectEvents": "false",
-        "createLogFile": "true"
+        "createLogFile": "false"
       }
     },
     {

--- a/buildpipeline/Core-Setup-Windows-BT.json
+++ b/buildpipeline/Core-Setup-Windows-BT.json
@@ -261,7 +261,7 @@
         "maximumCpuCount": "false",
         "restoreNugetPackages": "false",
         "logProjectEvents": "false",
-        "createLogFile": "true"
+        "createLogFile": "false"
       }
     },
     {


### PR DESCRIPTION
createLogFile "true" sets flp and expects the log file it specifies to be present when the step completes. Our arguments include another flp parameter that overrides the task's built-in flp, causing the file not to exist, failing the build. Fix this by setting createLogFile "false".

