### PR TITLE
Remove usage of atomic and rely on lock instead.

### DIFF
--- a/src/corehost/cli/coreclr.h
+++ b/src/corehost/cli/coreclr.h
@@ -6,7 +6,7 @@
 
 #include "pal.h"
 #include "trace.h"
-#include <atomic>
+#include <mutex>
 #include <cstdint>
 #include <memory>
 #include <vector>
@@ -45,7 +45,8 @@ public:
     pal::hresult_t shutdown(int* latchedExitCode);
 
 private:
-    std::atomic_bool _is_shutdown;
+    std::mutex _shutdown_lock;
+    bool _is_shutdown;
     host_handle_t _host_handle;
     domain_id_t _domain_id;
 };


### PR DESCRIPTION
- Please add a description for changes you are making.

Remove usage of atomic and replace with mutex.

- If there is an issue related to this PR, please add a reference to it.

See https://github.com/dotnet/coreclr/issues/22653

cc @vitek-karas @RussKeldorph 