### PR TITLE
Fix test bugs

### DIFF
--- a/src/test/HostActivationTests/GivenThatICareAboutMultilevelSDKLookup.cs
+++ b/src/test/HostActivationTests/GivenThatICareAboutMultilevelSDKLookup.cs
@@ -452,8 +452,8 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.MultilevelSDKLookup
                 .HaveStdErrContaining(Path.Combine(_exeSelectedMessage, "9999.3.399", _dotnetSdkDllMessageTerminator));
 
             // Add SDK versions
-            AddAvailableSdkVersions(_exeSdkBaseDir, "9999.3.2400, 9999.3.3004");
-            AddAvailableSdkVersions(_regSdkBaseDir, "9999.3.2400, 9999.3.3004");
+            AddAvailableSdkVersions(_exeSdkBaseDir, "9999.3.2400", "9999.3.3004");
+            AddAvailableSdkVersions(_regSdkBaseDir, "9999.3.2400", "9999.3.3004");
 
             // Specified SDK version: 9999.3.304-global-dummy
             // Cwd: empty

--- a/src/test/HostActivationTests/GivenThatICareAboutSDKLookup.cs
+++ b/src/test/HostActivationTests/GivenThatICareAboutSDKLookup.cs
@@ -398,7 +398,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.SDKLookup
                 .HaveStdErrContaining(Path.Combine(_exeSelectedMessage, "9999.3.399", _dotnetSdkDllMessageTerminator));
 
             // Add SDK versions
-            AddAvailableSdkVersions(_exeSdkBaseDir, "9999.3.2400, 9999.3.3004");
+            AddAvailableSdkVersions(_exeSdkBaseDir, "9999.3.2400", "9999.3.3004");
 
             // Specified SDK version: 9999.3.304-global-dummy
             // Exe: 9999.3.57, 9999.3.4-dummy, 9999.3.300, 9999.7.304-global-dummy, 9999.3.304, 9999.3.399, 9999.3.399-dummy, 9999.3.400, 9999.3.2400, 9999.3.3004


### PR DESCRIPTION
Fix typo in tests which caused a single SDK to be _installed_ with illegal Sem Version 
`9999.3.2400, 9999.3.3004` instead of two SDKs with two versions `9999.3.2400` and `9999.3.3004`