### PR TITLE
Remove comhost from the shared framework generation.

### DIFF
--- a/src/sharedFramework/sharedFramework.proj
+++ b/src/sharedFramework/sharedFramework.proj
@@ -58,6 +58,7 @@
       <ToDelete Include="$(SharedFrameworkNameAndVersionRoot)\framework.runtimeconfig.json" />
       <ToDelete Include="$(SharedFrameworkNameAndVersionRoot)\apphost$(ExeSuffix)" />
       <ToDelete Include="$(SharedFrameworkNameAndVersionRoot)\$(LibPrefix)hostfxr$(LibSuffix)" />
+      <ToDelete Include="$(SharedFrameworkNameAndVersionRoot)\$(LibPrefix)comhost$(LibSuffix)" />
     </ItemGroup>
 
     <Message Text="To delete: @(ToDelete)" />


### PR DESCRIPTION
- Please add a description for changes you are making.

Ensure that the comhost is not included in the shared framework. There's some work that may need to be done in the SDK as well to remove the need for the `<ToDelete />` element.

- If there is an issue related to this PR, please add a reference to it.

Fixes #5253