### PR TITLE
Introduce TestArtifact and some refactoring.

### DIFF
--- a/src/test/HostActivationTests/GivenThatICareAboutPortableAppActivation.cs
+++ b/src/test/HostActivationTests/GivenThatICareAboutPortableAppActivation.cs
@@ -99,11 +99,10 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.PortableApp
             var fixture = sharedTestState.PreviouslyBuiltAndRestoredPortableTestProjectFixture
                 .Copy();
 
-            MoveRuntimeConfigToSubdirectory(fixture);
+            var runtimeConfig = MoveRuntimeConfigToSubdirectory(fixture);
 
             var dotnet = fixture.BuiltDotnet;
             var appDll = fixture.TestProject.AppDll;
-            var runtimeConfig = fixture.TestProject.RuntimeConfigJson;
             
             dotnet.Exec("exec", "--runtimeconfig", runtimeConfig, appDll)
                 .CaptureStdErr()
@@ -119,11 +118,10 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.PortableApp
             var fixture = sharedTestState.PreviouslyBuiltAndRestoredPortableTestProjectFixture
                 .Copy();
 
-            MoveRuntimeConfigToSubdirectory(fixture);
+            var runtimeConfig = MoveRuntimeConfigToSubdirectory(fixture);
 
             var dotnet = fixture.BuiltDotnet;
             var appDll = fixture.TestProject.AppDll;
-            var runtimeConfig = fixture.TestProject.RuntimeConfigJson;
             var additionalProbingPath = sharedTestState.RepoDirectories.NugetPackages;
 
             dotnet.Exec(
@@ -181,11 +179,10 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.PortableApp
             var fixture = sharedTestState.PreviouslyBuiltAndRestoredPortableTestProjectFixture
                 .Copy();
 
-            MoveDepsJsonToSubdirectory(fixture);
+            var depsJson = MoveDepsJsonToSubdirectory(fixture);
 
             var dotnet = fixture.BuiltDotnet;
             var appDll = fixture.TestProject.AppDll;
-            var depsJson = fixture.TestProject.DepsJson;
 
             dotnet.Exec("exec", "--depsfile", depsJson, appDll)
                 .CaptureStdErr()
@@ -233,11 +230,10 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.PortableApp
             var fixture = sharedTestState.PreviouslyPublishedAndRestoredPortableTestProjectFixture
                 .Copy();
 
-            MoveRuntimeConfigToSubdirectory(fixture);
+            var runtimeConfig = MoveRuntimeConfigToSubdirectory(fixture);
 
             var dotnet = fixture.BuiltDotnet;
             var appDll = fixture.TestProject.AppDll;
-            var runtimeConfig = fixture.TestProject.RuntimeConfigJson;
 
             dotnet.Exec("exec", "--runtimeconfig", runtimeConfig, appDll)
                 .CaptureStdErr()
@@ -255,11 +251,10 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.PortableApp
             var fixture = sharedTestState.PreviouslyPublishedAndRestoredPortableTestProjectFixture
                 .Copy();
 
-            MoveDepsJsonToSubdirectory(fixture);
+            var depsJson = MoveDepsJsonToSubdirectory(fixture);
 
             var dotnet = fixture.BuiltDotnet;
             var appDll = fixture.TestProject.AppDll;
-            var depsJson = fixture.TestProject.DepsJson;
 
             dotnet.Exec("exec", "--depsfile", depsJson, appDll)
                 .CaptureStdErr()
@@ -333,7 +328,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.PortableApp
                 .HaveStdOutContaining($"Framework Version:{sharedTestState.RepoDirectories.MicrosoftNETCoreAppVersion}");
         }
 
-        private void MoveDepsJsonToSubdirectory(TestProjectFixture testProjectFixture)
+        private string MoveDepsJsonToSubdirectory(TestProjectFixture testProjectFixture)
         {
             var subdirectory = Path.Combine(testProjectFixture.TestProject.ProjectDirectory, "d");
             if (!Directory.Exists(subdirectory))
@@ -349,10 +344,10 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.PortableApp
             }
             File.Move(testProjectFixture.TestProject.DepsJson, destDepsJson);
 
-            testProjectFixture.TestProject.DepsJson = destDepsJson;
+            return destDepsJson;
         }
 
-        private void MoveRuntimeConfigToSubdirectory(TestProjectFixture testProjectFixture)
+        private string MoveRuntimeConfigToSubdirectory(TestProjectFixture testProjectFixture)
         {
             var subdirectory = Path.Combine(testProjectFixture.TestProject.ProjectDirectory, "r");
             if (!Directory.Exists(subdirectory))
@@ -368,7 +363,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.PortableApp
             }
             File.Move(testProjectFixture.TestProject.RuntimeConfigJson, destRuntimeConfig);
 
-            testProjectFixture.TestProject.RuntimeConfigJson = destRuntimeConfig;
+            return destRuntimeConfig;
         }
 
         private string CreateAStore(TestProjectFixture testProjectFixture)

--- a/src/test/TestUtils/TestApp.cs
+++ b/src/test/TestUtils/TestApp.cs
@@ -1,0 +1,47 @@
+﻿using System.IO;
+
+namespace Microsoft.DotNet.CoreSetup.Test
+{
+    public class TestApp : TestArtifact
+    {
+        public string AppDll { get; private set; }
+        public string AppExe { get; private set; }
+        public string DepsJson { get; private set; }
+        public string RuntimeConfigJson { get; private set; }
+        public string RuntimeDevConfigJson { get; private set; }
+        public string HostPolicyDll { get; private set; }
+        public string HostFxrDll { get; private set; }
+
+        public string AssemblyName { get; }
+
+        public TestApp(string basePath, string assemblyName = null)
+            : base(basePath)
+        {
+            AssemblyName = assemblyName ?? Name;
+            LoadAssets();
+        }
+
+        public TestApp(TestApp source)
+            : base(source)
+        {
+            AssemblyName = source.AssemblyName;
+            LoadAssets();
+        }
+
+        public TestApp Copy()
+        {
+            return new TestApp(this);
+        }
+
+        private void LoadAssets()
+        {
+            AppDll = Path.Combine(Location, $"{AssemblyName}.dll");
+            AppExe = Path.Combine(Location, RuntimeInformationExtensions.GetExeFileNameForCurrentPlatform(AssemblyName));
+            DepsJson = Path.Combine(Location, $"{AssemblyName}.deps.json");
+            RuntimeConfigJson = Path.Combine(Location, $"{AssemblyName}.runtimeconfig.json");
+            RuntimeDevConfigJson = Path.Combine(Location, $"{AssemblyName}.runtimeconfig.dev.json");
+            HostPolicyDll = Path.Combine(Location, RuntimeInformationExtensions.GetSharedLibraryFileNameForCurrentPlatform("hostpolicy"));
+            HostFxrDll = Path.Combine(Location, RuntimeInformationExtensions.GetSharedLibraryFileNameForCurrentPlatform("hostfxr"));
+        }
+    }
+}

--- a/src/test/TestUtils/TestArtifact.cs
+++ b/src/test/TestUtils/TestArtifact.cs
@@ -1,0 +1,102 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+
+namespace Microsoft.DotNet.CoreSetup.Test
+{
+    public class TestArtifact : IDisposable
+    {
+        private static readonly string TestArtifactDirectoryEnvironmentVariable = "TEST_ARTIFACTS";
+        private static Lazy<string> _testArtifactsPath = new Lazy<string>(() =>
+        {
+            return Environment.GetEnvironmentVariable(TestArtifactDirectoryEnvironmentVariable)
+                   ?? Path.Combine(AppContext.BaseDirectory, TestArtifactDirectoryEnvironmentVariable);
+        });
+
+        public static string TestArtifactsPath
+        {
+            get
+            {
+                return _testArtifactsPath.Value;
+            }
+        }
+
+        public string Location { get; }
+        public string Name { get; }
+
+        private List<TestArtifact> _copies = new List<TestArtifact>();
+
+        public TestArtifact(string location, string name = null)
+        {
+            Location = location;
+            Name = name ?? Path.GetFileName(Location);
+        }
+
+        protected TestArtifact(TestArtifact source)
+        {
+            Name = source.Name;
+            Location = GetNewTestArtifactPath(Name);
+
+            CopyRecursive(source.Location, Location, overwrite: true);
+
+            source._copies.Add(this);
+        }
+
+        public void Dispose()
+        {
+            if (!PreserveTestRuns())
+            {
+                Directory.Delete(Location, true);
+            }
+
+            foreach (TestArtifact copy in _copies)
+            {
+                copy.Dispose();
+            }
+
+            _copies.Clear();
+        }
+
+        public static bool PreserveTestRuns()
+        {
+            return Environment.GetEnvironmentVariable("PRESERVE_TEST_RUNS") == "1";
+        }
+
+        protected static string GetNewTestArtifactPath(string artifactName)
+        {
+            int projectCount = 0;
+            string projectDirectory = Path.Combine(TestArtifactsPath, projectCount.ToString(), artifactName);
+
+            while (Directory.Exists(projectDirectory))
+            {
+                projectDirectory = Path.Combine(TestArtifactsPath, (++projectCount).ToString(), artifactName);
+            }
+
+            return projectDirectory;
+        }
+
+        protected static void CopyRecursive(string sourceDirectory, string destinationDirectory, bool overwrite = false)
+        {
+            if (!Directory.Exists(destinationDirectory))
+            {
+                Directory.CreateDirectory(destinationDirectory);
+            }
+
+            foreach (var dir in Directory.EnumerateDirectories(sourceDirectory))
+            {
+                CopyRecursive(dir, Path.Combine(destinationDirectory, Path.GetFileName(dir)), overwrite);
+            }
+
+            foreach (var file in Directory.EnumerateFiles(sourceDirectory))
+            {
+                var dest = Path.Combine(destinationDirectory, Path.GetFileName(file));
+                if (!File.Exists(dest) || overwrite)
+                {
+                    // We say overwrite true, because we only get here if the file didn't exist (thus it doesn't matter) or we
+                    // wanted to overwrite :)
+                    File.Copy(file, dest, overwrite: true);
+                }
+            }
+        }
+    }
+}

--- a/src/test/TestUtils/TestProject.cs
+++ b/src/test/TestUtils/TestProject.cs
@@ -1,32 +1,48 @@
-﻿using System;
-using System.IO;
+﻿using System.IO;
 
 namespace Microsoft.DotNet.CoreSetup.Test
 {
-    public class TestProject : IDisposable
+    public class TestProject : TestArtifact
     {
-        public string ProjectDirectory { get; }
-        public string ProjectName { get; }
+        public string ProjectDirectory { get => Location; }
+        public string ProjectName { get => Name; }
 
+        public string AssemblyName { get; private set; }
         public string OutputDirectory { get; set; }
-        public string AssemblyName { get; set; }
-        public string ProjectFile { get; set; }
-        public string ProjectAssetsJson { get; set; }
-        public string RuntimeConfigJson { get; set; }
-        public string RuntimeDevConfigJson { get; set; }
-        public string DepsJson { get; set; }
-        public string AppDll { get; set; }
-        public string AppExe { get; set; }
-        public string HostPolicyDll { get; set; }
-        public string HostFxrDll { get; set; }
+        public string ProjectFile { get; private set; }
+        public string ProjectAssetsJson { get; private set; }
+        public string RuntimeConfigJson { get => BuiltApp?.RuntimeConfigJson; }
+        public string RuntimeDevConfigJson { get => BuiltApp?.RuntimeDevConfigJson; }
+        public string DepsJson { get => BuiltApp?.DepsJson; }
+        public string AppDll { get => BuiltApp?.AppDll; }
+        public string AppExe { get => BuiltApp?.AppExe; }
+        public string HostPolicyDll { get => BuiltApp?.HostPolicyDll; }
+        public string HostFxrDll { get => BuiltApp?.HostFxrDll; }
+
+        public TestApp BuiltApp { get; private set; }
 
         public TestProject(
             string projectDirectory,
             string outputDirectory = null,
             string assemblyName = null)
+            : base(projectDirectory)
         {
-            ProjectDirectory = projectDirectory;
-            ProjectName = Path.GetFileName(ProjectDirectory);
+            Initialize(outputDirectory, assemblyName);
+        }
+
+        public TestProject(TestProject source)
+            : base(source)
+        {
+            Initialize(null, source.AssemblyName);
+        }
+
+        public TestProject Copy()
+        {
+            return new TestProject(this);
+        }
+
+        private void Initialize(string outputDirectory, string assemblyName)
+        {
             AssemblyName = assemblyName ?? ProjectName;
             ProjectFile = Path.Combine(ProjectDirectory, $"{ProjectName}.csproj");
             ProjectAssetsJson = Path.Combine(ProjectDirectory, "obj", "project.assets.json");
@@ -38,28 +54,9 @@ namespace Microsoft.DotNet.CoreSetup.Test
             }
         }
 
-        public void Dispose()
-        {
-            if (!PreserveTestRuns())
-            {
-                Directory.Delete(ProjectDirectory, true);
-            }
-        }
-
-        public void CopyProjectFiles(string directory)
-        {
-            CopyRecursive(ProjectDirectory, directory, overwrite: true);
-        }
-
         public void LoadOutputFiles()
         {
-            AppDll = Path.Combine(OutputDirectory, $"{AssemblyName}.dll");
-            AppExe = Path.Combine(OutputDirectory, RuntimeInformationExtensions.GetExeFileNameForCurrentPlatform(AssemblyName));
-            DepsJson = Path.Combine(OutputDirectory, $"{AssemblyName}.deps.json");
-            RuntimeConfigJson = Path.Combine(OutputDirectory, $"{AssemblyName}.runtimeconfig.json");
-            RuntimeDevConfigJson = Path.Combine(OutputDirectory, $"{AssemblyName}.runtimeconfig.dev.json");
-            HostPolicyDll = Path.Combine(OutputDirectory, RuntimeInformationExtensions.GetSharedLibraryFileNameForCurrentPlatform("hostpolicy"));
-            HostFxrDll = Path.Combine(OutputDirectory, RuntimeInformationExtensions.GetSharedLibraryFileNameForCurrentPlatform("hostfxr"));
+            BuiltApp = new TestApp(OutputDirectory, AssemblyName);
         }
 
         public bool IsRestored()
@@ -70,35 +67,6 @@ namespace Microsoft.DotNet.CoreSetup.Test
             }
 
             return File.Exists(ProjectAssetsJson);
-        }
-
-        private void CopyRecursive(string sourceDirectory, string destinationDirectory, bool overwrite = false)
-        {
-            if ( ! Directory.Exists(destinationDirectory))
-            {
-                Directory.CreateDirectory(destinationDirectory);
-            }
-
-            foreach (var dir in Directory.EnumerateDirectories(sourceDirectory))
-            {
-                CopyRecursive(dir, Path.Combine(destinationDirectory, Path.GetFileName(dir)), overwrite);
-            }
-
-            foreach (var file in Directory.EnumerateFiles(sourceDirectory))
-            {
-                var dest = Path.Combine(destinationDirectory, Path.GetFileName(file));
-                if (!File.Exists(dest) || overwrite)
-                {
-                    // We say overwrite true, because we only get here if the file didn't exist (thus it doesn't matter) or we
-                    // wanted to overwrite :)
-                    File.Copy(file, dest, overwrite: true);
-                }
-            }
-        }
-
-        public static bool PreserveTestRuns()
-        {
-            return Environment.GetEnvironmentVariable("PRESERVE_TEST_RUNS") == "1";
         }
     }
 }


### PR DESCRIPTION
Refactor test artifact handling to a separate class.

Introduce TestApp - as the binaries only representation (versus TestProject which has the sources as well).
Some other small refactorings.

The main goal was to introduce the TestApp as I plan to have tests which don't need to actually compile an app to run (which is really slow as it invokes the entire SDK during a test run).