### PR TITLE
Use tests folder for test artifacts

### DIFF
--- a/src/test/Assets/TestProjects/PortableAppWithLongPath/Program.cs
+++ b/src/test/Assets/TestProjects/PortableAppWithLongPath/Program.cs
@@ -12,9 +12,10 @@ namespace PortableAppWithLongPath
             Console.WriteLine(string.Join(Environment.NewLine, args));
 
             // Create a path that is longer than MAX_PATH
-            DirectoryInfo newDir = Directory.CreateDirectory(Path.Combine(Directory.GetCurrentDirectory(), "longPath"));
+            DirectoryInfo newDir = Directory.CreateDirectory(Path.Combine(args[0], "longPath"));
             string longPath = Path.Combine(newDir.FullName, new string('x', 255));
 
+            Console.WriteLine($"Trying to create `{longPath}`");
             bool success = CreateDirectoryW(longPath, IntPtr.Zero);
             Console.WriteLine($"CreateDirectoryW with long path {(success ? "succeeded" : $"failed with {Marshal.GetLastWin32Error()}" )}");
 

--- a/src/test/HostActivationTests/WindowsSpecificBehavior.cs
+++ b/src/test/HostActivationTests/WindowsSpecificBehavior.cs
@@ -49,7 +49,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
             var dotnet = fixture.BuiltDotnet;
             var appDll = fixture.TestProject.AppDll;
 
-            dotnet.Exec(appDll)
+            dotnet.Exec(appDll, fixture.TestProject.Location)
                 .CaptureStdErr()
                 .CaptureStdOut()
                 .Execute()


### PR DESCRIPTION
It's cleaner to use the location of the copied test project as that will be deleted right after the test has finished.
The working directory used before is in the binaries folder which the tests should not modify if possible.