### PR TITLE
Statically link against libatomic on Linux-ARM32 platforms

### DIFF
--- a/src/corehost/cli/common.cmake
+++ b/src/corehost/cli/common.cmake
@@ -38,3 +38,25 @@ if(WIN32 AND NOT SKIP_VERSIONING)
     list(APPEND RESOURCES ${CMAKE_CURRENT_LIST_DIR}/native.rc)
 endif()
 
+function(set_common_libs TargetType)
+
+    # Libraries used for exe projects
+    if (${TargetType} STREQUAL "exe")
+        if(${CMAKE_SYSTEM_NAME} MATCHES "Linux|FreeBSD")
+            target_link_libraries (${DOTNET_PROJECT_NAME} "pthread")
+        endif()
+
+        if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
+            target_link_libraries (${DOTNET_PROJECT_NAME} "dl")
+        endif()
+    endif()
+
+    # Specify the import library to link against for Arm32 build since the default set is minimal
+    if (CLI_CMAKE_PLATFORM_ARCH_ARM)
+        if (WIN32)
+            target_link_libraries(${DOTNET_PROJECT_NAME} shell32.lib)
+        else()
+            target_link_libraries(${DOTNET_PROJECT_NAME} atomic.a)
+        endif()
+    endif()
+endfunction()

--- a/src/corehost/cli/exe.cmake
+++ b/src/corehost/cli/exe.cmake
@@ -22,15 +22,4 @@ endif()
 
 install(TARGETS ${DOTNET_PROJECT_NAME} DESTINATION bin)
 
-if(${CMAKE_SYSTEM_NAME} MATCHES "Linux|FreeBSD")
-    target_link_libraries (${DOTNET_PROJECT_NAME} "pthread")
-endif()
-
-if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
-    target_link_libraries (${DOTNET_PROJECT_NAME} "dl")
-endif()
-
-# Specify the import library to link against for Arm32 build since the default set is minimal
-if (WIN32 AND CLI_CMAKE_PLATFORM_ARCH_ARM)
-    target_link_libraries(${DOTNET_PROJECT_NAME} shell32.lib)
-endif()
+set_common_libs("exe")

--- a/src/corehost/cli/lib.cmake
+++ b/src/corehost/cli/lib.cmake
@@ -13,7 +13,4 @@ add_library(${DOTNET_PROJECT_NAME} SHARED ${SOURCES} ${RESOURCES})
 
 set_target_properties(${DOTNET_PROJECT_NAME} PROPERTIES MACOSX_RPATH TRUE)
 
-# Specify the import library to link against for Arm32 build since the default set is minimal
-if (WIN32 AND CLI_CMAKE_PLATFORM_ARCH_ARM)
-    target_link_libraries(${DOTNET_PROJECT_NAME} shell32.lib)
-endif()
+set_common_libs("lib")


### PR DESCRIPTION
- Please add a description for changes you are making.

Due to missing libatomic.so on ARM32 platforms, statically link against the lib.

- If there is an issue related to this PR, please add a reference to it.

See https://github.com/dotnet/coreclr/issues/22653

cc @vitek-karas @jeffschwMSFT 