### PR TITLE
Remove DependencyModel's dependency on PlatformAbstractions

### DIFF
--- a/src/managed/Microsoft.Extensions.DependencyModel/ApplicationEnvironment.cs
+++ b/src/managed/Microsoft.Extensions.DependencyModel/ApplicationEnvironment.cs
@@ -1,0 +1,25 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.IO;
+
+namespace Microsoft.Extensions.DependencyModel
+{
+    internal static class ApplicationEnvironment
+    {
+        public static string ApplicationBasePath { get; } = GetApplicationBasePath();
+
+        private static string GetApplicationBasePath()
+        {
+            var basePath =
+#if NET451
+                (string)AppDomain.CurrentDomain.GetData("APP_CONTEXT_BASE_DIRECTORY") ??
+                AppDomain.CurrentDomain.BaseDirectory;
+#else
+                AppContext.BaseDirectory;
+#endif
+            return Path.GetFullPath(basePath);
+        }
+    }
+}

--- a/src/managed/Microsoft.Extensions.DependencyModel/ApplicationEnvironment.cs
+++ b/src/managed/Microsoft.Extensions.DependencyModel/ApplicationEnvironment.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Extensions.DependencyModel
 
         private static string GetApplicationBasePath()
         {
-            var basePath =
+            string basePath =
 #if NET451
                 (string)AppDomain.CurrentDomain.GetData("APP_CONTEXT_BASE_DIRECTORY") ??
                 AppDomain.CurrentDomain.BaseDirectory;

--- a/src/managed/Microsoft.Extensions.DependencyModel/EnvironmentWrapper.cs
+++ b/src/managed/Microsoft.Extensions.DependencyModel/EnvironmentWrapper.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Runtime.InteropServices;
 
 namespace Microsoft.Extensions.DependencyModel
 {
@@ -12,6 +13,11 @@ namespace Microsoft.Extensions.DependencyModel
         public string GetEnvironmentVariable(string name)
         {
             return Environment.GetEnvironmentVariable(name);
+        }
+
+        public bool IsWindows()
+        {
+            return RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
         }
     }
 }

--- a/src/managed/Microsoft.Extensions.DependencyModel/IEnvironment.cs
+++ b/src/managed/Microsoft.Extensions.DependencyModel/IEnvironment.cs
@@ -6,5 +6,6 @@ namespace Microsoft.Extensions.DependencyModel
     internal interface IEnvironment
     {
         string GetEnvironmentVariable(string name);
+        bool IsWindows();
     }
 }

--- a/src/managed/Microsoft.Extensions.DependencyModel/Microsoft.Extensions.DependencyModel.csproj
+++ b/src/managed/Microsoft.Extensions.DependencyModel/Microsoft.Extensions.DependencyModel.csproj
@@ -8,6 +8,10 @@
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
 
+  <ItemGroup>
+    <Compile Include="..\Microsoft.DotNet.PlatformAbstractions\HashCodeCombiner.cs" />
+  </ItemGroup>
+  
   <Choose>
     <!--
     Since we added a target for netstandard2.0 so users aren't forced to download the 1.x dependencies,
@@ -39,6 +43,7 @@
     <Otherwise>
       <ItemGroup>
         <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
+        <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.0.0" />
       </ItemGroup>
       <ItemGroup>
         <Compile Remove="ArrayBufferWriter.cs" />
@@ -50,16 +55,11 @@
     </Otherwise>
   </Choose>
 
-  <ItemGroup>
-    <ProjectReference Include="..\Microsoft.DotNet.PlatformAbstractions\Microsoft.DotNet.PlatformAbstractions.csproj" />
-  </ItemGroup>
-
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' Or '$(TargetFramework)' == 'netstandard1.6' ">
+    <PackageReference Include="System.AppContext" Version="4.1.0" />
     <PackageReference Include="System.Diagnostics.Debug" Version="4.0.11" />
     <PackageReference Include="System.Dynamic.Runtime" Version="4.0.11" />
-    <PackageReference Include="System.Linq" Version="4.1.0" />
-    <PackageReference Include="System.Diagnostics.Debug" Version="4.0.11" />
-    <PackageReference Include="System.Dynamic.Runtime" Version="4.0.11" />
+    <PackageReference Include="System.IO.FileSystem" Version="4.0.1" />
     <PackageReference Include="System.Linq" Version="4.1.0" />
   </ItemGroup>
 

--- a/src/managed/Microsoft.Extensions.DependencyModel/Resolution/AppBaseCompilationAssemblyResolver.cs
+++ b/src/managed/Microsoft.Extensions.DependencyModel/Resolution/AppBaseCompilationAssemblyResolver.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using Microsoft.DotNet.PlatformAbstractions;
 
 #if !NETSTANDARD1_3
 

--- a/src/managed/Microsoft.Extensions.DependencyModel/Resolution/DotNetReferenceAssembliesPathResolver.cs
+++ b/src/managed/Microsoft.Extensions.DependencyModel/Resolution/DotNetReferenceAssembliesPathResolver.cs
@@ -1,7 +1,7 @@
 // Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using Microsoft.DotNet.PlatformAbstractions;
+using System.Runtime.InteropServices;
 
 namespace Microsoft.Extensions.DependencyModel.Resolution
 {
@@ -27,14 +27,12 @@ namespace Microsoft.Extensions.DependencyModel.Resolution
 
         private static string GetDefaultDotNetReferenceAssembliesPath(IFileSystem fileSystem)
         {
-            var os = RuntimeEnvironment.OperatingSystemPlatform;
-
-            if (os == Platform.Windows)
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
                 return null;
             }
 
-            if (os == Platform.Darwin &&
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX) &&
                 fileSystem.Directory.Exists("/Library/Frameworks/Mono.framework/Versions/Current/lib/mono/xbuild-frameworks"))
             {
                 return "/Library/Frameworks/Mono.framework/Versions/Current/lib/mono/xbuild-frameworks";

--- a/src/managed/Microsoft.Extensions.DependencyModel/Resolution/PackageCompilationAssemblyResolver.cs
+++ b/src/managed/Microsoft.Extensions.DependencyModel/Resolution/PackageCompilationAssemblyResolver.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using Microsoft.DotNet.PlatformAbstractions;
 
 namespace Microsoft.Extensions.DependencyModel.Resolution
 {
@@ -35,10 +34,7 @@ namespace Microsoft.Extensions.DependencyModel.Resolution
             _nugetPackageDirectories = nugetPackageDirectories;
         }
 
-        private static string[] GetDefaultProbeDirectories(IEnvironment environment) =>
-            GetDefaultProbeDirectories(RuntimeEnvironment.OperatingSystemPlatform, environment);
-
-        internal static string[] GetDefaultProbeDirectories(Platform osPlatform, IEnvironment environment)
+        internal static string[] GetDefaultProbeDirectories(IEnvironment environment)
         {
 #if !NETSTANDARD1_3            
 #if NETSTANDARD1_6
@@ -47,38 +43,37 @@ namespace Microsoft.Extensions.DependencyModel.Resolution
             var probeDirectories = AppDomain.CurrentDomain.GetData("PROBING_DIRECTORIES");
 #endif
 
-           var listOfDirectories = probeDirectories as string;
+            var listOfDirectories = probeDirectories as string;
 
-           if (!string.IsNullOrEmpty(listOfDirectories))
-           {
-               return listOfDirectories.Split(new char [] { Path.PathSeparator }, StringSplitOptions.RemoveEmptyEntries );
-           }
+            if (!string.IsNullOrEmpty(listOfDirectories))
+            {
+                return listOfDirectories.Split(new char[] { Path.PathSeparator }, StringSplitOptions.RemoveEmptyEntries);
+            }
 #endif
 
-           var packageDirectory = environment.GetEnvironmentVariable("NUGET_PACKAGES");
+            var packageDirectory = environment.GetEnvironmentVariable("NUGET_PACKAGES");
 
-           if (!string.IsNullOrEmpty(packageDirectory))
-           {
-               return new string[] { packageDirectory };
-           }
+            if (!string.IsNullOrEmpty(packageDirectory))
+            {
+                return new string[] { packageDirectory };
+            }
 
-           string basePath;
-           if (osPlatform == Platform.Windows)
-           {
-               basePath = environment.GetEnvironmentVariable("USERPROFILE");
-           }
-           else
-           {
-               basePath = environment.GetEnvironmentVariable("HOME");
-           }
+            string basePath;
+            if (environment.IsWindows())
+            {
+                basePath = environment.GetEnvironmentVariable("USERPROFILE");
+            }
+            else
+            {
+                basePath = environment.GetEnvironmentVariable("HOME");
+            }
 
-           if (string.IsNullOrEmpty(basePath))
-           {
-               return new string[] { string.Empty };
-           }
+            if (string.IsNullOrEmpty(basePath))
+            {
+                return new string[] { string.Empty };
+            }
 
-           return new string[] { Path.Combine(basePath, ".nuget", "packages") };
-
+            return new string[] { Path.Combine(basePath, ".nuget", "packages") };
         }
 
         public bool TryResolveAssemblyPaths(CompilationLibrary library, List<string> assemblies)

--- a/src/managed/Microsoft.Extensions.DependencyModel/Resolution/ReferenceAssemblyPathResolver.cs
+++ b/src/managed/Microsoft.Extensions.DependencyModel/Resolution/ReferenceAssemblyPathResolver.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using Microsoft.DotNet.PlatformAbstractions;
 
 namespace Microsoft.Extensions.DependencyModel.Resolution
 {
@@ -26,8 +25,8 @@ namespace Microsoft.Extensions.DependencyModel.Resolution
 
         internal ReferenceAssemblyPathResolver(IFileSystem fileSystem, IEnvironment environment)
             : this(fileSystem,
-                GetDefaultReferenceAssembliesPath(fileSystem, RuntimeEnvironment.OperatingSystemPlatform, environment),
-                GetFallbackSearchPaths(fileSystem, RuntimeEnvironment.OperatingSystemPlatform, environment))
+                GetDefaultReferenceAssembliesPath(fileSystem, environment),
+                GetFallbackSearchPaths(fileSystem, environment))
         {
         }
 
@@ -84,9 +83,9 @@ namespace Microsoft.Extensions.DependencyModel.Resolution
             return false;
         }
 
-        internal static string[] GetFallbackSearchPaths(IFileSystem fileSystem, Platform platform, IEnvironment environment)
+        internal static string[] GetFallbackSearchPaths(IFileSystem fileSystem, IEnvironment environment)
         {
-            if (platform != Platform.Windows)
+            if (!environment.IsWindows())
             {
                 return new string[0];
             }
@@ -100,7 +99,7 @@ namespace Microsoft.Extensions.DependencyModel.Resolution
             return new[] { net20Dir };
         }
 
-        internal static string GetDefaultReferenceAssembliesPath(IFileSystem fileSystem, Platform platform, IEnvironment environment)
+        internal static string GetDefaultReferenceAssembliesPath(IFileSystem fileSystem, IEnvironment environment)
         {
             // Allow setting the reference assemblies path via an environment variable
             var referenceAssembliesPath = DotNetReferenceAssembliesPathResolver.Resolve(environment, fileSystem); 
@@ -109,7 +108,7 @@ namespace Microsoft.Extensions.DependencyModel.Resolution
                 return referenceAssembliesPath;
             }
 
-            if (platform != Platform.Windows)
+            if (!environment.IsWindows())
             {
                 // There is no reference assemblies path outside of windows
                 // The environment variable can be used to specify one

--- a/src/test/Microsoft.Extensions.DependencyModel.Tests/EnvironmentMockBuilder.cs
+++ b/src/test/Microsoft.Extensions.DependencyModel.Tests/EnvironmentMockBuilder.cs
@@ -9,6 +9,7 @@ namespace Microsoft.Extensions.DependencyModel.Tests
     public class EnvironmentMockBuilder
     {
         private Dictionary<string, string> _variables = new Dictionary<string, string>();
+        private bool _isWindows;
 
         internal static IEnvironment Empty { get; } = Create().Build();
 
@@ -23,18 +24,26 @@ namespace Microsoft.Extensions.DependencyModel.Tests
             return this;
         }
 
+        public EnvironmentMockBuilder SetIsWindows(bool value)
+        {
+            _isWindows = value;
+            return this;
+        }
+
         internal IEnvironment Build()
         {
-            return new EnvironmentMock(_variables);
+            return new EnvironmentMock(_variables, _isWindows);
         }
 
         private class EnvironmentMock : IEnvironment
         {
             private Dictionary<string, string> _variables;
+            private bool _isWindows;
 
-            public EnvironmentMock(Dictionary<string, string> variables)
+            public EnvironmentMock(Dictionary<string, string> variables, bool isWindows)
             {
                 _variables = variables;
+                _isWindows = isWindows;
             }
 
             public string GetEnvironmentVariable(string name)
@@ -42,6 +51,11 @@ namespace Microsoft.Extensions.DependencyModel.Tests
                 string value = null;
                 _variables.TryGetValue(name, out value);
                 return value;
+            }
+
+            public bool IsWindows()
+            {
+                return _isWindows;
             }
         }
     }

--- a/src/test/Microsoft.Extensions.DependencyModel.Tests/PackageResolverTest.cs
+++ b/src/test/Microsoft.Extensions.DependencyModel.Tests/PackageResolverTest.cs
@@ -1,12 +1,9 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.Collections.Generic;
 using System.IO;
 using FluentAssertions;
-using Microsoft.DotNet.PlatformAbstractions;
-using Microsoft.Extensions.DependencyModel;
 using Microsoft.Extensions.DependencyModel.Resolution;
 using Xunit;
 using F = Microsoft.Extensions.DependencyModel.Tests.TestLibraryFactory;
@@ -24,7 +21,7 @@ namespace Microsoft.Extensions.DependencyModel.Tests
                 .AddVariable("NUGET_PACKAGES", PackagesPath)
                 .Build();
 
-            var result = PackageCompilationAssemblyResolver.GetDefaultProbeDirectories(Platform.Unknown, environment);
+            var result = PackageCompilationAssemblyResolver.GetDefaultProbeDirectories(environment);
             // The host for .NET Core 2.0 always sets the PROBING_DIRECTORIES property on the AppContext. Because of that,
             // no additional package directories should be returned from this, even if they are set as environment variables.
             result.Should().NotContain(PackagesPath);
@@ -35,10 +32,11 @@ namespace Microsoft.Extensions.DependencyModel.Tests
         public void ShouldUseNugetUnderUserProfileOnWindows()
         {
             var environment = EnvironmentMockBuilder.Create()
+                .SetIsWindows(true)
                 .AddVariable("USERPROFILE", "User Profile")
                 .Build();
 
-            var result = PackageCompilationAssemblyResolver.GetDefaultProbeDirectories(Platform.Windows, environment);
+            var result = PackageCompilationAssemblyResolver.GetDefaultProbeDirectories(environment);
             // The host for .NET Core 2.0 always sets the PROBING_DIRECTORIES property on the AppContext. Because of that,
             // no additional package directories should be returned from this, even if they are set as environment variables.
             result.Should().NotContain(Path.Combine("User Profile", ".nuget", "packages"));
@@ -48,10 +46,11 @@ namespace Microsoft.Extensions.DependencyModel.Tests
         public void ShouldUseNugetUnderHomeOnNonWindows()
         {
             var environment = EnvironmentMockBuilder.Create()
+                .SetIsWindows(false)
                 .AddVariable("HOME", "User Home")
                 .Build();
 
-            var result = PackageCompilationAssemblyResolver.GetDefaultProbeDirectories(Platform.Linux, environment);
+            var result = PackageCompilationAssemblyResolver.GetDefaultProbeDirectories(environment);
             // The host for .NET Core 2.0 always sets the PROBING_DIRECTORIES property on the AppContext. Because of that,
             // no additional package directories should be returned from this, even if they are set as environment variables.
             result.Should().NotContain(Path.Combine("User Home", ".nuget", "packages"));

--- a/src/test/Microsoft.Extensions.DependencyModel.Tests/ReferenceAssemblyResolverTests.cs
+++ b/src/test/Microsoft.Extensions.DependencyModel.Tests/ReferenceAssemblyResolverTests.cs
@@ -34,17 +34,18 @@ namespace Microsoft.Extensions.DependencyModel.Tests
         public void UsesEnvironmentVariableForDefaultPath()
         {
             var environment = EnvironmentMockBuilder.Create()
+                .SetIsWindows(true)
                 .AddVariable("DOTNET_REFERENCE_ASSEMBLIES_PATH", ReferencePath)
                 .Build();
 
-            var result = ReferenceAssemblyPathResolver.GetDefaultReferenceAssembliesPath(FileSystemMockBuilder.Empty, Platform.Windows, environment);
+            var result = ReferenceAssemblyPathResolver.GetDefaultReferenceAssembliesPath(FileSystemMockBuilder.Empty, environment);
             result.Should().Be(ReferencePath);
         }
 
         [Fact]
         public void LooksOnlyOnEnvironmentVariableOnNonWindows()
         {
-            var result = ReferenceAssemblyPathResolver.GetDefaultReferenceAssembliesPath(FileSystemMockBuilder.Empty, Platform.Linux, EnvironmentMockBuilder.Empty);
+            var result = ReferenceAssemblyPathResolver.GetDefaultReferenceAssembliesPath(FileSystemMockBuilder.Empty, EnvironmentMockBuilder.Empty);
             result.Should().BeNull();
         }
 
@@ -52,11 +53,12 @@ namespace Microsoft.Extensions.DependencyModel.Tests
         public void ReturnsProgramFiles86AsDefaultLocationOnWin64()
         {
             var environment = EnvironmentMockBuilder.Create()
+                .SetIsWindows(true)
                 .AddVariable("ProgramFiles(x86)", "Program Files (x86)")
                 .AddVariable("ProgramFiles", "Program Files")
                 .Build();
 
-            var result = ReferenceAssemblyPathResolver.GetDefaultReferenceAssembliesPath(FileSystemMockBuilder.Empty, Platform.Windows, environment);
+            var result = ReferenceAssemblyPathResolver.GetDefaultReferenceAssembliesPath(FileSystemMockBuilder.Empty, environment);
             result.Should().Be(Path.Combine("Program Files (x86)", "Reference Assemblies", "Microsoft", "Framework"));
         }
 
@@ -64,10 +66,11 @@ namespace Microsoft.Extensions.DependencyModel.Tests
         public void ReturnsProgramFilesAsDefaultLocationOnWin32()
         {
             var environment = EnvironmentMockBuilder.Create()
+                .SetIsWindows(true)
                 .AddVariable("ProgramFiles", "Program Files")
                 .Build();
 
-            var result = ReferenceAssemblyPathResolver.GetDefaultReferenceAssembliesPath(FileSystemMockBuilder.Empty, Platform.Windows, environment);
+            var result = ReferenceAssemblyPathResolver.GetDefaultReferenceAssembliesPath(FileSystemMockBuilder.Empty, environment);
             result.Should().Be(Path.Combine("Program Files", "Reference Assemblies", "Microsoft", "Framework"));
         }
 
@@ -80,10 +83,11 @@ namespace Microsoft.Extensions.DependencyModel.Tests
                 .Build();
 
             var environment = EnvironmentMockBuilder.Create()
+                .SetIsWindows(true)
                 .AddVariable("WINDIR", "Windows")
                 .Build();
 
-            var result = ReferenceAssemblyPathResolver.GetFallbackSearchPaths(fileSystem, Platform.Windows, environment);
+            var result = ReferenceAssemblyPathResolver.GetFallbackSearchPaths(fileSystem, environment);
             result.Should().Contain(net20Path);
         }
 


### PR DESCRIPTION
We are planning on removing PlatformAbstractions. The first step is to remove the dependency on it in DependencyModel. The dependency isn't necessary.

Working towards #5213 