### PR TITLE
Clean up RPM dotnet symlink to fix build failure

### DIFF
--- a/src/pkg/packaging/rpm/package.targets
+++ b/src/pkg/packaging/rpm/package.targets
@@ -113,6 +113,11 @@
           SkipUnchangedFiles="False"
           UseHardlinksIfPossible="False" />
 
+    <!--
+      Clean up dotnet symlink. Later build steps are confused and fail because the symlink points to
+      a path that doesn't exist on the build machine.
+    -->
+    <Delete Files="$(rpmLayoutUsrBinDir)dotnet" />
   </Target>
 
   <Target Name="GenerateHostFxrRpm">


### PR DESCRIPTION
Fixes https://github.com/dotnet/core-setup/issues/5449.

https://github.com/dotnet/core-setup/pull/5380 added this symlink, and I didn't notice the build was partially failing. (Shows up as green on the GitHub check.)

I'm porting this to the 2.1 port PR https://github.com/dotnet/core-setup/pull/5398 as well to keep the infra happy.

/cc @leecow 