### PR TITLE
Fix native build warnings

### DIFF
--- a/src/corehost/cli/args.h
+++ b/src/corehost/cli/args.h
@@ -13,7 +13,6 @@
 struct probe_config_t
 {
     pal::string_t probe_dir;
-    bool patch_roll_fwd;
     const deps_json_t* probe_deps_json;
     int fx_level;
 

--- a/src/corehost/cli/libhost.h
+++ b/src/corehost/cli/libhost.h
@@ -114,8 +114,6 @@ private:
     bool m_is_framework_dependent;
     std::vector<pal::string_t> m_probe_paths;
     std::vector<const pal::char_t*> m_probe_paths_cstr;
-    bool m_patch_roll_forward;
-    bool m_prerelease_roll_forward;
     host_mode_t m_host_mode;
     host_interface_t m_host_interface;
     std::vector<pal::string_t> m_fx_names;
@@ -223,8 +221,11 @@ public:
         hi.probe_paths.len = m_probe_paths_cstr.size();
         hi.probe_paths.arr = m_probe_paths_cstr.data();
 
-        hi.patch_roll_forward = m_patch_roll_forward;
-        hi.prerelease_roll_forward = m_prerelease_roll_forward;
+        // These are not used anymore, but we have to keep them for backward compat reasons.
+        // Set default values.
+        hi.patch_roll_forward = true;
+        hi.prerelease_roll_forward = false;
+
         hi.host_mode = m_host_mode;
 
         hi.tfm = m_tfm.c_str();
@@ -369,7 +370,7 @@ struct hostpolicy_init_t
 
                 // The found_ver was not passed previously, so obtain that from fx_dir
                 pal::string_t fx_found_ver;
-                int index = fx_dir.rfind(DIR_SEPARATOR);
+                size_t index = fx_dir.rfind(DIR_SEPARATOR);
                 if (index != pal::string_t::npos)
                 {
                     fx_found_ver = fx_dir.substr(index + 1);


### PR DESCRIPTION
The two fields in `host_interface_t` are the scary bit here. This is an ABI between `hostfxr` and `hostpolicy` and must be stable across versions (newer `hostfxr` can talk to older `hostpolicy`).
I checked that the fields were initialized with real values in 2.0 but then in 2.1 they were left uninitialized and then ever since. The outcome is that they're left with random values.
Fortunately enough it seems nobody ever used them, I checked in 2.0 source code and there are no consumers - the `hostpolicy` reads them and stores the values, but doesn't use it for anything.
So this change initializes them to their old defaults - `hostpolicy` should not really need them as they affect framework resolution only, which is the responsibility of `hostfxr`.