### PR TITLE
Framework resolution tests

### DIFF
--- a/src/corehost/cli/CMakeLists.txt
+++ b/src/corehost/cli/CMakeLists.txt
@@ -3,6 +3,8 @@ add_subdirectory(dotnet)
 add_subdirectory(fxr)
 add_subdirectory(hostpolicy)
 
+add_subdirectory(test)
+
 if(WIN32)
     add_subdirectory(comhost)
 endif()

--- a/src/corehost/cli/test/CMakeLists.txt
+++ b/src/corehost/cli/test/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_subdirectory(mockhostpolicy)

--- a/src/corehost/cli/test/mockhostpolicy/CMakeLists.txt
+++ b/src/corehost/cli/test/mockhostpolicy/CMakeLists.txt
@@ -1,0 +1,16 @@
+# Copyright (c) .NET Foundation and contributors. All rights reserved.
+# Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+cmake_minimum_required (VERSION 2.6)
+project(mockhostpolicy)
+
+set(DOTNET_PROJECT_NAME "mockhostpolicy")
+
+set(SOURCES
+    ./mockhostpolicy.cpp
+)
+
+include(../testlib.cmake)
+
+install(TARGETS mockhostpolicy DESTINATION corehost_test)
+install_symbols(mockhostpolicy corehost_test)

--- a/src/corehost/cli/test/mockhostpolicy/mockhostpolicy.cpp
+++ b/src/corehost/cli/test/mockhostpolicy/mockhostpolicy.cpp
@@ -65,6 +65,23 @@ SHARED_API int corehost_load(host_interface_t* init)
     std::cout << "mock host_info_dotnet_root:" << tostr(init->host_info_dotnet_root).data() << std::endl;
     std::cout << "mock host_info_app_path:" << tostr(init->host_info_app_path).data() << std::endl;
 
+    if (init->fx_names.len == 0)
+    {
+        std::cout << "mock frameworks: <empty>" << std::endl;
+    }
+    else
+    {
+        for (int i = 0; i < init->fx_names.len; i++)
+        {
+            std::cout << "mock frameworks: " 
+                << tostr(init->fx_names.arr[i]).data() << " " 
+                << tostr(init->fx_found_versions.arr[i]).data() << " [requested: "
+                << tostr(init->fx_requested_versions.arr[i]).data() << "] [path: "
+                << tostr(init->fx_dirs.arr[i]).data() << "]"
+                << std::endl;
+        }
+    }
+
     return StatusCode::Success;
 }
 

--- a/src/corehost/cli/test/mockhostpolicy/mockhostpolicy.cpp
+++ b/src/corehost/cli/test/mockhostpolicy/mockhostpolicy.cpp
@@ -1,0 +1,89 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#include <iostream>
+#include "pal.h"
+#include "trace.h"
+#include "error_codes.h"
+#include "host_interface.h"
+
+std::vector<char> tostr(const pal::char_t* value)
+{
+    std::vector<char> vect;
+    pal::pal_utf8string(pal::string_t(value), &vect);
+    return vect;
+}
+
+void print_strarr(const char* prefix, const strarr_t& arr)
+{
+    if (arr.len == 0)
+    {
+        std::cout << prefix << "<empty>" << std::endl;
+        return;
+    }
+
+    for (int i = 0; i < arr.len; i++)
+    {
+        std::cout << prefix << tostr(arr.arr[i]).data() << std::endl;
+    }
+}
+
+SHARED_API int corehost_load(host_interface_t* init)
+{
+    trace::setup();
+
+    trace::verbose(_X("--- Invoked hostpolicy mock - corehost_load"));
+    
+    std::cout << "--- Invoked hostpolicy mock - corehost_load" << std::endl;
+    std::cout << "mock version: " << init->version_hi << " " << init->version_lo << std::endl;
+    if (init->config_keys.len == 0)
+    {
+        std::cout << "mock config: <empty>" << std::endl;
+    }
+    else
+    {
+        for (int i = 0; i < init->config_keys.len; i++)
+        {
+            std::cout << "mock config: " << tostr(init->config_keys.arr[i]).data() << "=" << tostr(init->config_values.arr[i]).data() << std::endl;
+        }
+    }
+    std::cout << "mock fx_dir: " << tostr(init->fx_dir).data() << std::endl;
+    std::cout << "mock fx_name: " << tostr(init->fx_name).data() << std::endl;
+    std::cout << "mock deps_file: " << tostr(init->deps_file).data() << std::endl;
+    std::cout << "mock is_framework_dependent: " << init->is_framework_dependent << std::endl;
+    print_strarr("mock probe_paths: ", init->probe_paths);
+    std::cout << "mock host_mode: " << init->host_mode << std::endl;
+    std::cout << "mock tfm: " << tostr(init->tfm).data() << std::endl;
+    std::cout << "mock additional_deps_serialized: " << tostr(init->additional_deps_serialized).data() << std::endl;
+    std::cout << "mock fx_ver: " << tostr(init->fx_ver).data() << std::endl;
+    print_strarr("mock fx_names: ", init->fx_names);
+    print_strarr("mock fx_dirs: ", init->fx_dirs);
+    print_strarr("mock fx_requested_versions: ", init->fx_requested_versions);
+    print_strarr("mock fx_found_versions: ", init->fx_found_versions);
+    std::cout << "mock host_command:" << tostr(init->host_command).data() << std::endl;
+    std::cout << "mock host_info_host_path:" << tostr(init->host_info_host_path).data() << std::endl;
+    std::cout << "mock host_info_dotnet_root:" << tostr(init->host_info_dotnet_root).data() << std::endl;
+    std::cout << "mock host_info_app_path:" << tostr(init->host_info_app_path).data() << std::endl;
+
+    return StatusCode::Success;
+}
+
+SHARED_API int corehost_main(const int argc, const pal::char_t* argv[])
+{
+    trace::verbose(_X("--- Invoked hostpolicy mock - corehost_main"));
+    return StatusCode::Success;
+}
+
+SHARED_API int corehost_unload()
+{
+    trace::verbose(_X("--- Invoked hostpolicy mock - corehost_unload"));
+    return StatusCode::Success;
+}
+
+using corehost_error_writer_fn = void(*)(const pal::char_t* message);
+SHARED_API corehost_error_writer_fn corehost_set_error_writer(corehost_error_writer_fn error_writer)
+{
+    trace::verbose(_X("--- Invoked hostpolicy mock - corehost_set_error_writer"));
+    return nullptr;
+}
+

--- a/src/corehost/cli/test/testlib.cmake
+++ b/src/corehost/cli/test/testlib.cmake
@@ -1,0 +1,8 @@
+# Copyright (c) .NET Foundation and contributors. All rights reserved.
+# Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+project(${DOTNET_PROJECT_NAME})
+
+set(SKIP_VERSIONING 1)
+
+include(${CMAKE_CURRENT_LIST_DIR}/../lib.cmake)

--- a/src/test/HostActivationTests/Constants.cs
+++ b/src/test/HostActivationTests/Constants.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
+{
+    internal static class Constants
+    {
+        public static class ApplyPatchesSetting
+        {
+            public const string RuntimeConfigPropertyName = "applyPatches";
+        }
+
+        public static class RollFowardOnNoCandidateFxSetting
+        {
+            public const string RuntimeConfigPropertyName = "rollForwardOnNoCandidateFx";
+            public const string CommandLineArgument = "--roll-forward-on-no-candidate-fx";
+            public const string EnvironmentVariable = "DOTNET_ROLL_FORWARD_ON_NO_CANDIDATE_FX";
+        }
+    }
+}

--- a/src/test/HostActivationTests/FrameworkResolution/ApplyPatchesSettings.cs
+++ b/src/test/HostActivationTests/FrameworkResolution/ApplyPatchesSettings.cs
@@ -34,8 +34,8 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.FrameworkResolution
         {
             RunTest(
                 runtimeConfig => runtimeConfig
-                    .WithFramework(MicrosoftNETCoreApp, "5.1.2")
-                    .WithApplyPatches(false),
+                    .WithApplyPatches(false)
+                    .WithFramework(MicrosoftNETCoreApp, "5.1.2"),
                 result => result.Should().Pass()
                     .And.HaveResolvedFrameworkVersion("5.1.2"));
         }
@@ -56,17 +56,17 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.FrameworkResolution
         {
             RunTest(
                 runtimeConfig => runtimeConfig
+                    .WithApplyPatches(true)
                     .WithFramework(new RuntimeConfig.Framework(MicrosoftNETCoreApp, "5.1.2")
-                        .WithApplyPatches(false))
-                    .WithApplyPatches(true),
+                        .WithApplyPatches(false)),
                 result => result.Should().Pass()
                     .And.HaveResolvedFrameworkVersion("5.1.2"));
 
             RunTest(
                 runtimeConfig => runtimeConfig
+                    .WithApplyPatches(false)
                     .WithFramework(new RuntimeConfig.Framework(MicrosoftNETCoreApp, "5.1.2")
-                        .WithApplyPatches(true))
-                    .WithApplyPatches(false),
+                        .WithApplyPatches(true)),
                 result => result.Should().Pass()
                     .And.HaveResolvedFrameworkVersion("5.1.3"));
         }
@@ -110,8 +110,8 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.FrameworkResolution
         {
             RunTest(
                 runtimeConfig => runtimeConfig
-                    .WithFramework("MiddleWare", "2.1.2")
-                    .WithApplyPatches(false),
+                    .WithApplyPatches(false)
+                    .WithFramework("MiddleWare", "2.1.2"),
                 result => result.Should().Pass()
                     .And.HaveResolvedFrameworkVersion("5.1.3"));
 

--- a/src/test/HostActivationTests/FrameworkResolution/ApplyPatchesSettings.cs
+++ b/src/test/HostActivationTests/FrameworkResolution/ApplyPatchesSettings.cs
@@ -1,0 +1,160 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.DotNet.Cli.Build;
+using Microsoft.DotNet.Cli.Build.Framework;
+using System;
+using Xunit;
+
+namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.FrameworkResolution
+{
+    public class ApplyPatchesSettings :
+        FrameworkResolutionBase,
+        IClassFixture<ApplyPatchesSettings.SharedTestState>
+    {
+        private SharedTestState SharedState { get; }
+
+        public ApplyPatchesSettings(SharedTestState sharedState)
+        {
+            SharedState = sharedState;
+        }
+
+        [Fact]
+        public void Default()
+        {
+            RunTest(
+                runtimeConfig => runtimeConfig
+                    .WithFramework(MicrosoftNETCoreApp, "5.1.2"),
+                result => result.Should().Pass()
+                    .And.HaveResolvedFrameworkVersion("5.1.3"));
+        }
+
+        [Fact]
+        public void RuntimeConfigOnly()
+        {
+            RunTest(
+                runtimeConfig => runtimeConfig
+                    .WithFramework(MicrosoftNETCoreApp, "5.1.2")
+                    .WithApplyPatches(false),
+                result => result.Should().Pass()
+                    .And.HaveResolvedFrameworkVersion("5.1.2"));
+        }
+
+        [Fact]
+        public void FrameworkReferenceOnly()
+        {
+            RunTest(
+                runtimeConfig => runtimeConfig
+                    .WithFramework(new RuntimeConfig.Framework(MicrosoftNETCoreApp, "5.1.2")
+                        .WithApplyPatches(false)),
+                result => result.Should().Pass()
+                    .And.HaveResolvedFrameworkVersion("5.1.2"));
+        }
+
+        [Fact]
+        public void Priority()
+        {
+            RunTest(
+                runtimeConfig => runtimeConfig
+                    .WithFramework(new RuntimeConfig.Framework(MicrosoftNETCoreApp, "5.1.2")
+                        .WithApplyPatches(false))
+                    .WithApplyPatches(true),
+                result => result.Should().Pass()
+                    .And.HaveResolvedFrameworkVersion("5.1.2"));
+
+            RunTest(
+                runtimeConfig => runtimeConfig
+                    .WithFramework(new RuntimeConfig.Framework(MicrosoftNETCoreApp, "5.1.2")
+                        .WithApplyPatches(true))
+                    .WithApplyPatches(false),
+                result => result.Should().Pass()
+                    .And.HaveResolvedFrameworkVersion("5.1.3"));
+        }
+
+        [Fact]
+        public void InnerFrameworkReference_RuntimeConfig()
+        {
+            using (var dotnetCustomizer = SharedState.DotNetWithFrameworks.Customize())
+            {
+                dotnetCustomizer.Framework("MiddleWare").RuntimeConfig(runtimeConfig =>
+                    runtimeConfig.WithApplyPatches(false));
+
+                RunTest(
+                    runtimeConfig => runtimeConfig
+                        .WithFramework("MiddleWare", "2.1.0"),
+                    result => result.Should().Pass()
+                        .And.HaveResolvedFrameworkVersion("5.1.2")
+                        .And.HaveResolvedFrameworkVersion("2.1.2"));
+            }
+        }
+
+        [Fact]
+        public void InnerFrameworkReference_Framework()
+        {
+            using (var dotnetCustomizer = SharedState.DotNetWithFrameworks.Customize())
+            {
+                dotnetCustomizer.Framework("MiddleWare").RuntimeConfig(runtimeConfig =>
+                    runtimeConfig.GetFramework(MicrosoftNETCoreApp).WithApplyPatches(false));
+
+                RunTest(
+                    runtimeConfig => runtimeConfig
+                        .WithFramework("MiddleWare", "2.1.0"),
+                    result => result.Should().Pass()
+                        .And.HaveResolvedFrameworkVersion("5.1.2")
+                        .And.HaveResolvedFrameworkVersion("2.1.2"));
+            }
+        }
+
+        [Fact]
+        public void NoInheritance()
+        {
+            RunTest(
+                runtimeConfig => runtimeConfig
+                    .WithFramework("MiddleWare", "2.1.2")
+                    .WithApplyPatches(false),
+                result => result.Should().Pass()
+                    .And.HaveResolvedFrameworkVersion("5.1.3"));
+
+            RunTest(
+                runtimeConfig => runtimeConfig
+                    .WithFramework(new RuntimeConfig.Framework("MiddleWare", "2.1.2")
+                        .WithApplyPatches(false)),
+                result => result.Should().Pass()
+                    .And.HaveResolvedFrameworkVersion("5.1.3"));
+        }
+
+        private void RunTest(
+            Func<RuntimeConfig, RuntimeConfig> runtimeConfig,
+            Action<CommandResult> resultAction,
+            string[] environment = null,
+            string[] commandLine = null)
+        {
+            RunTest(
+                SharedState.DotNetWithFrameworks,
+                SharedState.FrameworkReferenceApp,
+                runtimeConfig,
+                resultAction,
+                environment,
+                commandLine);
+        }
+
+        public class SharedTestState : SharedTestStateBase
+        {
+            public TestApp FrameworkReferenceApp { get; }
+
+            public DotNetCli DotNetWithFrameworks { get; }
+
+            public SharedTestState()
+            {
+                DotNetWithFrameworks = DotNet("WithOneFramework")
+                    .AddMicrosoftNETCoreAppFramework("5.1.2")
+                    .AddMicrosoftNETCoreAppFramework("5.1.3")
+                    .AddFramework("MiddleWare", "2.1.2", runtimeConfig =>
+                        runtimeConfig.WithFramework(MicrosoftNETCoreApp, "5.1.2"))
+                    .Build();
+
+                FrameworkReferenceApp = CreateFrameworkReferenceApp();
+            }
+        }
+    }
+}

--- a/src/test/HostActivationTests/FrameworkResolution/ApplyPatchesSettings.cs
+++ b/src/test/HostActivationTests/FrameworkResolution/ApplyPatchesSettings.cs
@@ -12,6 +12,8 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.FrameworkResolution
         FrameworkResolutionBase,
         IClassFixture<ApplyPatchesSettings.SharedTestState>
     {
+        private const string MiddleWare = "MiddleWare";
+
         private SharedTestState SharedState { get; }
 
         public ApplyPatchesSettings(SharedTestState sharedState)
@@ -76,15 +78,15 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.FrameworkResolution
         {
             using (var dotnetCustomizer = SharedState.DotNetWithFrameworks.Customize())
             {
-                dotnetCustomizer.Framework("MiddleWare").RuntimeConfig(runtimeConfig =>
+                dotnetCustomizer.Framework(MiddleWare).RuntimeConfig(runtimeConfig =>
                     runtimeConfig.WithApplyPatches(false));
 
                 RunTest(
                     runtimeConfig => runtimeConfig
-                        .WithFramework("MiddleWare", "2.1.0"),
+                        .WithFramework(MiddleWare, "2.1.0"),
                     result => result.Should().Pass()
                         .And.HaveResolvedFramework(MicrosoftNETCoreApp, "5.1.2")
-                        .And.HaveResolvedFramework("MiddleWare", "2.1.2"));
+                        .And.HaveResolvedFramework(MiddleWare, "2.1.2"));
             }
         }
 
@@ -93,15 +95,15 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.FrameworkResolution
         {
             using (var dotnetCustomizer = SharedState.DotNetWithFrameworks.Customize())
             {
-                dotnetCustomizer.Framework("MiddleWare").RuntimeConfig(runtimeConfig =>
+                dotnetCustomizer.Framework(MiddleWare).RuntimeConfig(runtimeConfig =>
                     runtimeConfig.GetFramework(MicrosoftNETCoreApp).WithApplyPatches(false));
 
                 RunTest(
                     runtimeConfig => runtimeConfig
-                        .WithFramework("MiddleWare", "2.1.0"),
+                        .WithFramework(MiddleWare, "2.1.0"),
                     result => result.Should().Pass()
                         .And.HaveResolvedFramework(MicrosoftNETCoreApp, "5.1.2")
-                        .And.HaveResolvedFramework("MiddleWare", "2.1.2"));
+                        .And.HaveResolvedFramework(MiddleWare, "2.1.2"));
             }
         }
 
@@ -111,13 +113,13 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.FrameworkResolution
             RunTest(
                 runtimeConfig => runtimeConfig
                     .WithApplyPatches(false)
-                    .WithFramework("MiddleWare", "2.1.2"),
+                    .WithFramework(MiddleWare, "2.1.2"),
                 result => result.Should().Pass()
                     .And.HaveResolvedFramework(MicrosoftNETCoreApp, "5.1.3"));
 
             RunTest(
                 runtimeConfig => runtimeConfig
-                    .WithFramework(new RuntimeConfig.Framework("MiddleWare", "2.1.2")
+                    .WithFramework(new RuntimeConfig.Framework(MiddleWare, "2.1.2")
                         .WithApplyPatches(false)),
                 result => result.Should().Pass()
                     .And.HaveResolvedFramework(MicrosoftNETCoreApp, "5.1.3"));
@@ -149,7 +151,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.FrameworkResolution
                 DotNetWithFrameworks = DotNet("WithOneFramework")
                     .AddMicrosoftNETCoreAppFramework("5.1.2")
                     .AddMicrosoftNETCoreAppFramework("5.1.3")
-                    .AddFramework("MiddleWare", "2.1.2", runtimeConfig =>
+                    .AddFramework(MiddleWare, "2.1.2", runtimeConfig =>
                         runtimeConfig.WithFramework(MicrosoftNETCoreApp, "5.1.2"))
                     .Build();
 

--- a/src/test/HostActivationTests/FrameworkResolution/ApplyPatchesSettings.cs
+++ b/src/test/HostActivationTests/FrameworkResolution/ApplyPatchesSettings.cs
@@ -26,7 +26,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.FrameworkResolution
                 runtimeConfig => runtimeConfig
                     .WithFramework(MicrosoftNETCoreApp, "5.1.2"),
                 result => result.Should().Pass()
-                    .And.HaveResolvedFrameworkVersion("5.1.3"));
+                    .And.HaveResolvedFramework(MicrosoftNETCoreApp, "5.1.3"));
         }
 
         [Fact]
@@ -37,7 +37,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.FrameworkResolution
                     .WithApplyPatches(false)
                     .WithFramework(MicrosoftNETCoreApp, "5.1.2"),
                 result => result.Should().Pass()
-                    .And.HaveResolvedFrameworkVersion("5.1.2"));
+                    .And.HaveResolvedFramework(MicrosoftNETCoreApp, "5.1.2"));
         }
 
         [Fact]
@@ -48,7 +48,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.FrameworkResolution
                     .WithFramework(new RuntimeConfig.Framework(MicrosoftNETCoreApp, "5.1.2")
                         .WithApplyPatches(false)),
                 result => result.Should().Pass()
-                    .And.HaveResolvedFrameworkVersion("5.1.2"));
+                    .And.HaveResolvedFramework(MicrosoftNETCoreApp, "5.1.2"));
         }
 
         [Fact]
@@ -60,7 +60,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.FrameworkResolution
                     .WithFramework(new RuntimeConfig.Framework(MicrosoftNETCoreApp, "5.1.2")
                         .WithApplyPatches(false)),
                 result => result.Should().Pass()
-                    .And.HaveResolvedFrameworkVersion("5.1.2"));
+                    .And.HaveResolvedFramework(MicrosoftNETCoreApp, "5.1.2"));
 
             RunTest(
                 runtimeConfig => runtimeConfig
@@ -68,7 +68,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.FrameworkResolution
                     .WithFramework(new RuntimeConfig.Framework(MicrosoftNETCoreApp, "5.1.2")
                         .WithApplyPatches(true)),
                 result => result.Should().Pass()
-                    .And.HaveResolvedFrameworkVersion("5.1.3"));
+                    .And.HaveResolvedFramework(MicrosoftNETCoreApp, "5.1.3"));
         }
 
         [Fact]
@@ -83,8 +83,8 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.FrameworkResolution
                     runtimeConfig => runtimeConfig
                         .WithFramework("MiddleWare", "2.1.0"),
                     result => result.Should().Pass()
-                        .And.HaveResolvedFrameworkVersion("5.1.2")
-                        .And.HaveResolvedFrameworkVersion("2.1.2"));
+                        .And.HaveResolvedFramework(MicrosoftNETCoreApp, "5.1.2")
+                        .And.HaveResolvedFramework("MiddleWare", "2.1.2"));
             }
         }
 
@@ -100,8 +100,8 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.FrameworkResolution
                     runtimeConfig => runtimeConfig
                         .WithFramework("MiddleWare", "2.1.0"),
                     result => result.Should().Pass()
-                        .And.HaveResolvedFrameworkVersion("5.1.2")
-                        .And.HaveResolvedFrameworkVersion("2.1.2"));
+                        .And.HaveResolvedFramework(MicrosoftNETCoreApp, "5.1.2")
+                        .And.HaveResolvedFramework("MiddleWare", "2.1.2"));
             }
         }
 
@@ -113,14 +113,14 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.FrameworkResolution
                     .WithApplyPatches(false)
                     .WithFramework("MiddleWare", "2.1.2"),
                 result => result.Should().Pass()
-                    .And.HaveResolvedFrameworkVersion("5.1.3"));
+                    .And.HaveResolvedFramework(MicrosoftNETCoreApp, "5.1.3"));
 
             RunTest(
                 runtimeConfig => runtimeConfig
                     .WithFramework(new RuntimeConfig.Framework("MiddleWare", "2.1.2")
                         .WithApplyPatches(false)),
                 result => result.Should().Pass()
-                    .And.HaveResolvedFrameworkVersion("5.1.3"));
+                    .And.HaveResolvedFramework(MicrosoftNETCoreApp, "5.1.3"));
         }
 
         private void RunTest(

--- a/src/test/HostActivationTests/FrameworkResolution/DotNetCliExtensions.cs
+++ b/src/test/HostActivationTests/FrameworkResolution/DotNetCliExtensions.cs
@@ -1,0 +1,143 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.DotNet.Cli.Build;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.FrameworkResolution
+{
+    internal static class DotNetCliExtensions
+    {
+        public static DotNetCliCustomizer Customize(this DotNetCli dotnet)
+        {
+            return new DotNetCliCustomizer(dotnet);
+        }
+
+        internal interface ITestFileBackup
+        {
+            void Backup(string path);
+        }
+
+        internal class DotNetCliCustomizer : IDisposable, ITestFileBackup
+        {
+            private readonly DotNetCli _dotnet;
+            private readonly string _basePath;
+            private readonly string _backupPath;
+
+            public DotNetCliCustomizer(DotNetCli dotnet)
+            {
+                _dotnet = dotnet;
+                _basePath = Path.GetFullPath(dotnet.BinPath);
+                _backupPath = Path.Combine(_basePath, ".test.backup");
+
+                if (Directory.Exists(_backupPath))
+                {
+                    throw new Exception($"The backup directory already exists. Please make sure that all customizers are correctly disposed.");
+                }
+            }
+
+            void ITestFileBackup.Backup(string path)
+            {
+                path = Path.GetFullPath(path);
+                if (!path.StartsWith(_basePath))
+                {
+                    throw new Exception($"Trying to backup file {path} which is outside of the backup root {_basePath}.");
+                }
+
+                if (!Directory.Exists(_backupPath))
+                {
+                    Directory.CreateDirectory(_backupPath);
+                }
+
+                string backupFile = Path.Combine(_backupPath, path.Substring(_basePath.Length + 1));
+                string containingDirectory = Path.GetDirectoryName(backupFile);
+                if (!Directory.Exists(containingDirectory))
+                {
+                    Directory.CreateDirectory(containingDirectory);
+                    if (!File.Exists(backupFile))
+                    {
+                        File.Copy(path, backupFile);
+                    }
+                }
+            }
+
+            public void Dispose()
+            {
+                if (Directory.Exists(_backupPath))
+                {
+                    CopyOverDirectory(_backupPath, _dotnet.BinPath);
+
+                    Directory.Delete(_backupPath, recursive: true);
+                }
+            }
+
+            private static void CopyOverDirectory(string source, string destination)
+            {
+                foreach (string directory in Directory.GetDirectories(source))
+                {
+                    CopyOverDirectory(directory, Path.Combine(destination, Path.GetFileName(directory)));
+                }
+
+                foreach (string file in Directory.GetFiles(source))
+                {
+                    File.Copy(file, Path.Combine(destination, Path.GetFileName(file)), overwrite: true);
+                }
+            }
+
+            public DotNetFramework Framework(string name, string version = null)
+            {
+                string path = Path.Combine(_dotnet.BinPath, "shared", name);
+                IEnumerable<string> versions =
+                    Directory.Exists(path) ? Directory.GetDirectories(path) : Enumerable.Empty<string>();
+
+                if (version == null)
+                {
+                    version = versions.FirstOrDefault();
+                    if (versions.Skip(1).Any())
+                    {
+                        throw new Exception($"Multiple versions of framework {name} found, but no version selector specified.");
+                    }
+                }
+                else
+                {
+                    version = versions.FirstOrDefault(v => v == version);
+                }
+
+                if (version == null)
+                {
+                    throw new Exception($"No framework {name}, version {version} found.");
+                }
+
+                return new DotNetFramework(this, Path.Combine(path, version));
+            }
+        }
+
+        internal class DotNetFramework
+        {
+            private readonly ITestFileBackup _backup;
+            private readonly string _path;
+            private readonly string _name;
+
+            internal DotNetFramework(ITestFileBackup backup, string path)
+            {
+                _backup = backup;
+                _path = path;
+                _name = Path.GetFileName(Path.GetDirectoryName(path));
+            }
+
+            public DotNetFramework RuntimeConfig(Action<RuntimeConfig> runtimeConfigCustomizer)
+            {
+                string runtimeConfigPath = Path.Combine(_path, _name + ".runtimeconfig.json");
+                _backup.Backup(runtimeConfigPath);
+                RuntimeConfig runtimeConfig = HostActivation.RuntimeConfig.FromFile(runtimeConfigPath);
+                runtimeConfigCustomizer(runtimeConfig);
+                runtimeConfig.Save();
+
+                return this;
+            }
+        }
+    }
+}

--- a/src/test/HostActivationTests/FrameworkResolution/FrameworkResolutionBase.cs
+++ b/src/test/HostActivationTests/FrameworkResolution/FrameworkResolutionBase.cs
@@ -1,0 +1,160 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.DotNet.Cli.Build;
+using Microsoft.DotNet.Cli.Build.Framework;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.FrameworkResolution
+{
+    public abstract class FrameworkResolutionBase
+    {
+        protected const string MicrosoftNETCoreApp = "Microsoft.NETCore.App";
+
+        protected void RunTest(
+            DotNetCli dotnet,
+            TestApp app,
+            Func<RuntimeConfig, RuntimeConfig> runtimeConfig,
+            Action<CommandResult> resultAction,
+            string[] environment = null,
+            string[] commandLine = null,
+            bool multiLevelLookup = false)
+        {
+            runtimeConfig(RuntimeConfig.Path(app.RuntimeConfigJson)).Save();
+
+            IEnumerable<string> args = commandLine ?? Enumerable.Empty<string>();
+            args = args.Concat(new string[] { app.AppDll });
+
+            IDictionary<string, string> environmentVariables = null;
+            if (environment != null)
+            {
+                environmentVariables = new Dictionary<string, string>();
+                foreach (string v in environment)
+                {
+                    string[] s = v.Split('=');
+                    environmentVariables.Add(s[0], s[1]);
+                }
+            }
+
+            CommandResult result = dotnet.Exec(args.First(), args.Skip(1).ToArray())
+                .EnvironmentVariable("COREHOST_TRACE", "1")
+                .EnvironmentVariable("DOTNET_MULTILEVEL_LOOKUP", multiLevelLookup ? "1" : "0")
+                .Environment(environmentVariables)
+                .CaptureStdOut()
+                .CaptureStdErr()
+                .Execute();
+            resultAction(result);
+        }
+
+        public class SharedTestStateBase : IDisposable
+        {
+            private readonly string _builtDotnet;
+            private readonly string _baseDir;
+
+            public SharedTestStateBase()
+            {
+                _builtDotnet = Path.Combine(TestArtifact.TestArtifactsPath, "sharedFrameworkPublish");
+
+                string baseDir = Path.Combine(TestArtifact.TestArtifactsPath, "frameworkResolution");
+                _baseDir = SharedFramework.CalculateUniqueTestDirectory(baseDir);
+            }
+
+            public DotNetBuilder DotNet(string name)
+            {
+                return new DotNetBuilder(_baseDir, _builtDotnet, name);
+            }
+
+            public TestApp CreateFrameworkReferenceApp()
+            {
+                // Prepare the app mock - we're not going to run anything really, so we just need the basic files
+                string testAppDir = Path.Combine(_baseDir, "FrameworkReferenceApp");
+                Directory.CreateDirectory(testAppDir);
+
+                // ./FrameworkReferenceApp.dll
+                File.WriteAllText(Path.Combine(testAppDir, "FrameworkReferenceApp.dll"), string.Empty);
+
+                // ./FrameworkReferenceApp.runtimeconfig.json
+                File.WriteAllText(Path.Combine(testAppDir, "FrameworkReferenceApp.runtimeconfig.json"), "{}");
+
+                return new TestApp(testAppDir);
+            }
+
+            public void Dispose()
+            {
+                if (!TestArtifact.PreserveTestRuns() && Directory.Exists(_baseDir))
+                {
+                    Directory.Delete(_baseDir, true);
+                }
+            }
+
+            public class DotNetBuilder
+            {
+                private readonly string _path;
+                private readonly RepoDirectoriesProvider _repoDirectories;
+
+                public DotNetBuilder(string basePath, string builtDotnet, string name)
+                {
+                    _path = Path.Combine(basePath, name);
+                    Directory.CreateDirectory(_path);
+
+                    _repoDirectories = new RepoDirectoriesProvider(builtDotnet: _path);
+
+                    // Prepare the dotnet installation mock
+
+                    // ./dotnet.exe - used as a convenient way to load and invoke hostfxr. May change in the future to use test-specific executable
+                    var builtDotNetCli = new DotNetCli(builtDotnet);
+                    File.Copy(
+                        builtDotNetCli.DotnetExecutablePath,
+                        Path.Combine(_path, RuntimeInformationExtensions.GetExeFileNameForCurrentPlatform("dotnet")),
+                        true);
+
+                    // ./host/fxr/<version>/hostfxr.dll - this is the component being tested
+                    SharedFramework.CopyDirectory(
+                        builtDotNetCli.GreatestVersionHostFxrPath,
+                        Path.Combine(_path, "host", "fxr", Path.GetFileName(builtDotNetCli.GreatestVersionHostFxrPath)));
+                }
+
+                public DotNetBuilder AddMicrosoftNETCoreAppFramework(string version)
+                {
+                    // ./shared/Microsoft.NETCore.App/<version> - create a mock of the root framework
+                    string netCoreAppPath = Path.Combine(_path, "shared", MicrosoftNETCoreApp, version);
+                    Directory.CreateDirectory(netCoreAppPath);
+
+                    // ./shared/Microsoft.NETCore.App/<version>/hostpolicy.dll - this is a mock, will not actually load CoreCLR
+                    string mockHostPolicyFileName = RuntimeInformationExtensions.GetSharedLibraryFileNameForCurrentPlatform("mockhostpolicy");
+                    File.Copy(
+                        Path.Combine(_repoDirectories.Artifacts, "corehost_test", mockHostPolicyFileName),
+                        Path.Combine(netCoreAppPath, RuntimeInformationExtensions.GetSharedLibraryFileNameForCurrentPlatform("hostpolicy")),
+                        true);
+
+                    return this;
+                }
+
+                public DotNetBuilder AddFramework(
+                    string name,
+                    string version,
+                    Action<RuntimeConfig> runtimeConfigCustomizer)
+                {
+                    // ./shared/<name>/<version> - create a mock of effectively empty non-root framework
+                    string path = Path.Combine(_path, "shared", name, version);
+                    Directory.CreateDirectory(path);
+
+                    // ./shared/<name>/<version>/<name>.runtimeconfig.json - runtime config which can be customized
+                    RuntimeConfig runtimeConfig = new RuntimeConfig(Path.Combine(path, name + ".runtimeconfig.json"));
+                    runtimeConfigCustomizer(runtimeConfig);
+                    runtimeConfig.Save();
+
+                    return this;
+                }
+
+                public DotNetCli Build()
+                {
+                    return new DotNetCli(_path);
+                }
+            }
+        }
+    }
+}

--- a/src/test/HostActivationTests/FrameworkResolution/FrameworkResolutionCommandResultExtensions.cs
+++ b/src/test/HostActivationTests/FrameworkResolution/FrameworkResolutionCommandResultExtensions.cs
@@ -7,9 +7,9 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.FrameworkResolution
 {
     internal static class FrameworkResolutionCommandResultExtensions
     {
-        public static AndConstraint<CommandResultAssertions> HaveResolvedFrameworkVersion(this CommandResultAssertions assertion, string version)
+        public static AndConstraint<CommandResultAssertions> HaveResolvedFramework(this CommandResultAssertions assertion, string name, string version)
         {
-            return assertion.HaveStdOutContaining("mock fx_found_versions: " + version);
+            return assertion.HaveStdOutContaining($"mock frameworks: {name} {version}");
         }
 
         public static AndConstraint<CommandResultAssertions> DidNotFindCompatibleFrameworkVersion(this CommandResultAssertions assertion)

--- a/src/test/HostActivationTests/FrameworkResolution/FrameworkResolutionCommandResultExtensions.cs
+++ b/src/test/HostActivationTests/FrameworkResolution/FrameworkResolutionCommandResultExtensions.cs
@@ -1,0 +1,30 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using FluentAssertions;
+
+namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.FrameworkResolution
+{
+    internal static class FrameworkResolutionCommandResultExtensions
+    {
+        public static AndConstraint<CommandResultAssertions> HaveResolvedFrameworkVersion(this CommandResultAssertions assertion, string version)
+        {
+            return assertion.HaveStdOutContaining("mock fx_found_versions: " + version);
+        }
+
+        public static AndConstraint<CommandResultAssertions> DidNotFindCompatibleFrameworkVersion(this CommandResultAssertions assertion)
+        {
+            return assertion.HaveStdErrContaining("It was not possible to find any compatible framework version");
+        }
+
+        public static AndConstraint<CommandResultAssertions> FailedToSoftRollForward(this CommandResultAssertions assertion, string frameworkName, string newVersion, string previousVersion)
+        {
+            return assertion.HaveStdErrMatching($".*The specified framework '{frameworkName}', version '{newVersion}', patch_roll_fwd=[0-1], roll_fwd_on_no_candidate_fx=[0-2] cannot roll-forward to the previously referenced version '{previousVersion}'.*");
+        }
+
+        public static AndConstraint<CommandResultAssertions> RestartedFrameworkResolution(this CommandResultAssertions assertion, string resolvedVersion, string newVersion)
+        {
+            return assertion.HaveStdErrContaining($"--- Restarting all framework resolution because the previously resolved framework 'Microsoft.NETCore.App', version '{resolvedVersion}' must be re-resolved with the new version '{newVersion}'");
+        }
+    }
+}

--- a/src/test/HostActivationTests/FrameworkResolution/MultipleFrameworks.cs
+++ b/src/test/HostActivationTests/FrameworkResolution/MultipleFrameworks.cs
@@ -303,7 +303,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.FrameworkResolution
                     commandResult.Should().Pass()
                         .And.RestartedFrameworkResolution("5.1.3", "5.4.1")
                         .And.RestartedFrameworkResolution("5.4.1", "5.6.0")
-                        .And.HaveResolvedFrameworkVersion("5.6.0"));
+                        .And.HaveResolvedFramework(MicrosoftNETCoreApp, "5.6.0"));
         }
 
         // This test does:
@@ -334,7 +334,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.FrameworkResolution
                     commandResult.Should().Pass()
                         .And.RestartedFrameworkResolution("5.1.3", "5.4.1")
                         .And.RestartedFrameworkResolution("5.4.1", "5.6.0")
-                        .And.HaveResolvedFrameworkVersion("5.6.0"));
+                        .And.HaveResolvedFramework(MicrosoftNETCoreApp, "5.6.0"));
         }
 
         private void RunTest(
@@ -356,7 +356,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.FrameworkResolution
                         if (resolvedFramework != null)
                         {
                             commandResult.Should().Pass()
-                                .And.HaveResolvedFrameworkVersion(resolvedFramework);
+                                .And.HaveResolvedFramework(MicrosoftNETCoreApp, resolvedFramework);
                         }
                         else
                         {

--- a/src/test/HostActivationTests/FrameworkResolution/MultipleFrameworks.cs
+++ b/src/test/HostActivationTests/FrameworkResolution/MultipleFrameworks.cs
@@ -12,6 +12,10 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.FrameworkResolution
         FrameworkResolutionBase,
         IClassFixture<MultipleFrameworks.SharedTestState>
     {
+        private const string MiddleWare = "MiddleWare";
+        private const string AnotherMiddleWare = "AnotherMiddleWare";
+        private const string HighWare = "HighWare";
+
         private SharedTestState SharedState { get; }
 
         public MultipleFrameworks(SharedTestState sharedState)
@@ -37,9 +41,9 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.FrameworkResolution
         {
             RunTest(
                 runtimeConfig => runtimeConfig
-                    .WithFramework("MiddleWare", "2.1.0")
+                    .WithFramework(MiddleWare, "2.1.0")
                     .WithFramework(MicrosoftNETCoreApp, "5.1.1"),
-                dotnetCustomizer => dotnetCustomizer.Framework("MiddleWare").RuntimeConfig(runtimeConfig =>
+                dotnetCustomizer => dotnetCustomizer.Framework(MiddleWare).RuntimeConfig(runtimeConfig =>
                     runtimeConfig.GetFramework(MicrosoftNETCoreApp)
                         .WithRollForwardOnNoCandidateFx(rollForwardOnNoCandidateFx)
                         .WithApplyPatches(applyPatches)
@@ -71,8 +75,8 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.FrameworkResolution
             RunTest(
                 runtimeConfig => runtimeConfig
                     .WithFramework(MicrosoftNETCoreApp, "5.1.1")
-                    .WithFramework("MiddleWare", "2.1.0"),
-                dotnetCustomizer => dotnetCustomizer.Framework("MiddleWare").RuntimeConfig(runtimeConfig =>
+                    .WithFramework(MiddleWare, "2.1.0"),
+                dotnetCustomizer => dotnetCustomizer.Framework(MiddleWare).RuntimeConfig(runtimeConfig =>
                     runtimeConfig.GetFramework(MicrosoftNETCoreApp)
                         .WithRollForwardOnNoCandidateFx(rollForwardOnNoCandidateFx)
                         .WithApplyPatches(applyPatches)
@@ -94,9 +98,9 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.FrameworkResolution
         {
             RunTest(
                 runtimeConfig => runtimeConfig
-                    .WithFramework("MiddleWare", "2.1.0")
+                    .WithFramework(MiddleWare, "2.1.0")
                     .WithFramework(MicrosoftNETCoreApp, "5.1.1"),
-                dotnetCustomizer => dotnetCustomizer.Framework("MiddleWare").RuntimeConfig(runtimeConfig =>
+                dotnetCustomizer => dotnetCustomizer.Framework(MiddleWare).RuntimeConfig(runtimeConfig =>
                     runtimeConfig.GetFramework(MicrosoftNETCoreApp)
                         .WithRollForwardOnNoCandidateFx(rollForwardOnNoCandidateFx)
                         .WithApplyPatches(applyPatches)
@@ -122,8 +126,8 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.FrameworkResolution
             RunTest(
                 runtimeConfig => runtimeConfig
                     .WithFramework(MicrosoftNETCoreApp, "5.1.1")
-                    .WithFramework("MiddleWare", "2.1.0"),
-                dotnetCustomizer => dotnetCustomizer.Framework("MiddleWare").RuntimeConfig(runtimeConfig =>
+                    .WithFramework(MiddleWare, "2.1.0"),
+                dotnetCustomizer => dotnetCustomizer.Framework(MiddleWare).RuntimeConfig(runtimeConfig =>
                     runtimeConfig.GetFramework(MicrosoftNETCoreApp)
                         .WithRollForwardOnNoCandidateFx(rollForwardOnNoCandidateFx)
                         .WithApplyPatches(applyPatches)
@@ -149,8 +153,8 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.FrameworkResolution
             RunTest(
                 runtimeConfig => runtimeConfig
                     .WithFramework(MicrosoftNETCoreApp, "6.0.1-preview.0")
-                    .WithFramework("MiddleWare", "2.1.0"),
-                dotnetCustomizer => dotnetCustomizer.Framework("MiddleWare").RuntimeConfig(runtimeConfig =>
+                    .WithFramework(MiddleWare, "2.1.0"),
+                dotnetCustomizer => dotnetCustomizer.Framework(MiddleWare).RuntimeConfig(runtimeConfig =>
                     runtimeConfig.GetFramework(MicrosoftNETCoreApp)
                         .WithRollForwardOnNoCandidateFx(rollForwardOnNoCandidateFx)
                         .Version = versionReference),
@@ -177,11 +181,11 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.FrameworkResolution
         {
             RunTest(
                 runtimeConfig => runtimeConfig
-                    .WithFramework("MiddleWare", "2.1.0")
+                    .WithFramework(MiddleWare, "2.1.0")
                     .WithFramework(new RuntimeConfig.Framework(MicrosoftNETCoreApp, versionReference)
                         .WithRollForwardOnNoCandidateFx(rollForwardOnNoCandidateFx)
                         .WithApplyPatches(applyPatches)),
-                dotnetCustomizer => dotnetCustomizer.Framework("MiddleWare").RuntimeConfig(runtimeConfig =>
+                dotnetCustomizer => dotnetCustomizer.Framework(MiddleWare).RuntimeConfig(runtimeConfig =>
                     runtimeConfig.GetFramework(MicrosoftNETCoreApp)
                         .Version = "5.1.1"),
                 resolvedFramework: resolvedFramework,
@@ -201,11 +205,11 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.FrameworkResolution
         {
             RunTest(
                 runtimeConfig => runtimeConfig
-                    .WithFramework("MiddleWare", "2.1.0")
+                    .WithFramework(MiddleWare, "2.1.0")
                     .WithFramework(new RuntimeConfig.Framework(MicrosoftNETCoreApp, versionReference)
                         .WithRollForwardOnNoCandidateFx(rollForwardOnNoCandidateFx)
                         .WithApplyPatches(applyPatches)),
-                dotnetCustomizer => dotnetCustomizer.Framework("MiddleWare").RuntimeConfig(runtimeConfig =>
+                dotnetCustomizer => dotnetCustomizer.Framework(MiddleWare).RuntimeConfig(runtimeConfig =>
                     runtimeConfig.GetFramework(MicrosoftNETCoreApp)
                         .Version = "5.1.1"),
                 resolvedFramework: resolvedFramework,
@@ -230,13 +234,13 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.FrameworkResolution
         {
             RunTest(
                 runtimeConfig => runtimeConfig
-                    .WithFramework("HighWare", "7.0.0"),
+                    .WithFramework(HighWare, "7.0.0"),
                 dotnetCustomizer =>
                 {
-                    dotnetCustomizer.Framework("HighWare").RuntimeConfig(runtimeConfig =>
+                    dotnetCustomizer.Framework(HighWare).RuntimeConfig(runtimeConfig =>
                         runtimeConfig.GetFramework(MicrosoftNETCoreApp)
                             .Version = "5.1.1");
-                    dotnetCustomizer.Framework("MiddleWare").RuntimeConfig(runtimeConfig =>
+                    dotnetCustomizer.Framework(MiddleWare).RuntimeConfig(runtimeConfig =>
                         runtimeConfig.GetFramework(MicrosoftNETCoreApp)
                             .WithRollForwardOnNoCandidateFx(rollForwardOnNoCandidateFx)
                             .WithApplyPatches(applyPatches)
@@ -259,13 +263,13 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.FrameworkResolution
         {
             RunTest(
                 runtimeConfig => runtimeConfig
-                    .WithFramework("HighWare", "7.0.0"),
+                    .WithFramework(HighWare, "7.0.0"),
                 dotnetCustomizer =>
                 {
-                    dotnetCustomizer.Framework("HighWare").RuntimeConfig(runtimeConfig =>
+                    dotnetCustomizer.Framework(HighWare).RuntimeConfig(runtimeConfig =>
                         runtimeConfig.GetFramework(MicrosoftNETCoreApp)
                             .Version = "5.1.1");
-                    dotnetCustomizer.Framework("MiddleWare").RuntimeConfig(runtimeConfig =>
+                    dotnetCustomizer.Framework(MiddleWare).RuntimeConfig(runtimeConfig =>
                         runtimeConfig.GetFramework(MicrosoftNETCoreApp)
                             .WithRollForwardOnNoCandidateFx(rollForwardOnNoCandidateFx)
                             .WithApplyPatches(applyPatches)
@@ -289,13 +293,13 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.FrameworkResolution
                 runtimeConfig => runtimeConfig
                     .WithRollForwardOnNoCandidateFx(2)
                     .WithFramework(MicrosoftNETCoreApp, "5.1.1")
-                    .WithFramework("HighWare", "7.3.1"),
+                    .WithFramework(HighWare, "7.3.1"),
                 dotnetCustomizer =>
                 {
-                    dotnetCustomizer.Framework("HighWare").RuntimeConfig(runtimeConfig =>
+                    dotnetCustomizer.Framework(HighWare).RuntimeConfig(runtimeConfig =>
                         runtimeConfig.GetFramework(MicrosoftNETCoreApp)
                             .Version = "5.4.1");
-                    dotnetCustomizer.Framework("MiddleWare").RuntimeConfig(runtimeConfig =>
+                    dotnetCustomizer.Framework(MiddleWare).RuntimeConfig(runtimeConfig =>
                         runtimeConfig.GetFramework(MicrosoftNETCoreApp)
                             .Version = "5.6.0");
                 },
@@ -319,14 +323,14 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.FrameworkResolution
                 runtimeConfig => runtimeConfig
                     .WithRollForwardOnNoCandidateFx(2)
                     .WithFramework(MicrosoftNETCoreApp, "5.1.1")
-                    .WithFramework("MiddleWare", "2.1.2")
-                    .WithFramework("AnotherMiddleWare", "3.0.0"),
+                    .WithFramework(MiddleWare, "2.1.2")
+                    .WithFramework(AnotherMiddleWare, "3.0.0"),
                 dotnetCustomizer =>
                 {
-                    dotnetCustomizer.Framework("MiddleWare").RuntimeConfig(runtimeConfig =>
+                    dotnetCustomizer.Framework(MiddleWare).RuntimeConfig(runtimeConfig =>
                         runtimeConfig.GetFramework(MicrosoftNETCoreApp)
                             .Version = "5.4.1");
-                    dotnetCustomizer.Framework("AnotherMiddleWare").RuntimeConfig(runtimeConfig =>
+                    dotnetCustomizer.Framework(AnotherMiddleWare).RuntimeConfig(runtimeConfig =>
                         runtimeConfig.GetFramework(MicrosoftNETCoreApp)
                             .Version = "5.6.0");
                 },
@@ -380,14 +384,14 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.FrameworkResolution
                     .AddMicrosoftNETCoreAppFramework("5.4.1")
                     .AddMicrosoftNETCoreAppFramework("5.6.0")
                     .AddMicrosoftNETCoreAppFramework("6.0.1-preview.1")
-                    .AddFramework("MiddleWare", "2.1.2", runtimeConfig =>
+                    .AddFramework(MiddleWare, "2.1.2", runtimeConfig =>
                         runtimeConfig.WithFramework(MicrosoftNETCoreApp, "5.1.3"))
-                    .AddFramework("AnotherMiddleWare", "3.0.0", runtimeConfig =>
+                    .AddFramework(AnotherMiddleWare, "3.0.0", runtimeConfig =>
                         runtimeConfig.WithFramework(MicrosoftNETCoreApp, "5.1.3"))
-                    .AddFramework("HighWare", "7.3.1", runtimeConfig =>
+                    .AddFramework(HighWare, "7.3.1", runtimeConfig =>
                         runtimeConfig
                             .WithFramework(MicrosoftNETCoreApp, "5.1.3")
-                            .WithFramework("MiddleWare", "2.1.2"))
+                            .WithFramework(MiddleWare, "2.1.2"))
                     .Build();
 
                 FrameworkReferenceApp = CreateFrameworkReferenceApp();

--- a/src/test/HostActivationTests/FrameworkResolution/MultipleFrameworks.cs
+++ b/src/test/HostActivationTests/FrameworkResolution/MultipleFrameworks.cs
@@ -1,0 +1,397 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.DotNet.Cli.Build;
+using Microsoft.DotNet.Cli.Build.Framework;
+using System;
+using Xunit;
+
+namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.FrameworkResolution
+{
+    public class MultipleFrameworks :
+        FrameworkResolutionBase,
+        IClassFixture<MultipleFrameworks.SharedTestState>
+    {
+        private SharedTestState SharedState { get; }
+
+        public MultipleFrameworks(SharedTestState sharedState)
+        {
+            SharedState = sharedState;
+        }
+
+        // Soft roll forward from app's 5.1.1 (defaults) to inner framework reference with [specified version]
+        [Theory]
+        [InlineData("5.0.0", 0,    null,  null)]
+        [InlineData("5.1.0", 0,    null,  "5.1.3")]
+        [InlineData("5.1.0", 0,    false, null)]
+        [InlineData("5.1.1", 0,    false, "5.1.1")]
+        [InlineData("5.0.0", null, null,  "5.1.3")]
+        [InlineData("5.0.0", 1,    null,  "5.1.3")]
+        [InlineData("1.0.0", 1,    null,  null)]
+        [InlineData("1.0.0", 2,    null,  "5.1.3")]
+        public void SoftRollForward_InnerFrameworkReference_ToLower(
+            string versionReference,
+            int? rollForwardOnNoCandidateFx,
+            bool? applyPatches,
+            string resolvedFramework)
+        {
+            RunTest(
+                runtimeConfig => runtimeConfig
+                    .WithFramework("MiddleWare", "2.1.0")
+                    .WithFramework(MicrosoftNETCoreApp, "5.1.1"),
+                dotnetCustomizer => dotnetCustomizer.Framework("MiddleWare").RuntimeConfig(runtimeConfig =>
+                    runtimeConfig.GetFramework(MicrosoftNETCoreApp)
+                        .WithRollForwardOnNoCandidateFx(rollForwardOnNoCandidateFx)
+                        .WithApplyPatches(applyPatches)
+                        .Version = versionReference),
+                resolvedFramework: resolvedFramework,
+                resultValidator: resolvedFramework != null ? null : new Action<CommandResult>(
+                    commandResult => commandResult.Should().Fail().And.FailedToSoftRollForward(MicrosoftNETCoreApp, versionReference, "5.1.1")));
+        }
+
+        // Soft roll forward from app's 5.1.1 (defaults) to inner framework reference with [specified version]
+        // In this case the direct reference from app is first, so the framework reference from app
+        // is actually resolved against the disk - and the resolved framework is than compared to
+        // the inner framework reference .
+        [Theory]
+        [InlineData("5.0.0", 0, null, null)]
+        //[InlineData("5.1.0", 0, null, "5.1.3")] https://github.com/dotnet/core-setup/issues/4947
+        [InlineData("5.1.0", 0, false, null)]
+        [InlineData("5.1.3", 0, false, "5.1.3")]
+        // [InlineData("5.0.0", null, null, "5.1.3")] https://github.com/dotnet/core-setup/issues/4947
+        // [InlineData("5.0.0", 1, null, "5.1.3")] https://github.com/dotnet/core-setup/issues/4947
+        [InlineData("1.0.0", 1, null, null)]
+        // [InlineData("1.0.0", 2, null, "5.1.3")] https://github.com/dotnet/core-setup/issues/4947
+        public void SoftRollForward_InnerFrameworkReference_ToLower_HardResolve(
+            string versionReference,
+            int? rollForwardOnNoCandidateFx,
+            bool? applyPatches,
+            string resolvedFramework)
+        {
+            RunTest(
+                runtimeConfig => runtimeConfig
+                    .WithFramework(MicrosoftNETCoreApp, "5.1.1")
+                    .WithFramework("MiddleWare", "2.1.0"),
+                dotnetCustomizer => dotnetCustomizer.Framework("MiddleWare").RuntimeConfig(runtimeConfig =>
+                    runtimeConfig.GetFramework(MicrosoftNETCoreApp)
+                        .WithRollForwardOnNoCandidateFx(rollForwardOnNoCandidateFx)
+                        .WithApplyPatches(applyPatches)
+                        .Version = versionReference),
+                resolvedFramework: resolvedFramework,
+                resultValidator: resolvedFramework != null ? null : new Action<CommandResult>(
+                    commandResult => commandResult.Should().Fail().And.FailedToSoftRollForward(MicrosoftNETCoreApp, versionReference, "5.1.3")));
+        }
+
+        // Soft roll forward from app's 5.1.1 (defaults) to inner framework reference with [specified version]
+        [Theory]
+        [InlineData("5.4.0", null, null, "5.4.1")]
+        [InlineData("6.0.0", null, null, null)]
+        public void SoftRollForward_InnerFrameworkReference_ToHigher(
+            string versionReference,
+            int? rollForwardOnNoCandidateFx,
+            bool? applyPatches,
+            string resolvedFramework)
+        {
+            RunTest(
+                runtimeConfig => runtimeConfig
+                    .WithFramework("MiddleWare", "2.1.0")
+                    .WithFramework(MicrosoftNETCoreApp, "5.1.1"),
+                dotnetCustomizer => dotnetCustomizer.Framework("MiddleWare").RuntimeConfig(runtimeConfig =>
+                    runtimeConfig.GetFramework(MicrosoftNETCoreApp)
+                        .WithRollForwardOnNoCandidateFx(rollForwardOnNoCandidateFx)
+                        .WithApplyPatches(applyPatches)
+                        .Version = versionReference),
+                resolvedFramework: resolvedFramework,
+                resultValidator: resolvedFramework != null ? null : new Action<CommandResult>(
+                    commandResult => commandResult.Should().Fail().And.FailedToSoftRollForward(MicrosoftNETCoreApp, "5.1.1", versionReference)));
+        }
+
+        // Soft roll forward from app's 5.1.1 (defaults) to inner framework reference with [specified version]
+        // In this case the app reference to core framework comes first, which means it's going to be hard resolved
+        // and only then the soft roll forward to the inner reference is performed. So the hard resolved version
+        // is use in the soft roll forward.
+        [Theory]
+        // [InlineData("5.4.0", null, null, "5.4.1")] https://github.com/dotnet/core-setup/issues/4947
+        [InlineData("6.0.0", null, null, null)]
+        public void SoftRollForward_InnerFrameworkReference_ToHigher_HardResolve(
+            string versionReference,
+            int? rollForwardOnNoCandidateFx,
+            bool? applyPatches,
+            string resolvedFramework)
+        {
+            RunTest(
+                runtimeConfig => runtimeConfig
+                    .WithFramework(MicrosoftNETCoreApp, "5.1.1")
+                    .WithFramework("MiddleWare", "2.1.0"),
+                dotnetCustomizer => dotnetCustomizer.Framework("MiddleWare").RuntimeConfig(runtimeConfig =>
+                    runtimeConfig.GetFramework(MicrosoftNETCoreApp)
+                        .WithRollForwardOnNoCandidateFx(rollForwardOnNoCandidateFx)
+                        .WithApplyPatches(applyPatches)
+                        .Version = versionReference),
+                resolvedFramework: resolvedFramework,
+                resultValidator: resolvedFramework != null ? null : new Action<CommandResult>(
+                    commandResult => commandResult.Should().Fail().And.FailedToSoftRollForward(MicrosoftNETCoreApp, "5.1.3", versionReference)));
+        }
+
+        // Soft roll forward from app's 5.1.1 (defaults) to inner framework reference with [specified version]
+        [Theory]
+        [InlineData("6.0.0", null, null)]    // Can't roll forward from release to pre-release
+
+        // This fails due to bug https://github.com/dotnet/core-setup/issues/4947
+        // It should be possible to roll forward from pre-release to pre-release, but the bug causes wrong framework order
+        // and inability to resolve hostpolicy.
+        // [InlineData("6.0.1-preview.0", null, "6.0.1-preview.1")]
+        public void SoftRollForward_InnerFrameworkReference_PreRelease(
+            string versionReference,
+            int? rollForwardOnNoCandidateFx,
+            string resolvedFramework)
+        {
+            RunTest(
+                runtimeConfig => runtimeConfig
+                    .WithFramework(MicrosoftNETCoreApp, "6.0.1-preview.0")
+                    .WithFramework("MiddleWare", "2.1.0"),
+                dotnetCustomizer => dotnetCustomizer.Framework("MiddleWare").RuntimeConfig(runtimeConfig =>
+                    runtimeConfig.GetFramework(MicrosoftNETCoreApp)
+                        .WithRollForwardOnNoCandidateFx(rollForwardOnNoCandidateFx)
+                        .Version = versionReference),
+                resolvedFramework: resolvedFramework,
+                resultValidator: resolvedFramework != null ? null : new Action<CommandResult>(
+                    commandResult => commandResult.Should().Fail().And.FailedToSoftRollForward(MicrosoftNETCoreApp, versionReference, "6.0.1-preview.1")));
+        }
+
+        // Soft roll forward from app [specified version] to inner framework reference 5.1.1
+        [Theory]
+        [InlineData("5.0.0", 0, null, null)]
+        [InlineData("5.1.0", 0, null, "5.1.3")]
+        [InlineData("5.1.0", 0, false, null)]
+        [InlineData("5.1.1", 0, false, "5.1.1")]
+        [InlineData("5.0.0", null, null, "5.1.3")]
+        [InlineData("5.0.0", 1, null, "5.1.3")]
+        [InlineData("1.0.0", 1, null, null)]
+        [InlineData("1.0.0", 2, null, "5.1.3")]
+        public void SoftRollForward_AppFrameworkReference_ToLower(
+            string versionReference,
+            int? rollForwardOnNoCandidateFx,
+            bool? applyPatches,
+            string resolvedFramework)
+        {
+            RunTest(
+                runtimeConfig => runtimeConfig
+                    .WithFramework("MiddleWare", "2.1.0")
+                    .WithFramework(new RuntimeConfig.Framework(MicrosoftNETCoreApp, versionReference)
+                        .WithRollForwardOnNoCandidateFx(rollForwardOnNoCandidateFx)
+                        .WithApplyPatches(applyPatches)),
+                dotnetCustomizer => dotnetCustomizer.Framework("MiddleWare").RuntimeConfig(runtimeConfig =>
+                    runtimeConfig.GetFramework(MicrosoftNETCoreApp)
+                        .Version = "5.1.1"),
+                resolvedFramework: resolvedFramework,
+                resultValidator: resolvedFramework != null ? null : new Action<CommandResult>(
+                    commandResult => commandResult.Should().Fail().And.FailedToSoftRollForward(MicrosoftNETCoreApp, versionReference, "5.1.1")));
+        }
+
+        // Soft roll forward from app [specified version] to inner framework reference 5.1.1
+        [Theory]
+        [InlineData("5.4.0", null, null, "5.4.1")]
+        [InlineData("6.0.0", null, null, null)]
+        public void SoftRollForward_AppFrameworkReference_ToHigher(
+            string versionReference,
+            int? rollForwardOnNoCandidateFx,
+            bool? applyPatches,
+            string resolvedFramework)
+        {
+            RunTest(
+                runtimeConfig => runtimeConfig
+                    .WithFramework("MiddleWare", "2.1.0")
+                    .WithFramework(new RuntimeConfig.Framework(MicrosoftNETCoreApp, versionReference)
+                        .WithRollForwardOnNoCandidateFx(rollForwardOnNoCandidateFx)
+                        .WithApplyPatches(applyPatches)),
+                dotnetCustomizer => dotnetCustomizer.Framework("MiddleWare").RuntimeConfig(runtimeConfig =>
+                    runtimeConfig.GetFramework(MicrosoftNETCoreApp)
+                        .Version = "5.1.1"),
+                resolvedFramework: resolvedFramework,
+                resultValidator: resolvedFramework != null ? null : new Action<CommandResult>(
+                    commandResult => commandResult.Should().Fail().And.FailedToSoftRollForward(MicrosoftNETCoreApp, "5.1.1", versionReference)));
+        }
+
+        // Soft roll forward inner framework reference (defaults) to inner framework reference with [specified version]
+        [Theory]
+        [InlineData("5.0.0", 0,    null,  null)]
+        // [InlineData("5.1.0", 0,    null,  "5.1.3")] https://github.com/dotnet/core-setup/issues/4947
+        [InlineData("5.1.0", 0,    false, null)]
+        // [InlineData("5.0.0", null, null,  "5.1.3")] https://github.com/dotnet/core-setup/issues/4947
+        // [InlineData("5.0.0", 1,    null,  "5.1.3")] https://github.com/dotnet/core-setup/issues/4947
+        [InlineData("1.0.0", 1,    null,  null)]
+        // [InlineData("1.0.0", 2,    null,  "5.1.3")] https://github.com/dotnet/core-setup/issues/4947
+        public void SoftRollForward_InnerToInnerFrameworkReference_ToLower(
+            string versionReference,
+            int? rollForwardOnNoCandidateFx,
+            bool? applyPatches,
+            string resolvedFramework)
+        {
+            RunTest(
+                runtimeConfig => runtimeConfig
+                    .WithFramework("HighWare", "7.0.0"),
+                dotnetCustomizer =>
+                {
+                    dotnetCustomizer.Framework("HighWare").RuntimeConfig(runtimeConfig =>
+                        runtimeConfig.GetFramework(MicrosoftNETCoreApp)
+                            .Version = "5.1.1");
+                    dotnetCustomizer.Framework("MiddleWare").RuntimeConfig(runtimeConfig =>
+                        runtimeConfig.GetFramework(MicrosoftNETCoreApp)
+                            .WithRollForwardOnNoCandidateFx(rollForwardOnNoCandidateFx)
+                            .WithApplyPatches(applyPatches)
+                            .Version = versionReference);
+                },
+                resolvedFramework: resolvedFramework,
+                resultValidator: resolvedFramework != null ? null : new Action<CommandResult>(
+                    commandResult => commandResult.Should().Fail().And.FailedToSoftRollForward(MicrosoftNETCoreApp, versionReference, "5.1.3")));
+        }
+
+        // Soft roll forward inner framework reference (defaults) to inner framework reference with [specified version]
+        [Theory]
+        // [InlineData("5.4.0", null, null, "5.4.1")] https://github.com/dotnet/core-setup/issues/4947
+        [InlineData("6.0.0", null, null, null)]
+        public void SoftRollForward_InnerToInnerFrameworkReference_ToHigher(
+            string versionReference,
+            int? rollForwardOnNoCandidateFx,
+            bool? applyPatches,
+            string resolvedFramework)
+        {
+            RunTest(
+                runtimeConfig => runtimeConfig
+                    .WithFramework("HighWare", "7.0.0"),
+                dotnetCustomizer =>
+                {
+                    dotnetCustomizer.Framework("HighWare").RuntimeConfig(runtimeConfig =>
+                        runtimeConfig.GetFramework(MicrosoftNETCoreApp)
+                            .Version = "5.1.1");
+                    dotnetCustomizer.Framework("MiddleWare").RuntimeConfig(runtimeConfig =>
+                        runtimeConfig.GetFramework(MicrosoftNETCoreApp)
+                            .WithRollForwardOnNoCandidateFx(rollForwardOnNoCandidateFx)
+                            .WithApplyPatches(applyPatches)
+                            .Version = versionReference);
+                },
+                resolvedFramework: resolvedFramework,
+                resultValidator: resolvedFramework != null ? null : new Action<CommandResult>(
+                    commandResult => commandResult.Should().Fail().And.FailedToSoftRollForward(MicrosoftNETCoreApp, "5.1.3", versionReference)));
+        }
+
+        // This test does:
+        //  - Forces hard resolve of 5.1.1 -> 5.1.3 (direct reference from app)
+        //  - Loads HighWare which has 5.4.1 
+        //    - This forces a retry since 5.1.3 was hard resolved, so we have reload with 5.4.1 instead
+        //  - Loads MiddleWare which has 5.6.0
+        //    - This forces a retry since by this time 5.4.1 was hard resolved, so we have to reload with 5.6.0 instead
+        [Fact]
+        public void FrameworkResolutionRetry_FrameworkChain()
+        {
+            RunTest(
+                runtimeConfig => runtimeConfig
+                    .WithRollForwardOnNoCandidateFx(2)
+                    .WithFramework(MicrosoftNETCoreApp, "5.1.1")
+                    .WithFramework("HighWare", "7.3.1"),
+                dotnetCustomizer =>
+                {
+                    dotnetCustomizer.Framework("HighWare").RuntimeConfig(runtimeConfig =>
+                        runtimeConfig.GetFramework(MicrosoftNETCoreApp)
+                            .Version = "5.4.1");
+                    dotnetCustomizer.Framework("MiddleWare").RuntimeConfig(runtimeConfig =>
+                        runtimeConfig.GetFramework(MicrosoftNETCoreApp)
+                            .Version = "5.6.0");
+                },
+                resultValidator: commandResult =>
+                    commandResult.Should().Pass()
+                        .And.RestartedFrameworkResolution("5.1.3", "5.4.1")
+                        .And.RestartedFrameworkResolution("5.4.1", "5.6.0")
+                        .And.HaveResolvedFrameworkVersion("5.6.0"));
+        }
+
+        // This test does:
+        //  - Forces hard resolve of 5.1.1 -> 5.1.3 (direct reference from app)
+        //  - Loads MiddleWare which has 5.4.1 
+        //    - This forces a retry since 5.1.3 was hard resolved, so we have reload with 5.4.1 instead
+        //  - Loads AnotherMiddleWare which has 5.6.0
+        //    - This forces a retry since by this time 5.4.1 was hard resolved, so we have to reload with 5.6.0 instead
+        [Fact]
+        public void FrameworkResolutionRetry_FrameworkTree()
+        {
+            RunTest(
+                runtimeConfig => runtimeConfig
+                    .WithRollForwardOnNoCandidateFx(2)
+                    .WithFramework(MicrosoftNETCoreApp, "5.1.1")
+                    .WithFramework("MiddleWare", "2.1.2")
+                    .WithFramework("AnotherMiddleWare", "3.0.0"),
+                dotnetCustomizer =>
+                {
+                    dotnetCustomizer.Framework("MiddleWare").RuntimeConfig(runtimeConfig =>
+                        runtimeConfig.GetFramework(MicrosoftNETCoreApp)
+                            .Version = "5.4.1");
+                    dotnetCustomizer.Framework("AnotherMiddleWare").RuntimeConfig(runtimeConfig =>
+                        runtimeConfig.GetFramework(MicrosoftNETCoreApp)
+                            .Version = "5.6.0");
+                },
+                resultValidator: commandResult =>
+                    commandResult.Should().Pass()
+                        .And.RestartedFrameworkResolution("5.1.3", "5.4.1")
+                        .And.RestartedFrameworkResolution("5.4.1", "5.6.0")
+                        .And.HaveResolvedFrameworkVersion("5.6.0"));
+        }
+
+        private void RunTest(
+            Func<RuntimeConfig, RuntimeConfig> runtimeConfig,
+            Action<DotNetCliExtensions.DotNetCliCustomizer> customizeDotNet = null,
+            string resolvedFramework = null,
+            Action<CommandResult> resultValidator = null)
+        {
+            using (DotNetCliExtensions.DotNetCliCustomizer dotnetCustomizer = SharedState.DotNetWithMultipleFrameworks.Customize())
+            {
+                customizeDotNet?.Invoke(dotnetCustomizer);
+
+                RunTest(
+                    SharedState.DotNetWithMultipleFrameworks,
+                    SharedState.FrameworkReferenceApp,
+                    runtimeConfig,
+                    commandResult =>
+                    {
+                        if (resolvedFramework != null)
+                        {
+                            commandResult.Should().Pass()
+                                .And.HaveResolvedFrameworkVersion(resolvedFramework);
+                        }
+                        else
+                        {
+                            resultValidator?.Invoke(commandResult);
+                        }
+                    });
+            }
+        }
+
+        public class SharedTestState : SharedTestStateBase
+        {
+            public TestApp FrameworkReferenceApp { get; }
+
+            public DotNetCli DotNetWithMultipleFrameworks { get; }
+
+            public SharedTestState()
+            {
+                DotNetWithMultipleFrameworks = DotNet("WithOneFramework")
+                    .AddMicrosoftNETCoreAppFramework("5.1.1")
+                    .AddMicrosoftNETCoreAppFramework("5.1.3")
+                    .AddMicrosoftNETCoreAppFramework("5.4.1")
+                    .AddMicrosoftNETCoreAppFramework("5.6.0")
+                    .AddMicrosoftNETCoreAppFramework("6.0.1-preview.1")
+                    .AddFramework("MiddleWare", "2.1.2", runtimeConfig =>
+                        runtimeConfig.WithFramework(MicrosoftNETCoreApp, "5.1.3"))
+                    .AddFramework("AnotherMiddleWare", "3.0.0", runtimeConfig =>
+                        runtimeConfig.WithFramework(MicrosoftNETCoreApp, "5.1.3"))
+                    .AddFramework("HighWare", "7.3.1", runtimeConfig =>
+                        runtimeConfig
+                            .WithFramework(MicrosoftNETCoreApp, "5.1.3")
+                            .WithFramework("MiddleWare", "2.1.2"))
+                    .Build();
+
+                FrameworkReferenceApp = CreateFrameworkReferenceApp();
+            }
+        }
+    }
+}

--- a/src/test/HostActivationTests/FrameworkResolution/RollForwardOnNoCandidateFx.cs
+++ b/src/test/HostActivationTests/FrameworkResolution/RollForwardOnNoCandidateFx.cs
@@ -45,9 +45,9 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.FrameworkResolution
         {
             RunTestWithOneFramework(
                 runtimeConfig => runtimeConfig
-                    .WithFramework(MicrosoftNETCoreApp, "5.1.0")
                     .WithRollForwardOnNoCandidateFx(rollForwardOnNoCandidateFx)
-                    .WithApplyPatches(applyPatches),
+                    .WithApplyPatches(applyPatches)
+                    .WithFramework(MicrosoftNETCoreApp, "5.1.0"),
                 commandResult => commandResult.Should().Pass()
                     .And.HaveResolvedFrameworkVersion("5.1.3"));
         }
@@ -64,9 +64,9 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.FrameworkResolution
         {
             RunTestWithOneFramework(
                 runtimeConfig => runtimeConfig
-                    .WithFramework(MicrosoftNETCoreApp, "5.0.0")
                     .WithRollForwardOnNoCandidateFx(rollForwardOnNoCandidateFx)
-                    .WithApplyPatches(applyPatches),
+                    .WithApplyPatches(applyPatches)
+                    .WithFramework(MicrosoftNETCoreApp, "5.0.0"),
                 commandResult =>
                 {
                     if (passes)
@@ -93,9 +93,9 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.FrameworkResolution
         {
             RunTestWithOneFramework(
                 runtimeConfig => runtimeConfig
-                    .WithFramework(MicrosoftNETCoreApp, "4.1.0")
                     .WithRollForwardOnNoCandidateFx(rollForwardOnNoCandidateFx)
-                    .WithApplyPatches(applyPatches),
+                    .WithApplyPatches(applyPatches)
+                    .WithFramework(MicrosoftNETCoreApp, "4.1.0"),
                 commandResult =>
                 {
                     if (passes)
@@ -116,9 +116,9 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.FrameworkResolution
         {
             RunTestWithOneFramework(
                 runtimeConfig => runtimeConfig
-                    .WithFramework(MicrosoftNETCoreApp, "5.1.0")
                     .WithRollForwardOnNoCandidateFx(0)
-                    .WithApplyPatches(false),
+                    .WithApplyPatches(false)
+                    .WithFramework(MicrosoftNETCoreApp, "5.1.0"),
                 commandResult => commandResult.Should().Fail()
                     .And.HaveStdErrContaining("Did not roll forward because patch_roll_fwd=0, roll_fwd_on_no_candidate_fx=0, use_exact_version=0 chose [5.1.0]"));
         }
@@ -128,9 +128,9 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.FrameworkResolution
         {
             RunTestWithOneFramework(
                 runtimeConfig => runtimeConfig
-                    .WithFramework(MicrosoftNETCoreApp, "5.1.3")
                     .WithRollForwardOnNoCandidateFx(0)
-                    .WithApplyPatches(false),
+                    .WithApplyPatches(false)
+                    .WithFramework(MicrosoftNETCoreApp, "5.1.3"),
                 commandResult => commandResult.Should().Pass()
                     .And.HaveResolvedFrameworkVersion("5.1.3"));
         }
@@ -140,8 +140,8 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.FrameworkResolution
         {
             RunTestWithOneFramework(
                 runtimeConfig => runtimeConfig
-                    .WithFramework(MicrosoftNETCoreApp, "5.0.0")
-                    .WithRollForwardOnNoCandidateFx(0),
+                    .WithRollForwardOnNoCandidateFx(0)
+                    .WithFramework(MicrosoftNETCoreApp, "5.0.0"),
                 // Will still attempt roll forward to latest patch
                 commandResult => commandResult.Should().Fail()
                     .And.HaveStdErrContaining("Attempting FX roll forward")
@@ -199,9 +199,9 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.FrameworkResolution
         {
             RunTestWithPreReleaseFramework(
                 runtimeConfig => runtimeConfig
-                    .WithFramework(MicrosoftNETCoreApp, "5.1.3-preview.1")
                     .WithRollForwardOnNoCandidateFx(rollForwardOnNoCandidateFx)
-                    .WithApplyPatches(applyPatches),
+                    .WithApplyPatches(applyPatches)
+                    .WithFramework(MicrosoftNETCoreApp, "5.1.3-preview.1"),
                 commandResult => commandResult.Should().Pass()
                     .And.HaveResolvedFrameworkVersion("5.1.3-preview.2"));
         }
@@ -217,9 +217,9 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.FrameworkResolution
         {
             RunTestWithPreReleaseFramework(
                 runtimeConfig => runtimeConfig
-                    .WithFramework(MicrosoftNETCoreApp, "5.1.0")
                     .WithRollForwardOnNoCandidateFx(rollForwardOnNoCandidateFx)
-                    .WithApplyPatches(applyPatches),
+                    .WithApplyPatches(applyPatches)
+                    .WithFramework(MicrosoftNETCoreApp, "5.1.0"),
                 commandResult =>
                 {
                     if (passes)
@@ -247,9 +247,9 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.FrameworkResolution
         {
             RunTestWithPreReleaseFramework(
                 runtimeConfig => runtimeConfig
-                    .WithFramework(MicrosoftNETCoreApp, "5.0.0")
                     .WithRollForwardOnNoCandidateFx(rollForwardOnNoCandidateFx)
-                    .WithApplyPatches(applyPatches),
+                    .WithApplyPatches(applyPatches)
+                    .WithFramework(MicrosoftNETCoreApp, "5.0.0"),
                 commandResult =>
                 {
                     if (passes)
@@ -276,9 +276,9 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.FrameworkResolution
         {
             RunTestWithPreReleaseFramework(
                 runtimeConfig => runtimeConfig
-                    .WithFramework(MicrosoftNETCoreApp, "4.1.0")
                     .WithRollForwardOnNoCandidateFx(rollForwardOnNoCandidateFx)
-                    .WithApplyPatches(applyPatches),
+                    .WithApplyPatches(applyPatches)
+                    .WithFramework(MicrosoftNETCoreApp, "4.1.0"),
                 commandResult =>
                 {
                     if (passes)
@@ -330,9 +330,9 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.FrameworkResolution
         {
             RunTestWithManyVersions(
                 runtimeConfig => runtimeConfig
-                    .WithFramework(MicrosoftNETCoreApp, "4.1.1")
                     .WithRollForwardOnNoCandidateFx(rollForwardOnNoCandidateFx)
-                    .WithApplyPatches(applyPatches),
+                    .WithApplyPatches(applyPatches)
+                    .WithFramework(MicrosoftNETCoreApp, "4.1.1"),
                 commandResult => commandResult.Should().Pass()
                     .And.HaveResolvedFrameworkVersion(resolvedVersion));
         }
@@ -350,9 +350,9 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.FrameworkResolution
         {
             RunTestWithManyVersions(
                 runtimeConfig => runtimeConfig
-                    .WithFramework(MicrosoftNETCoreApp, "4.0.0")
                     .WithRollForwardOnNoCandidateFx(rollForwardOnNoCandidateFx)
-                    .WithApplyPatches(applyPatches),
+                    .WithApplyPatches(applyPatches)
+                    .WithFramework(MicrosoftNETCoreApp, "4.0.0"),
                 commandResult =>
                 {
                     if (resolvedVersion != null)
@@ -381,9 +381,9 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.FrameworkResolution
         {
             RunTestWithManyVersions(
                 runtimeConfig => runtimeConfig
-                    .WithFramework(MicrosoftNETCoreApp, "3.0.0")
                     .WithRollForwardOnNoCandidateFx(rollForwardOnNoCandidateFx)
-                    .WithApplyPatches(applyPatches),
+                    .WithApplyPatches(applyPatches)
+                    .WithFramework(MicrosoftNETCoreApp, "3.0.0"),
                 commandResult =>
                 {
                     if (resolvedVersion != null)
@@ -412,9 +412,9 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.FrameworkResolution
         {
             RunTestWithManyVersions(
                 runtimeConfig => runtimeConfig
-                    .WithFramework(MicrosoftNETCoreApp, "5.1.2")
                     .WithRollForwardOnNoCandidateFx(rollForwardOnNoCandidateFx)
-                    .WithApplyPatches(applyPatches),
+                    .WithApplyPatches(applyPatches)
+                    .WithFramework(MicrosoftNETCoreApp, "5.1.2"),
                 commandResult =>
                 {
                     if (resolvedVersion != null)
@@ -443,9 +443,9 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.FrameworkResolution
         {
             RunTestWithManyVersions(
                 runtimeConfig => runtimeConfig
-                    .WithFramework(MicrosoftNETCoreApp, "5.0.0")
                     .WithRollForwardOnNoCandidateFx(rollForwardOnNoCandidateFx)
-                    .WithApplyPatches(applyPatches),
+                    .WithApplyPatches(applyPatches)
+                    .WithFramework(MicrosoftNETCoreApp, "5.0.0"),
                 commandResult =>
                 {
                     if (resolvedVersion != null)
@@ -474,9 +474,9 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.FrameworkResolution
         {
             RunTestWithManyVersions(
                 runtimeConfig => runtimeConfig
-                    .WithFramework(MicrosoftNETCoreApp, "6.2.0")
                     .WithRollForwardOnNoCandidateFx(rollForwardOnNoCandidateFx)
-                    .WithApplyPatches(applyPatches),
+                    .WithApplyPatches(applyPatches)
+                    .WithFramework(MicrosoftNETCoreApp, "6.2.0"),
                 commandResult =>
                 {
                     if (resolvedVersion != null)
@@ -501,9 +501,9 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.FrameworkResolution
         {
             RunTestWithManyVersions(
                 runtimeConfig => runtimeConfig
-                    .WithFramework(MicrosoftNETCoreApp, "5.1.1-preview.1")
                     .WithRollForwardOnNoCandidateFx(rollForwardOnNoCandidateFx)
-                    .WithApplyPatches(applyPatches),
+                    .WithApplyPatches(applyPatches)
+                    .WithFramework(MicrosoftNETCoreApp, "5.1.1-preview.1"),
                 commandResult =>
                 {
                     if (resolvedVersion != null)
@@ -529,9 +529,9 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.FrameworkResolution
         {
             RunTestWithManyVersions(
                 runtimeConfig => runtimeConfig
-                    .WithFramework(MicrosoftNETCoreApp, "5.1.3-preview.0")
                     .WithRollForwardOnNoCandidateFx(rollForwardOnNoCandidateFx)
-                    .WithApplyPatches(applyPatches),
+                    .WithApplyPatches(applyPatches)
+                    .WithFramework(MicrosoftNETCoreApp, "5.1.3-preview.0"),
                 commandResult =>
                 {
                     if (resolvedVersion != null)
@@ -555,8 +555,8 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.FrameworkResolution
         {
             RunTestWithManyVersions(
                 runtimeConfig => runtimeConfig
-                    .WithFramework(MicrosoftNETCoreApp, "6.1.0")
-                    .WithRollForwardOnNoCandidateFx(rollForwardOnNoCandidateFx),
+                    .WithRollForwardOnNoCandidateFx(rollForwardOnNoCandidateFx)
+                    .WithFramework(MicrosoftNETCoreApp, "6.1.0"),
                 commandResult => commandResult.Should().Pass()
                     .And.HaveResolvedFrameworkVersion("6.1.1"));
         }

--- a/src/test/HostActivationTests/FrameworkResolution/RollForwardOnNoCandidateFx.cs
+++ b/src/test/HostActivationTests/FrameworkResolution/RollForwardOnNoCandidateFx.cs
@@ -31,7 +31,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.FrameworkResolution
                 runtimeConfig => runtimeConfig
                     .WithFramework(MicrosoftNETCoreApp, "5.1.3"),
                 commandResult => commandResult.Should().Pass()
-                    .And.HaveResolvedFrameworkVersion("5.1.3"));
+                    .And.HaveResolvedFramework(MicrosoftNETCoreApp, "5.1.3"));
         }
 
         [Theory]
@@ -49,7 +49,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.FrameworkResolution
                     .WithApplyPatches(applyPatches)
                     .WithFramework(MicrosoftNETCoreApp, "5.1.0"),
                 commandResult => commandResult.Should().Pass()
-                    .And.HaveResolvedFrameworkVersion("5.1.3"));
+                    .And.HaveResolvedFramework(MicrosoftNETCoreApp, "5.1.3"));
         }
 
         [Theory]
@@ -72,7 +72,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.FrameworkResolution
                     if (passes)
                     {
                         commandResult.Should().Pass()
-                            .And.HaveResolvedFrameworkVersion("5.1.3");
+                            .And.HaveResolvedFramework(MicrosoftNETCoreApp, "5.1.3");
                     }
                     else
                     {
@@ -101,7 +101,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.FrameworkResolution
                     if (passes)
                     {
                         commandResult.Should().Pass()
-                            .And.HaveResolvedFrameworkVersion("5.1.3");
+                            .And.HaveResolvedFramework(MicrosoftNETCoreApp, "5.1.3");
                     }
                     else
                     {
@@ -132,7 +132,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.FrameworkResolution
                     .WithApplyPatches(false)
                     .WithFramework(MicrosoftNETCoreApp, "5.1.3"),
                 commandResult => commandResult.Should().Pass()
-                    .And.HaveResolvedFrameworkVersion("5.1.3"));
+                    .And.HaveResolvedFramework(MicrosoftNETCoreApp, "5.1.3"));
         }
 
         [Fact]
@@ -178,7 +178,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.FrameworkResolution
                 runtimeConfig => runtimeConfig
                     .WithFramework(MicrosoftNETCoreApp, "5.1.3-preview.2"),
                 commandResult => commandResult.Should().Pass()
-                    .And.HaveResolvedFrameworkVersion("5.1.3-preview.2"));
+                    .And.HaveResolvedFramework(MicrosoftNETCoreApp, "5.1.3-preview.2"));
         }
 
         [Fact]
@@ -203,7 +203,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.FrameworkResolution
                     .WithApplyPatches(applyPatches)
                     .WithFramework(MicrosoftNETCoreApp, "5.1.3-preview.1"),
                 commandResult => commandResult.Should().Pass()
-                    .And.HaveResolvedFrameworkVersion("5.1.3-preview.2"));
+                    .And.HaveResolvedFramework(MicrosoftNETCoreApp, "5.1.3-preview.2"));
         }
 
         [Theory]
@@ -225,7 +225,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.FrameworkResolution
                     if (passes)
                     {
                         commandResult.Should().Pass()
-                            .And.HaveResolvedFrameworkVersion("5.1.3-preview.2");
+                            .And.HaveResolvedFramework(MicrosoftNETCoreApp, "5.1.3-preview.2");
                     }
                     else
                     {
@@ -255,7 +255,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.FrameworkResolution
                     if (passes)
                     {
                         commandResult.Should().Pass()
-                            .And.HaveResolvedFrameworkVersion("5.1.3-preview.2");
+                            .And.HaveResolvedFramework(MicrosoftNETCoreApp, "5.1.3-preview.2");
                     }
                     else
                     {
@@ -284,7 +284,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.FrameworkResolution
                     if (passes)
                     {
                         commandResult.Should().Pass()
-                            .And.HaveResolvedFrameworkVersion("5.1.3-preview.2");
+                            .And.HaveResolvedFramework(MicrosoftNETCoreApp, "5.1.3-preview.2");
                     }
                     else
                     {
@@ -334,7 +334,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.FrameworkResolution
                     .WithApplyPatches(applyPatches)
                     .WithFramework(MicrosoftNETCoreApp, "4.1.1"),
                 commandResult => commandResult.Should().Pass()
-                    .And.HaveResolvedFrameworkVersion(resolvedVersion));
+                    .And.HaveResolvedFramework(MicrosoftNETCoreApp, resolvedVersion));
         }
 
         [Theory]
@@ -358,7 +358,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.FrameworkResolution
                     if (resolvedVersion != null)
                     {
                         commandResult.Should().Pass()
-                            .And.HaveResolvedFrameworkVersion(resolvedVersion);
+                            .And.HaveResolvedFramework(MicrosoftNETCoreApp, resolvedVersion);
                     }
                     else
                     {
@@ -389,7 +389,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.FrameworkResolution
                     if (resolvedVersion != null)
                     {
                         commandResult.Should().Pass()
-                            .And.HaveResolvedFrameworkVersion(resolvedVersion);
+                            .And.HaveResolvedFramework(MicrosoftNETCoreApp, resolvedVersion);
                     }
                     else
                     {
@@ -420,7 +420,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.FrameworkResolution
                     if (resolvedVersion != null)
                     {
                         commandResult.Should().Pass()
-                            .And.HaveResolvedFrameworkVersion(resolvedVersion);
+                            .And.HaveResolvedFramework(MicrosoftNETCoreApp, resolvedVersion);
                     }
                     else
                     {
@@ -451,7 +451,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.FrameworkResolution
                     if (resolvedVersion != null)
                     {
                         commandResult.Should().Pass()
-                            .And.HaveResolvedFrameworkVersion(resolvedVersion);
+                            .And.HaveResolvedFramework(MicrosoftNETCoreApp, resolvedVersion);
                     }
                     else
                     {
@@ -482,7 +482,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.FrameworkResolution
                     if (resolvedVersion != null)
                     {
                         commandResult.Should().Pass()
-                            .And.HaveResolvedFrameworkVersion(resolvedVersion);
+                            .And.HaveResolvedFramework(MicrosoftNETCoreApp, resolvedVersion);
                     }
                     else
                     {
@@ -509,7 +509,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.FrameworkResolution
                     if (resolvedVersion != null)
                     {
                         commandResult.Should().Pass()
-                            .And.HaveResolvedFrameworkVersion(resolvedVersion);
+                            .And.HaveResolvedFramework(MicrosoftNETCoreApp, resolvedVersion);
                     }
                     else
                     {
@@ -537,7 +537,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.FrameworkResolution
                     if (resolvedVersion != null)
                     {
                         commandResult.Should().Pass()
-                            .And.HaveResolvedFrameworkVersion(resolvedVersion);
+                            .And.HaveResolvedFramework(MicrosoftNETCoreApp, resolvedVersion);
                     }
                     else
                     {
@@ -558,7 +558,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.FrameworkResolution
                     .WithRollForwardOnNoCandidateFx(rollForwardOnNoCandidateFx)
                     .WithFramework(MicrosoftNETCoreApp, "6.1.0"),
                 commandResult => commandResult.Should().Pass()
-                    .And.HaveResolvedFrameworkVersion("6.1.1"));
+                    .And.HaveResolvedFramework(MicrosoftNETCoreApp, "6.1.1"));
         }
 
 

--- a/src/test/HostActivationTests/FrameworkResolution/RollForwardOnNoCandidateFx.cs
+++ b/src/test/HostActivationTests/FrameworkResolution/RollForwardOnNoCandidateFx.cs
@@ -1,0 +1,625 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.DotNet.Cli.Build;
+using Microsoft.DotNet.Cli.Build.Framework;
+using System;
+using Xunit;
+
+namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.FrameworkResolution
+{
+    public class RollForwardOnNoCandidateFx : 
+        FrameworkResolutionBase,
+        IClassFixture<RollForwardOnNoCandidateFx.SharedTestState>
+    {
+        private SharedTestState SharedState { get; }
+
+        public RollForwardOnNoCandidateFx(SharedTestState sharedState)
+        {
+            SharedState = sharedState;
+        }
+
+        #region With one release framework
+        // RunTestWithOneFramework
+        //   dotnet with
+        //     - Microsoft.NETCore.App 5.1.3
+
+        [Fact]
+        public void ExactMatchOnRelease_NoSettings()
+        {
+            RunTestWithOneFramework(
+                runtimeConfig => runtimeConfig
+                    .WithFramework(MicrosoftNETCoreApp, "5.1.3"),
+                commandResult => commandResult.Should().Pass()
+                    .And.HaveResolvedFrameworkVersion("5.1.3"));
+        }
+
+        [Theory]
+        [InlineData(null, null)]
+        [InlineData(0, null)]
+        [InlineData(1, null)]
+        [InlineData(1, false)]  // Rolls on patches even when applyPatches = false if rollForwardOnNoCandidateFx != 0
+        [InlineData(2, null)]
+        [InlineData(2, false)]  // Rolls on patches even when applyPatches = false if rollForwardOnNoCandidateFx != 0
+        public void RollForwardToLatestPatch_RollForwardOnNoCandidateFx(int? rollForwardOnNoCandidateFx, bool? applyPatches)
+        {
+            RunTestWithOneFramework(
+                runtimeConfig => runtimeConfig
+                    .WithFramework(MicrosoftNETCoreApp, "5.1.0")
+                    .WithRollForwardOnNoCandidateFx(rollForwardOnNoCandidateFx)
+                    .WithApplyPatches(applyPatches),
+                commandResult => commandResult.Should().Pass()
+                    .And.HaveResolvedFrameworkVersion("5.1.3"));
+        }
+
+        [Theory]
+        [InlineData(null, null, true)]
+        [InlineData(null, false, true)]
+        [InlineData(0, null, false)]
+        [InlineData(1, null, true)]
+        [InlineData(1, false, true)] // Rolls on patches even when applyPatches = false if rollForwardOnNoCandidateFx != 0
+        [InlineData(2, null, true)]
+        [InlineData(2, false, true)] // Rolls on patches even when applyPatches = false if rollForwardOnNoCandidateFx != 0
+        public void RollForwardOnMinor_RollForwardOnNoCandidateFx(int? rollForwardOnNoCandidateFx, bool? applyPatches, bool passes)
+        {
+            RunTestWithOneFramework(
+                runtimeConfig => runtimeConfig
+                    .WithFramework(MicrosoftNETCoreApp, "5.0.0")
+                    .WithRollForwardOnNoCandidateFx(rollForwardOnNoCandidateFx)
+                    .WithApplyPatches(applyPatches),
+                commandResult =>
+                {
+                    if (passes)
+                    {
+                        commandResult.Should().Pass()
+                            .And.HaveResolvedFrameworkVersion("5.1.3");
+                    }
+                    else
+                    {
+                        commandResult.Should().Fail()
+                            .And.DidNotFindCompatibleFrameworkVersion();
+                    }
+                });
+        }
+
+        [Theory]
+        [InlineData(null, null, false)]
+        [InlineData(0, null, false)]
+        [InlineData(1, null, false)]
+        [InlineData(1, false, false)]
+        [InlineData(2, null, true)]
+        [InlineData(2, false, true)] // Rolls on patches even when applyPatches = false if rollForwardOnNoCandidateFx != 0
+        public void RollForwardOnMajor_RollForwardOnNoCandidateFx(int? rollForwardOnNoCandidateFx, bool? applyPatches, bool passes)
+        {
+            RunTestWithOneFramework(
+                runtimeConfig => runtimeConfig
+                    .WithFramework(MicrosoftNETCoreApp, "4.1.0")
+                    .WithRollForwardOnNoCandidateFx(rollForwardOnNoCandidateFx)
+                    .WithApplyPatches(applyPatches),
+                commandResult =>
+                {
+                    if (passes)
+                    {
+                        commandResult.Should().Pass()
+                            .And.HaveResolvedFrameworkVersion("5.1.3");
+                    }
+                    else
+                    {
+                        commandResult.Should().Fail()
+                            .And.DidNotFindCompatibleFrameworkVersion();
+                    }
+                });
+        }
+
+        [Fact]
+        public void RollForwardDisabledOnCandidateFxAndDisabledApplyPatches_FailsToRollPatches()
+        {
+            RunTestWithOneFramework(
+                runtimeConfig => runtimeConfig
+                    .WithFramework(MicrosoftNETCoreApp, "5.1.0")
+                    .WithRollForwardOnNoCandidateFx(0)
+                    .WithApplyPatches(false),
+                commandResult => commandResult.Should().Fail()
+                    .And.HaveStdErrContaining("Did not roll forward because patch_roll_fwd=0, roll_fwd_on_no_candidate_fx=0, use_exact_version=0 chose [5.1.0]"));
+        }
+
+        [Fact]
+        public void RollForwardDisabledOnCandidateFxAndDisabledApplyPatches_MatchesExact()
+        {
+            RunTestWithOneFramework(
+                runtimeConfig => runtimeConfig
+                    .WithFramework(MicrosoftNETCoreApp, "5.1.3")
+                    .WithRollForwardOnNoCandidateFx(0)
+                    .WithApplyPatches(false),
+                commandResult => commandResult.Should().Pass()
+                    .And.HaveResolvedFrameworkVersion("5.1.3"));
+        }
+
+        [Fact]
+        public void RollForwardOnMinorDisabledOnNoCandidateFx_FailsToRoll()
+        {
+            RunTestWithOneFramework(
+                runtimeConfig => runtimeConfig
+                    .WithFramework(MicrosoftNETCoreApp, "5.0.0")
+                    .WithRollForwardOnNoCandidateFx(0),
+                // Will still attempt roll forward to latest patch
+                commandResult => commandResult.Should().Fail()
+                    .And.HaveStdErrContaining("Attempting FX roll forward")
+                    .And.DidNotFindCompatibleFrameworkVersion());
+        }
+
+        [Fact]
+        public void PreReleaseReference_FailsToRollToRelease()
+        {
+            RunTestWithOneFramework(
+                runtimeConfig => runtimeConfig
+                    .WithFramework(MicrosoftNETCoreApp, "5.1.0-preview.1"),
+                commandResult => commandResult.Should().Fail()
+                    .And.DidNotFindCompatibleFrameworkVersion());
+        }
+
+        private void RunTestWithOneFramework(
+            Func<RuntimeConfig, RuntimeConfig> runtimeConfig,
+            Action<CommandResult> resultAction)
+        {
+            RunTest(SharedState.DotNetWithOneFramework, runtimeConfig, resultAction);
+        }
+        #endregion
+
+        #region With one pre-release framework
+        // RunTestWithPreReleaseFramework
+        //   dotnet with
+        //     - Microsoft.NETCore.App 5.1.3-preview.2
+
+        [Fact]
+        public void ExactMatchOnPreRelease_NoSettings()
+        {
+            RunTestWithPreReleaseFramework(
+                runtimeConfig => runtimeConfig
+                    .WithFramework(MicrosoftNETCoreApp, "5.1.3-preview.2"),
+                commandResult => commandResult.Should().Pass()
+                    .And.HaveResolvedFrameworkVersion("5.1.3-preview.2"));
+        }
+
+        [Fact]
+        public void RollForwardToPreRelease_FailsOnVersionMismatch()
+        {
+            RunTestWithPreReleaseFramework(
+                runtimeConfig => runtimeConfig
+                    .WithFramework(MicrosoftNETCoreApp, "5.1.2-preview.2"),
+                commandResult => commandResult.Should().Fail()
+                    .And.DidNotFindCompatibleFrameworkVersion());
+        }
+
+        [Theory]
+        [InlineData(null, null)]
+        [InlineData(0, false)] // Pre-Release ignores roll forward on no candidate FX and apply patches settings
+        [InlineData(2, true)]
+        public void RollForwardToPreRelease(int? rollForwardOnNoCandidateFx, bool? applyPatches)
+        {
+            RunTestWithPreReleaseFramework(
+                runtimeConfig => runtimeConfig
+                    .WithFramework(MicrosoftNETCoreApp, "5.1.3-preview.1")
+                    .WithRollForwardOnNoCandidateFx(rollForwardOnNoCandidateFx)
+                    .WithApplyPatches(applyPatches),
+                commandResult => commandResult.Should().Pass()
+                    .And.HaveResolvedFrameworkVersion("5.1.3-preview.2"));
+        }
+
+        [Theory]
+        [InlineData(null, null, true)]
+        [InlineData(0, null, false)]  // Roll forward to pre-release on patch from release is blocked
+        [InlineData(1, null, true)]
+        [InlineData(1, false, true)]  // Rolls on patches even when applyPatches = false if rollForwardOnNoCandidateFx != 0
+        [InlineData(2, null, true)]
+        [InlineData(2, false, true)]  // Rolls on patches even when applyPatches = false if rollForwardOnNoCandidateFx != 0
+        public void RollForwardToPreReleaseLatestPatch_RollForwardOnNoCandidateFx(int? rollForwardOnNoCandidateFx, bool? applyPatches, bool passes)
+        {
+            RunTestWithPreReleaseFramework(
+                runtimeConfig => runtimeConfig
+                    .WithFramework(MicrosoftNETCoreApp, "5.1.0")
+                    .WithRollForwardOnNoCandidateFx(rollForwardOnNoCandidateFx)
+                    .WithApplyPatches(applyPatches),
+                commandResult =>
+                {
+                    if (passes)
+                    {
+                        commandResult.Should().Pass()
+                            .And.HaveResolvedFrameworkVersion("5.1.3-preview.2");
+                    }
+                    else
+                    {
+                        commandResult.Should().Fail()
+                            .And.DidNotFindCompatibleFrameworkVersion();
+                    }
+                });
+        }
+
+        [Theory]
+        [InlineData(null, null, true)]
+        [InlineData(null, false, true)]
+        [InlineData(0, null, false)]
+        [InlineData(1, null, true)]
+        [InlineData(1, false, true)] // Rolls on patches even when applyPatches = false if rollForwardOnNoCandidateFx != 0
+        [InlineData(2, null, true)]
+        [InlineData(2, false, true)] // Rolls on patches even when applyPatches = false if rollForwardOnNoCandidateFx != 0
+        public void RollForwardToPreReleaseOnMinor_RollForwardOnNoCandidateFx(int? rollForwardOnNoCandidateFx, bool? applyPatches, bool passes)
+        {
+            RunTestWithPreReleaseFramework(
+                runtimeConfig => runtimeConfig
+                    .WithFramework(MicrosoftNETCoreApp, "5.0.0")
+                    .WithRollForwardOnNoCandidateFx(rollForwardOnNoCandidateFx)
+                    .WithApplyPatches(applyPatches),
+                commandResult =>
+                {
+                    if (passes)
+                    {
+                        commandResult.Should().Pass()
+                            .And.HaveResolvedFrameworkVersion("5.1.3-preview.2");
+                    }
+                    else
+                    {
+                        commandResult.Should().Fail()
+                            .And.DidNotFindCompatibleFrameworkVersion();
+                    }
+                });
+        }
+
+        [Theory]
+        [InlineData(null, null, false)]
+        [InlineData(0, null, false)]
+        [InlineData(1, null, false)]
+        [InlineData(1, false, false)]
+        [InlineData(2, null, true)]
+        [InlineData(2, false, true)] // Rolls on patches even when applyPatches = false if rollForwardOnNoCandidateFx != 0
+        public void RollForwardToPreReleaseOnMajor_RollForwardOnNoCandidateFx(int? rollForwardOnNoCandidateFx, bool? applyPatches, bool passes)
+        {
+            RunTestWithPreReleaseFramework(
+                runtimeConfig => runtimeConfig
+                    .WithFramework(MicrosoftNETCoreApp, "4.1.0")
+                    .WithRollForwardOnNoCandidateFx(rollForwardOnNoCandidateFx)
+                    .WithApplyPatches(applyPatches),
+                commandResult =>
+                {
+                    if (passes)
+                    {
+                        commandResult.Should().Pass()
+                            .And.HaveResolvedFrameworkVersion("5.1.3-preview.2");
+                    }
+                    else
+                    {
+                        commandResult.Should().Fail()
+                            .And.DidNotFindCompatibleFrameworkVersion();
+                    }
+                });
+        }
+
+        private void RunTestWithPreReleaseFramework(
+            Func<RuntimeConfig, RuntimeConfig> runtimeConfig,
+            Action<CommandResult> resultAction)
+        {
+            RunTest(SharedState.DotNetWithPreReleaseFramework, runtimeConfig, resultAction);
+        }
+        #endregion
+
+        #region With many versions
+        // RunWithManyVersions has these frameworks
+        //  - Microsoft.NETCore.App 4.1.1
+        //  - Microsoft.NETCore.App 4.1.2
+        //  - Microsoft.NETCore.App 4.1.3-preview.1
+        //  - Microsoft.NETCore.App 4.2.1
+        //  - Microsoft.NETCore.App 5.1.3-preview.1
+        //  - Microsoft.NETCore.App 5.1.3-preview.2
+        //  - Microsoft.NETCore.App 5.1.4-preview.1
+        //  - Microsoft.NETCore.App 5.2.3-preview.1
+        //  - Microsoft.NETCore.App 6.1.1
+        //  - Microsoft.NETCore.App 6.1.2-preview.1
+        //  - Microsoft.NETCore.App 7.1.1-preview.1
+        //  - Microsoft.NETCore.App 7.1.2-preview.1
+
+        [Theory]
+        [InlineData(null, null, "4.1.2")]
+        [InlineData(null, false, "4.1.1")]
+        [InlineData(0, null, "4.1.2")]
+        [InlineData(0, false, "4.1.1")]
+        [InlineData(1, null, "4.1.2")]
+        [InlineData(1, false, "4.1.1")]
+        [InlineData(2, null, "4.1.2")]
+        [InlineData(2, false, "4.1.1")]
+        public void RollForwardToLatestPatch_PicksLatestReleasePatch(int? rollForwardOnNoCandidateFx, bool? applyPatches, string resolvedVersion)
+        {
+            RunTestWithManyVersions(
+                runtimeConfig => runtimeConfig
+                    .WithFramework(MicrosoftNETCoreApp, "4.1.1")
+                    .WithRollForwardOnNoCandidateFx(rollForwardOnNoCandidateFx)
+                    .WithApplyPatches(applyPatches),
+                commandResult => commandResult.Should().Pass()
+                    .And.HaveResolvedFrameworkVersion(resolvedVersion));
+        }
+
+        [Theory]
+        [InlineData(null, null, "4.1.2")]
+        [InlineData(null, false, "4.1.1")]
+        [InlineData(0, null, null)]
+        [InlineData(0, false, null)]
+        [InlineData(1, null, "4.1.2")]
+        [InlineData(1, false, "4.1.1")]
+        [InlineData(2, null, "4.1.2")]
+        [InlineData(2, false, "4.1.1")]
+        public void RollForwardOnMinor_PicksLatestReleasePatch(int? rollForwardOnNoCandidateFx, bool? applyPatches, string resolvedVersion)
+        {
+            RunTestWithManyVersions(
+                runtimeConfig => runtimeConfig
+                    .WithFramework(MicrosoftNETCoreApp, "4.0.0")
+                    .WithRollForwardOnNoCandidateFx(rollForwardOnNoCandidateFx)
+                    .WithApplyPatches(applyPatches),
+                commandResult =>
+                {
+                    if (resolvedVersion != null)
+                    {
+                        commandResult.Should().Pass()
+                            .And.HaveResolvedFrameworkVersion(resolvedVersion);
+                    }
+                    else
+                    {
+                        commandResult.Should().Fail()
+                            .And.DidNotFindCompatibleFrameworkVersion();
+                    }
+                });
+        }
+
+        [Theory]
+        [InlineData(null, null, null)]
+        [InlineData(null, false, null)]
+        [InlineData(0, null, null)]
+        [InlineData(0, false, null)]
+        [InlineData(1, null, null)]
+        [InlineData(1, false, null)]
+        [InlineData(2, null, "4.1.2")]
+        [InlineData(2, false, "4.1.1")]
+        public void RollForwardOnMajor_PicksLatestReleasePatch(int? rollForwardOnNoCandidateFx, bool? applyPatches, string resolvedVersion)
+        {
+            RunTestWithManyVersions(
+                runtimeConfig => runtimeConfig
+                    .WithFramework(MicrosoftNETCoreApp, "3.0.0")
+                    .WithRollForwardOnNoCandidateFx(rollForwardOnNoCandidateFx)
+                    .WithApplyPatches(applyPatches),
+                commandResult =>
+                {
+                    if (resolvedVersion != null)
+                    {
+                        commandResult.Should().Pass()
+                            .And.HaveResolvedFrameworkVersion(resolvedVersion);
+                    }
+                    else
+                    {
+                        commandResult.Should().Fail()
+                            .And.DidNotFindCompatibleFrameworkVersion();
+                    }
+                });
+        }
+
+        [Theory]
+        [InlineData(null, null, "5.1.4-preview.1")]
+        [InlineData(null, false, "5.1.3-preview.1")]
+        [InlineData(0, null, null)]   // This is interesting - we prevent roll forward from release to preview on patch alone
+        [InlineData(0, false, null)]
+        [InlineData(1, null, "5.1.4-preview.1")]
+        [InlineData(1, false, "5.1.3-preview.1")]
+        [InlineData(2, null, "6.1.1")]   // Not really testing the pre-release roll forward, but valid test anyway
+        [InlineData(2, false, "6.1.1")]  // Not really testing the pre-release roll forward, but valid test anyway
+        public void RollForwardToPreReleaseToLatestPatch_FromRelease(int? rollForwardOnNoCandidateFx, bool? applyPatches, string resolvedVersion)
+        {
+            RunTestWithManyVersions(
+                runtimeConfig => runtimeConfig
+                    .WithFramework(MicrosoftNETCoreApp, "5.1.2")
+                    .WithRollForwardOnNoCandidateFx(rollForwardOnNoCandidateFx)
+                    .WithApplyPatches(applyPatches),
+                commandResult =>
+                {
+                    if (resolvedVersion != null)
+                    {
+                        commandResult.Should().Pass()
+                            .And.HaveResolvedFrameworkVersion(resolvedVersion);
+                    }
+                    else
+                    {
+                        commandResult.Should().Fail()
+                            .And.DidNotFindCompatibleFrameworkVersion();
+                    }
+                });
+        }
+
+        [Theory]
+        [InlineData(null, null, "5.1.4-preview.1")]
+        [InlineData(null, false, "5.1.3-preview.1")]
+        [InlineData(0, null, null)]
+        [InlineData(0, false, null)]
+        [InlineData(1, null, "5.1.4-preview.1")]
+        [InlineData(1, false, "5.1.3-preview.1")]
+        [InlineData(2, null, "6.1.1")]   // Not really testing the pre-release roll forward, but valid test anyway
+        [InlineData(2, false, "6.1.1")]  // Not really testing the pre-release roll forward, but valid test anyway
+        public void RollForwardToPreReleaseOnMinor_FromRelease(int? rollForwardOnNoCandidateFx, bool? applyPatches, string resolvedVersion)
+        {
+            RunTestWithManyVersions(
+                runtimeConfig => runtimeConfig
+                    .WithFramework(MicrosoftNETCoreApp, "5.0.0")
+                    .WithRollForwardOnNoCandidateFx(rollForwardOnNoCandidateFx)
+                    .WithApplyPatches(applyPatches),
+                commandResult =>
+                {
+                    if (resolvedVersion != null)
+                    {
+                        commandResult.Should().Pass()
+                            .And.HaveResolvedFrameworkVersion(resolvedVersion);
+                    }
+                    else
+                    {
+                        commandResult.Should().Fail()
+                            .And.DidNotFindCompatibleFrameworkVersion();
+                    }
+                });
+        }
+
+        [Theory]
+        [InlineData(null, null, null)]
+        [InlineData(null, false, null)]
+        [InlineData(0, null, null)]
+        [InlineData(0, false, null)]
+        [InlineData(1, null, null)]
+        [InlineData(1, false, null)]
+        [InlineData(2, null, "7.1.2-preview.1")]
+        [InlineData(2, false, "7.1.1-preview.1")]
+        public void RollForwardToPreReleaseOnMajor_FromRelease(int? rollForwardOnNoCandidateFx, bool? applyPatches, string resolvedVersion)
+        {
+            RunTestWithManyVersions(
+                runtimeConfig => runtimeConfig
+                    .WithFramework(MicrosoftNETCoreApp, "6.2.0")
+                    .WithRollForwardOnNoCandidateFx(rollForwardOnNoCandidateFx)
+                    .WithApplyPatches(applyPatches),
+                commandResult =>
+                {
+                    if (resolvedVersion != null)
+                    {
+                        commandResult.Should().Pass()
+                            .And.HaveResolvedFrameworkVersion(resolvedVersion);
+                    }
+                    else
+                    {
+                        commandResult.Should().Fail()
+                            .And.DidNotFindCompatibleFrameworkVersion();
+                    }
+                });
+        }
+
+        [Theory]
+        [InlineData(null, null, null)]   // Pre-release will only match the extact x.y.z version, regardless of settings
+        [InlineData(0, false, null)]
+        [InlineData(1, null, null)]
+        [InlineData(2, null, null)]
+        public void RollForwardToPreRelease_FromDifferentPreRelease(int? rollForwardOnNoCandidateFx, bool? applyPatches, string resolvedVersion)
+        {
+            RunTestWithManyVersions(
+                runtimeConfig => runtimeConfig
+                    .WithFramework(MicrosoftNETCoreApp, "5.1.1-preview.1")
+                    .WithRollForwardOnNoCandidateFx(rollForwardOnNoCandidateFx)
+                    .WithApplyPatches(applyPatches),
+                commandResult =>
+                {
+                    if (resolvedVersion != null)
+                    {
+                        commandResult.Should().Pass()
+                            .And.HaveResolvedFrameworkVersion(resolvedVersion);
+                    }
+                    else
+                    {
+                        commandResult.Should().Fail()
+                            .And.DidNotFindCompatibleFrameworkVersion();
+                    }
+                });
+        }
+
+        [Theory]
+        [InlineData(null, null, "5.1.3-preview.1")]   // Pre-release will select the closest higher version
+        [InlineData(null, false, "5.1.3-preview.1")]
+        [InlineData(0, false, "5.1.3-preview.1")]
+        [InlineData(1, null, "5.1.3-preview.1")]
+        [InlineData(2, null, "5.1.3-preview.1")]
+        public void RollForwardToPreRelease_FromSamePreRelease(int? rollForwardOnNoCandidateFx, bool? applyPatches, string resolvedVersion)
+        {
+            RunTestWithManyVersions(
+                runtimeConfig => runtimeConfig
+                    .WithFramework(MicrosoftNETCoreApp, "5.1.3-preview.0")
+                    .WithRollForwardOnNoCandidateFx(rollForwardOnNoCandidateFx)
+                    .WithApplyPatches(applyPatches),
+                commandResult =>
+                {
+                    if (resolvedVersion != null)
+                    {
+                        commandResult.Should().Pass()
+                            .And.HaveResolvedFrameworkVersion(resolvedVersion);
+                    }
+                    else
+                    {
+                        commandResult.Should().Fail()
+                            .And.DidNotFindCompatibleFrameworkVersion();
+                    }
+                });
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData(1)]
+        [InlineData(2)]
+        public void RollForwardToLatestPatch_WithHigherPreReleasePresent(int? rollForwardOnNoCandidateFx)
+        {
+            RunTestWithManyVersions(
+                runtimeConfig => runtimeConfig
+                    .WithFramework(MicrosoftNETCoreApp, "6.1.0")
+                    .WithRollForwardOnNoCandidateFx(rollForwardOnNoCandidateFx),
+                commandResult => commandResult.Should().Pass()
+                    .And.HaveResolvedFrameworkVersion("6.1.1"));
+        }
+
+
+
+        private void RunTestWithManyVersions(
+            Func<RuntimeConfig, RuntimeConfig> runtimeConfig,
+            Action<CommandResult> resultAction)
+        {
+            RunTest(SharedState.DotNetWithManyVersions, runtimeConfig, resultAction);
+        }
+        #endregion
+
+        private void RunTest(
+            DotNetCli dotNet,
+            Func<RuntimeConfig, RuntimeConfig> runtimeConfig,
+            Action<CommandResult> resultAction)
+        {
+            RunTest(
+                dotNet,
+                SharedState.FrameworkReferenceApp,
+                runtimeConfig,
+                resultAction);
+        }
+
+        public class SharedTestState : SharedTestStateBase
+        {
+            public TestApp FrameworkReferenceApp { get; }
+
+            public DotNetCli DotNetWithOneFramework { get; }
+
+            public DotNetCli DotNetWithPreReleaseFramework { get; }
+
+            public DotNetCli DotNetWithManyVersions { get; }
+
+            public SharedTestState()
+            {
+                DotNetWithOneFramework = DotNet("WithOneFramework")
+                    .AddMicrosoftNETCoreAppFramework("5.1.3")
+                    .Build();
+
+                DotNetWithPreReleaseFramework = DotNet("WithPreReleaseFramework")
+                    .AddMicrosoftNETCoreAppFramework("5.1.3-preview.2")
+                    .Build();
+
+                DotNetWithManyVersions = DotNet("WithManyVersions")
+                    .AddMicrosoftNETCoreAppFramework("4.1.1")
+                    .AddMicrosoftNETCoreAppFramework("4.1.2")
+                    .AddMicrosoftNETCoreAppFramework("4.1.3-preview.1")
+                    .AddMicrosoftNETCoreAppFramework("4.2.1")
+                    .AddMicrosoftNETCoreAppFramework("5.1.3-preview.1")
+                    .AddMicrosoftNETCoreAppFramework("5.1.3-preview.2")
+                    .AddMicrosoftNETCoreAppFramework("5.1.4-preview.1")
+                    .AddMicrosoftNETCoreAppFramework("5.2.3-preview.1")
+                    .AddMicrosoftNETCoreAppFramework("6.1.1")
+                    .AddMicrosoftNETCoreAppFramework("6.1.2-preview.1")
+                    .AddMicrosoftNETCoreAppFramework("7.1.1-preview.1")
+                    .AddMicrosoftNETCoreAppFramework("7.1.2-preview.1")
+                    .Build();
+
+                FrameworkReferenceApp = CreateFrameworkReferenceApp();
+            }
+        }
+    }
+}

--- a/src/test/HostActivationTests/FrameworkResolution/RollForwardOnNoCandidateFxSettings.cs
+++ b/src/test/HostActivationTests/FrameworkResolution/RollForwardOnNoCandidateFxSettings.cs
@@ -12,6 +12,8 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.FrameworkResolution
         FrameworkResolutionBase,
         IClassFixture<RollForwardOnNoCandidateFxSettings.SharedTestState>
     {
+        private const string MiddleWare = "MiddleWare";
+
         private SharedTestState SharedState { get; }
 
         public RollForwardOnNoCandidateFxSettings(SharedTestState sharedState)
@@ -76,7 +78,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.FrameworkResolution
                     .WithFramework(MicrosoftNETCoreApp, "4.0.0"),
                 result => result.Should().Pass()
                     .And.HaveResolvedFramework(MicrosoftNETCoreApp, "5.1.3"),
-                commandLine: new string[] { "--roll-forward-on-no-candidate-fx", "2" });
+                commandLine: new string[] { Constants.RollFowardOnNoCandidateFxSetting.CommandLineArgument, "2" });
         }
 
         [Theory]  // CLI wins over everything
@@ -88,7 +90,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.FrameworkResolution
             RunTestWithRollForwardOnNoCandidateFxSetting(
                 runtimeConfig => runtimeConfig
                     .WithFramework(MicrosoftNETCoreApp, "4.0.0"),
-                commandLine: new string[] { "--roll-forward-on-no-candidate-fx", "2" },
+                commandLine: new string[] { Constants.RollFowardOnNoCandidateFxSetting.CommandLineArgument, "2" },
                 settingLocation: settingLocation,
                 settingValue: 0,
                 resolvedFramework: resolvedFramework);
@@ -133,7 +135,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.FrameworkResolution
             RunTestWithRollForwardOnNoCandidateFxSetting(
                 runtimeConfig => runtimeConfig
                     .WithFramework(MicrosoftNETCoreApp, "4.0.0"),
-                environment: new string[] { "DOTNET_ROLL_FORWARD_ON_NO_CANDIDATE_FX=2" },
+                environment: new string[] { Constants.RollFowardOnNoCandidateFxSetting.EnvironmentVariable + "=2" },
                 settingLocation: settingLocation,
                 settingValue: 0,
                 resolvedFramework: resolvedFramework);
@@ -148,14 +150,14 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.FrameworkResolution
         {
             RunTestWithRollForwardOnNoCandidateFxSetting(
                 runtimeConfig => runtimeConfig
-                    .WithFramework(new RuntimeConfig.Framework("MiddleWare", "2.1.0")),
-                customizeDotNet: dotnetCustomizer => dotnetCustomizer.Framework("MiddleWare").RuntimeConfig(runtimeConfig =>
+                    .WithFramework(new RuntimeConfig.Framework(MiddleWare, "2.1.0")),
+                customizeDotNet: dotnetCustomizer => dotnetCustomizer.Framework(MiddleWare).RuntimeConfig(runtimeConfig =>
                     runtimeConfig
                         .WithRollForwardOnNoCandidateFx(2)
                         .GetFramework(MicrosoftNETCoreApp).Version = "4.0.0"),
                 settingLocation: settingLocation,
                 settingValue: 1,
-                frameworkReferenceName: "MiddleWare",
+                frameworkReferenceName: MiddleWare,
                 resolvedFramework: resolvedFramework);
         }
 
@@ -168,13 +170,13 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.FrameworkResolution
         {
             RunTestWithRollForwardOnNoCandidateFxSetting(
                 runtimeConfig => runtimeConfig
-                    .WithFramework(new RuntimeConfig.Framework("MiddleWare", "1.0.0")),
-                customizeDotNet: dotnetCustomizer => dotnetCustomizer.Framework("MiddleWare").RuntimeConfig(runtimeConfig =>
+                    .WithFramework(new RuntimeConfig.Framework(MiddleWare, "1.0.0")),
+                customizeDotNet: dotnetCustomizer => dotnetCustomizer.Framework(MiddleWare).RuntimeConfig(runtimeConfig =>
                     runtimeConfig
                         .GetFramework(MicrosoftNETCoreApp).Version = "4.0.0"),
                 settingLocation: settingLocation,
                 settingValue: 2,
-                frameworkReferenceName: "MiddleWare",
+                frameworkReferenceName: MiddleWare,
                 resolvedFramework: resolvedFramework);
         }
 
@@ -187,13 +189,13 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.FrameworkResolution
         {
             RunTestWithRollForwardOnNoCandidateFxSetting(
                 runtimeConfig => runtimeConfig
-                    .WithFramework(new RuntimeConfig.Framework("MiddleWare", "2.1.2")),
-                customizeDotNet: dotnetCustomizer => dotnetCustomizer.Framework("MiddleWare").RuntimeConfig(runtimeConfig =>
+                    .WithFramework(new RuntimeConfig.Framework(MiddleWare, "2.1.2")),
+                customizeDotNet: dotnetCustomizer => dotnetCustomizer.Framework(MiddleWare).RuntimeConfig(runtimeConfig =>
                     runtimeConfig
                         .GetFramework(MicrosoftNETCoreApp).Version = "5.0.0"),
                 settingLocation: settingLocation,
                 settingValue: 0,
-                frameworkReferenceName: "MiddleWare",
+                frameworkReferenceName: MiddleWare,
                 resolvedFramework: resolvedFramework);
         }
 
@@ -216,10 +218,10 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.FrameworkResolution
                 switch (settingLocation)
                 {
                     case "Environment":
-                        environment = new string[] { $"DOTNET_ROLL_FORWARD_ON_NO_CANDIDATE_FX={settingValue}" };
+                        environment = new string[] { $"{Constants.RollFowardOnNoCandidateFxSetting.EnvironmentVariable}={settingValue}" };
                         break;
                     case "CommandLine":
-                        commandLine = new string[] { "--roll-forward-on-no-candidate-fx", settingValue.ToString() };
+                        commandLine = new string[] { Constants.RollFowardOnNoCandidateFxSetting.CommandLineArgument, settingValue.ToString() };
                         break;
                     case "RuntimeConfig":
                         runtimeConfigCustomization = rc => runtimeConfig(rc).WithRollForwardOnNoCandidateFx(settingValue);
@@ -279,7 +281,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.FrameworkResolution
                 DotNetWithFrameworks = DotNet("WithOneFramework")
                     .AddMicrosoftNETCoreAppFramework("5.1.3")
                     .AddFramework(
-                        "MiddleWare", "2.1.2", 
+                        MiddleWare, "2.1.2", 
                         runtimeConfig => runtimeConfig.WithFramework(MicrosoftNETCoreApp, "5.1.3"))
                     .Build();
 

--- a/src/test/HostActivationTests/FrameworkResolution/RollForwardOnNoCandidateFxSettings.cs
+++ b/src/test/HostActivationTests/FrameworkResolution/RollForwardOnNoCandidateFxSettings.cs
@@ -1,0 +1,290 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.DotNet.Cli.Build;
+using Microsoft.DotNet.Cli.Build.Framework;
+using System;
+using Xunit;
+
+namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.FrameworkResolution
+{
+    public class RollForwardOnNoCandidateFxSettings :
+        FrameworkResolutionBase,
+        IClassFixture<RollForwardOnNoCandidateFxSettings.SharedTestState>
+    {
+        private SharedTestState SharedState { get; }
+
+        public RollForwardOnNoCandidateFxSettings(SharedTestState sharedState)
+        {
+            SharedState = sharedState;
+        }
+
+        [Fact]
+        public void Default()
+        {
+            RunTest(
+                runtimeConfig => runtimeConfig
+                    .WithFramework(MicrosoftNETCoreApp, "4.0.0"),
+                result => result.Should().Fail()
+                    .And.DidNotFindCompatibleFrameworkVersion());
+
+            RunTest(
+                runtimeConfig => runtimeConfig
+                    .WithFramework(MicrosoftNETCoreApp, "5.0.0"),
+                result => result.Should().Pass()
+                    .And.HaveResolvedFrameworkVersion("5.1.3"));
+        }
+
+        [Fact]
+        public void RuntimeConfigOnly()
+        {
+            RunTest(
+                runtimeConfig => runtimeConfig
+                    .WithFramework(MicrosoftNETCoreApp, "4.0.0")
+                    .WithRollForwardOnNoCandidateFx(2),
+                result => result.Should().Pass()
+                    .And.HaveResolvedFrameworkVersion("5.1.3"));
+        }
+
+        [Fact]
+        public void FrameworkReferenceOnly()
+        {
+            RunTest(
+                runtimeConfig => runtimeConfig
+                    .WithFramework(new RuntimeConfig.Framework(MicrosoftNETCoreApp, "4.0.0")
+                        .WithRollForwardOnNoCandidateFx(2)),
+                result => result.Should().Pass()
+                    .And.HaveResolvedFrameworkVersion("5.1.3"));
+        }
+
+        [Fact]
+        public void EnvironmentVariableOnly()
+        {
+            RunTest(
+                runtimeConfig => runtimeConfig
+                    .WithFramework(MicrosoftNETCoreApp, "4.0.0"),
+                result => result.Should().Pass()
+                    .And.HaveResolvedFrameworkVersion("5.1.3"),
+                environment: new string[] { "DOTNET_ROLL_FORWARD_ON_NO_CANDIDATE_FX=2" });
+        }
+
+        [Fact]
+        public void CommandLineOnly()
+        {
+            RunTest(
+                runtimeConfig => runtimeConfig
+                    .WithFramework(MicrosoftNETCoreApp, "4.0.0"),
+                result => result.Should().Pass()
+                    .And.HaveResolvedFrameworkVersion("5.1.3"),
+                commandLine: new string[] { "--roll-forward-on-no-candidate-fx", "2" });
+        }
+
+        [Theory]  // CLI wins over everything
+        [InlineData("Environment", "5.1.3")]
+        [InlineData("RuntimeConfig", "5.1.3")]
+        [InlineData("Framework", "5.1.3")]
+        public void CommandLinePriority(string settingLocation, string resolvedFramework)
+        {
+            RunTestWithRollForwardOnNoCandidateFxSetting(
+                runtimeConfig => runtimeConfig
+                    .WithFramework(MicrosoftNETCoreApp, "4.0.0"),
+                commandLine: new string[] { "--roll-forward-on-no-candidate-fx", "2" },
+                settingLocation: settingLocation,
+                settingValue: 0,
+                resolvedFramework: resolvedFramework);
+        }
+
+        [Theory]  // Framework loses only to CLI
+        [InlineData("CommandLine", null)]
+        [InlineData("Environment", "5.1.3")]
+        [InlineData("RuntimeConfig", "5.1.3")]
+        public void FrameworkPriority(string settingLocation, string resolvedFramework)
+        {
+            RunTestWithRollForwardOnNoCandidateFxSetting(
+                runtimeConfig => runtimeConfig
+                    .WithFramework(new RuntimeConfig.Framework(MicrosoftNETCoreApp, "4.0.0")
+                        .WithRollForwardOnNoCandidateFx(2)),
+                settingLocation: settingLocation,
+                settingValue: 0,
+                resolvedFramework: resolvedFramework);
+        }
+
+        [Theory]  // Runtime config only wins over env
+        [InlineData("CommandLine", null)]
+        [InlineData("Environment", "5.1.3")]
+        [InlineData("Framework", null)]
+        public void RuntimeConfigPriority(string settingLocation, string resolvedFramework)
+        {
+            RunTestWithRollForwardOnNoCandidateFxSetting(
+                runtimeConfig => runtimeConfig
+                    .WithFramework(MicrosoftNETCoreApp, "4.0.0")
+                    .WithRollForwardOnNoCandidateFx(2),
+                settingLocation: settingLocation,
+                settingValue: 0,
+                resolvedFramework: resolvedFramework);
+        }
+
+        [Theory]  // Env loses to everything else
+        [InlineData("CommandLine", null)]
+        [InlineData("RuntimeConfig", null)]
+        [InlineData("Framework", null)]
+        public void EnvironmentPriority(string settingLocation, string resolvedFramework)
+        {
+            RunTestWithRollForwardOnNoCandidateFxSetting(
+                runtimeConfig => runtimeConfig
+                    .WithFramework(MicrosoftNETCoreApp, "4.0.0"),
+                environment: new string[] { "DOTNET_ROLL_FORWARD_ON_NO_CANDIDATE_FX=2" },
+                settingLocation: settingLocation,
+                settingValue: 0,
+                resolvedFramework: resolvedFramework);
+        }
+
+        [Theory]
+        [InlineData("CommandLine", null)]   // Command line overrides everything - even inner framework references
+        [InlineData("RuntimeConfig", "5.1.3")]
+        [InlineData("Framework", "5.1.3")]
+        [InlineData("Environment", "5.1.3")]
+        public void InnerFrameworkReference(string settingLocation, string resolvedFramework)
+        {
+            RunTestWithRollForwardOnNoCandidateFxSetting(
+                runtimeConfig => runtimeConfig
+                    .WithFramework(new RuntimeConfig.Framework("MiddleWare", "2.1.0")),
+                customizeDotNet: dotnetCustomizer => dotnetCustomizer.Framework("MiddleWare").RuntimeConfig(runtimeConfig =>
+                    runtimeConfig
+                        .WithRollForwardOnNoCandidateFx(2)
+                        .GetFramework(MicrosoftNETCoreApp).Version = "4.0.0"),
+                settingLocation: settingLocation,
+                settingValue: 1,
+                frameworkReferenceName: "MiddleWare",
+                resolvedFramework: resolvedFramework);
+        }
+
+        [Theory]
+        [InlineData("CommandLine", "5.1.3")]   // Command line overrides everything - even inner framework references
+        [InlineData("RuntimeConfig", null)]    // RuntimeConfig and Framework settings are not inherited to inner reference
+        [InlineData("Framework", null)]        // RuntimeConfig and Framework settings are not inherited to inner reference
+        [InlineData("Environment", "5.1.3")]   // Since none is specified for the inner reference, environment is used
+        public void NoInheritance_MoreRelaxed(string settingLocation, string resolvedFramework)
+        {
+            RunTestWithRollForwardOnNoCandidateFxSetting(
+                runtimeConfig => runtimeConfig
+                    .WithFramework(new RuntimeConfig.Framework("MiddleWare", "1.0.0")),
+                customizeDotNet: dotnetCustomizer => dotnetCustomizer.Framework("MiddleWare").RuntimeConfig(runtimeConfig =>
+                    runtimeConfig
+                        .GetFramework(MicrosoftNETCoreApp).Version = "4.0.0"),
+                settingLocation: settingLocation,
+                settingValue: 2,
+                frameworkReferenceName: "MiddleWare",
+                resolvedFramework: resolvedFramework);
+        }
+
+        [Theory]
+        [InlineData("CommandLine", null)]      // Command line overrides everything - even inner framework references
+        [InlineData("RuntimeConfig", "5.1.3")] // RuntimeConfig and Framework settings are not inherited to inner reference
+        [InlineData("Framework", "5.1.3")]     // RuntimeConfig and Framework settings are not inherited to inner reference
+        [InlineData("Environment", null)]      // Since none is specified for the inner reference, environment is used
+        public void NoInheritance_MoreRestrictive(string settingLocation, string resolvedFramework)
+        {
+            RunTestWithRollForwardOnNoCandidateFxSetting(
+                runtimeConfig => runtimeConfig
+                    .WithFramework(new RuntimeConfig.Framework("MiddleWare", "2.1.2")),
+                customizeDotNet: dotnetCustomizer => dotnetCustomizer.Framework("MiddleWare").RuntimeConfig(runtimeConfig =>
+                    runtimeConfig
+                        .GetFramework(MicrosoftNETCoreApp).Version = "5.0.0"),
+                settingLocation: settingLocation,
+                settingValue: 0,
+                frameworkReferenceName: "MiddleWare",
+                resolvedFramework: resolvedFramework);
+        }
+
+
+        private void RunTestWithRollForwardOnNoCandidateFxSetting(
+            Func<RuntimeConfig, RuntimeConfig> runtimeConfig,
+            Action<DotNetCliExtensions.DotNetCliCustomizer> customizeDotNet = null,
+            string[] environment = null,
+            string[] commandLine = null,
+            string settingLocation = null,
+            int settingValue = 1,
+            string frameworkReferenceName = MicrosoftNETCoreApp,
+            string resolvedFramework = null)
+        {
+            using (DotNetCliExtensions.DotNetCliCustomizer dotnetCustomizer = SharedState.DotNetWithFrameworks.Customize())
+            {
+                customizeDotNet?.Invoke(dotnetCustomizer);
+
+                Func<RuntimeConfig, RuntimeConfig> runtimeConfigCustomization = runtimeConfig;
+                switch (settingLocation)
+                {
+                    case "Environment":
+                        environment = new string[] { $"DOTNET_ROLL_FORWARD_ON_NO_CANDIDATE_FX={settingValue}" };
+                        break;
+                    case "CommandLine":
+                        commandLine = new string[] { "--roll-forward-on-no-candidate-fx", settingValue.ToString() };
+                        break;
+                    case "RuntimeConfig":
+                        runtimeConfigCustomization = rc => runtimeConfig(rc).WithRollForwardOnNoCandidateFx(settingValue);
+                        break;
+                    case "Framework":
+                        runtimeConfigCustomization = rc =>
+                        {
+                            runtimeConfig(rc).GetFramework(frameworkReferenceName).WithRollForwardOnNoCandidateFx(settingValue);
+                            return rc;
+                        };
+                        break;
+                }
+
+                RunTest(
+                    runtimeConfigCustomization,
+                    commandResult =>
+                    {
+                        if (resolvedFramework != null)
+                        {
+                            commandResult.Should().Pass()
+                                .And.HaveResolvedFrameworkVersion(resolvedFramework);
+                        }
+                        else
+                        {
+                            commandResult.Should().Fail()
+                                .And.DidNotFindCompatibleFrameworkVersion();
+                        }
+                    },
+                    environment,
+                    commandLine);
+            }
+        }
+
+        private void RunTest(
+            Func<RuntimeConfig, RuntimeConfig> runtimeConfig,
+            Action<CommandResult> resultAction,
+            string[] environment = null,
+            string[] commandLine = null)
+        {
+            RunTest(
+                SharedState.DotNetWithFrameworks,
+                SharedState.FrameworkReferenceApp,
+                runtimeConfig,
+                resultAction,
+                environment,
+                commandLine);
+        }
+
+        public class SharedTestState : SharedTestStateBase
+        {
+            public TestApp FrameworkReferenceApp { get; }
+
+            public DotNetCli DotNetWithFrameworks { get; }
+
+            public SharedTestState()
+            {
+                DotNetWithFrameworks = DotNet("WithOneFramework")
+                    .AddMicrosoftNETCoreAppFramework("5.1.3")
+                    .AddFramework(
+                        "MiddleWare", "2.1.2", 
+                        runtimeConfig => runtimeConfig.WithFramework(MicrosoftNETCoreApp, "5.1.3"))
+                    .Build();
+
+                FrameworkReferenceApp = CreateFrameworkReferenceApp();
+            }
+        }
+    }
+}

--- a/src/test/HostActivationTests/FrameworkResolution/RollForwardOnNoCandidateFxSettings.cs
+++ b/src/test/HostActivationTests/FrameworkResolution/RollForwardOnNoCandidateFxSettings.cs
@@ -40,8 +40,8 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.FrameworkResolution
         {
             RunTest(
                 runtimeConfig => runtimeConfig
-                    .WithFramework(MicrosoftNETCoreApp, "4.0.0")
-                    .WithRollForwardOnNoCandidateFx(2),
+                    .WithRollForwardOnNoCandidateFx(2)
+                    .WithFramework(MicrosoftNETCoreApp, "4.0.0"),
                 result => result.Should().Pass()
                     .And.HaveResolvedFrameworkVersion("5.1.3"));
         }
@@ -117,8 +117,8 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.FrameworkResolution
         {
             RunTestWithRollForwardOnNoCandidateFxSetting(
                 runtimeConfig => runtimeConfig
-                    .WithFramework(MicrosoftNETCoreApp, "4.0.0")
-                    .WithRollForwardOnNoCandidateFx(2),
+                    .WithRollForwardOnNoCandidateFx(2)
+                    .WithFramework(MicrosoftNETCoreApp, "4.0.0"),
                 settingLocation: settingLocation,
                 settingValue: 0,
                 resolvedFramework: resolvedFramework);

--- a/src/test/HostActivationTests/FrameworkResolution/RollForwardOnNoCandidateFxSettings.cs
+++ b/src/test/HostActivationTests/FrameworkResolution/RollForwardOnNoCandidateFxSettings.cs
@@ -32,7 +32,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.FrameworkResolution
                 runtimeConfig => runtimeConfig
                     .WithFramework(MicrosoftNETCoreApp, "5.0.0"),
                 result => result.Should().Pass()
-                    .And.HaveResolvedFrameworkVersion("5.1.3"));
+                    .And.HaveResolvedFramework(MicrosoftNETCoreApp, "5.1.3"));
         }
 
         [Fact]
@@ -43,7 +43,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.FrameworkResolution
                     .WithRollForwardOnNoCandidateFx(2)
                     .WithFramework(MicrosoftNETCoreApp, "4.0.0"),
                 result => result.Should().Pass()
-                    .And.HaveResolvedFrameworkVersion("5.1.3"));
+                    .And.HaveResolvedFramework(MicrosoftNETCoreApp, "5.1.3"));
         }
 
         [Fact]
@@ -54,7 +54,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.FrameworkResolution
                     .WithFramework(new RuntimeConfig.Framework(MicrosoftNETCoreApp, "4.0.0")
                         .WithRollForwardOnNoCandidateFx(2)),
                 result => result.Should().Pass()
-                    .And.HaveResolvedFrameworkVersion("5.1.3"));
+                    .And.HaveResolvedFramework(MicrosoftNETCoreApp, "5.1.3"));
         }
 
         [Fact]
@@ -64,7 +64,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.FrameworkResolution
                 runtimeConfig => runtimeConfig
                     .WithFramework(MicrosoftNETCoreApp, "4.0.0"),
                 result => result.Should().Pass()
-                    .And.HaveResolvedFrameworkVersion("5.1.3"),
+                    .And.HaveResolvedFramework(MicrosoftNETCoreApp, "5.1.3"),
                 environment: new string[] { "DOTNET_ROLL_FORWARD_ON_NO_CANDIDATE_FX=2" });
         }
 
@@ -75,7 +75,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.FrameworkResolution
                 runtimeConfig => runtimeConfig
                     .WithFramework(MicrosoftNETCoreApp, "4.0.0"),
                 result => result.Should().Pass()
-                    .And.HaveResolvedFrameworkVersion("5.1.3"),
+                    .And.HaveResolvedFramework(MicrosoftNETCoreApp, "5.1.3"),
                 commandLine: new string[] { "--roll-forward-on-no-candidate-fx", "2" });
         }
 
@@ -240,7 +240,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.FrameworkResolution
                         if (resolvedFramework != null)
                         {
                             commandResult.Should().Pass()
-                                .And.HaveResolvedFrameworkVersion(resolvedFramework);
+                                .And.HaveResolvedFramework(MicrosoftNETCoreApp, resolvedFramework);
                         }
                         else
                         {

--- a/src/test/HostActivationTests/RuntimeConfig.cs
+++ b/src/test/HostActivationTests/RuntimeConfig.cs
@@ -47,12 +47,16 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
 
                 if (RollForwardOnNoCandidateFx.HasValue)
                 {
-                    frameworkReference.Add("rollForwardOnNoCandidateFx", RollForwardOnNoCandidateFx.Value);
+                    frameworkReference.Add(
+                        Constants.RollFowardOnNoCandidateFxSetting.RuntimeConfigPropertyName,
+                        RollForwardOnNoCandidateFx.Value);
                 }
 
                 if (ApplyPatches.HasValue)
                 {
-                    frameworkReference.Add("applyPatches", ApplyPatches.Value);
+                    frameworkReference.Add(
+                        Constants.ApplyPatchesSetting.RuntimeConfigPropertyName,
+                        ApplyPatches.Value);
                 }
 
                 return frameworkReference;
@@ -62,8 +66,8 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
             {
                 return new Framework((string)jobject["name"], (string)jobject["version"])
                 {
-                    RollForwardOnNoCandidateFx = (int?)jobject["rollForwardOnNoCandidateFx"],
-                    ApplyPatches = (bool?)jobject["applyPatches"]
+                    RollForwardOnNoCandidateFx = (int?)jobject[Constants.RollFowardOnNoCandidateFxSetting.RuntimeConfigPropertyName],
+                    ApplyPatches = (bool?)jobject[Constants.ApplyPatchesSetting.RuntimeConfigPropertyName]
                 };
             }
         }
@@ -100,8 +104,8 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
                         runtimeConfig.WithFramework(Framework.FromJson(framework));
                     }
 
-                    runtimeConfig._rollForwardOnNoCandidateFx = (int?)runtimeOptions["rollForwardOnNoCandidateFx"];
-                    runtimeConfig._applyPatches = (bool?)runtimeOptions["applyPatches"];
+                    runtimeConfig._rollForwardOnNoCandidateFx = (int?)runtimeOptions[Constants.RollFowardOnNoCandidateFxSetting.RuntimeConfigPropertyName];
+                    runtimeConfig._applyPatches = (bool?)runtimeOptions[Constants.ApplyPatchesSetting.RuntimeConfigPropertyName];
                 }
             }
 
@@ -150,12 +154,16 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
 
             if (_rollForwardOnNoCandidateFx.HasValue)
             {
-                runtimeOptions.Add("rollForwardOnNoCandidateFx", _rollForwardOnNoCandidateFx.Value);
+                runtimeOptions.Add(
+                    Constants.RollFowardOnNoCandidateFxSetting.RuntimeConfigPropertyName,
+                    _rollForwardOnNoCandidateFx.Value);
             }
 
             if (_applyPatches.HasValue)
             {
-                runtimeOptions.Add("applyPatches", _applyPatches.Value);
+                runtimeOptions.Add(
+                    Constants.ApplyPatchesSetting.RuntimeConfigPropertyName,
+                    _applyPatches.Value);
             }
 
             JObject json = new JObject()

--- a/src/test/HostActivationTests/RuntimeConfig.cs
+++ b/src/test/HostActivationTests/RuntimeConfig.cs
@@ -1,0 +1,169 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
+{
+    public class RuntimeConfig
+    {
+        public class Framework
+        {
+            public string Name { get; }
+            public string Version { get; set;  }
+
+            public int? RollForwardOnNoCandidateFx { get; set; }
+            public bool? ApplyPatches { get; set; }
+
+            public Framework(string name, string version)
+            {
+                Name = name;
+                Version = version;
+            }
+
+            public Framework WithRollForwardOnNoCandidateFx(int? value)
+            {
+                RollForwardOnNoCandidateFx = value;
+                return this;
+            }
+
+            public Framework WithApplyPatches(bool? value)
+            {
+                ApplyPatches = value;
+                return this;
+            }
+
+            internal JObject ToJson()
+            {
+                JObject frameworkReference =
+                    new JObject(
+                        new JProperty("name", Name),
+                        new JProperty("version", Version)
+                        );
+
+                if (RollForwardOnNoCandidateFx.HasValue)
+                {
+                    frameworkReference.Add("rollForwardOnNoCandidateFx", RollForwardOnNoCandidateFx.Value);
+                }
+
+                if (ApplyPatches.HasValue)
+                {
+                    frameworkReference.Add("applyPatches", ApplyPatches.Value);
+                }
+
+                return frameworkReference;
+            }
+
+            internal static Framework FromJson(JObject jobject)
+            {
+                return new Framework((string)jobject["name"], (string)jobject["version"])
+                {
+                    RollForwardOnNoCandidateFx = (int?)jobject["rollForwardOnNoCandidateFx"],
+                    ApplyPatches = (bool?)jobject["applyPatches"]
+                };
+            }
+        }
+
+        private int? _rollForwardOnNoCandidateFx;
+        private bool? _applyPatches;
+        private readonly string _path;
+        private readonly List<Framework> _frameworks = new List<Framework>();
+
+        /// <summary>
+        /// Creates new runtime config - overwrites existing file on Save if any.
+        /// </summary>
+        public RuntimeConfig(string path)
+        {
+            _path = path;
+        }
+
+        /// <summary>
+        /// Creates the object over existing file - reading its content. Save should recreate the file
+        /// assuming we can store all the values in it in this class.
+        /// </summary>
+        public static RuntimeConfig FromFile(string path)
+        {
+            RuntimeConfig runtimeConfig = new RuntimeConfig(path);
+            if (File.Exists(path))
+            {
+                using (TextReader textReader = File.OpenText(path))
+                using (JsonTextReader reader = new JsonTextReader(textReader))
+                {
+                    JObject root = (JObject)JToken.ReadFrom(reader);
+                    JObject runtimeOptions = (JObject)root["runtimeOptions"];
+                    foreach (JObject framework in runtimeOptions["frameworks"])
+                    {
+                        runtimeConfig.WithFramework(Framework.FromJson(framework));
+                    }
+
+                    runtimeConfig._rollForwardOnNoCandidateFx = (int?)runtimeOptions["rollForwardOnNoCandidateFx"];
+                    runtimeConfig._applyPatches = (bool?)runtimeOptions["applyPatches"];
+                }
+            }
+
+            return runtimeConfig;
+        }
+
+        public static RuntimeConfig Path(string path)
+        {
+            return new RuntimeConfig(path);
+        }
+
+        public Framework GetFramework(string name)
+        {
+            return _frameworks.FirstOrDefault(f => f.Name == name);
+        }
+
+        public RuntimeConfig WithFramework(Framework framework)
+        {
+            _frameworks.Add(framework);
+            return this;
+        }
+
+        public RuntimeConfig WithFramework(string name, string version)
+        {
+            return WithFramework(new Framework(name, version));
+        }
+
+        public RuntimeConfig WithRollForwardOnNoCandidateFx(int? value)
+        {
+            _rollForwardOnNoCandidateFx = value;
+            return this;
+        }
+
+        public RuntimeConfig WithApplyPatches(bool? value)
+        {
+            _applyPatches = value;
+            return this;
+        }
+
+        public void Save()
+        {
+            JObject runtimeOptions = new JObject()
+                {
+                    { "frameworks", new JArray(_frameworks.Select(f => f.ToJson()).ToArray()) }
+                };
+
+            if (_rollForwardOnNoCandidateFx.HasValue)
+            {
+                runtimeOptions.Add("rollForwardOnNoCandidateFx", _rollForwardOnNoCandidateFx.Value);
+            }
+
+            if (_applyPatches.HasValue)
+            {
+                runtimeOptions.Add("applyPatches", _applyPatches.Value);
+            }
+
+            JObject json = new JObject()
+                {
+                    { "runtimeOptions", runtimeOptions }
+                };
+
+            File.WriteAllText(_path, json.ToString());
+        }
+    }
+}

--- a/src/test/HostActivationTests/SharedFramework.cs
+++ b/src/test/HostActivationTests/SharedFramework.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Newtonsoft.Json.Linq;
-using System;
 using System.IO;
 using System.Threading;
 

--- a/src/test/TestUtils/TestArtifact.cs
+++ b/src/test/TestUtils/TestArtifact.cs
@@ -47,7 +47,7 @@ namespace Microsoft.DotNet.CoreSetup.Test
 
         public void Dispose()
         {
-            if (!PreserveTestRuns())
+            if (!PreserveTestRuns() && Directory.Exists(Location))
             {
                 Directory.Delete(Location, true);
             }


### PR DESCRIPTION
Backfill detailed tests for framework resolution behavior, specifically
around roll-forward.

Introduces some new test helpers
* hostpolicy mock, to avoid actually loading and running coreclr just to
validate selected frameworks
* Builder-like API for `.runtimeconfig.js`
* Builder-like API for shared frameworks
* Some helper classes to limit file copy while keeping the tests fully
isolated

This is in preparation for the upcoming roll-forward changes. Having these tests should verify that the new roll-forward doesn't break backward compatibility.