### PR TITLE
Fix WindowsDesktop Targeting Pack file list root attributes

### DIFF
--- a/src/pkg/projects/dir.props
+++ b/src/pkg/projects/dir.props
@@ -30,13 +30,6 @@
     <ProjectExclusions Include="windowsdesktop\**\*.*proj" />
   </ItemGroup>
 
-  <ItemGroup>
-    <FrameworkListRootAttributes Include="Name" Value="$(NETCoreAppFrameworkBrandName)" />
-    <FrameworkListRootAttributes Include="TargetFrameworkIdentifier" Value="$(NETCoreAppFrameworkIdentifier)" />
-    <FrameworkListRootAttributes Include="TargetFrameworkVersion" Value="$(NETCoreAppFrameworkVersion)" />
-    <FrameworkListRootAttributes Include="FrameworkName" Value="$(SharedFrameworkName)" />
-  </ItemGroup>
-
   <PropertyGroup Condition="'$(PackageTargetRuntime)' == ''">
     <SkipValidatePackage>true</SkipValidatePackage>
     <IncludeRuntimeJson>true</IncludeRuntimeJson>

--- a/src/pkg/projects/dir.targets
+++ b/src/pkg/projects/dir.targets
@@ -193,6 +193,17 @@
       <FrameworkListFile>$(IntermediateOutputPath)FrameworkList.xml</FrameworkListFile>
     </PropertyGroup>
 
+    <ItemGroup>
+      <FrameworkListRootAttributes Include="Name" Value="$(FrameworkListName)" />
+      <FrameworkListRootAttributes Include="TargetFrameworkIdentifier" Value="$(FrameworkListTargetFrameworkIdentifier)" />
+      <FrameworkListRootAttributes Include="TargetFrameworkVersion" Value="$(FrameworkListTargetFrameworkVersion)" />
+      <FrameworkListRootAttributes Include="FrameworkName" Value="$(FrameworkListFrameworkName)" />
+    </ItemGroup>
+
+    <Error
+      Condition="'%(FrameworkListRootAttributes.Value)' == ''"
+      Text="Missing value for property 'FrameworkList%(FrameworkListRootAttributes.Identity)'" />
+
     <CreateFrameworkListFile
       Files="@(File)"
       TargetFile="$(FrameworkListFile)"

--- a/src/pkg/projects/netcoreapp/pkg/dir.props
+++ b/src/pkg/projects/netcoreapp/pkg/dir.props
@@ -7,6 +7,13 @@
 
   <Import Project="..\..\dir.props" />
 
+  <PropertyGroup>
+    <FrameworkListName>$(NETCoreAppFrameworkBrandName)</FrameworkListName>
+    <FrameworkListTargetFrameworkIdentifier>$(NETCoreAppFrameworkIdentifier)</FrameworkListTargetFrameworkIdentifier>
+    <FrameworkListTargetFrameworkVersion>$(NETCoreAppFrameworkVersion)</FrameworkListTargetFrameworkVersion>
+    <FrameworkListFrameworkName>$(SharedFrameworkName)</FrameworkListFrameworkName>
+  </PropertyGroup>
+
   <!-- Redistribute package content from other nuget packages. -->
   <ItemGroup>
     <ProjectReference Include="..\src\netcoreapp.depproj">

--- a/src/pkg/projects/windowsdesktop/dir.props
+++ b/src/pkg/projects/windowsdesktop/dir.props
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory).., dir.props))\dir.props" />
+
+  <PropertyGroup>
+    <FrameworkPackageName>Microsoft.WindowsDesktop.App</FrameworkPackageName>
+  </PropertyGroup>
+</Project>

--- a/src/pkg/projects/windowsdesktop/pkg/dir.props
+++ b/src/pkg/projects/windowsdesktop/pkg/dir.props
@@ -6,7 +6,14 @@
     <ProductBrandPrefix>Microsoft Windows Desktop</ProductBrandPrefix>
   </PropertyGroup>
 
-  <Import Project="..\..\dir.props" />
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory).., dir.props))\dir.props" />
+
+  <PropertyGroup>
+    <FrameworkListName>Windows Desktop $(NETCoreAppFrameworkVersion)</FrameworkListName>
+    <FrameworkListTargetFrameworkIdentifier>$(NETCoreAppFrameworkIdentifier)</FrameworkListTargetFrameworkIdentifier>
+    <FrameworkListTargetFrameworkVersion>$(NETCoreAppFrameworkVersion)</FrameworkListTargetFrameworkVersion>
+    <FrameworkListFrameworkName>$(FrameworkPackageName)</FrameworkListFrameworkName>
+  </PropertyGroup>
 
   <PropertyGroup>
     <BuildDebPackage>false</BuildDebPackage>

--- a/src/pkg/projects/windowsdesktop/src/windowsdesktop.depproj
+++ b/src/pkg/projects/windowsdesktop/src/windowsdesktop.depproj
@@ -2,10 +2,6 @@
 <Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" DefaultTargets="Build">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
 
-  <PropertyGroup>
-    <FrameworkPackageName>Microsoft.WindowsDesktop.App</FrameworkPackageName>
-  </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="Microsoft.WindowsDesktop.App">
       <Version>$(MicrosoftWindowsDesktopAppPackageVersion)</Version>


### PR DESCRIPTION
I noticed that the netcoreapp and windowsdesktop Targeting Packs had the same root attributes:

```xml
<FileList
  Name=".NET Core 3.0"
  TargetFrameworkIdentifier=".NETCoreApp"
  TargetFrameworkVersion="3.0"
  FrameworkName="Microsoft.NETCore.App">
```

This PR stops defaulting to .NET Core values, making it harder to hit this again. WindowsDesktop Targeting Pack file list attributes are set to:

```xml
<FileList
  Name="Windows Desktop 3.0"
  TargetFrameworkIdentifier=".NETCoreApp"
  TargetFrameworkVersion="3.0"
  FrameworkName="Microsoft.WindowsDesktop.App">
```

Not sure if expectations for these are ironed out, but it seemed worth at least making the values make sense. Saw the duplication while making a .NET Standard targeting pack.

/cc @nguerrera 