### PR TITLE
Include header files in projects

### DIFF
--- a/src/corehost/cli/apphost/CMakeLists.txt
+++ b/src/corehost/cli/apphost/CMakeLists.txt
@@ -21,6 +21,10 @@ set(SOURCES
     ../fxr/fx_ver.cpp
 )
 
+set(HEADERS
+    ../fxr/fx_ver.h
+)
+
 include(../exe.cmake)
 
 add_definitions(-DFEATURE_APPHOST=1)

--- a/src/corehost/cli/comhost/CMakeLists.txt
+++ b/src/corehost/cli/comhost/CMakeLists.txt
@@ -22,6 +22,12 @@ set(SOURCES
     ../json/casablanca/src/utilities/asyncrt_utils.cpp
 )
 
+set(HEADERS
+    comhost.h
+    ../fxr/fx_ver.h
+    ../json/casablanca/include/cpprest/json.h
+)
+
 if(WIN32)
     list(APPEND SOURCES
         Exports.def)

--- a/src/corehost/cli/common.cmake
+++ b/src/corehost/cli/common.cmake
@@ -26,11 +26,18 @@ include_directories(${CMAKE_CURRENT_LIST_DIR}/../common)
 list(APPEND SOURCES
     ${CMAKE_CURRENT_LIST_DIR}/../common/trace.cpp
     ${CMAKE_CURRENT_LIST_DIR}/../common/utils.cpp)
-    
+
+list(APPEND HEADERS
+    ${CMAKE_CURRENT_LIST_DIR}/../common/trace.h
+    ${CMAKE_CURRENT_LIST_DIR}/../common/utils.h
+    ${CMAKE_CURRENT_LIST_DIR}/../common/pal.h)
+
 if(WIN32)
     list(APPEND SOURCES 
         ${CMAKE_CURRENT_LIST_DIR}/../common/pal.windows.cpp
         ${CMAKE_CURRENT_LIST_DIR}/../common/longfile.windows.cpp)
+    list(APPEND HEADERS
+        ${CMAKE_CURRENT_LIST_DIR}/../common/longfile.h)
 else()
     list(APPEND SOURCES
         ${CMAKE_CURRENT_LIST_DIR}/../common/pal.unix.cpp
@@ -40,6 +47,10 @@ endif()
 set(RESOURCES)
 if(WIN32 AND NOT SKIP_VERSIONING)
     list(APPEND RESOURCES ${CMAKE_CURRENT_LIST_DIR}/native.rc)
+endif()
+
+if(WIN32)
+    list(APPEND SOURCES ${HEADERS})
 endif()
 
 function(set_common_libs TargetType)

--- a/src/corehost/cli/dotnet/CMakeLists.txt
+++ b/src/corehost/cli/dotnet/CMakeLists.txt
@@ -4,8 +4,14 @@
 cmake_minimum_required (VERSION 2.6)
 project(dotnet)
 set(DOTNET_PROJECT_NAME "dotnet")
+
 set(SOURCES 
-    ../fxr/fx_ver.cpp)
+    ../fxr/fx_ver.cpp
+)
+
+set(HEADERS
+    ../fxr/fx_ver.h
+)
 
 if(WIN32)
     list(APPEND SOURCES

--- a/src/corehost/cli/fxr/CMakeLists.txt
+++ b/src/corehost/cli/fxr/CMakeLists.txt
@@ -32,6 +32,23 @@ set(SOURCES
     ./sdk_resolver.cpp
 )
 
+set(HEADERS
+    ../deps_format.h
+    ../deps_entry.h
+    ../host_startup_info.h
+    ../runtime_config.h
+    ../json/casablanca/include/cpprest/json.h
+    ../fx_definition.h
+    ../fx_reference.h
+    ../version.h
+    ./corehost_init.h
+    ./fx_ver.h
+    ./fx_muxer.h
+    ./framework_info.h
+    ./sdk_info.h
+    ./sdk_resolver.h
+)
+
 include(../lib.cmake)
 
 install(TARGETS hostfxr DESTINATION corehost)

--- a/src/corehost/cli/hostpolicy/CMakeLists.txt
+++ b/src/corehost/cli/hostpolicy/CMakeLists.txt
@@ -32,6 +32,23 @@ set(SOURCES
     ../version.cpp
 )
 
+set(HEADERS
+    ../runtime_config.h
+    ../json/casablanca/include/cpprest/json.h
+    ../fxr/fx_ver.h
+    ../breadcrumbs.h
+    ../args.h
+    ../hostpolicy_init.h
+    ../host_startup_info.h
+    ../coreclr.h
+    ../deps_resolver.h
+    ../deps_format.h
+    ../deps_entry.h
+    ../fx_definition.h
+    ../fx_reference.h
+    ../version.h
+)
+
 include(../lib.cmake)
 
 install(TARGETS hostpolicy DESTINATION corehost)


### PR DESCRIPTION
Currently the project files generated by CMake which can be opened in VS don't contain any header files. For the most part intellisense works, but simple Find In Files mostly doesn't and some other navigation in VS is a bit flaky.

This change adds the header files to the projects.

This is Windows only as CMake doesn't generate any project files on Linux/macOS.

Adds header files to the SOURCES list on windows only.