### PR TITLE
Don't save CI packages as artifacts

### DIFF
--- a/eng/jobs/bash-build.yml
+++ b/eng/jobs/bash-build.yml
@@ -173,24 +173,6 @@ jobs:
       continueOnError: true
       condition: succeededOrFailed()
 
-    - task: CopyFiles@2
-      displayName: Copy packages to stage
-      inputs:
-        SourceFolder: '$(Build.SourcesDirectory)/bin/'
-        Contents: |
-          */packages/*
-        TargetFolder: '$(Build.StagingDirectory)\Packages'
-      continueOnError: true
-      condition: succeededOrFailed()
-
-    - task: PublishBuildArtifacts@1
-      displayName: Publish Artifact Packages
-      inputs:
-        PathtoPublish: '$(Build.StagingDirectory)\Packages'
-        ArtifactName: ${{ parameters.displayName }}-$(_BuildConfig)-Packages
-      continueOnError: true
-      condition: succeededOrFailed()
-
     - script: df -h
       displayName: Check space (df -h)
       condition: always()


### PR DESCRIPTION
Publishing to a build artifact can take long enough to time out the build, and isn't useful very often.

Example failure: https://github.com/dotnet/core-setup/pull/5506