### PR TITLE
Use correct way to pin dependencies

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -9,12 +9,12 @@
       <Uri>https://github.com/dotnet/corefx</Uri>
       <Sha>d6a30736858f91b297fdd3ed4e3d1dfde67bdbdb</Sha>
     </Dependency>
-    <PinnedDependency Name="Microsoft.NETCore.Targets" Version="2.0.0">
+    <Dependency Name="Microsoft.NETCore.Targets" Version="2.0.0" Pinned="true">
       <Uri>https://github.com/dotnet/corefx</Uri>
-    </PinnedDependency>
-    <PinnedDependency Name="NETStandard.Library" Version="2.0.3">
+    </Dependency>
+    <Dependency Name="NETStandard.Library" Version="2.0.3" Pinned="true">
       <Uri>https://github.com/dotnet/standard</Uri>
-    </PinnedDependency>
+    </Dependency>
     <Dependency Name="Microsoft.NETCore.Runtime.CoreCLR" Version="3.0.0-preview4-27525-71">
       <Uri>https://github.com/dotnet/coreclr</Uri>
       <Sha>a593024b85a6e074770c88867491f4f30cc6fc8a</Sha>


### PR DESCRIPTION
Previous way....works? But only because the system wouldn't recognize it as a dependency