### PR TITLE
Fix product name included in the binaries

### DIFF
--- a/dir.targets
+++ b/dir.targets
@@ -72,7 +72,7 @@
       <NativeVersionLines Include="#define VER_ORIGINALFILENAME_STR    VER_FILEDESCRIPTION_STR" />
       <NativeVersionLines Include="#endif" />
       <NativeVersionLines Include="#ifndef VER_PRODUCTNAME_STR" />
-      <NativeVersionLines Include="#define VER_PRODUCTNAME_STR         &quot;Microsoft\xae .NET Core Framework&quot;" />
+      <NativeVersionLines Include="#define VER_PRODUCTNAME_STR         &quot;Microsoft\xae .NET Core&quot;" />
       <NativeVersionLines Include="#endif" />
       <NativeVersionLines Include="#undef VER_PRODUCTVERSION" />
       <NativeVersionLines Include="#define VER_PRODUCTVERSION          $(MajorVersion),$(MinorVersion),$(BuildNumberMajor),$(BuildNumberMinor)" />

--- a/src/corehost/cli/fxr/fx_muxer.cpp
+++ b/src/corehost/cli/fxr/fx_muxer.cpp
@@ -243,7 +243,7 @@ void fx_muxer_t::display_missing_framework_error(
 
     trace::error(_X("  - Check application dependencies and target a framework version installed at:"));
     trace::error(_X("      %s"), fx_ver_dirs.c_str());
-    trace::error(_X("  - The .NET Core framework and SDK can be installed from:"));
+    trace::error(_X("  - The .NET Core Runtime and SDK can be installed from:"));
     trace::error(_X("      %s"), DOTNET_CORE_DOWNLOAD_URL);
 
     // Gather the list of versions installed at the shared FX location.


### PR DESCRIPTION
There is no product called ".NET Core Framework".