### PR TITLE
[release/3.0] Fix 3.0 publish channel

### DIFF
--- a/BranchInfo.props
+++ b/BranchInfo.props
@@ -13,7 +13,7 @@
 
     <ReleaseSuffix>$(PreReleaseLabel)</ReleaseSuffix>
     <ReleaseBrandSuffix>Preview 3</ReleaseBrandSuffix>
-    <Channel>master</Channel>
+    <Channel>release/3.0</Channel>
     <ContainerName>dotnet</ContainerName>
     <ChecksumContainerName>$(ContainerName)</ChecksumContainerName>
     <NETCoreAppMaximumVersion>$(MajorVersion).$(MinorVersion)</NETCoreAppMaximumVersion>


### PR DESCRIPTION
This wasn't needed in 2.1/2.2 because they build in ProdCon, which copies to the latest channel with its own infra. In ProdCon v2, we have to use our own infra, so the channel needs to be updated. At the moment I think the `master` channel is thrashing between `master` and `release/3.0` official builds.

Noticed this while looking for `release/3.0` latest blobs to link to in the readme. 😄 