### PR TITLE
Move pkg tools import for runtime.json override

### DIFF
--- a/src/pkg/projects/dir.props
+++ b/src/pkg/projects/dir.props
@@ -20,8 +20,6 @@
     <PackProjectDependencies>true</PackProjectDependencies>
   </PropertyGroup>
 
-  <Import Project="packaging-tools\packaging-tools.props" />
-
   <!-- In *.builds projects, the current phase's name is the same as the project name. -->
   <PropertyGroup>
     <BuildPhase>$(MSBuildProjectName)</BuildPhase>
@@ -70,6 +68,8 @@
       </PropertyGroup>
     </Otherwise>
   </Choose>
+
+  <Import Project="packaging-tools\packaging-tools.props" />
 
   <PropertyGroup Condition="'$(MSBuildProjectExtension)' == '.depproj'">
     <!-- we intentionally don't want to produce output -->


### PR DESCRIPTION
The value of `IncludeRuntimeJson` in `packaging-tools.props` was being overridden by `dir.props`, but the value in `dir.props` should have been overridden by `packaging-tools.props`.

I didn't pay enough attention to override order when I centralized the framework pack tools in https://github.com/dotnet/core-setup/pull/5491. This PR moves the import to where it should have been based on where the properties I centralized came from.

Fixes https://github.com/dotnet/core-setup/issues/5511.