### PR TITLE
Remove atomic usage for preview 3

### DIFF
--- a/src/corehost/cli/coreclr.cpp
+++ b/src/corehost/cli/coreclr.cpp
@@ -119,7 +119,7 @@ pal::hresult_t coreclr_t::create(
 }
 
 coreclr_t::coreclr_t(host_handle_t host_handle, domain_id_t domain_id)
-    : _is_shutdown{}
+    : _is_shutdown{ false }
     , _host_handle{ host_handle }
     , _domain_id{ domain_id }
 {
@@ -169,11 +169,9 @@ pal::hresult_t coreclr_t::shutdown(int* latchedExitCode)
 {
     assert(g_coreclr != nullptr && coreclr_shutdown != nullptr);
 
-    bool is_false = false;
-
     // If already shut down return success since the result
     // has already been reported to a previous caller.
-    if (!_is_shutdown.compare_exchange_strong(is_false, true))
+    if (_is_shutdown)
     {
         if (latchedExitCode != nullptr)
             *latchedExitCode = StatusCode::Success;
@@ -181,6 +179,7 @@ pal::hresult_t coreclr_t::shutdown(int* latchedExitCode)
         return StatusCode::Success;
     }
 
+    _is_shutdown = true;
     return coreclr_shutdown(_host_handle, _domain_id, latchedExitCode);
 }
 

--- a/src/corehost/cli/coreclr.h
+++ b/src/corehost/cli/coreclr.h
@@ -6,7 +6,6 @@
 
 #include "pal.h"
 #include "trace.h"
-#include <atomic>
 #include <cstdint>
 #include <memory>
 #include <vector>
@@ -45,7 +44,7 @@ public:
     pal::hresult_t shutdown(int* latchedExitCode);
 
 private:
-    std::atomic_bool _is_shutdown;
+    bool _is_shutdown;
     host_handle_t _host_handle;
     domain_id_t _domain_id;
 };


### PR DESCRIPTION
- Please add a description for changes you are making.

Remove usage of `std::atomic_bool` since this breaks on Ubuntu ARM32.

- If there is an issue related to this PR, please add a reference to it.

https://github.com/dotnet/coreclr/issues/22653

cc @dagood @leecow @RussKeldorph @MichaelSimons 