### PR TITLE
Unblock build: patch out _PublishUsingPipelines

### DIFF
--- a/eng/common/templates/job/publish-build-assets.yml
+++ b/eng/common/templates/job/publish-build-assets.yml
@@ -52,7 +52,7 @@ jobs:
           /p:ManifestsPath='$(Build.StagingDirectory)/Download/AssetManifests'
           /p:BuildAssetRegistryToken=$(MaestroAccessToken)
           /p:MaestroApiEndpoint=https://maestro-prod.westus2.cloudapp.azure.com
-          /p:PublishUsingPipelines=$(_PublishUsingPipelines)
+          /p:PublishUsingPipelines=false
           /p:Configuration=$(_BuildConfig)
       condition: ${{ parameters.condition }}
       continueOnError: ${{ parameters.continueOnError }}


### PR DESCRIPTION
This is a manual patch for https://github.com/dotnet/arcade/issues/2279. That issue has a fix checked into Arcade, but Arcade hasn't built successfully since then.

Once Arcade flow starts again, this change will be overwritten, but this is ok because this problem should be fixed.

E.g. https://dev.azure.com/dnceng/internal/_build/results?buildId=128623

```
_PublishUsingPipelines : The term '_PublishUsingPipelines' is not recognized as the name of a cmdlet, function, script 
file, or operable program. Check the spelling of the name, or if a path was included, verify that the path is correct 
and try again.
At F:\vsagent\_temp\5b05ad13-27b8-40cd-87fb-5bab7b0c3cca.ps1:2 char:312
+ ... p.azure.com /p:PublishUsingPipelines=$(_PublishUsingPipelines) /p:Con ...
+                                            ~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : ObjectNotFound: (_PublishUsingPipelines:String) [], ParentContainsErrorRecordException
    + FullyQualifiedErrorId : CommandNotFoundException
```

/cc @JohnTortugo