### PR TITLE
Create .NET Core Targeting Pack macOS pkg installer

### DIFF
--- a/src/pkg/dir.props
+++ b/src/pkg/dir.props
@@ -71,6 +71,8 @@
     <GenerateMSI>true</GenerateMSI>
     <GenerateMSI Condition="'$(TargetArchitecture)' == 'arm' or '$(TargetArchitecture)' == 'arm64'">false</GenerateMSI>
     <GenerateMSI Condition="'$(OSGroup)' != 'Windows_NT'">false</GenerateMSI>
+
+    <GeneratePkg Condition="'$(OSGroup)' == 'OSX'">true</GeneratePkg>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/pkg/projects/packaging-tools/framework.packaging.targets
+++ b/src/pkg/projects/packaging-tools/framework.packaging.targets
@@ -10,11 +10,13 @@
           DependsOnTargets="
             GenerateDeb;
             GenerateRpm;
-            GenerateMsi" />
+            GenerateMsi;
+            GeneratePkg" />
 
   <Target Name="GenerateDeb" DependsOnTargets="TestDebuild;CreateDeb" Condition="'$(BuildDebPackage)' == 'true'"/>
   <Target Name="GenerateRpm" DependsOnTargets="TestFPMTool;CreateRpm" Condition="'$(BuildRpmPackage)' == 'true'"/>
   <Target Name="GenerateMsi" DependsOnTargets="CreateMsi" Condition="'$(GenerateMSI)' == 'true'"/>
+  <Target Name="GeneratePkg" DependsOnTargets="CreatePkg" Condition="'$(GeneratePkg)' == 'true'"/>
 
   <!--
     Create Debian package.
@@ -222,6 +224,22 @@
 
     <Message Importance="High" Text="Light '$(MSBuildProjectName)'" />
     <Exec Command="light.exe $(_wixArgs)" WorkingDirectory="$(WixToolsDir)" />
+  </Target>
+
+  <!--
+    Create macOS pkg installer.
+  -->
+  <Target Name="CreatePkg">
+    <PropertyGroup>
+      <_pkgArgs></_pkgArgs>
+      <_pkgArgs>$(_pkgArgs) --root $(PackLayoutDir)</_pkgArgs>
+      <_pkgArgs>$(_pkgArgs) --identifier $(MacOSComponentName)</_pkgArgs>
+      <_pkgArgs>$(_pkgArgs) --version $(SharedFrameworkNugetVersion)</_pkgArgs>
+      <_pkgArgs>$(_pkgArgs) --install-location $(MacOSSharedInstallDir)</_pkgArgs>
+      <_pkgArgs>$(_pkgArgs) $(InstallerFile)</_pkgArgs>
+    </PropertyGroup>
+
+    <Exec Command="pkgbuild $(_pkgArgs)" />
   </Target>
 
   <!--

--- a/src/pkg/projects/packaging-tools/packaging-tools.props
+++ b/src/pkg/projects/packaging-tools/packaging-tools.props
@@ -40,11 +40,15 @@
     <PackLayoutDir>$(InstallerSourceIntermediateOutputDir)layout/$(FrameworkPackType)/</PackLayoutDir>
 
     <InstallerName>$(ShortFrameworkName)-targeting-pack</InstallerName>
+
+    <MacOSComponentName>com.microsoft.$(ShortFrameworkName).pack.$(FrameworkPackType).$(SharedFrameworkNuGetVersion).component.osx.x64</MacOSComponentName>
+    <MacOSSharedInstallDir>/usr/local/share/dotnet</MacOSSharedInstallDir>
   </PropertyGroup>
 
   <!-- Only targeting pack MSIs are currently supported by this infrastructure. -->
   <PropertyGroup Condition="'$(FrameworkPackType)' != 'targeting'">
     <GenerateMSI>false</GenerateMSI>
+    <GeneratePkg>false</GeneratePkg>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/pkg/projects/windowsdesktop/pkg/dir.props
+++ b/src/pkg/projects/windowsdesktop/pkg/dir.props
@@ -11,6 +11,7 @@
   <PropertyGroup>
     <BuildDebPackage>false</BuildDebPackage>
     <BuildRpmPackage>false</BuildRpmPackage>
+    <GeneratePkg>false</GeneratePkg>
   </PropertyGroup>
 
   <!-- Redistribute package content from other nuget packages. -->


### PR DESCRIPTION
Resolves https://github.com/dotnet/core-setup/issues/5176.

Creates a macOS `pkg` that installs targeting pack assets to `/usr/local/share/dotnet/packs/...`. This component package can be bundled into Core-SDK.

ID ends up e.g. `com.microsoft.dotnet.pack.targeting.3.0.0-preview4-27515-0.component.osx.x64`

The plan is to add a standalone bundle in the future, this PR doesn't include one. A bundle would be where we put branding and localization. macOS native packaging is more like Windows than Linux (although way more basic than either).

/cc @dsplaisted @nguerrera @johnbeisner 