### PR TITLE
Add linux-musl-arm64 (Alpine) build leg

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -122,6 +122,17 @@ jobs:
 
 - template: /eng/jobs/bash-build.yml
   parameters:
+    additionalMSBuildArgs: /p:OutputRid=linux-musl-arm64
+    crossBuild: true
+    displayName: Build_Linux_Arm64_Alpine37
+    dockerImage: microsoft/dotnet-buildtools-prereqs:ubuntu-16.04-cross-arm64-alpine10fcdcf-20190208200917
+    additionalRunArgs: -e ROOTFS_DIR=/crossrootfs/arm64
+    portableBuild: true
+    skipTests: true
+    targetArchitecture: arm64
+
+- template: /eng/jobs/bash-build.yml
+  parameters:
     additionalMSBuildArgs: /p:OutputRid=linux-musl-x64
     displayName: Build_Linux_x64_Alpine36
     dockerImage: microsoft/dotnet-buildtools-prereqs:alpine-3.6-3148f11-20171119021156

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -90,7 +90,7 @@ jobs:
   parameters:
     crossBuild: true
     displayName: Build_Linux_Arm
-    dockerImage: microsoft/dotnet-buildtools-prereqs:ubuntu-14.04-cross-e435274-20180323032140
+    dockerImage: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-14.04-cross-e435274-20180323032140
     additionalRunArgs: -e ROOTFS_DIR=/crossrootfs/arm
     portableBuild: true
     skipTests: true
@@ -100,7 +100,7 @@ jobs:
   parameters:
     crossBuild: true
     displayName: Build_Linux_Arm64
-    dockerImage: microsoft/dotnet-buildtools-prereqs:ubuntu-16.04-cross-arm64-a3ae44b-20180316023254
+    dockerImage: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-16.04-cross-arm64-a3ae44b-20180316023254
     additionalRunArgs: -e ROOTFS_DIR=/crossrootfs/arm64
     portableBuild: true
     skipTests: true
@@ -125,7 +125,7 @@ jobs:
     additionalMSBuildArgs: /p:OutputRid=linux-musl-arm64
     crossBuild: true
     displayName: Build_Linux_Arm64_Alpine37
-    dockerImage: microsoft/dotnet-buildtools-prereqs:ubuntu-16.04-cross-arm64-alpine10fcdcf-20190208200917
+    dockerImage: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-16.04-cross-arm64-alpine10fcdcf-20190208200917
     additionalRunArgs: -e ROOTFS_DIR=/crossrootfs/arm64
     portableBuild: true
     skipTests: true
@@ -135,14 +135,14 @@ jobs:
   parameters:
     additionalMSBuildArgs: /p:OutputRid=linux-musl-x64
     displayName: Build_Linux_x64_Alpine36
-    dockerImage: microsoft/dotnet-buildtools-prereqs:alpine-3.6-3148f11-20171119021156
+    dockerImage: mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.6-3148f11-20171119021156
     portableBuild: false
     targetArchitecture: x64
 
 - template: /eng/jobs/bash-build.yml
   parameters:
     displayName: Build_Linux_x64_glibc
-    dockerImage: microsoft/dotnet-buildtools-prereqs:centos-7-d485f41-20173404063424
+    dockerImage: mcr.microsoft.com/dotnet-buildtools/prereqs:centos-7-d485f41-20173404063424
     packageDistroListDeb: [debian.8,debian.9,ubuntu.16.04,ubuntu.18.04]
     packageDistroListRpm: [centos.7,fedora.27,opensuse.42,oraclelinux.7,sles.12]
     portableBuild: true
@@ -152,7 +152,7 @@ jobs:
   parameters:
     additionalMSBuildArgs: /p:OutputRid=rhel.6-x64
     displayName: Build_Linux_x64_Rhel6
-    dockerImage: microsoft/dotnet-buildtools-prereqs:centos-6-376e1a3-20174311014331
+    dockerImage: mcr.microsoft.com/dotnet-buildtools/prereqs:centos-6-376e1a3-20174311014331
     portableBuild: false
     targetArchitecture: x64
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -201,6 +201,18 @@ jobs:
   ################################################################################
   - template: /eng/jobs/finalize-publish.yml
     parameters:
+      DependsOn:
+      - Build_Linux_Arm
+      - Build_Linux_Arm64
+      - Build_Linux_Arm64_Alpine37
+      - Build_Linux_x64_Alpine36
+      - Build_Linux_x64_glibc
+      - Build_Linux_x64_Rhel6
+      - Build_OSX
+      - Build_Windows_Arm
+      - Build_Windows_Arm64
+      - Build_Windows_x64
+      - Build_Windows_x86
       _PublishType: nopublishtype
 
   ################################################################################

--- a/eng/jobs/bash-build.yml
+++ b/eng/jobs/bash-build.yml
@@ -78,7 +78,7 @@ jobs:
         -v $(Build.SourcesDirectory):/root/coresetup
         -v $(Build.StagingDirectory)/sharedFrameworkPublish/:/root/sharedFrameworkPublish/
         -w=/root/coresetup
-        microsoft/dotnet-buildtools-prereqs:ubuntu-14.04-debpkg-e5cf912-20175003025046
+        mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-14.04-debpkg-e5cf912-20175003025046
         /root/coresetup/Tools/msbuild.sh
       DebianPackagingCommand: $(CommonDebianRunCommand)
         /root/coresetup/src/pkg/packaging/dir.proj
@@ -91,7 +91,7 @@ jobs:
         -v $(Build.SourcesDirectory):/root/coresetup
         -v $(Build.StagingDirectory)/sharedFrameworkPublish/:/root/sharedFrameworkPublish/
         -w=/root/coresetup
-        microsoft/dotnet-buildtools-prereqs:rhel-7-rpmpkg-c982313-20174116044113
+        mcr.microsoft.com/dotnet-buildtools/prereqs:rhel-7-rpmpkg-c982313-20174116044113
         /root/coresetup/Tools/msbuild.sh
       RpmPackagingCommand: $(CommonRpmRunCommand)
         /root/coresetup/src/pkg/packaging/dir.proj

--- a/eng/jobs/finalize-publish.yml
+++ b/eng/jobs/finalize-publish.yml
@@ -1,33 +1,11 @@
 parameters:
+  DependsOn: {}
   _PublishType: {}
 jobs:
   - job: Finalize_Publish
     displayName: Finalize_Publish
-    # Run only if all build legs succeeded
-    condition: and(
-                  succeeded('Build_Linux_Arm'),
-                  succeeded('Build_Linux_Arm64'),
-                  succeeded('Build_Linux_x64_Alpine36'),
-                  succeeded('Build_Linux_x64_glibc'),
-                  succeeded('Build_Linux_x64_Rhel6'),
-                  succeeded('Build_OSX'),
-                  succeeded('Build_Windows_Arm'),
-                  succeeded('Build_Windows_Arm64'),
-                  succeeded('Build_Windows_x64'),
-                  succeeded('Build_Windows_x86'),
-                  ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest'))
     # Run after all dependent legs are executed
-    dependsOn: 
-    - Build_Linux_Arm
-    - Build_Linux_Arm64
-    - Build_Linux_x64_Alpine36
-    - Build_Linux_x64_glibc
-    - Build_Linux_x64_Rhel6
-    - Build_OSX
-    - Build_Windows_Arm
-    - Build_Windows_Arm64
-    - Build_Windows_x64
-    - Build_Windows_x86
+    dependsOn: ${{ parameters.DependsOn }}
     pool:
       # For public or PR jobs, use the hosted pool.  For internal jobs use the internal pool.
       # Will eventually change this to two BYOC pools.

--- a/publish/dir.props
+++ b/publish/dir.props
@@ -53,6 +53,7 @@
     <PublishRid Include="win-arm" />
     <PublishRid Include="win-arm64" />
     <PublishRid Include="linux-arm" />
+    <PublishRid Include="linux-musl-arm64" />
     <PublishRid Include="rhel.7-x64" />
     <PublishRid Include="opensuse.42-x64" />
     <PublishRid Include="centos.7-x64" />

--- a/src/corehost/build.sh
+++ b/src/corehost/build.sh
@@ -211,12 +211,15 @@ elif command -v "clang-3.6" > /dev/null 2>&1; then
 elif command -v "clang-3.9" > /dev/null 2>&1; then
     export CC="$(command -v clang-3.9)"
     export CXX="$(command -v clang++-3.9)"
+elif command -v "clang-5.0" > /dev/null 2>&1; then
+    export CC="$(command -v clang-5.0)"
+    export CXX="$(command -v clang++-5.0)"
 elif command -v clang > /dev/null 2>&1; then
     export CC="$(command -v clang)"
     export CXX="$(command -v clang++)"
 else
     echo "Unable to find Clang Compiler"
-    echo "Install clang-3.5 or clang3.6 or clang3.9"
+    echo "Install clang-3.5 or clang3.6 or clang3.9 or clang5.0"
     exit 1
 fi
 
@@ -237,9 +240,12 @@ if [ $__CrossBuild == 1 ]; then
     elif command -v "clang-4.0" > /dev/null 2>&1; then
         export CC="$(command -v clang-4.0)"
         export CXX="$(command -v clang++-4.0)"
+    elif command -v "clang-5.0" > /dev/null 2>&1; then
+        export CC="$(command -v clang-5.0)"
+        export CXX="$(command -v clang++-5.0)"
     else
-        echo "Unable to find Clang 3.9 or Clang 4.0 Compiler"
-        echo "Install clang-3.9 or clang-4.0 for cross compilation"
+        echo "Unable to find Clang 3.9 or Clang 4.0 or Clang 5.0 Compiler"
+        echo "Install clang-3.9 or clang-4.0 or clang-5.0 for cross compilation"
         exit 1
     fi
     export TARGET_BUILD_ARCH=$__build_arch_lowcase

--- a/src/pkg/projects/netcoreappRIDs.props
+++ b/src/pkg/projects/netcoreappRIDs.props
@@ -28,6 +28,9 @@
     <OfficialBuildRID Include="linux-arm64">
       <Platform>arm64</Platform>
     </OfficialBuildRID>
+    <OfficialBuildRID Include="linux-musl-arm64">
+      <Platform>arm64</Platform>
+    </OfficialBuildRID>
 
     <!-- The following RIDs are not officically supported and are not
          built during official builds, however we wish to include them


### PR DESCRIPTION
https://github.com/dotnet/core-setup/issues/5112

CoreFX PR: https://github.com/dotnet/corefx/pull/35778
CoreFX build was brought in by https://github.com/dotnet/core-setup/pull/5328

I'm planning to do a mock build to validate framework package content and publish behavior.

/cc @safern @richlander @MichaelSimons 