### PR TITLE
Update dotnet.exe win32 manifest to support long paths

### DIFF
--- a/src/corehost/cli/dotnet/dotnet.manifest
+++ b/src/corehost/cli/dotnet/dotnet.manifest
@@ -3,7 +3,7 @@
   <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
     <application>
       <!-- A list of the Windows versions that this application has been tested on and is
-           is designed to work with. Uncomment the appropriate elements and Windows will 
+           is designed to work with. Uncomment the appropriate elements and Windows will
            automatically selected the most compatible environment. -->
 
       <!-- Windows 7 -->
@@ -16,4 +16,9 @@
       <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}" />
     </application>
   </compatibility>
+  <application xmlns="urn:schemas-microsoft-com:asm.v3">
+    <windowsSettings>
+      <longPathAware xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">true</longPathAware>
+    </windowsSettings>
+  </application>
 </assembly>

--- a/src/test/Assets/TestProjects/PortableAppWithLongPath/PortableAppWithLongPath.csproj
+++ b/src/test/Assets/TestProjects/PortableAppWithLongPath/PortableAppWithLongPath.csproj
@@ -1,0 +1,9 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>$(NETCoreAppFramework)</TargetFramework>
+    <OutputType>Exe</OutputType>
+    <RuntimeFrameworkVersion>$(MNAVersion)</RuntimeFrameworkVersion>
+  </PropertyGroup>
+
+</Project>

--- a/src/test/Assets/TestProjects/PortableAppWithLongPath/Program.cs
+++ b/src/test/Assets/TestProjects/PortableAppWithLongPath/Program.cs
@@ -1,0 +1,27 @@
+using System;
+using System.IO;
+using System.Runtime.InteropServices;
+
+namespace PortableAppWithLongPath
+{
+    public static class Program
+    {
+        public static void Main(string[] args)
+        {
+            Console.WriteLine("Hello World!");
+            Console.WriteLine(string.Join(Environment.NewLine, args));
+
+            // Create a path that is longer than MAX_PATH
+            DirectoryInfo newDir = Directory.CreateDirectory(Path.Combine(Directory.GetCurrentDirectory(), "longPath"));
+            string longPath = Path.Combine(newDir.FullName, new string('x', 255));
+
+            bool success = CreateDirectoryW(longPath, IntPtr.Zero);
+            Console.WriteLine($"CreateDirectoryW with long path {(success ? "succeeded" : $"failed with {Marshal.GetLastWin32Error()}" )}");
+
+            Directory.Delete(newDir.FullName, true /*recursive*/);
+        }
+
+        [DllImport("kernel32.dll", CharSet = CharSet.Auto, SetLastError = true)]
+        internal static extern bool CreateDirectoryW(string path, IntPtr securityAttributes);
+    }
+}


### PR DESCRIPTION
Fix #5262