### PR TITLE
Add "Internal implementation package" notice to Targeting Pack nupkg description

### DIFF
--- a/src/pkg/projects/packaging-tools/framework.packaging.targets
+++ b/src/pkg/projects/packaging-tools/framework.packaging.targets
@@ -383,6 +383,22 @@
       Include="@(TargetingPackDataEntries)" />
   </Target>
 
+  <!--
+    Add note to Targeting Pack nupkg description that this package shouldn't be referenced directly.
+    The packaging tooling normally only adds this to runtime packages.
+  -->
+  <Target Name="AddTargetingPackNuGetDescriptionInternalNotice"
+          AfterTargets="GetPackageDescription"
+          Condition="'$(FrameworkPackType)' == 'targeting'">
+    <GetPackageDescription DescriptionFile="$(PackageDescriptionFile)" PackageId="RuntimePackage">
+      <Output TaskParameter="Description" PropertyName="RuntimeDisclaimer" />
+    </GetPackageDescription>
+
+    <PropertyGroup>
+      <Description>$(RuntimeDisclaimer) %0A$(Description)</Description>
+    </PropertyGroup>
+  </Target>
+
   <!-- Target overrides (can't be shared with other package projects) -->
 
   <Target Name="GetPackageReport" />


### PR DESCRIPTION
Fixes https://github.com/dotnet/core-setup/issues/5107

Adds the `Internal implementation package not meant for direct consumption. Please do not reference directly.` line to the Targeting Pack nupkg's description. I copied the `GetPackageDescription` task out from the `GetPackageDescription` target (buildtools packaging infra) to grab the string from `descriptions.json`.