### PR TITLE
Support building core-setup with VS2019

### DIFF
--- a/Documentation/building/windows-instructions.md
+++ b/Documentation/building/windows-instructions.md
@@ -11,9 +11,10 @@ You must install several components to build the Core-Setup repo. These instruct
 ## Visual Studio
 
 Visual Studio must be installed. Supported versions:
-- [Visual Studio 2015 Update 3](https://www.visualstudio.com/vs/older-downloads/) (Community, Professional, Enterprise).  The community version is completely free.
+- [Visual Studio 2019 RC](https://visualstudio.microsoft.com/downloads/#2019rc) (Community, Professional, Enterprise).  The community version is completely free.
+- [Visual Studio 2017](https://visualstudio.microsoft.com/vs/) (Community, Professional, Enterprise).  The community version is completely free.
 
-For Visual Studio 2015:
+For Visual Studio:
 * Required installer options that need to be manually enabled:
   * Universal Windows App Development Tools: Tools and Windows 10 SDK (10.0.14393) + Windows 10 SDK (10.0.10586)
   * Visual C++
@@ -22,7 +23,8 @@ Visual Studio Express is not supported.
 
 ## CMake
 
-The Core-Setup repo build has been validated using CMake 3.6.3 
+The Core-Setup repo build has been validated using CMake 3.6.3.
+If using Visual Studio 2019, then at least CMake 3.14 is required.
 
 - Install [CMake](http://www.cmake.org/download) for Windows.
 - Add its location (e.g. C:\Program Files (x86)\CMake\bin) to the PATH environment variable.  

--- a/src/corehost/Windows/gen-buildsys-win.bat
+++ b/src/corehost/Windows/gen-buildsys-win.bat
@@ -17,9 +17,9 @@ set __ExtraCmakeParams=
 
 :: Set the target architecture to a format cmake understands. ANYCPU defaults to x64
 set __RIDArch=%3
-if /i "%3" == "x86"     (set cm_BaseRid=win7&&set cm_Arch=I386&&set __VSString=%__VSString%)
-if /i "%3" == "x64"     (set cm_BaseRid=win7&&set cm_Arch=AMD64&&set __VSString=%__VSString% Win64)
-if /i "%3" == "arm"     (set cm_BaseRid=win8&&set cm_Arch=ARM&&set __VSString=%__VSString% ARM)
+if /i "%3" == "x64"     (set cm_BaseRid=win7&&set  cm_Arch=AMD64&&set __ExtraCmakeParams=%__ExtraCmakeParams% -A x64)
+if /i "%3" == "x86"     (set cm_BaseRid=win7&&set  cm_Arch=I386&&set  __ExtraCmakeParams=%__ExtraCmakeParams% -A Win32)
+if /i "%3" == "arm"     (set cm_BaseRid=win8&&set  cm_Arch=ARM&&set   __ExtraCmakeParams=%__ExtraCmakeParams% -A ARM)
 if /i "%3" == "arm64"   (set cm_BaseRid=win10&&set cm_Arch=ARM64&&set __ExtraCmakeParams=%__ExtraCmakeParams% -A ARM64)
 
 set __LatestCommit=%4
@@ -50,7 +50,7 @@ GOTO :DONE
   echo "Usage..."
   echo "gen-buildsys-win.bat <path to top level CMakeLists.txt> <VSVersion> <Target Architecture>"
   echo "Specify the path to the top level CMake file"
-  echo "Specify the VSVersion to be used - VS2015 or VS2017"
+  echo "Specify the VSVersion to be used - VS2017 or VS2019"
   echo "Specify the Target Architecture - AnyCPU, x86, x64, ARM, or ARM64."
   echo "Specify latest commit hash"
   echo "Specify the host version, apphost version, hostresolver version, hostpolicy version"

--- a/src/corehost/build.cmd
+++ b/src/corehost/build.cmd
@@ -58,17 +58,25 @@ set VSCMD_START_DIR="%~dp0"
 call "%_VSCOMNTOOLS%\VsDevCmd.bat"
 
 :RunVCVars
-if "%VisualStudioVersion%"=="15.0" (
+if "%VisualStudioVersion%"=="16.0" (
+    goto :VS2019
+) else if "%VisualStudioVersion%"=="15.0" (
     goto :VS2017
-) else if "%VisualStudioVersion%"=="14.0" (
-    goto :VS2015
 )
 
 :MissingVersion
-:: Can't find VS 2015 or 2017
-echo Error: Visual Studio 2015 or 2017 required
-echo        Please see https://github.com/dotnet/corefx/tree/master/Documentation for build instructions.
+:: Can't find VS 2017, 2019
+echo Error: Visual Studio 2017 or 2019 required
+echo        Please see https://github.com/dotnet/core-setup/tree/master/Documentation/building/windows-instructions.md for build instructions.
 exit /b 1
+
+:VS2019
+:: Setup vars for VS2019
+set __PlatformToolset=v142
+set __VSVersion=16 2019
+:: Set the environment for the native build
+call "%VS160COMNTOOLS%..\..\VC\Auxiliary\Build\vcvarsall.bat" %__VCBuildArch%
+goto :SetupDirs
 
 :VS2017
 :: Setup vars for VS2017
@@ -76,14 +84,6 @@ set __PlatformToolset=v141
 set __VSVersion=15 2017
 :: Set the environment for the native build
 call "%VS150COMNTOOLS%..\..\VC\Auxiliary\Build\vcvarsall.bat" %__VCBuildArch%
-goto :SetupDirs
-
-:VS2015
-:: Setup vars for VS2015build
-set __PlatformToolset=v140
-set __VSVersion=14 2015
-:: Set the environment for the native build
-call "%VS140COMNTOOLS%..\..\VC\vcvarsall.bat" %__VCBuildArch%
 
 :SetupDirs
 :: Setup to cmake the native components


### PR DESCRIPTION
This is mostly adaptation of similar fixes in dotnet/CoreFx#35197.
Removed support for VS 2015 (CoreFx and CoreCLR don't support it either).
Updated documentation.