### PR TITLE
Generalize test settings for framework resolution tests

### DIFF
--- a/src/test/HostActivationTests/Constants.cs
+++ b/src/test/HostActivationTests/Constants.cs
@@ -11,7 +11,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
             public const string RuntimeConfigPropertyName = "applyPatches";
         }
 
-        public static class RollFowardOnNoCandidateFxSetting
+        public static class RollForwardOnNoCandidateFxSetting
         {
             public const string RuntimeConfigPropertyName = "rollForwardOnNoCandidateFx";
             public const string CommandLineArgument = "--roll-forward-on-no-candidate-fx";

--- a/src/test/HostActivationTests/FrameworkResolution/ApplyPatchesSettings.cs
+++ b/src/test/HostActivationTests/FrameworkResolution/ApplyPatchesSettings.cs
@@ -124,17 +124,13 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.FrameworkResolution
 
         private void RunTest(
             Func<RuntimeConfig, RuntimeConfig> runtimeConfig,
-            Action<CommandResult> resultAction,
-            string[] environment = null,
-            string[] commandLine = null)
+            Action<CommandResult> resultAction)
         {
             RunTest(
                 SharedState.DotNetWithFrameworks,
                 SharedState.FrameworkReferenceApp,
                 runtimeConfig,
-                resultAction,
-                environment,
-                commandLine);
+                resultAction);
         }
 
         private void RunTest(

--- a/src/test/HostActivationTests/FrameworkResolution/ApplyPatchesSettings.cs
+++ b/src/test/HostActivationTests/FrameworkResolution/ApplyPatchesSettings.cs
@@ -108,20 +108,16 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.FrameworkResolution
             }
         }
 
-        [Fact]
-        public void NoInheritance()
+        [Theory]
+        [InlineData(SettingLocation.RuntimeOptions)]
+        [InlineData(SettingLocation.FrameworkReference)]
+        public void NoInheritance(SettingLocation settingLocation)
         {
             RunTest(
-                runtimeConfig => runtimeConfig
-                    .WithApplyPatches(false)
-                    .WithFramework(MiddleWare, "2.1.2"),
-                result => result.Should().Pass()
-                    .And.HaveResolvedFramework(MicrosoftNETCoreApp, "5.1.3"));
-
-            RunTest(
-                runtimeConfig => runtimeConfig
-                    .WithFramework(new RuntimeConfig.Framework(MiddleWare, "2.1.2")
-                        .WithApplyPatches(false)),
+                new TestSettings()
+                    .WithRuntimeConfigCustomizer(runtimeConfig => runtimeConfig
+                        .WithFramework(MiddleWare, "2.1.2"))
+                    .With(ApplyPatchesSetting(settingLocation, false, MiddleWare)),
                 result => result.Should().Pass()
                     .And.HaveResolvedFramework(MicrosoftNETCoreApp, "5.1.3"));
         }
@@ -139,6 +135,17 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.FrameworkResolution
                 resultAction,
                 environment,
                 commandLine);
+        }
+
+        private void RunTest(
+            TestSettings testSettings,
+            Action<CommandResult> resultAction)
+        {
+            RunTest(
+                SharedState.DotNetWithFrameworks,
+                SharedState.FrameworkReferenceApp,
+                testSettings,
+                resultAction);
         }
 
         public class SharedTestState : SharedTestStateBase

--- a/src/test/HostActivationTests/FrameworkResolution/FrameworkResolutionBase.Settings.cs
+++ b/src/test/HostActivationTests/FrameworkResolution/FrameworkResolutionBase.Settings.cs
@@ -1,0 +1,73 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.FrameworkResolution
+{
+    public partial class FrameworkResolutionBase
+    {
+        public enum SettingLocation
+        {
+            CommandLine,
+            Environment,
+            RuntimeOptions,
+            FrameworkReference
+        }
+
+        public static Func<TestSettings, TestSettings> RollForwardOnNoCandidateFxSetting(
+            SettingLocation location,
+            int? value,
+            string frameworkReferenceName = MicrosoftNETCoreApp)
+        {
+            if (!value.HasValue)
+            {
+                return testSettings => testSettings;
+            }
+
+            switch (location)
+            {
+                case SettingLocation.Environment:
+                    return testSettings => testSettings.WithEnvironment(Constants.RollFowardOnNoCandidateFxSetting.EnvironmentVariable, value.ToString());
+                case SettingLocation.CommandLine:
+                    return testSettings => testSettings.WithCommandLine(Constants.RollFowardOnNoCandidateFxSetting.CommandLineArgument, value.ToString());
+                case SettingLocation.RuntimeOptions:
+                    return testSettings => testSettings.WithRuntimeConfigCustomizer(rc => rc.WithRollForwardOnNoCandidateFx(value));
+                case SettingLocation.FrameworkReference:
+                    return testSettings => testSettings.WithRuntimeConfigCustomizer(rc =>
+                    {
+                        rc.GetFramework(frameworkReferenceName).WithRollForwardOnNoCandidateFx(value);
+                        return rc;
+                    });
+                default:
+                    throw new Exception($"RollFowardOnNoCandidateFx doesn't support setting location {location}.");
+            }
+        }
+
+        public static Func<TestSettings, TestSettings> ApplyPatchesSetting(
+            SettingLocation location,
+            bool? value,
+            string frameworkReferenceName = MicrosoftNETCoreApp)
+        {
+            if (!value.HasValue)
+            {
+                return testSettings => testSettings;
+            }
+
+            switch (location)
+            {
+                case SettingLocation.RuntimeOptions:
+                    return testSettings => testSettings.WithRuntimeConfigCustomizer(rc => rc.WithApplyPatches(value));
+                case SettingLocation.FrameworkReference:
+                    return testSettings => testSettings.WithRuntimeConfigCustomizer(rc =>
+                    {
+                        rc.GetFramework(frameworkReferenceName).WithApplyPatches(value);
+                        return rc;
+                    });
+                default:
+                    throw new Exception($"ApplyPatches doesn't support setting location {location}.");
+            }
+        }
+    }
+}

--- a/src/test/HostActivationTests/FrameworkResolution/FrameworkResolutionBase.Settings.cs
+++ b/src/test/HostActivationTests/FrameworkResolution/FrameworkResolutionBase.Settings.cs
@@ -29,9 +29,9 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.FrameworkResolution
             switch (location)
             {
                 case SettingLocation.Environment:
-                    return testSettings => testSettings.WithEnvironment(Constants.RollFowardOnNoCandidateFxSetting.EnvironmentVariable, value.ToString());
+                    return testSettings => testSettings.WithEnvironment(Constants.RollForwardOnNoCandidateFxSetting.EnvironmentVariable, value.ToString());
                 case SettingLocation.CommandLine:
-                    return testSettings => testSettings.WithCommandLine(Constants.RollFowardOnNoCandidateFxSetting.CommandLineArgument, value.ToString());
+                    return testSettings => testSettings.WithCommandLine(Constants.RollForwardOnNoCandidateFxSetting.CommandLineArgument, value.ToString());
                 case SettingLocation.RuntimeOptions:
                     return testSettings => testSettings.WithRuntimeConfigCustomizer(rc => rc.WithRollForwardOnNoCandidateFx(value));
                 case SettingLocation.FrameworkReference:
@@ -41,7 +41,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.FrameworkResolution
                         return rc;
                     });
                 default:
-                    throw new Exception($"RollFowardOnNoCandidateFx doesn't support setting location {location}.");
+                    throw new Exception($"RollForwardOnNoCandidateFx doesn't support setting location {location}.");
             }
         }
 

--- a/src/test/HostActivationTests/FrameworkResolution/FrameworkResolutionBase.cs
+++ b/src/test/HostActivationTests/FrameworkResolution/FrameworkResolutionBase.cs
@@ -11,7 +11,7 @@ using System.Linq;
 
 namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.FrameworkResolution
 {
-    public abstract class FrameworkResolutionBase
+    public abstract partial class FrameworkResolutionBase
     {
         protected const string MicrosoftNETCoreApp = "Microsoft.NETCore.App";
 
@@ -24,23 +24,85 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.FrameworkResolution
             string[] commandLine = null,
             bool multiLevelLookup = false)
         {
-            runtimeConfig(RuntimeConfig.Path(app.RuntimeConfigJson)).Save();
+            RunTest(
+                dotnet,
+                app,
+                new TestSettings()
+                {
+                    RuntimeConfigCustomizer = runtimeConfig,
+                    Environment = environment,
+                    CommandLine = commandLine
+                },
+                resultAction,
+                multiLevelLookup);
+        }
 
-            IEnumerable<string> args = commandLine ?? Enumerable.Empty<string>();
-            args = args.Concat(new string[] { app.AppDll });
+        public class TestSettings
+        {
+            public Func<RuntimeConfig, RuntimeConfig> RuntimeConfigCustomizer { get; set; }
+            public IEnumerable<string> Environment { get; set; }
+            public IEnumerable<string> CommandLine { get; set; }
+
+            public TestSettings WithRuntimeConfigCustomizer(Func<RuntimeConfig, RuntimeConfig> customizer)
+            {
+                Func<RuntimeConfig, RuntimeConfig> previousCustomizer = RuntimeConfigCustomizer;
+                if (previousCustomizer == null)
+                {
+                    RuntimeConfigCustomizer = customizer;
+                }
+                else
+                {
+                    RuntimeConfigCustomizer = runtimeConfig => customizer(previousCustomizer(runtimeConfig));
+                }
+
+                return this;
+            }
+
+            public TestSettings WithEnvironment(string key, string value)
+            {
+                string [] env = new string[] { key + "=" + value };
+                Environment = Environment == null ? env : Environment.Concat(env);
+                return this;
+            }
+
+            public TestSettings WithCommandLine(params string[] args)
+            {
+                CommandLine = CommandLine == null ? args : CommandLine.Concat(args);
+                return this;
+            }
+
+            public TestSettings With(Func<TestSettings, TestSettings> modifier)
+            {
+                return modifier(this);
+            }
+        }
+
+        protected void RunTest(
+            DotNetCli dotnet,
+            TestApp app,
+            TestSettings settings,
+            Action<CommandResult> resultAction,
+            bool multiLevelLookup = false)
+        {
+            if (settings.RuntimeConfigCustomizer != null)
+            {
+                settings.RuntimeConfigCustomizer(RuntimeConfig.Path(app.RuntimeConfigJson)).Save();
+            }
+
+            settings.WithCommandLine(app.AppDll);
 
             IDictionary<string, string> environmentVariables = null;
-            if (environment != null)
+            if (settings.Environment != null)
             {
                 environmentVariables = new Dictionary<string, string>();
-                foreach (string v in environment)
+                foreach (string v in settings.Environment)
                 {
                     string[] s = v.Split('=');
                     environmentVariables.Add(s[0], s[1]);
                 }
             }
 
-            CommandResult result = dotnet.Exec(args.First(), args.Skip(1).ToArray())
+            CommandResult result = dotnet.Exec(settings.CommandLine.First(), settings.CommandLine.Skip(1).ToArray())
                 .EnvironmentVariable("COREHOST_TRACE", "1")
                 .EnvironmentVariable("DOTNET_MULTILEVEL_LOOKUP", multiLevelLookup ? "1" : "0")
                 .Environment(environmentVariables)

--- a/src/test/HostActivationTests/FrameworkResolution/RollForwardOnNoCandidateFxSettings.cs
+++ b/src/test/HostActivationTests/FrameworkResolution/RollForwardOnNoCandidateFxSettings.cs
@@ -83,161 +83,133 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.FrameworkResolution
         }
 
         [Theory]  // CLI wins over everything
-        [InlineData("Environment", "5.1.3")]
-        [InlineData("RuntimeConfig", "5.1.3")]
-        [InlineData("Framework", "5.1.3")]
-        public void CommandLinePriority(string settingLocation, string resolvedFramework)
+        [InlineData(SettingLocation.Environment, "5.1.3")]
+        [InlineData(SettingLocation.RuntimeOptions, "5.1.3")]
+        [InlineData(SettingLocation.FrameworkReference, "5.1.3")]
+        public void CommandLinePriority(SettingLocation settingLocation, string resolvedFramework)
         {
             RunTestWithRollForwardOnNoCandidateFxSetting(
-                runtimeConfig => runtimeConfig
-                    .WithFramework(MicrosoftNETCoreApp, "4.0.0"),
-                commandLine: new string[] { Constants.RollFowardOnNoCandidateFxSetting.CommandLineArgument, "2" },
-                settingLocation: settingLocation,
-                settingValue: 0,
+                new TestSettings()
+                    .WithRuntimeConfigCustomizer(runtimeConfig => runtimeConfig
+                        .WithFramework(MicrosoftNETCoreApp, "4.0.0"))
+                    .With(RollForwardOnNoCandidateFxSetting(settingLocation, 0))
+                    .WithCommandLine(Constants.RollFowardOnNoCandidateFxSetting.CommandLineArgument, "2"),
                 resolvedFramework: resolvedFramework);
         }
 
         [Theory]  // Framework loses only to CLI
-        [InlineData("CommandLine", null)]
-        [InlineData("Environment", "5.1.3")]
-        [InlineData("RuntimeConfig", "5.1.3")]
-        public void FrameworkPriority(string settingLocation, string resolvedFramework)
+        [InlineData(SettingLocation.CommandLine, null)]
+        [InlineData(SettingLocation.Environment, "5.1.3")]
+        [InlineData(SettingLocation.RuntimeOptions, "5.1.3")]
+        public void FrameworkPriority(SettingLocation settingLocation, string resolvedFramework)
         {
             RunTestWithRollForwardOnNoCandidateFxSetting(
-                runtimeConfig => runtimeConfig
-                    .WithFramework(new RuntimeConfig.Framework(MicrosoftNETCoreApp, "4.0.0")
-                        .WithRollForwardOnNoCandidateFx(2)),
-                settingLocation: settingLocation,
-                settingValue: 0,
+                new TestSettings()
+                    .WithRuntimeConfigCustomizer(runtimeConfig => runtimeConfig
+                        .WithFramework(new RuntimeConfig.Framework(MicrosoftNETCoreApp, "4.0.0")
+                            .WithRollForwardOnNoCandidateFx(2)))
+                    .With(RollForwardOnNoCandidateFxSetting(settingLocation, 0)),
                 resolvedFramework: resolvedFramework);
         }
 
         [Theory]  // Runtime config only wins over env
-        [InlineData("CommandLine", null)]
-        [InlineData("Environment", "5.1.3")]
-        [InlineData("Framework", null)]
-        public void RuntimeConfigPriority(string settingLocation, string resolvedFramework)
+        [InlineData(SettingLocation.CommandLine, null)]
+        [InlineData(SettingLocation.Environment, "5.1.3")]
+        [InlineData(SettingLocation.FrameworkReference, null)]
+        public void RuntimeConfigPriority(SettingLocation settingLocation, string resolvedFramework)
         {
             RunTestWithRollForwardOnNoCandidateFxSetting(
-                runtimeConfig => runtimeConfig
-                    .WithRollForwardOnNoCandidateFx(2)
-                    .WithFramework(MicrosoftNETCoreApp, "4.0.0"),
-                settingLocation: settingLocation,
-                settingValue: 0,
+                new TestSettings()
+                    .WithRuntimeConfigCustomizer(runtimeConfig => runtimeConfig
+                        .WithRollForwardOnNoCandidateFx(2)
+                        .WithFramework(MicrosoftNETCoreApp, "4.0.0"))
+                    .With(RollForwardOnNoCandidateFxSetting(settingLocation, 0)),
                 resolvedFramework: resolvedFramework);
         }
 
         [Theory]  // Env loses to everything else
-        [InlineData("CommandLine", null)]
-        [InlineData("RuntimeConfig", null)]
-        [InlineData("Framework", null)]
-        public void EnvironmentPriority(string settingLocation, string resolvedFramework)
+        [InlineData(SettingLocation.CommandLine, null)]
+        [InlineData(SettingLocation.RuntimeOptions, null)]
+        [InlineData(SettingLocation.FrameworkReference, null)]
+        public void EnvironmentPriority(SettingLocation settingLocation, string resolvedFramework)
         {
             RunTestWithRollForwardOnNoCandidateFxSetting(
-                runtimeConfig => runtimeConfig
-                    .WithFramework(MicrosoftNETCoreApp, "4.0.0"),
-                environment: new string[] { Constants.RollFowardOnNoCandidateFxSetting.EnvironmentVariable + "=2" },
-                settingLocation: settingLocation,
-                settingValue: 0,
+                new TestSettings()
+                    .WithRuntimeConfigCustomizer(runtimeConfig => runtimeConfig
+                        .WithFramework(MicrosoftNETCoreApp, "4.0.0"))
+                    .With(RollForwardOnNoCandidateFxSetting(settingLocation, 0))
+                    .WithEnvironment(Constants.RollFowardOnNoCandidateFxSetting.EnvironmentVariable, "2"),
                 resolvedFramework: resolvedFramework);
         }
 
         [Theory]
-        [InlineData("CommandLine", null)]   // Command line overrides everything - even inner framework references
-        [InlineData("RuntimeConfig", "5.1.3")]
-        [InlineData("Framework", "5.1.3")]
-        [InlineData("Environment", "5.1.3")]
-        public void InnerFrameworkReference(string settingLocation, string resolvedFramework)
+        [InlineData(SettingLocation.CommandLine, null)]   // Command line overrides everything - even inner framework references
+        [InlineData(SettingLocation.RuntimeOptions, "5.1.3")]
+        [InlineData(SettingLocation.FrameworkReference, "5.1.3")]
+        [InlineData(SettingLocation.Environment, "5.1.3")]
+        public void InnerFrameworkReference(SettingLocation settingLocation, string resolvedFramework)
         {
             RunTestWithRollForwardOnNoCandidateFxSetting(
-                runtimeConfig => runtimeConfig
-                    .WithFramework(new RuntimeConfig.Framework(MiddleWare, "2.1.0")),
+                new TestSettings()
+                    .WithRuntimeConfigCustomizer(runtimeConfig => runtimeConfig
+                        .WithFramework(new RuntimeConfig.Framework(MiddleWare, "2.1.0")))
+                    .With(RollForwardOnNoCandidateFxSetting(settingLocation, 1, MiddleWare)),
                 customizeDotNet: dotnetCustomizer => dotnetCustomizer.Framework(MiddleWare).RuntimeConfig(runtimeConfig =>
                     runtimeConfig
                         .WithRollForwardOnNoCandidateFx(2)
                         .GetFramework(MicrosoftNETCoreApp).Version = "4.0.0"),
-                settingLocation: settingLocation,
-                settingValue: 1,
-                frameworkReferenceName: MiddleWare,
-                resolvedFramework: resolvedFramework);
+                resolvedFramework);
         }
 
         [Theory]
-        [InlineData("CommandLine", "5.1.3")]   // Command line overrides everything - even inner framework references
-        [InlineData("RuntimeConfig", null)]    // RuntimeConfig and Framework settings are not inherited to inner reference
-        [InlineData("Framework", null)]        // RuntimeConfig and Framework settings are not inherited to inner reference
-        [InlineData("Environment", "5.1.3")]   // Since none is specified for the inner reference, environment is used
-        public void NoInheritance_MoreRelaxed(string settingLocation, string resolvedFramework)
+        [InlineData(SettingLocation.CommandLine, "5.1.3")]     // Command line overrides everything - even inner framework references
+        [InlineData(SettingLocation.RuntimeOptions, null)]     // RuntimeOptions and FrameworkReference settings are not inherited to inner reference
+        [InlineData(SettingLocation.FrameworkReference, null)] // RuntimeOptions and FrameworkReference settings are not inherited to inner reference
+        [InlineData(SettingLocation.Environment, "5.1.3")]     // Since none is specified for the inner reference, environment is used
+        public void NoInheritance_MoreRelaxed(SettingLocation settingLocation, string resolvedFramework)
         {
             RunTestWithRollForwardOnNoCandidateFxSetting(
-                runtimeConfig => runtimeConfig
-                    .WithFramework(new RuntimeConfig.Framework(MiddleWare, "1.0.0")),
+                new TestSettings()
+                    .WithRuntimeConfigCustomizer(runtimeConfig => runtimeConfig
+                        .WithFramework(MiddleWare, "1.0.0"))
+                    .With(RollForwardOnNoCandidateFxSetting(settingLocation, 2, MiddleWare)),
                 customizeDotNet: dotnetCustomizer => dotnetCustomizer.Framework(MiddleWare).RuntimeConfig(runtimeConfig =>
                     runtimeConfig
                         .GetFramework(MicrosoftNETCoreApp).Version = "4.0.0"),
-                settingLocation: settingLocation,
-                settingValue: 2,
-                frameworkReferenceName: MiddleWare,
-                resolvedFramework: resolvedFramework);
+                resolvedFramework);
         }
 
         [Theory]
-        [InlineData("CommandLine", null)]      // Command line overrides everything - even inner framework references
-        [InlineData("RuntimeConfig", "5.1.3")] // RuntimeConfig and Framework settings are not inherited to inner reference
-        [InlineData("Framework", "5.1.3")]     // RuntimeConfig and Framework settings are not inherited to inner reference
-        [InlineData("Environment", null)]      // Since none is specified for the inner reference, environment is used
-        public void NoInheritance_MoreRestrictive(string settingLocation, string resolvedFramework)
+        [InlineData(SettingLocation.CommandLine, null)]           // Command line overrides everything - even inner framework references
+        [InlineData(SettingLocation.RuntimeOptions, "5.1.3")]     // RuntimeOptions and FrameworkReference settings are not inherited to inner reference
+        [InlineData(SettingLocation.FrameworkReference, "5.1.3")] // RuntimeOptions and FrameworkReference settings are not inherited to inner reference
+        [InlineData(SettingLocation.Environment, null)]           // Since none is specified for the inner reference, environment is used
+        public void NoInheritance_MoreRestrictive(SettingLocation settingLocation, string resolvedFramework)
         {
             RunTestWithRollForwardOnNoCandidateFxSetting(
-                runtimeConfig => runtimeConfig
-                    .WithFramework(new RuntimeConfig.Framework(MiddleWare, "2.1.2")),
+                new TestSettings()
+                    .WithRuntimeConfigCustomizer(runtimeConfig => runtimeConfig
+                        .WithFramework(new RuntimeConfig.Framework(MiddleWare, "2.1.2")))
+                    .With(RollForwardOnNoCandidateFxSetting(settingLocation, 0, MiddleWare)),
                 customizeDotNet: dotnetCustomizer => dotnetCustomizer.Framework(MiddleWare).RuntimeConfig(runtimeConfig =>
                     runtimeConfig
                         .GetFramework(MicrosoftNETCoreApp).Version = "5.0.0"),
-                settingLocation: settingLocation,
-                settingValue: 0,
-                frameworkReferenceName: MiddleWare,
-                resolvedFramework: resolvedFramework);
+                resolvedFramework);
         }
 
-
         private void RunTestWithRollForwardOnNoCandidateFxSetting(
-            Func<RuntimeConfig, RuntimeConfig> runtimeConfig,
+            TestSettings testSettings,
             Action<DotNetCliExtensions.DotNetCliCustomizer> customizeDotNet = null,
-            string[] environment = null,
-            string[] commandLine = null,
-            string settingLocation = null,
-            int settingValue = 1,
-            string frameworkReferenceName = MicrosoftNETCoreApp,
             string resolvedFramework = null)
         {
             using (DotNetCliExtensions.DotNetCliCustomizer dotnetCustomizer = SharedState.DotNetWithFrameworks.Customize())
             {
                 customizeDotNet?.Invoke(dotnetCustomizer);
 
-                Func<RuntimeConfig, RuntimeConfig> runtimeConfigCustomization = runtimeConfig;
-                switch (settingLocation)
-                {
-                    case "Environment":
-                        environment = new string[] { $"{Constants.RollFowardOnNoCandidateFxSetting.EnvironmentVariable}={settingValue}" };
-                        break;
-                    case "CommandLine":
-                        commandLine = new string[] { Constants.RollFowardOnNoCandidateFxSetting.CommandLineArgument, settingValue.ToString() };
-                        break;
-                    case "RuntimeConfig":
-                        runtimeConfigCustomization = rc => runtimeConfig(rc).WithRollForwardOnNoCandidateFx(settingValue);
-                        break;
-                    case "Framework":
-                        runtimeConfigCustomization = rc =>
-                        {
-                            runtimeConfig(rc).GetFramework(frameworkReferenceName).WithRollForwardOnNoCandidateFx(settingValue);
-                            return rc;
-                        };
-                        break;
-                }
-
                 RunTest(
-                    runtimeConfigCustomization,
+                    SharedState.DotNetWithFrameworks,
+                    SharedState.FrameworkReferenceApp,
+                    testSettings,
                     commandResult =>
                     {
                         if (resolvedFramework != null)
@@ -250,9 +222,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.FrameworkResolution
                             commandResult.Should().Fail()
                                 .And.DidNotFindCompatibleFrameworkVersion();
                         }
-                    },
-                    environment,
-                    commandLine);
+                    });
             }
         }
 

--- a/src/test/HostActivationTests/FrameworkResolution/RollForwardOnNoCandidateFxSettings.cs
+++ b/src/test/HostActivationTests/FrameworkResolution/RollForwardOnNoCandidateFxSettings.cs
@@ -154,7 +154,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.FrameworkResolution
                     .WithRuntimeConfigCustomizer(runtimeConfig => runtimeConfig
                         .WithFramework(new RuntimeConfig.Framework(MiddleWare, "2.1.0")))
                     .With(RollForwardOnNoCandidateFxSetting(settingLocation, 1, MiddleWare)),
-                customizeDotNet: dotnetCustomizer => dotnetCustomizer.Framework(MiddleWare).RuntimeConfig(runtimeConfig =>
+                dotnetCustomizer => dotnetCustomizer.Framework(MiddleWare).RuntimeConfig(runtimeConfig =>
                     runtimeConfig
                         .WithRollForwardOnNoCandidateFx(2)
                         .GetFramework(MicrosoftNETCoreApp).Version = "4.0.0"),
@@ -173,7 +173,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.FrameworkResolution
                     .WithRuntimeConfigCustomizer(runtimeConfig => runtimeConfig
                         .WithFramework(MiddleWare, "1.0.0"))
                     .With(RollForwardOnNoCandidateFxSetting(settingLocation, 2, MiddleWare)),
-                customizeDotNet: dotnetCustomizer => dotnetCustomizer.Framework(MiddleWare).RuntimeConfig(runtimeConfig =>
+                dotnetCustomizer => dotnetCustomizer.Framework(MiddleWare).RuntimeConfig(runtimeConfig =>
                     runtimeConfig
                         .GetFramework(MicrosoftNETCoreApp).Version = "4.0.0"),
                 resolvedFramework);
@@ -191,7 +191,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.FrameworkResolution
                     .WithRuntimeConfigCustomizer(runtimeConfig => runtimeConfig
                         .WithFramework(new RuntimeConfig.Framework(MiddleWare, "2.1.2")))
                     .With(RollForwardOnNoCandidateFxSetting(settingLocation, 0, MiddleWare)),
-                customizeDotNet: dotnetCustomizer => dotnetCustomizer.Framework(MiddleWare).RuntimeConfig(runtimeConfig =>
+                dotnetCustomizer => dotnetCustomizer.Framework(MiddleWare).RuntimeConfig(runtimeConfig =>
                     runtimeConfig
                         .GetFramework(MicrosoftNETCoreApp).Version = "5.0.0"),
                 resolvedFramework);

--- a/src/test/HostActivationTests/FrameworkResolution/RollForwardOnNoCandidateFxSettings.cs
+++ b/src/test/HostActivationTests/FrameworkResolution/RollForwardOnNoCandidateFxSettings.cs
@@ -5,6 +5,7 @@
 using Microsoft.DotNet.Cli.Build;
 using Microsoft.DotNet.Cli.Build.Framework;
 using System;
+using System.Collections.Generic;
 using Xunit;
 
 namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.FrameworkResolution
@@ -68,7 +69,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.FrameworkResolution
                     .WithFramework(MicrosoftNETCoreApp, "4.0.0"),
                 result => result.Should().Pass()
                     .And.HaveResolvedFramework(MicrosoftNETCoreApp, "5.1.3"),
-                environment: new string[] { "DOTNET_ROLL_FORWARD_ON_NO_CANDIDATE_FX=2" });
+                environment: new Dictionary<string, string>() { { "DOTNET_ROLL_FORWARD_ON_NO_CANDIDATE_FX", "2" } });
         }
 
         [Fact]
@@ -79,7 +80,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.FrameworkResolution
                     .WithFramework(MicrosoftNETCoreApp, "4.0.0"),
                 result => result.Should().Pass()
                     .And.HaveResolvedFramework(MicrosoftNETCoreApp, "5.1.3"),
-                commandLine: new string[] { Constants.RollFowardOnNoCandidateFxSetting.CommandLineArgument, "2" });
+                commandLine: new string[] { Constants.RollForwardOnNoCandidateFxSetting.CommandLineArgument, "2" });
         }
 
         [Theory]  // CLI wins over everything
@@ -93,7 +94,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.FrameworkResolution
                     .WithRuntimeConfigCustomizer(runtimeConfig => runtimeConfig
                         .WithFramework(MicrosoftNETCoreApp, "4.0.0"))
                     .With(RollForwardOnNoCandidateFxSetting(settingLocation, 0))
-                    .WithCommandLine(Constants.RollFowardOnNoCandidateFxSetting.CommandLineArgument, "2"),
+                    .WithCommandLine(Constants.RollForwardOnNoCandidateFxSetting.CommandLineArgument, "2"),
                 resolvedFramework: resolvedFramework);
         }
 
@@ -138,7 +139,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.FrameworkResolution
                     .WithRuntimeConfigCustomizer(runtimeConfig => runtimeConfig
                         .WithFramework(MicrosoftNETCoreApp, "4.0.0"))
                     .With(RollForwardOnNoCandidateFxSetting(settingLocation, 0))
-                    .WithEnvironment(Constants.RollFowardOnNoCandidateFxSetting.EnvironmentVariable, "2"),
+                    .WithEnvironment(Constants.RollForwardOnNoCandidateFxSetting.EnvironmentVariable, "2"),
                 resolvedFramework: resolvedFramework);
         }
 
@@ -229,7 +230,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.FrameworkResolution
         private void RunTest(
             Func<RuntimeConfig, RuntimeConfig> runtimeConfig,
             Action<CommandResult> resultAction,
-            string[] environment = null,
+            IDictionary<string, string> environment = null,
             string[] commandLine = null)
         {
             RunTest(

--- a/src/test/HostActivationTests/HostActivationTests.csproj
+++ b/src/test/HostActivationTests/HostActivationTests.csproj
@@ -8,6 +8,10 @@
     <DefineConstants Condition="'$(OSGroup)' == 'Windows_NT'">$(DefineConstants);WINDOWS</DefineConstants>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(BuildingInsideVisualStudio)' == 'true'">
+    <LangVersion>7.1</LangVersion>
+  </PropertyGroup>
+  
   <ItemGroup>
     <ProjectReference Include="..\TestUtils\TestUtils.csproj" />
   </ItemGroup>

--- a/src/test/HostActivationTests/RuntimeConfig.cs
+++ b/src/test/HostActivationTests/RuntimeConfig.cs
@@ -49,7 +49,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
                 if (RollForwardOnNoCandidateFx.HasValue)
                 {
                     frameworkReference.Add(
-                        Constants.RollFowardOnNoCandidateFxSetting.RuntimeConfigPropertyName,
+                        Constants.RollForwardOnNoCandidateFxSetting.RuntimeConfigPropertyName,
                         RollForwardOnNoCandidateFx.Value);
                 }
 
@@ -67,7 +67,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
             {
                 return new Framework((string)jobject["name"], (string)jobject["version"])
                 {
-                    RollForwardOnNoCandidateFx = (int?)jobject[Constants.RollFowardOnNoCandidateFxSetting.RuntimeConfigPropertyName],
+                    RollForwardOnNoCandidateFx = (int?)jobject[Constants.RollForwardOnNoCandidateFxSetting.RuntimeConfigPropertyName],
                     ApplyPatches = (bool?)jobject[Constants.ApplyPatchesSetting.RuntimeConfigPropertyName]
                 };
             }
@@ -105,7 +105,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
                         runtimeConfig.WithFramework(Framework.FromJson(framework));
                     }
 
-                    runtimeConfig._rollForwardOnNoCandidateFx = (int?)runtimeOptions[Constants.RollFowardOnNoCandidateFxSetting.RuntimeConfigPropertyName];
+                    runtimeConfig._rollForwardOnNoCandidateFx = (int?)runtimeOptions[Constants.RollForwardOnNoCandidateFxSetting.RuntimeConfigPropertyName];
                     runtimeConfig._applyPatches = (bool?)runtimeOptions[Constants.ApplyPatchesSetting.RuntimeConfigPropertyName];
                 }
             }
@@ -156,7 +156,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
             if (_rollForwardOnNoCandidateFx.HasValue)
             {
                 runtimeOptions.Add(
-                    Constants.RollFowardOnNoCandidateFxSetting.RuntimeConfigPropertyName,
+                    Constants.RollForwardOnNoCandidateFxSetting.RuntimeConfigPropertyName,
                     _rollForwardOnNoCandidateFx.Value);
             }
 


### PR DESCRIPTION
Add ability to easily apply settings (roll forward and so on) in a dynamic way (picking location via variable).
This simplifies testing of settings combinations.

This is very useful in the new rollForward tests where we need to test combinations of rollForward, rollForwardOnNoCandidateFx and applyPatches settings. I separated the change out into its own PR to simplify the rollForward change.