### PR TITLE
Fix framework ordering if graphs

### DIFF
--- a/src/corehost/cli/fxr/fx_muxer.cpp
+++ b/src/corehost/cli/fxr/fx_muxer.cpp
@@ -1201,12 +1201,8 @@ int fx_muxer_t::read_framework(
                 break; // Error or retry case
             }
 
-            fx_reference_t& newest_ref = newest_references[fx_name];
-            if (fx_ref.get_fx_version_number() == newest_ref.get_fx_version_number())
-            {
-                // Success but move it to the back (without calling dtors) so that lower-level frameworks come last including Microsoft.NetCore.App
-                std::rotate(existing_framework, existing_framework + 1, fx_definitions.end());
-            }
+            // Success but move it to the back (without calling dtors) so that lower-level frameworks come last including Microsoft.NetCore.App
+            std::rotate(existing_framework, existing_framework + 1, fx_definitions.end());
         }
     }
 

--- a/src/test/HostActivationTests/FrameworkResolution/MultipleFrameworks.cs
+++ b/src/test/HostActivationTests/FrameworkResolution/MultipleFrameworks.cs
@@ -60,13 +60,13 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.FrameworkResolution
         // the inner framework reference .
         [Theory]
         [InlineData("5.0.0", 0, null, null)]
-        //[InlineData("5.1.0", 0, null, "5.1.3")] https://github.com/dotnet/core-setup/issues/4947
+        [InlineData("5.1.0", 0, null, "5.1.3")]
         [InlineData("5.1.0", 0, false, null)]
         [InlineData("5.1.3", 0, false, "5.1.3")]
-        // [InlineData("5.0.0", null, null, "5.1.3")] https://github.com/dotnet/core-setup/issues/4947
-        // [InlineData("5.0.0", 1, null, "5.1.3")] https://github.com/dotnet/core-setup/issues/4947
+        [InlineData("5.0.0", null, null, "5.1.3")]
+        [InlineData("5.0.0", 1, null, "5.1.3")]
         [InlineData("1.0.0", 1, null, null)]
-        // [InlineData("1.0.0", 2, null, "5.1.3")] https://github.com/dotnet/core-setup/issues/4947
+        [InlineData("1.0.0", 2, null, "5.1.3")]
         public void SoftRollForward_InnerFrameworkReference_ToLower_HardResolve(
             string versionReference,
             int? rollForwardOnNoCandidateFx,
@@ -116,7 +116,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.FrameworkResolution
         // and only then the soft roll forward to the inner reference is performed. So the hard resolved version
         // is use in the soft roll forward.
         [Theory]
-        // [InlineData("5.4.0", null, null, "5.4.1")] https://github.com/dotnet/core-setup/issues/4947
+        [InlineData("5.4.0", null, null, "5.4.1")]
         [InlineData("6.0.0", null, null, null)]
         public void SoftRollForward_InnerFrameworkReference_ToHigher_HardResolve(
             string versionReference,
@@ -141,11 +141,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.FrameworkResolution
         // Soft roll forward from app's 5.1.1 (defaults) to inner framework reference with [specified version]
         [Theory]
         [InlineData("6.0.0", null, null)]    // Can't roll forward from release to pre-release
-
-        // This fails due to bug https://github.com/dotnet/core-setup/issues/4947
-        // It should be possible to roll forward from pre-release to pre-release, but the bug causes wrong framework order
-        // and inability to resolve hostpolicy.
-        // [InlineData("6.0.1-preview.0", null, "6.0.1-preview.1")]
+        [InlineData("6.0.1-preview.0", null, "6.0.1-preview.1")]
         public void SoftRollForward_InnerFrameworkReference_PreRelease(
             string versionReference,
             int? rollForwardOnNoCandidateFx,
@@ -221,12 +217,12 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.FrameworkResolution
         // Soft roll forward inner framework reference (defaults) to inner framework reference with [specified version]
         [Theory]
         [InlineData("5.0.0", 0,    null,  null)]
-        // [InlineData("5.1.0", 0,    null,  "5.1.3")] https://github.com/dotnet/core-setup/issues/4947
+        [InlineData("5.1.0", 0,    null,  "5.1.3")]
         [InlineData("5.1.0", 0,    false, null)]
-        // [InlineData("5.0.0", null, null,  "5.1.3")] https://github.com/dotnet/core-setup/issues/4947
-        // [InlineData("5.0.0", 1,    null,  "5.1.3")] https://github.com/dotnet/core-setup/issues/4947
+        [InlineData("5.0.0", null, null,  "5.1.3")]
+        [InlineData("5.0.0", 1,    null,  "5.1.3")]
         [InlineData("1.0.0", 1,    null,  null)]
-        // [InlineData("1.0.0", 2,    null,  "5.1.3")] https://github.com/dotnet/core-setup/issues/4947
+        [InlineData("1.0.0", 2,    null,  "5.1.3")]
         public void SoftRollForward_InnerToInnerFrameworkReference_ToLower(
             string versionReference,
             int? rollForwardOnNoCandidateFx,
@@ -254,7 +250,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.FrameworkResolution
 
         // Soft roll forward inner framework reference (defaults) to inner framework reference with [specified version]
         [Theory]
-        // [InlineData("5.4.0", null, null, "5.4.1")] https://github.com/dotnet/core-setup/issues/4947
+        [InlineData("5.4.0", null, null, "5.4.1")]
         [InlineData("6.0.0", null, null, null)]
         public void SoftRollForward_InnerToInnerFrameworkReference_ToHigher(
             string versionReference,


### PR DESCRIPTION
If both the app and framework (for example ASP.NET) have dependency on the root Microsoft.NETCore.App and these references are for different versions the product may not find `hostpolicy`.

The problem happens if the framework (ASP.NET for example) has a reference to lower (but still compatible) version to what the app has. In such case the app will resolve the framework and put it into the list. Then we process ASP.NET framework which gets added to the end of that list as well. And then we process references for ASP.NET, we find that the reference to NETCore.App is compatible with the one we already have (soft-roll-forward). In this case the NETCore.App should be moved to the end of the list (the list is ordered such that the root framework should be last), but the code used to only do that if the versions were an exact match.

The fix is to always move the dependent framework to the last position.

Tests we already added as part of the framework resolution test improvement, but commented out as they were failing. Just uncommenting the tests.

Fixes #4947 