### PR TITLE
Disable using clang 3.9 for linux ARM cross build

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -91,7 +91,7 @@ jobs:
   parameters:
     crossBuild: true
     displayName: Build_Linux_Arm
-    dockerImage: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-14.04-cross-e435274-20180323032140
+    dockerImage: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-14.04-cross-e435274-20180426002420
     additionalRunArgs: -e ROOTFS_DIR=/crossrootfs/arm
     portableBuild: true
     skipTests: true

--- a/src/corehost/build.sh
+++ b/src/corehost/build.sh
@@ -245,9 +245,11 @@ echo "Building Corehost from $DIR to $(pwd)"
 set -x # turn on trace
 if [ $__CrossBuild == 1 ]; then
     # clang-3.9 or clang-4.0 are default compilers for cross compilation
-    if command -v "clang-3.9" > /dev/null 2>&1; then
-        export CC="$(command -v clang-3.9)"
-        export CXX="$(command -v clang++-3.9)"
+    if [[ "$__build_arch" != "arm" && "$__build_arch" != "armel" ]]; then
+        if command -v "clang-3.9" > /dev/null 2>&1; then
+            export CC="$(command -v clang-3.9)"
+            export CXX="$(command -v clang++-3.9)"
+        fi
     elif command -v "clang-4.0" > /dev/null 2>&1; then
         export CC="$(command -v clang-4.0)"
         export CXX="$(command -v clang++-4.0)"


### PR DESCRIPTION
The clang 3.9 was found to be generating broken code when cross
building for arm/armel long time ago for coreclr repo builds.
It was generating e.g. incorrect code for interlocked operations.
Now with a recent change in core-setup (adding linking of libatomic.a),
it started to generate broken code in core-setup too (leading to
SIGILL in libhostpolicy.so).
This change disables usage of clang 3.9 for ARM cross building, like
we do in the coreclr repo.

Close https://github.com/dotnet/core-sdk/issues/1063