### PR TITLE
FX resolution small cleanup

### DIFF
--- a/src/corehost/cli/fxr/fx_muxer.cpp
+++ b/src/corehost/cli/fxr/fx_muxer.cpp
@@ -1154,7 +1154,7 @@ StatusCode fx_muxer_t::soft_roll_forward(
 //     Frameworks are never updated in the list. If such operation is required, instead the function returns FrameworkCompatRetry
 //     and the caller will restart the framework resolution process (with new fx_definitions).
 // Return value
-//     Success - if all frameworks were successfully resolved and the final (disk resolved) frameworks are in the fx_definitions.
+//     Success - all frameworks were successfully resolved and the final (disk resolved) frameworks are in the fx_definitions.
 //     FrameworkCompatRetry - the resolution algorithm needs to restart as some of already processed references has changed.
 //     FrameworkCompatFailure - the resolution failed with unrecoverable error which is due to framework resolution algorithm itself.
 //     FrameworkMissingFailure - the resolution failed because the requested framework doesn't exist on disk.

--- a/src/corehost/cli/fxr/fx_muxer.h
+++ b/src/corehost/cli/fxr/fx_muxer.h
@@ -102,7 +102,7 @@ private:
         const fx_ver_t& specified,
         bool patch_roll_fwd,
         roll_fwd_on_no_candidate_fx_option roll_fwd_on_no_candidate_fx);
-    static int read_framework(
+    static StatusCode read_framework(
         const host_startup_info_t& host_info,
         const fx_reference_t& override_settings,
         const runtime_config_t& config,
@@ -114,12 +114,12 @@ private:
         const pal::string_t& oldest_requested_version,
         const pal::string_t& dotnet_dir);
     static void muxer_usage(bool is_sdk_present);
-    static int soft_roll_forward_helper(
+    static StatusCode soft_roll_forward_helper(
         const fx_reference_t& newer,
         const fx_reference_t& older,
         bool older_is_hard_roll_forward,
         fx_name_to_fx_reference_map_t& newest_references);
-    static int soft_roll_forward(
+    static StatusCode soft_roll_forward(
         const fx_reference_t existing_ref,
         bool current_is_hard_roll_forward,
         fx_name_to_fx_reference_map_t& newest_references);

--- a/src/corehost/cli/fxr/fx_muxer.h
+++ b/src/corehost/cli/fxr/fx_muxer.h
@@ -110,7 +110,7 @@ private:
         fx_name_to_fx_reference_map_t& newest_references,
         fx_name_to_fx_reference_map_t& oldest_references,
         fx_definition_vector_t& fx_definitions);
-    static StatusCode fx_muxer_t::resolve_frameworks_for_app(
+    static StatusCode resolve_frameworks_for_app(
         const host_startup_info_t& host_info,
         const fx_reference_t& override_settings,
         const runtime_config_t& app_config,

--- a/src/corehost/cli/fxr/fx_muxer.h
+++ b/src/corehost/cli/fxr/fx_muxer.h
@@ -11,6 +11,7 @@ struct host_startup_info_t;
 #include "fx_definition.h"
 #include "host_interface.h"
 #include "host_startup_info.h"
+#include "error_codes.h"
 
 const int Max_Framework_Resolve_Retries = 100;
 
@@ -108,6 +109,11 @@ private:
         const runtime_config_t& config,
         fx_name_to_fx_reference_map_t& newest_references,
         fx_name_to_fx_reference_map_t& oldest_references,
+        fx_definition_vector_t& fx_definitions);
+    static StatusCode fx_muxer_t::resolve_frameworks_for_app(
+        const host_startup_info_t& host_info,
+        const fx_reference_t& override_settings,
+        const runtime_config_t& app_config,
         fx_definition_vector_t& fx_definitions);
     static fx_definition_t* resolve_fx(
         const fx_reference_t& config,


### PR DESCRIPTION
Add comments to some of the framework resolution functions, to make the code more readable.
Rename some variables for them to make more sense.
Refactor small amount of code duplication.

No functional changes.