### PR TITLE
Try to fix ARM CI flakiness by removing NuGet http cache for Windows builds

### DIFF
--- a/eng/jobs/windows-build.yml
+++ b/eng/jobs/windows-build.yml
@@ -52,6 +52,11 @@ jobs:
         continueOnError: false
         condition: and(succeeded(), in(variables['SignType'], 'real', 'test'))
 
+    # NuGet's http cache lasts 30 minutes. If we're on a static machine, this may interfere with
+    # auto-update PRs by preventing the CI build from fetching the new version. Delete the cache.
+    - powershell: Remove-Item -Recurse -ErrorAction Ignore "$env:LocalAppData\NuGet\v3-cache"
+      displayName: Clear NuGet http cache (if exists)
+
     # Initialize building
     - script: $(Build.SourcesDirectory)\build.cmd
         -- $(CommonMSBuildArgs)


### PR DESCRIPTION
> Windows builds (specifically ARM builds in CI) use static machines, which may have an out of date cache that NuGet considers alive. Ensure the cache is not used by deleting it.

See https://github.com/dotnet/core-setup/issues/5341. This isn't backed by any info about what's on the machines, just going to give it a shot because it sounds pretty likely to me.

/cc @wtgodbe @safern @danmosemsft, maybe this is a problem in other repos too?