### PR TITLE
Publish Microsoft.Dotnet.Build.Bundle package

### DIFF
--- a/src/managed/CommonManaged.props
+++ b/src/managed/CommonManaged.props
@@ -24,7 +24,7 @@
     <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
   </PropertyGroup>
 
-  <PropertyGroup Condition=" '$(TargetFramework)' != 'netstandard2.0' ">
+  <PropertyGroup Condition=" '$(TargetFramework)' != 'netstandard2.0' And '$(TargetFramework)' != 'netcoreapp2.0' ">
     <DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences>
   </PropertyGroup>
 

--- a/src/managed/Microsoft.DotNet.Build.Bundle/FileEntry.cs
+++ b/src/managed/Microsoft.DotNet.Build.Bundle/FileEntry.cs
@@ -14,7 +14,7 @@ namespace Microsoft.DotNet.Build.Bundle
     /// file embedded in the bundle:
     /// * Type       (1 byte)
     /// * NameLength (7-bit extension encoding, typically 1 byte)
-    /// * Name       (<NameLength> Bytes)
+    /// * Name       ("NameLength" Bytes)
     /// * Offset     (Int64)
     /// * Size       (Int64)
     /// </summary>

--- a/src/managed/Microsoft.DotNet.Build.Bundle/Microsoft.DotNet.Build.Bundle.csproj
+++ b/src/managed/Microsoft.DotNet.Build.Bundle/Microsoft.DotNet.Build.Bundle.csproj
@@ -1,9 +1,15 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp2.0</TargetFramework>
+    <Description>.Net Core Single File Bundler</Description>
   </PropertyGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), CommonManaged.props))\CommonManaged.props" />
+  
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <DefineConstants>DEBUG</DefineConstants>
   </PropertyGroup>
 </Project>
+
+

--- a/src/managed/Microsoft.DotNet.Build.Bundle/Microsoft.DotNet.Build.Bundle.csproj
+++ b/src/managed/Microsoft.DotNet.Build.Bundle/Microsoft.DotNet.Build.Bundle.csproj
@@ -5,11 +5,16 @@
     <TargetFramework>netcoreapp2.0</TargetFramework>
     <Description>.Net Core Single File Bundler</Description>
   </PropertyGroup>
+
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), CommonManaged.props))\CommonManaged.props" />
-  
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <DefineConstants>DEBUG</DefineConstants>
-  </PropertyGroup>
+
+  <ItemGroup>
+    <Content Include="Sdk.props">
+      <Pack>true</Pack>
+      <PackagePath>Sdk</PackagePath>
+    </Content>
+  </ItemGroup>
+
 </Project>
 
 

--- a/src/managed/Microsoft.DotNet.Build.Bundle/Sdk.props
+++ b/src/managed/Microsoft.DotNet.Build.Bundle/Sdk.props
@@ -1,0 +1,18 @@
+<!--
+***********************************************************************************************
+Sdk.props
+
+WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and have
+          created a backup copy.  Incorrect changes to this file will make it
+          impossible to load or build your projects from the command-line or the IDE.
+
+Copyright (c) .NET Foundation. All rights reserved.
+***********************************************************************************************
+-->
+<Project ToolsVersion="14.0">
+
+  <PropertyGroup>
+    <MicrosoftDotnetBundle>$(MSBuildThisFileDirectory)..\lib\netcoreapp2.0\Microsoft.DotNet.Build.Bundle.dll</MicrosoftDotnetBundle>
+  </PropertyGroup>
+
+</Project>

--- a/src/pkg/packaging/dir.proj
+++ b/src/pkg/packaging/dir.proj
@@ -176,6 +176,7 @@
       <!-- The list of packages we are servicing -->
       <PackageProjects Include="$(ProjectDir)src\managed\Microsoft.DotNet.PlatformAbstractions\Microsoft.DotNet.PlatformAbstractions.csproj" />
       <PackageProjects Include="$(ProjectDir)src\managed\Microsoft.Extensions.DependencyModel\Microsoft.Extensions.DependencyModel.csproj" />
+      <PackageProjects Include="$(ProjectDir)src\managed\Microsoft.DotNet.Build.Bundle\Microsoft.DotNet.Build.Bundle.csproj" />
     </ItemGroup>
 
     <ItemGroup Condition="'$(BuildAllPackages)' == 'true'">


### PR DESCRIPTION
This change publishes the Bundle tool as a package for consumption in the toolset/sdk repos.

The changes are:
* Enable package publishing for the Bundler
* Add a property in sdk.props so help find the tool easily from the MSBuild tooling
  (similar to https://github.com/mono/linker/pull/487/files)

