### PR TITLE
Add .NET Standard 2.1 Targeting Pack

### DIFF
--- a/dir.props
+++ b/dir.props
@@ -78,8 +78,8 @@
     <VersionSuffix Condition="'$(IncludeBuildNumberInPackageVersion)' == 'true'">$(VersionSuffix)-$(BuildNumberMajor)-$(BuildNumberMinor)</VersionSuffix>
 
     <ProductVersionSuffix Condition="'$(IncludePreReleaseLabelInPackageVersion)' == 'true'">-$(VersionSuffix)</ProductVersionSuffix>
-    <ProductBandVersion>$(MajorVersion).$(MinorVersion)</ProductBandVersion>
-    <ProductionVersion>$(ProductBandVersion).$(PatchVersion)</ProductionVersion>
+    <ProductBandVersion Condition="'$(ProductBandVersion)' == ''">$(MajorVersion).$(MinorVersion)</ProductBandVersion>
+    <ProductionVersion Condition="'$(ProductionVersion)' == ''">$(ProductBandVersion).$(PatchVersion)</ProductionVersion>
     <ProductVersion>$(ProductionVersion)$(ProductVersionSuffix)</ProductVersion>
 
     <SharedFrameworkNugetVersion>$(ProductVersion)</SharedFrameworkNugetVersion>

--- a/dir.props
+++ b/dir.props
@@ -462,14 +462,10 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(InstallerExtension)' == '.deb' or '$(InstallerExtension)' == '.rpm' ">
-
-    <PackageNameSuffix>$(MajorVersion).$(MinorVersion)</PackageNameSuffix>
-
     <SharedHostInstallerFile Condition="'$(InstallerExtension)' == '.deb' or '$(InstallerExtension)' == '.rpm' ">$(SharedHostInstallerStart)$(SharedFrameworkNugetVersion)-$(TargetArchitecture)$(InstallerExtension)</SharedHostInstallerFile>
     <HostFxrInstallerFile Condition="'$(InstallerExtension)' == '.deb' or '$(InstallerExtension)' == '.rpm'">$(HostFxrInstallerStart)$(HostResolverVersion)-$(TargetArchitecture)$(InstallerExtension)</HostFxrInstallerFile>
     <SharedFrameworkInstallerFile Condition="'$(InstallerExtension)' == '.deb' or '$(InstallerExtension)' == '.rpm'">$(SharedFrameworkInstallerStart)$(SharedFrameworkNugetVersion)-$(TargetArchitecture)$(InstallerExtension)</SharedFrameworkInstallerFile>
     <DotnetRuntimeDependenciesPackageInstallerFile>$(DotnetRuntimeDependenciesPackageInstallerStart)$(ProductMoniker)$(InstallerExtension)</DotnetRuntimeDependenciesPackageInstallerFile>
-
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(UsingNETSdkCompiler)' != 'true'">

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -12,9 +12,10 @@
     <PinnedDependency Name="Microsoft.NETCore.Targets" Version="2.0.0">
       <Uri>https://github.com/dotnet/corefx</Uri>
     </PinnedDependency>
-    <PinnedDependency Name="NETStandard.Library" Version="2.0.3">
+    <Dependency Name="NETStandard.Library" Version="2.1.0-prerelease.19168.1">
       <Uri>https://github.com/dotnet/standard</Uri>
-    </PinnedDependency>
+      <Sha>fc4a92712cff169e451bc097b2dc57590fd5de36</Sha>
+    </Dependency>
     <Dependency Name="Microsoft.NETCore.Runtime.CoreCLR" Version="3.0.0-preview4-27522-71">
       <Uri>https://github.com/dotnet/coreclr</Uri>
       <Sha>5d57b87227b7fd116735edf9f5f75b3154953d8e</Sha>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -10,7 +10,7 @@
     <MicrosoftPrivateCoreFxNETCoreAppPackageVersion>4.6.0-preview4.19164.7</MicrosoftPrivateCoreFxNETCoreAppPackageVersion>
     <MicrosoftNETCorePlatformsPackageVersion>3.0.0-preview4.19164.7</MicrosoftNETCorePlatformsPackageVersion>
     <MicrosoftNETCoreTargetsPackageVersion>2.0.0</MicrosoftNETCoreTargetsPackageVersion>
-    <NETStandardLibraryPackageVersion>2.0.3</NETStandardLibraryPackageVersion>
+    <NETStandardLibraryPackageVersion>2.1.0-prerelease.19168.1</NETStandardLibraryPackageVersion>
     <MicrosoftNETCoreRuntimeCoreCLRPackageVersion>3.0.0-preview4-27522-71</MicrosoftNETCoreRuntimeCoreCLRPackageVersion>
     <MicrosoftBclJsonSourcesPackageVersion>4.6.0-preview.19072.2</MicrosoftBclJsonSourcesPackageVersion>
     <MicrosoftWindowsDesktopAppPackageVersion>3.0.0-preview4-27520-2</MicrosoftWindowsDesktopAppPackageVersion>

--- a/src/pkg/packaging/deb/package.props
+++ b/src/pkg/packaging/deb/package.props
@@ -4,11 +4,11 @@
     <debPackaginfConfigPath>$(PackagingRoot)deb/</debPackaginfConfigPath>
     <SharedHostDebPkgName>dotnet-host</SharedHostDebPkgName>
     <SharedHostDebPkgName>$(SharedHostDebPkgName.ToLower())</SharedHostDebPkgName>  
-    <HostFxrDebPkgName>$(DotnetHostFxrString)$(PackageNameSuffix)</HostFxrDebPkgName>
+    <HostFxrDebPkgName>$(DotnetHostFxrString)$(ProductBandVersion)</HostFxrDebPkgName>
     <HostFxrDebPkgName>$(HostFxrDebPkgName.ToLower())</HostFxrDebPkgName>
-    <SharedFxDebPkgName>$(DotnetRuntimeString)$(PackageNameSuffix)</SharedFxDebPkgName>
+    <SharedFxDebPkgName>$(DotnetRuntimeString)$(ProductBandVersion)</SharedFxDebPkgName>
     <SharedFxDebPkgName>$(SharedFxDebPkgName.ToLower())</SharedFxDebPkgName>
-    <RuntimeDependenciesDebPkgName>$(DotnetRuntimeDependenciesPackageString)$(PackageNameSuffix)</RuntimeDependenciesDebPkgName>
+    <RuntimeDependenciesDebPkgName>$(DotnetRuntimeDependenciesPackageString)$(ProductBandVersion)</RuntimeDependenciesDebPkgName>
     <RuntimeDependenciesDebPkgName>$(RuntimeDependenciesDebPkgName.ToLower())</RuntimeDependenciesDebPkgName>
   </PropertyGroup>
   <PropertyGroup Condition="'$(InstallerExtension)' == '.deb'">

--- a/src/pkg/packaging/rpm/package.props
+++ b/src/pkg/packaging/rpm/package.props
@@ -5,11 +5,11 @@
     <rpmPackagingConfigPath>$(PackagingRoot)rpm/</rpmPackagingConfigPath>
     <SharedHostRpmPkgName>dotnet-host</SharedHostRpmPkgName>
     <SharedHostRpmPkgName>$(SharedHostRpmPkgName.ToLower())</SharedHostRpmPkgName>
-    <HostFxrRpmPkgName>dotnet-hostfxr-$(PackageNameSuffix)</HostFxrRpmPkgName>
+    <HostFxrRpmPkgName>dotnet-hostfxr-$(ProductBandVersion)</HostFxrRpmPkgName>
     <HostFxrRpmPkgName>$(HostFxrRpmPkgName.ToLower())</HostFxrRpmPkgName>
-    <SharedFxRpmPkgName>dotnet-runtime-$(PackageNameSuffix)</SharedFxRpmPkgName>
+    <SharedFxRpmPkgName>dotnet-runtime-$(ProductBandVersion)</SharedFxRpmPkgName>
     <SharedFxRpmPkgName>$(SharedFxRpmPkgName.ToLower())</SharedFxRpmPkgName>
-    <RuntimeDependenciesRpmPkgName>$(DotnetRuntimeDependenciesPackageString)$(PackageNameSuffix)</RuntimeDependenciesRpmPkgName>
+    <RuntimeDependenciesRpmPkgName>$(DotnetRuntimeDependenciesPackageString)$(ProductBandVersion)</RuntimeDependenciesRpmPkgName>
     <RuntimeDependenciesRpmPkgName>$(RuntimeDependenciesRpmPkgName.ToLower())</RuntimeDependenciesRpmPkgName>
 
     <TemplatesDir>$(RpmTemplatesDir)</TemplatesDir>

--- a/src/pkg/projects/descriptions.json
+++ b/src/pkg/projects/descriptions.json
@@ -48,5 +48,10 @@
         "Name": "Microsoft.WindowsDesktop.App.Ref",
         "Description": "Windows Forms and WPF targeting pack. Contains reference assemblies, documentation, and other design-time assets.",
         "CommonTypes": [ ]
+    },
+    {
+        "Name": "NETStandard.Library.Ref",
+        "Description": "A set of standard .NET APIs that are prescribed to be used and supported together. Contains reference assemblies, documentation, and other design-time assets.",
+        "CommonTypes": [ ]
     }
 ]

--- a/src/pkg/projects/netstandard/pkg/NETStandard.Library.Ref.pkgproj
+++ b/src/pkg/projects/netstandard/pkg/NETStandard.Library.Ref.pkgproj
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+
+  <PropertyGroup>
+    <!-- .NET Standard has no platforms.-->
+    <PlatformManifestTargetPath />
+  </PropertyGroup>
+
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/pkg/projects/netstandard/pkg/NETStandard.Library.Ref.pkgproj
+++ b/src/pkg/projects/netstandard/pkg/NETStandard.Library.Ref.pkgproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
 
   <PropertyGroup>
-    <!-- .NET Standard has no platforms.-->
+    <!-- .NET Standard has no shared framework, so there is no data for a platform manifest. -->
     <PlatformManifestTargetPath />
   </PropertyGroup>
 

--- a/src/pkg/projects/netstandard/pkg/dir.props
+++ b/src/pkg/projects/netstandard/pkg/dir.props
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <IsFrameworkPackage>true</IsFrameworkPackage>
+    <ShortFrameworkName>netstandard</ShortFrameworkName>
+    <ProductBrandPrefix>Microsoft .NET Standard</ProductBrandPrefix>
+  </PropertyGroup>
+
+  <Import Project="..\..\dir.props" />
+
+  <PropertyGroup>
+    <FrameworkListName>.NET Standard 2.1</FrameworkListName>
+    <FrameworkListTargetFrameworkIdentifier>.NETStandard</FrameworkListTargetFrameworkIdentifier>
+    <FrameworkListTargetFrameworkVersion>2.1</FrameworkListTargetFrameworkVersion>
+    <FrameworkListFrameworkName>NETStandard.Library</FrameworkListFrameworkName>
+  </PropertyGroup>
+
+  <!-- Redistribute package content from other nuget packages. -->
+  <ItemGroup>
+    <ProjectReference Include="..\src\netstandard.depproj">
+      <AdditionalProperties Condition="'$(PackageTargetRuntime)' != ''">NuGetRuntimeIdentifier=$(PackageTargetRuntime)</AdditionalProperties>
+    </ProjectReference>
+  </ItemGroup>
+</Project>

--- a/src/pkg/projects/netstandard/pkg/dir.props
+++ b/src/pkg/projects/netstandard/pkg/dir.props
@@ -4,6 +4,9 @@
     <IsFrameworkPackage>true</IsFrameworkPackage>
     <ShortFrameworkName>netstandard</ShortFrameworkName>
     <ProductBrandPrefix>Microsoft .NET Standard</ProductBrandPrefix>
+
+    <ProductBandVersion>2.1</ProductBandVersion>
+    <ProductionVersion>$(ProductBandVersion).0</ProductionVersion>
   </PropertyGroup>
 
   <Import Project="..\..\dir.props" />

--- a/src/pkg/projects/netstandard/src/netstandard.depproj
+++ b/src/pkg/projects/netstandard/src/netstandard.depproj
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" DefaultTargets="Build">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+
+  <PropertyGroup>
+    <NETStandardTargetFramework>netstandard2.1</NETStandardTargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="$(NETStandardLibraryPackage)" Version="$(NETStandardLibraryPackageVersion)" />
+  </ItemGroup>
+
+  <!--
+    Redistribute files from the netstandard package's build/ dir. When this project consumes a 
+    transport package from dotnet/standard with ref assemblies in ref/netstandard2.1, this target
+    can be removed.
+  -->
+  <Target Name="GetNETStandardRefFilesToPackage"
+          BeforeTargets="GetFilesToPackage">
+    <ItemGroup>
+      <FilesToPackage
+        Include="$(PackagesDir)$(NETStandardLibraryPackage.ToLowerInvariant())\$(NETStandardLibraryPackageVersion)\build\$(NETStandardTargetFramework)\ref\*"
+        TargetPath="ref/$(NETStandardTargetFramework)" />
+    </ItemGroup>
+  </Target>
+
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/pkg/projects/packaging-tools/framework.dependency.targets
+++ b/src/pkg/projects/packaging-tools/framework.dependency.targets
@@ -33,7 +33,7 @@
     </ItemGroup>
 
     <!-- Add versions file with the hashes of the repos we consume -->
-    <ItemGroup>
+    <ItemGroup Condition="'$(FrameworkPackageName)' != ''">
       <FilesToPackage Include="$(IntermediateOutputPath)\$(FrameworkPackageName).versions.txt">
         <TargetPath></TargetPath>
       </FilesToPackage>
@@ -59,7 +59,9 @@
   </Target>
 
   <!-- Creates the *.versions.txt file describing where data in this package came from. -->
-  <Target Name="GenerateHashVersionsFile" DependsOnTargets="GetDependencyVersionFiles">
+  <Target Name="GenerateHashVersionsFile"
+          DependsOnTargets="GetDependencyVersionFiles"
+          Condition="'$(FrameworkPackageName)' != ''">
     <Error
       Condition="!Exists('%(DependencyVersionFile.Identity)')"
       Text="'%(Name)' version file does not exist: %(Identity)" />

--- a/src/pkg/projects/packaging-tools/framework.packaging.targets
+++ b/src/pkg/projects/packaging-tools/framework.packaging.targets
@@ -187,7 +187,7 @@
       <_wixArgs>$(_wixArgs) -dMicrosoftEula="$(MicrosoftEulaFile)"</_wixArgs>
       <_wixArgs>$(_wixArgs) -dProductMoniker="$(TargetingPackBrandName)"</_wixArgs>
       <_wixArgs>$(_wixArgs) -dBuildVersion="$(MsiVersionString)"</_wixArgs>
-      <_wixArgs>$(_wixArgs) -dNugetVersion="$(SharedFrameworkNugetVersion)"</_wixArgs>
+      <_wixArgs>$(_wixArgs) -dNugetVersion="$(ProductVersion)"</_wixArgs>
       <_wixArgs>$(_wixArgs) -dTargetArchitecture="$(TargetArchitecture)"</_wixArgs>
       <_wixArgs>$(_wixArgs) -dUpgradeCode="$(UpgradeCode)"</_wixArgs>
       <_wixArgs>$(_wixArgs) -dDependencyKeyName="$(InstallerName.Replace('-', '_'))"</_wixArgs>
@@ -234,7 +234,7 @@
       <_pkgArgs></_pkgArgs>
       <_pkgArgs>$(_pkgArgs) --root $(PackLayoutDir)</_pkgArgs>
       <_pkgArgs>$(_pkgArgs) --identifier $(MacOSComponentName)</_pkgArgs>
-      <_pkgArgs>$(_pkgArgs) --version $(SharedFrameworkNugetVersion)</_pkgArgs>
+      <_pkgArgs>$(_pkgArgs) --version $(ProductVersion)</_pkgArgs>
       <_pkgArgs>$(_pkgArgs) --install-location $(MacOSSharedInstallDir)</_pkgArgs>
       <_pkgArgs>$(_pkgArgs) $(InstallerFile)</_pkgArgs>
     </PropertyGroup>

--- a/src/pkg/projects/packaging-tools/packaging-tools.props
+++ b/src/pkg/projects/packaging-tools/packaging-tools.props
@@ -52,7 +52,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <VersionedInstallerName>$(InstallerName)-$(PackageNameSuffix)</VersionedInstallerName>
+    <VersionedInstallerName>$(InstallerName)-$(ProductBandVersion)</VersionedInstallerName>
     <VersionedInstallerName>$(VersionedInstallerName.ToLowerInvariant())</VersionedInstallerName>
     <InstallerPackageRelease>1</InstallerPackageRelease>
 

--- a/src/pkg/projects/packaging-tools/packaging-tools.props
+++ b/src/pkg/projects/packaging-tools/packaging-tools.props
@@ -22,7 +22,7 @@
     <BuildRuntimePackages>false</BuildRuntimePackages>
 
     <PackageType>DotnetPlatform</PackageType>
-    <Version>$(SharedFrameworkNugetVersion)</Version>
+    <Version>$(ProductVersion)</Version>
 
     <!-- Include the platform manifest in the data dir. -->
     <PlatformManifestTargetPath>data/PlatformManifest.txt</PlatformManifestTargetPath>
@@ -41,7 +41,7 @@
 
     <InstallerName>$(ShortFrameworkName)-targeting-pack</InstallerName>
 
-    <MacOSComponentName>com.microsoft.$(ShortFrameworkName).pack.$(FrameworkPackType).$(SharedFrameworkNuGetVersion).component.osx.x64</MacOSComponentName>
+    <MacOSComponentName>com.microsoft.$(ShortFrameworkName).pack.$(FrameworkPackType).$(ProductVersion).component.osx.x64</MacOSComponentName>
     <MacOSSharedInstallDir>/usr/local/share/dotnet</MacOSSharedInstallDir>
   </PropertyGroup>
 
@@ -73,7 +73,7 @@
 
     <InstallerBuildPart>$(ProductMoniker)</InstallerBuildPart>
     <InstallerBuildPart Condition="'$(InstallerExtension)' == '.deb' or '$(InstallerExtension)' == '.rpm'"
-      >$(SharedFrameworkNugetVersion)-$(TargetArchitecture)</InstallerBuildPart>
+      >$(ProductVersion)-$(TargetArchitecture)</InstallerBuildPart>
 
     <!-- Location to place the installer, in bin. -->
     <InstallerFileNameWithoutExtension>$(InstallerName)-$(InstallerBuildPart)</InstallerFileNameWithoutExtension>
@@ -81,7 +81,7 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(IsFrameworkPackage)' == 'true'">
-    <Version>$(SharedFrameworkNugetVersion)</Version>
+    <Version>$(ProductVersion)</Version>
     <OmitDependencies>true</OmitDependencies>
     <SkipValidatePackage>true</SkipValidatePackage>
   </PropertyGroup>


### PR DESCRIPTION
Resolves https://github.com/dotnet/core-setup/issues/5066.

Example nupkg:
~[NETStandard.Library.Ref.3.0.0-preview4-27522-0.zip](https://github.com/dotnet/core-setup/files/2998387/NETStandard.Library.Ref.3.0.0-preview4-27522-0.zip)~
[NETStandard.Library.Ref.2.1.0-preview4-27522-0.zip](https://github.com/dotnet/core-setup/files/2998481/NETStandard.Library.Ref.2.1.0-preview4-27522-0.zip)


The MSI, macOS component pkg, and Linux packages are built too. (No standalone installers yet.)

/cc @wtgodbe @johnbeisner @dsplaisted @nguerrera 