### PR TITLE
Use the CMake install target to place binaries instead of MSBuild post-processing

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -128,7 +128,7 @@ jobs:
     displayName: Build_Linux_Arm64_Alpine37
     dockerImage: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-16.04-cross-arm64-alpine10fcdcf-20190208200917
     additionalRunArgs: -e ROOTFS_DIR=/crossrootfs/arm64
-    portableBuild: true
+    portableBuild: false
     skipTests: true
     targetArchitecture: arm64
 

--- a/src/corehost/build.cmd
+++ b/src/corehost/build.cmd
@@ -91,7 +91,7 @@ echo Commencing build of corehost
 echo.
 
 if %__CMakeBinDir% == "" (
-    set "__CMakeBinDir=%__binDir%\%__TargetRid%.%CMAKE_BUILD_TYPE%\corehost"
+    set "__CMakeBinDir=%__binDir%\%__TargetRid%.%CMAKE_BUILD_TYPE%"
 )
 if %__IntermediatesDir% == "" (
     set "__IntermediatesDir=%__binDir%\obj\%__TargetRid%.%CMAKE_BUILD_TYPE%\corehost"

--- a/src/corehost/build.cmd
+++ b/src/corehost/build.cmd
@@ -129,7 +129,7 @@ popd
 
 :CheckForProj
 :: Check that the project created by Cmake exists
-if exist "%__IntermediatesDir%\ALL_BUILD.vcxproj" goto BuildNativeProj
+if exist "%__IntermediatesDir%\INSTALL.vcxproj" goto BuildNativeProj
 goto :Failure
 
 :BuildNativeProj
@@ -141,8 +141,8 @@ cd %__rootDir%
 SET __NativeBuildArgs=/t:rebuild
 if /i "%__IncrementalNativeBuild%" == "1" SET __NativeBuildArgs=
 
-echo msbuild "%__IntermediatesDir%\ALL_BUILD.vcxproj" %__NativeBuildArgs% /m /p:Configuration=%CMAKE_BUILD_TYPE% %__msbuildArgs%
-call msbuild "%__IntermediatesDir%\ALL_BUILD.vcxproj" %__NativeBuildArgs% /m /p:Configuration=%CMAKE_BUILD_TYPE% %__msbuildArgs%
+echo msbuild "%__IntermediatesDir%\INSTALL.vcxproj" %__NativeBuildArgs% /m /p:Configuration=%CMAKE_BUILD_TYPE% %__msbuildArgs%
+call msbuild "%__IntermediatesDir%\INSTALL.vcxproj" %__NativeBuildArgs% /m /p:Configuration=%CMAKE_BUILD_TYPE% %__msbuildArgs%
 IF ERRORLEVEL 1 (
     goto :Failure
 )

--- a/src/corehost/build.proj
+++ b/src/corehost/build.proj
@@ -32,19 +32,6 @@
     <Message Text="$(MSBuildProjectDirectory)\build.sh $(BuildArgs)" Importance="High"/>
     <Exec Command="$(MSBuildProjectDirectory)\build.sh $(BuildArgs)"
           WorkingDirectory="$(CMakeBuildDir)"/>
-
-    <ItemGroup>
-      <CMakeOutput Include="$(CMakeBuildDir)cli\dotnet\dotnet" />
-      <CMakeOutput Include="$(CMakeBuildDir)cli\apphost\apphost" />
-      <CMakeOutput Include="$(CMakeBuildDir)cli\hostpolicy\$(HostPolicyBaseName)" />
-      <CMakeOutput Include="$(CMakeBuildDir)cli\fxr\$(DotnetHostFxrBaseName)" />
-    </ItemGroup>
-    <ItemGroup Condition="'$(StripSymbols)' == 'true'">
-      <CMakeOutput Include="@(CmakeOutput -> '%(Identity)$(SymbolFileExtension)')" />
-    </ItemGroup>
-
-    <Copy SourceFiles="@(CMakeOutput)"
-          DestinationFolder="$(CoreHostOutputDir)"/>
   </Target>
 
   <Target Name="BuildCoreHostWindows"
@@ -80,21 +67,5 @@
     <!-- Run script that invokes Cmake to create VS files, and then calls msbuild to compile them -->
     <Message Text="$(MSBuildProjectDirectory)\build.cmd $(BuildArgs)" Importance="High"/>
     <Exec Command="$(MSBuildProjectDirectory)\build.cmd $(BuildArgs)" />
-
-    <ItemGroup>
-      <CMakeOutput Include="$(IntermediateOutputRootPath)corehost\cli\dotnet\$(ConfigurationGroup)\dotnet.exe" />
-      <CMakeOutput Include="$(IntermediateOutputRootPath)corehost\cli\dotnet\$(ConfigurationGroup)\dotnet.pdb" />
-      <CMakeOutput Include="$(IntermediateOutputRootPath)corehost\cli\apphost\$(ConfigurationGroup)\apphost.exe" />
-      <CMakeOutput Include="$(IntermediateOutputRootPath)corehost\cli\apphost\$(ConfigurationGroup)\apphost.pdb" />
-      <CMakeOutput Include="$(IntermediateOutputRootPath)corehost\cli\comhost\$(ConfigurationGroup)\comhost.dll" />
-      <CMakeOutput Include="$(IntermediateOutputRootPath)corehost\cli\comhost\$(ConfigurationGroup)\comhost.pdb" />
-      <CMakeOutput Include="$(IntermediateOutputRootPath)corehost\cli\hostpolicy\$(ConfigurationGroup)\$(HostPolicyBaseName)" />
-      <CMakeOutput Include="$(IntermediateOutputRootPath)corehost\cli\hostpolicy\$(ConfigurationGroup)\hostpolicy.pdb" />
-      <CMakeOutput Include="$(IntermediateOutputRootPath)corehost\cli\fxr\$(ConfigurationGroup)\$(DotnetHostFxrBaseName)" />
-      <CMakeOutput Include="$(IntermediateOutputRootPath)corehost\cli\fxr\$(ConfigurationGroup)\hostfxr.pdb" />
-    </ItemGroup>
-    
-    <Copy SourceFiles="@(CMakeOutput)"
-          DestinationFolder="$(CoreHostOutputDir)"/>
   </Target>
 </Project>

--- a/src/corehost/build.proj
+++ b/src/corehost/build.proj
@@ -20,12 +20,12 @@
     <PropertyGroup>
       <CMakeBuildDir>$(IntermediateOutputRootPath)corehost\cmake\</CMakeBuildDir>
     
-      <BuildArgs>--arch $(TargetArchitecture) --apphostver $(AppHostVersion) --hostver $(HostVersion) --fxrver $(HostResolverVersion) --policyver $(HostPolicyVersion) --commithash $(LatestCommit)</BuildArgs>
+      <BuildArgs>--configuration $(ConfigurationGroup) --arch $(TargetArchitecture) --apphostver $(AppHostVersion) --hostver $(HostVersion) --fxrver $(HostResolverVersion) --policyver $(HostPolicyVersion) --commithash $(LatestCommit)</BuildArgs>
       <BuildArgs Condition="'$(PortableBuild)' == 'true'">$(BuildArgs) -portable</BuildArgs>     
       <BuildArgs Condition="'$(CrossBuild)' == 'true'">$(BuildArgs) --cross</BuildArgs>  
       <BuildArgs Condition="'$(StripSymbols)' == 'true'">$(BuildArgs) --stripsymbols</BuildArgs>   
     </PropertyGroup>
-    
+
     <Message Text="$(MSBuildProjectDirectory)\build.sh $(BuildArgs)" Importance="High"/>
     <Exec Command="$(MSBuildProjectDirectory)\build.sh $(BuildArgs)" />
   </Target>

--- a/src/corehost/build.proj
+++ b/src/corehost/build.proj
@@ -25,13 +25,9 @@
       <BuildArgs Condition="'$(CrossBuild)' == 'true'">$(BuildArgs) --cross</BuildArgs>  
       <BuildArgs Condition="'$(StripSymbols)' == 'true'">$(BuildArgs) --stripsymbols</BuildArgs>   
     </PropertyGroup>
-
-    <RemoveDir Directories="$(CMakeBuildDir)" Condition="Exists('$(CMakeBuildDir)') And '$(IncrementalNativeBuild)' != 'true'" />
-    <MakeDir Directories="$(CMakeBuildDir)" Condition="!(Exists('$(CMakeBuildDir)'))" />
-
+    
     <Message Text="$(MSBuildProjectDirectory)\build.sh $(BuildArgs)" Importance="High"/>
-    <Exec Command="$(MSBuildProjectDirectory)\build.sh $(BuildArgs)"
-          WorkingDirectory="$(CMakeBuildDir)"/>
+    <Exec Command="$(MSBuildProjectDirectory)\build.sh $(BuildArgs)" />
   </Target>
 
   <Target Name="BuildCoreHostWindows"

--- a/src/corehost/build.sh
+++ b/src/corehost/build.sh
@@ -236,6 +236,7 @@ fi
 
 __cmake_defines="${__cmake_defines} -DVERSION_FILE_PATH:STRING=${__versionSourceFile}"
 
+mkdir -p $__intermediateOutputPath
 pushd $__intermediateOutputPath
 
 echo "Building Corehost from $DIR to $(pwd)"

--- a/src/corehost/build.sh
+++ b/src/corehost/build.sh
@@ -11,7 +11,7 @@ init_rid_plat()
             if [ -e $ROOTFS_DIR/etc/os-release ]; then
                 source $ROOTFS_DIR/etc/os-release
                 __rid_plat="$ID.$VERSION_ID"
-                if [[ "$ID" == "alpine" ]]
+                if [[ "$ID" == "alpine" ]]; then
                     __rid_plat="linux-musl"
                 fi
             fi

--- a/src/corehost/build.sh
+++ b/src/corehost/build.sh
@@ -266,4 +266,4 @@ fi
 popd
 
 set +x # turn off trace
-cmake --build $__intermediateOutputPath --target install
+cmake --build $__intermediateOutputPath --target install --config $__configuration

--- a/src/corehost/build.sh
+++ b/src/corehost/build.sh
@@ -202,7 +202,6 @@ if [ -z $__commit_hash ]; then
     exit -1
 fi
 
-
 __build_arch_lowcase=$(echo "$__build_arch" | tr '[:upper:]' '[:lower:]')
 __base_rid=$__rid_plat-$__build_arch_lowcase
 echo "Computed RID for native build is $__base_rid"

--- a/src/corehost/build.sh
+++ b/src/corehost/build.sh
@@ -255,4 +255,4 @@ else
     cmake "$DIR" -G "Unix Makefiles" $__cmake_defines -DCLI_CMAKE_HOST_VER:STRING=$__host_ver -DCLI_CMAKE_APPHOST_VER:STRING=$__apphost_ver -DCLI_CMAKE_HOST_FXR_VER:STRING=$__fxr_ver -DCLI_CMAKE_HOST_POLICY_VER:STRING=$__policy_ver -DCLI_CMAKE_PKG_RID:STRING=$__base_rid -DCLI_CMAKE_COMMIT_HASH:STRING=$__commit_hash
 fi
 set +x # turn off trace
-make
+make install

--- a/src/corehost/build.sh
+++ b/src/corehost/build.sh
@@ -100,6 +100,7 @@ __linkPortable=0
 __cmake_defines=
 __baseIntermediateOutputPath="$RootRepo/bin/obj"
 __versionSourceFile="$__baseIntermediateOutputPath/version.cpp"
+__cmake_bin_prefix=
 
 while [ "$1" != "" ]; do
         lowerI="$(echo $1 | awk '{print tolower($0)}')"
@@ -182,7 +183,8 @@ if [ "$__CrossBuild" == 1 ]; then
     fi
 fi
 
-# __rid_plat is the base RID that corehost is shipped for, effectively, the name of the folder in "runtimes/{__rid_plat}/native/" inside the nupkgs.
+# __base_rid is the base RID that corehost is shipped for, effectively, the name of the folder in "runtimes/{__base_rid}/native/" inside the nupkgs.
+# __rid_plat is the OS portion of the RID.
 __rid_plat=
 init_rid_plat
 
@@ -196,9 +198,11 @@ if [ -z $__commit_hash ]; then
     exit -1
 fi
 
+
 __build_arch_lowcase=$(echo "$__build_arch" | tr '[:upper:]' '[:lower:]')
 __base_rid=$__rid_plat-$__build_arch_lowcase
 echo "Computed RID for native build is $__base_rid"
+__cmake_bin_prefix="${__base_rid}.${__configuration}"
 export __CrossToolChainTargetRID=$__base_rid
 
 # Set up the environment to be used for building with clang.
@@ -250,9 +254,9 @@ if [ $__CrossBuild == 1 ]; then
     fi
     export TARGET_BUILD_ARCH=$__build_arch_lowcase
     export __DistroRid=$__rid_plat
-    cmake "$DIR" -G "Unix Makefiles" $__cmake_defines -DCLI_CMAKE_HOST_VER:STRING=$__host_ver -DCLI_CMAKE_APPHOST_VER:STRING=$__apphost_ver -DCLI_CMAKE_HOST_FXR_VER:STRING=$__fxr_ver -DCLI_CMAKE_HOST_POLICY_VER:STRING=$__policy_ver -DCLI_CMAKE_PKG_RID:STRING=$__base_rid -DCLI_CMAKE_COMMIT_HASH:STRING=$__commit_hash -DCMAKE_TOOLCHAIN_FILE=$DIR/../../cross/toolchain.cmake
+    cmake "$DIR" -G "Unix Makefiles" $__cmake_defines -DCLI_CMAKE_HOST_VER:STRING=$__host_ver -DCLI_CMAKE_APPHOST_VER:STRING=$__apphost_ver -DCLI_CMAKE_HOST_FXR_VER:STRING=$__fxr_ver -DCLI_CMAKE_HOST_POLICY_VER:STRING=$__policy_ver -DCLI_CMAKE_PKG_RID:STRING=$__base_rid -DCLI_CMAKE_COMMIT_HASH:STRING=$__commit_hash -DCMAKE_INSTALL_PREFIX=$__cmake_bin_prefix -DCMAKE_TOOLCHAIN_FILE=$DIR/../../cross/toolchain.cmake
 else
-    cmake "$DIR" -G "Unix Makefiles" $__cmake_defines -DCLI_CMAKE_HOST_VER:STRING=$__host_ver -DCLI_CMAKE_APPHOST_VER:STRING=$__apphost_ver -DCLI_CMAKE_HOST_FXR_VER:STRING=$__fxr_ver -DCLI_CMAKE_HOST_POLICY_VER:STRING=$__policy_ver -DCLI_CMAKE_PKG_RID:STRING=$__base_rid -DCLI_CMAKE_COMMIT_HASH:STRING=$__commit_hash
+    cmake "$DIR" -G "Unix Makefiles" $__cmake_defines -DCLI_CMAKE_HOST_VER:STRING=$__host_ver -DCLI_CMAKE_APPHOST_VER:STRING=$__apphost_ver -DCLI_CMAKE_HOST_FXR_VER:STRING=$__fxr_ver -DCLI_CMAKE_HOST_POLICY_VER:STRING=$__policy_ver -DCLI_CMAKE_PKG_RID:STRING=$__base_rid -DCLI_CMAKE_COMMIT_HASH:STRING=$__commit_hash -DCMAKE_INSTALL_PREFIX=$__cmake_bin_prefix
 fi
 set +x # turn off trace
 make install

--- a/src/corehost/build.sh
+++ b/src/corehost/build.sh
@@ -11,6 +11,9 @@ init_rid_plat()
             if [ -e $ROOTFS_DIR/etc/os-release ]; then
                 source $ROOTFS_DIR/etc/os-release
                 __rid_plat="$ID.$VERSION_ID"
+                if [[ "$ID" == "alpine" ]]
+                    __rid_plat="linux-musl"
+                fi
             fi
             echo "__rid_plat is $__rid_plat"
         fi

--- a/src/corehost/build.sh
+++ b/src/corehost/build.sh
@@ -87,6 +87,7 @@ done
 DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
 RootRepo="$DIR/../.."
 
+__bin_dir="$RootRepo/bin"
 __build_arch=
 __host_ver=
 __apphost_ver=
@@ -202,7 +203,8 @@ fi
 __build_arch_lowcase=$(echo "$__build_arch" | tr '[:upper:]' '[:lower:]')
 __base_rid=$__rid_plat-$__build_arch_lowcase
 echo "Computed RID for native build is $__base_rid"
-__cmake_bin_prefix="${__base_rid}.${__configuration}"
+__cmake_bin_prefix="$__bin_dir/$__base_rid.$__configuration"
+__intermediateOutputPath="$__baseIntermediateOutputPath/$__base_rid.$__configuration/corehost"
 export __CrossToolChainTargetRID=$__base_rid
 
 # Set up the environment to be used for building with clang.
@@ -234,6 +236,8 @@ fi
 
 __cmake_defines="${__cmake_defines} -DVERSION_FILE_PATH:STRING=${__versionSourceFile}"
 
+pushd $__intermediateOutputPath
+
 echo "Building Corehost from $DIR to $(pwd)"
 set -x # turn on trace
 if [ $__CrossBuild == 1 ]; then
@@ -258,5 +262,7 @@ if [ $__CrossBuild == 1 ]; then
 else
     cmake "$DIR" -G "Unix Makefiles" $__cmake_defines -DCLI_CMAKE_HOST_VER:STRING=$__host_ver -DCLI_CMAKE_APPHOST_VER:STRING=$__apphost_ver -DCLI_CMAKE_HOST_FXR_VER:STRING=$__fxr_ver -DCLI_CMAKE_HOST_POLICY_VER:STRING=$__policy_ver -DCLI_CMAKE_PKG_RID:STRING=$__base_rid -DCLI_CMAKE_COMMIT_HASH:STRING=$__commit_hash -DCMAKE_INSTALL_PREFIX=$__cmake_bin_prefix
 fi
+popd
+
 set +x # turn off trace
-make install
+cmake --build $__intermediateOutputPath --target install

--- a/src/corehost/cli/apphost/CMakeLists.txt
+++ b/src/corehost/cli/apphost/CMakeLists.txt
@@ -25,8 +25,6 @@ include(../exe.cmake)
 
 add_definitions(-DFEATURE_APPHOST=1)
 
-install_symbols(apphost corehost)
-
 # Disable manifest generation into the file .exe on Windows
 if(WIN32)
     set_property(TARGET ${PROJECT_NAME} PROPERTY 

--- a/src/corehost/cli/apphost/CMakeLists.txt
+++ b/src/corehost/cli/apphost/CMakeLists.txt
@@ -25,7 +25,7 @@ include(../exe.cmake)
 
 add_definitions(-DFEATURE_APPHOST=1)
 
-install_symbols(apphost .)
+install_symbols(apphost corehost)
 
 # Disable manifest generation into the file .exe on Windows
 if(WIN32)

--- a/src/corehost/cli/apphost/CMakeLists.txt
+++ b/src/corehost/cli/apphost/CMakeLists.txt
@@ -25,7 +25,7 @@ include(../exe.cmake)
 
 add_definitions(-DFEATURE_APPHOST=1)
 
-install_library_and_symbols (apphost)
+install_symbols(apphost .)
 
 # Disable manifest generation into the file .exe on Windows
 if(WIN32)

--- a/src/corehost/cli/comhost/CMakeLists.txt
+++ b/src/corehost/cli/comhost/CMakeLists.txt
@@ -40,5 +40,5 @@ if (WIN32 AND (CLI_CMAKE_PLATFORM_ARCH_ARM OR CLI_CMAKE_PLATFORM_ARCH_ARM64))
     target_link_libraries(comhost Advapi32.lib Ole32.lib OleAut32.lib)
 endif()
 
-install(TARGETS comhost DESTINATION .)
-install_symbols(comhost .)
+install(TARGETS comhost DESTINATION corehost)
+install_symbols(comhost corehost)

--- a/src/corehost/cli/comhost/CMakeLists.txt
+++ b/src/corehost/cli/comhost/CMakeLists.txt
@@ -40,4 +40,5 @@ if (WIN32 AND (CLI_CMAKE_PLATFORM_ARCH_ARM OR CLI_CMAKE_PLATFORM_ARCH_ARM64))
     target_link_libraries(comhost Advapi32.lib Ole32.lib OleAut32.lib)
 endif()
 
-install_library_and_symbols (comhost)
+install(TARGETS comhost DESTINATION .)
+install_symbols(comhost .)

--- a/src/corehost/cli/dotnet/CMakeLists.txt
+++ b/src/corehost/cli/dotnet/CMakeLists.txt
@@ -14,4 +14,5 @@ endif()
 
 include(../exe.cmake)
 
-install_library_and_symbols (dotnet)
+install(TARGETS dotnet DESTINATION .)
+install_symbols(dotnet .)

--- a/src/corehost/cli/dotnet/CMakeLists.txt
+++ b/src/corehost/cli/dotnet/CMakeLists.txt
@@ -13,6 +13,3 @@ if(WIN32)
 endif()
 
 include(../exe.cmake)
-
-install(TARGETS dotnet DESTINATION corehost)
-install_symbols(dotnet corehost)

--- a/src/corehost/cli/dotnet/CMakeLists.txt
+++ b/src/corehost/cli/dotnet/CMakeLists.txt
@@ -14,5 +14,5 @@ endif()
 
 include(../exe.cmake)
 
-install(TARGETS dotnet DESTINATION .)
-install_symbols(dotnet .)
+install(TARGETS dotnet DESTINATION corehost)
+install_symbols(dotnet corehost)

--- a/src/corehost/cli/exe.cmake
+++ b/src/corehost/cli/exe.cmake
@@ -20,6 +20,7 @@ if(NOT WIN32)
     disable_pax_mprotect(${DOTNET_PROJECT_NAME})
 endif()
 
-install(TARGETS ${DOTNET_PROJECT_NAME} DESTINATION bin)
+install(TARGETS ${DOTNET_PROJECT_NAME} DESTINATION .)
+install_symbols(${DOTNET_PROJECT_NAME} .)
 
 set_common_libs("exe")

--- a/src/corehost/cli/exe.cmake
+++ b/src/corehost/cli/exe.cmake
@@ -20,7 +20,7 @@ if(NOT WIN32)
     disable_pax_mprotect(${DOTNET_PROJECT_NAME})
 endif()
 
-install(TARGETS ${DOTNET_PROJECT_NAME} DESTINATION .)
-install_symbols(${DOTNET_PROJECT_NAME} .)
+install(TARGETS ${DOTNET_PROJECT_NAME} DESTINATION corehost)
+install_symbols(${DOTNET_PROJECT_NAME} corehost)
 
 set_common_libs("exe")

--- a/src/corehost/cli/fxr/CMakeLists.txt
+++ b/src/corehost/cli/fxr/CMakeLists.txt
@@ -36,5 +36,5 @@ set(SOURCES
 
 include(../lib.cmake)
 
-install(TARGETS hostfxr DESTINATION .)
-install_symbols(hostfxr .)
+install(TARGETS hostfxr DESTINATION corehost)
+install_symbols(hostfxr corehost)

--- a/src/corehost/cli/fxr/CMakeLists.txt
+++ b/src/corehost/cli/fxr/CMakeLists.txt
@@ -36,4 +36,5 @@ set(SOURCES
 
 include(../lib.cmake)
 
-install_library_and_symbols (hostfxr)
+install(TARGETS hostfxr DESTINATION .)
+install_symbols(hostfxr .)

--- a/src/corehost/cli/hostpolicy/CMakeLists.txt
+++ b/src/corehost/cli/hostpolicy/CMakeLists.txt
@@ -36,5 +36,5 @@ set(SOURCES
 
 include(../lib.cmake)
 
-install(TARGETS hostpolicy DESTINATION .)
-install_symbols(hostpolicy .)
+install(TARGETS hostpolicy DESTINATION corehost)
+install_symbols(hostpolicy corehost)

--- a/src/corehost/cli/hostpolicy/CMakeLists.txt
+++ b/src/corehost/cli/hostpolicy/CMakeLists.txt
@@ -36,4 +36,5 @@ set(SOURCES
 
 include(../lib.cmake)
 
-install_library_and_symbols (hostpolicy)
+install(TARGETS hostpolicy DESTINATION .)
+install_symbols(hostpolicy .)

--- a/src/settings.cmake
+++ b/src/settings.cmake
@@ -111,23 +111,12 @@ function(strip_symbols targetName outputFilename)
     endif(CLR_CMAKE_PLATFORM_UNIX)
 endfunction()
 
-function(install_library_and_symbols targetName)
-    strip_symbols(${targetName} strip_destination_file)
-
-    # On the older version of cmake (2.8.12) used on Ubuntu 14.04 the TARGET_FILE
-    # generator expression doesn't work correctly returning the wrong path and on
-    # the newer cmake versions the LOCATION property isn't supported anymore.
-    if(CMAKE_VERSION VERSION_EQUAL 3.0 OR CMAKE_VERSION VERSION_GREATER 3.0)
-        set(install_source_file $<TARGET_FILE:${targetName}>)
-    else()
-        get_property(install_source_file TARGET ${targetName} PROPERTY LOCATION)
-    endif()
-
-    install(PROGRAMS ${install_source_file} DESTINATION .)
+function(install_symbols targetName destination_path)
     if(WIN32)
-        install(FILES ${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>/${targetName}.pdb DESTINATION PDB)
+        install(FILES ${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>/${targetName}.pdb DESTINATION ${destination_path})
     else()
-        install(FILES ${strip_destination_file} DESTINATION .)
+        strip_symbols(${targetName} strip_destination_file)
+        install(FILES ${strip_destination_file} DESTINATION ${destination_path})
     endif()
 endfunction()
 


### PR DESCRIPTION
We generate an install target to place our binaries and symbols in the right location via CMake, but we never use it. Additionally, we effectively replicate that functionality in `core-host/build.proj`.

This PR switches the native build to place the native output via the CMake install target and removes the MSBuild scripting that was duplicating it.

Also fixes a few build bugs in our RID construction in `src/corehost/build.sh` with cross-compilation.