### PR TITLE
Improve .NET Shared Framework bundle installer accessibility

### DIFF
--- a/src/pkg/packaging/windows/sharedframework/bundle.thm
+++ b/src/pkg/packaging/windows/sharedframework/bundle.thm
@@ -81,9 +81,9 @@
         <Text X="0" Y="0" Width="660" Height="75" FontId="1" />
 
         <Text Name="SuccessHeader" X="11" Y="80"  Width="-11" Height="30" FontId="2" HideWhenDisabled="yes" DisablePrefix="yes">#(loc.SuccessHeader)</Text>
-        <Text Name="SuccessInstallHeader" X="160" Y="80" Width="400" Height="400" FontId="2" HideWhenDisabled="yes" DisablePrefix="yes">#(loc.SuccessInstallHeader)</Text>
-        <Text Name="SuccessRepairHeader" X="160" Y="80" Width="-11" Height="400" FontId="2" HideWhenDisabled="yes" DisablePrefix="yes">#(loc.SuccessRepairHeader)</Text>
-        <Text Name="SuccessUninstallHeader" X="160" Y="80" Width="-11" Height="400" FontId="2" HideWhenDisabled="yes" DisablePrefix="yes">#(loc.SuccessUninstallHeader)</Text>
+        <Text Name="SuccessInstallHeader" X="160" Y="80" Width="400" Height="30" FontId="2" HideWhenDisabled="yes" DisablePrefix="yes">#(loc.SuccessInstallHeader)</Text>
+        <Text Name="SuccessRepairHeader" X="160" Y="80" Width="-11" Height="30" FontId="2" HideWhenDisabled="yes" DisablePrefix="yes">#(loc.SuccessRepairHeader)</Text>
+        <Text Name="SuccessUninstallHeader" X="160" Y="80" Width="-11" Height="30" FontId="2" HideWhenDisabled="yes" DisablePrefix="yes">#(loc.SuccessUninstallHeader)</Text>
         <Button Name="LaunchButton" X="-91" Y="-11" Width="75" Height="23" TabStop="yes" FontId="0" HideWhenDisabled="yes">#(loc.SuccessLaunchButton)</Button>
         <Text Name="SuccessRestartText" X="-11" Y="-51" Width="400" Height="34" FontId="3" HideWhenDisabled="yes" DisablePrefix="yes">#(loc.SuccessRestartText)</Text>
         

--- a/src/pkg/packaging/windows/sharedframework/bundle.thm
+++ b/src/pkg/packaging/windows/sharedframework/bundle.thm
@@ -22,13 +22,13 @@
         <Image Name="BackgroundImage" X="0" Y="0" Width="620" Height="418" ImageFile="bg.png" />
         <Text X="0" Y="0" Width="660" Height="75" FontId="1" />
 
-        <Text Name="WelcomeText" X="155" Y="80" Width="-11" Height="-70" TabStop="no" FontId="2" HexStyle="0x800000" DisablePrefix="yes" />
-        <Text Name="WelcomeHeaderMessage" X="160" Y="81" Width="300" Height="30" TabStop="yes" FontId="2">#(loc.WelcomeHeaderMessage)</Text>
-        <Text Name="WelcomeDescription" X="160" Y="125" Width="460" Height="65" TabStop="yes" FontId="3">#(loc.WelcomeDescription)</Text>
-        <Text Name="LearnMoreTitle" X="160" Y="200" Width="460" Height="30" TabStop="yes" FontId="2">#(loc.LearnMoreTitle)</Text>
-        <Hypertext Name="WelcomeDocumentationLink" X="185" Y="238" Width="400" Height="22" FontId="3" HideWhenDisabled="yes" DisablePrefix="yes">#(loc.DocumentationLink)</Hypertext>
-        <Hypertext Name="PrivacyStatementLink" X="185" Y="259" Width="400" Height="22" FontId="3" HideWhenDisabled="yes" DisablePrefix="yes">#(loc.PrivacyStatementLink)</Hypertext>
-        <Hypertext Name="EulaLink" X="185" Y="281" Width="400" Height="22" FontId="3" HideWhenDisabled="yes" DisablePrefix="yes">#(loc.EulaLink)</Hypertext>
+        <Text Name="WelcomeText" X="155" Y="80" Width="-11" Height="-70" FontId="2" HexStyle="0x800000" DisablePrefix="yes" />
+        <Text Name="WelcomeHeaderMessage" X="160" Y="81" Width="300" Height="30" FontId="2">#(loc.WelcomeHeaderMessage)</Text>
+        <Text Name="WelcomeDescription" X="160" Y="125" Width="460" Height="65" FontId="3">#(loc.WelcomeDescription)</Text>
+        <Text Name="LearnMoreTitle" X="160" Y="200" Width="460" Height="30" FontId="2">#(loc.LearnMoreTitle)</Text>
+        <Hypertext Name="WelcomeDocumentationLink" X="185" Y="238" Width="400" Height="22" FontId="3" TabStop="yes" HideWhenDisabled="yes" DisablePrefix="yes">#(loc.DocumentationLink)</Hypertext>
+        <Hypertext Name="PrivacyStatementLink" X="185" Y="259" Width="400" Height="22" FontId="3" TabStop="yes" HideWhenDisabled="yes" DisablePrefix="yes">#(loc.PrivacyStatementLink)</Hypertext>
+        <Hypertext Name="EulaLink" X="185" Y="281" Width="400" Height="22" FontId="3" TabStop="yes" HideWhenDisabled="yes" DisablePrefix="yes">#(loc.EulaLink)</Hypertext>
         <Button Name="InstallButton" X="-91" Y="-11" Width="75" Height="23" TabStop="yes" FontId="0">#(loc.InstallInstallButton)</Button>
         <Button Name="WelcomeCancelButton" X="-11" Y="-11" Width="75" Height="23" TabStop="yes" FontId="0">#(loc.InstallCloseButton)</Button>
     </Page>
@@ -90,10 +90,10 @@
          <Text Name="SuccessInstallLocation" X="160" Y="130" Width="400" Height="20" FontId="3" HideWhenDisabled="yes" DisablePrefix="yes">#(loc.SuccessInstallLocation)</Text>
          <Text Name="SuccessInstallProductName" X="185" Y="155" Width="400" Height="30" FontId="3" HideWhenDisabled="yes" DisablePrefix="yes">#(loc.SuccessInstallProductName)</Text>
          <Text Name="SuccessInstallResourcesHeader" X="160" Y="195" Width="400" Height="30" FontId="2" HideWhenDisabled="yes" DisablePrefix="yes">#(loc.ResourcesHeader)</Text>
-         <Hypertext Name="DocumentationLink" X="185" Y="238" Width="400" Height="22" FontId="3" HideWhenDisabled="yes" DisablePrefix="yes">#(loc.DocumentationLink)</Hypertext>
-         <Hypertext Name="RelaseNotesLink" X="185" Y="259" Width="400" Height="22" FontId="3" HideWhenDisabled="yes" DisablePrefix="yes">#(loc.RelaseNotesLink)</Hypertext>
-         <Hypertext Name="TutorialLink" X="185" Y="280" Width="400" Height="22" FontId="3" HideWhenDisabled="yes" DisablePrefix="yes">#(loc.TutorialLink)</Hypertext>
-         <Hypertext Name="TelemetryLink" X="185" Y="301" Width="400" Height="22" FontId="3" HideWhenDisabled="yes" DisablePrefix="yes">#(loc.TelemetryLink)</Hypertext>
+         <Hypertext Name="DocumentationLink" X="185" Y="238" Width="400" Height="22" FontId="3" TabStop="yes" HideWhenDisabled="yes" DisablePrefix="yes">#(loc.DocumentationLink)</Hypertext>
+         <Hypertext Name="RelaseNotesLink" X="185" Y="259" Width="400" Height="22" FontId="3" TabStop="yes" HideWhenDisabled="yes" DisablePrefix="yes">#(loc.RelaseNotesLink)</Hypertext>
+         <Hypertext Name="TutorialLink" X="185" Y="280" Width="400" Height="22" FontId="3" TabStop="yes" HideWhenDisabled="yes" DisablePrefix="yes">#(loc.TutorialLink)</Hypertext>
+         <Hypertext Name="TelemetryLink" X="185" Y="301" Width="400" Height="22" FontId="3" TabStop="yes" HideWhenDisabled="yes" DisablePrefix="yes">#(loc.TelemetryLink)</Hypertext>
         
         <Button Name="SuccessRestartButton" X="-91" Y="-11" Width="75" Height="23" TabStop="yes" FontId="0" HideWhenDisabled="yes">#(loc.SuccessRestartButton)</Button>
         <Button Name="SuccessCancelButton" X="-11" Y="-11" Width="75" Height="23" TabStop="yes" FontId="0">#(loc.SuccessCloseButton)</Button>

--- a/src/pkg/packaging/windows/sharedframework/bundle.thm
+++ b/src/pkg/packaging/windows/sharedframework/bundle.thm
@@ -8,21 +8,21 @@
     <Font Id="4" Height="-12" Weight="500" Foreground="ff0000" Background="FFFFFF" Underline="yes">Segoe UI</Font>
     <Font Id="5" Height="-14" Weight="500" Foreground="444444">Segoe UI</Font>
 
-    <Text X="11" Y="11" Width="-11" Height="64" FontId="1" Visible="yes" Center="yes" DisablePrefix="yes">#(loc.Title)</Text>
+    <Text Name="Title" X="11" Y="11" Width="-11" Height="64" FontId="1" Visible="yes" Center="yes" DisablePrefix="yes">#(loc.Title)</Text>
 
     <Page Name="Help">
         <Text X="0" Y="0" Width="620" Height="75" FontId="1" />
 
-        <Text X="11" Y="80" Width="-11" Height="30" FontId="2" DisablePrefix="yes">#(loc.HelpHeader)</Text>
-        <Text X="20" Y="115" Width="-11" Height="-35" FontId="3" DisablePrefix="yes">#(loc.HelpText)</Text>
+        <Text Name="HelpHeader" X="11" Y="80" Width="-11" Height="30" FontId="2" DisablePrefix="yes">#(loc.HelpHeader)</Text>
+        <Text Name="HelpText" X="20" Y="115" Width="-11" Height="-35" FontId="3" DisablePrefix="yes">#(loc.HelpText)</Text>
         <Button Name="HelpCancelButton" X="-11" Y="-11" Width="75" Height="23" TabStop="yes" FontId="0">#(loc.HelpCloseButton)</Button>
-        <Image X="0" Y="0" Width="620" Height="418" ImageFile="bg.png" />
+        <Image Name="BackgroundImage" X="0" Y="0" Width="620" Height="418" ImageFile="bg.png" />
     </Page>
     <Page Name="Install">
-        <Image X="0" Y="0" Width="620" Height="418" ImageFile="bg.png" />
+        <Image Name="BackgroundImage" X="0" Y="0" Width="620" Height="418" ImageFile="bg.png" />
         <Text X="0" Y="0" Width="660" Height="75" FontId="1" />
 
-        <Text X="155" Y="80" Width="-11" Height="-70" TabStop="no" FontId="2" HexStyle="0x800000" DisablePrefix="yes" />
+        <Text Name="WelcomeText" X="155" Y="80" Width="-11" Height="-70" TabStop="no" FontId="2" HexStyle="0x800000" DisablePrefix="yes" />
         <Text Name="WelcomeHeaderMessage" X="160" Y="81" Width="300" Height="30" TabStop="yes" FontId="2">#(loc.WelcomeHeaderMessage)</Text>
         <Text Name="WelcomeDescription" X="160" Y="125" Width="460" Height="65" TabStop="yes" FontId="3">#(loc.WelcomeDescription)</Text>
         <Text Name="LearnMoreTitle" X="160" Y="200" Width="460" Height="30" TabStop="yes" FontId="2">#(loc.LearnMoreTitle)</Text>
@@ -46,38 +46,38 @@
     <Page Name="FilesInUse">
         <Text X="0" Y="0" Width="660" Height="75" FontId="1" />
 
-      <Text X="11" Y="80" Width="-11" Height="30" FontId="2" DisablePrefix="yes">#(loc.FilesInUseHeader)</Text>
-      <Text X="11" Y="121" Width="-11" Height="34" FontId="3" DisablePrefix="yes">#(loc.FilesInUseLabel)</Text>
-      <Text Name="FilesInUseText" X="11" Y="150" Width="-11" Height="-86" FontId="3" DisablePrefix="yes" HexStyle="0x0000000C"></Text>
+        <Text Name="FilesInUseHeader" X="11" Y="80" Width="-11" Height="30" FontId="2" DisablePrefix="yes">#(loc.FilesInUseHeader)</Text>
+        <Text Name="FilesInUseLabel" X="11" Y="121" Width="-11" Height="34" FontId="3" DisablePrefix="yes">#(loc.FilesInUseLabel)</Text>
+        <Text Name="FilesInUseText" X="11" Y="150" Width="-11" Height="-86" FontId="3" DisablePrefix="yes" HexStyle="0x0000000C"></Text>
 
-      <Button Name="FilesInUseCloseRadioButton" X="300" Y="-65" Width="-11" Height="23" TabStop="yes" FontId="0" HideWhenDisabled="yes" HexStyle="0x000009">#(loc.FilesInUseCloseRadioButton)</Button>
-      <Button Name="FilesInUseDontCloseRadioButton" X="300" Y="-45" Width="-11" Height="23" TabStop="yes" FontId="0" HideWhenDisabled="yes" HexStyle="0x000009">#(loc.FilesInUseDontCloseRadioButton)</Button>
+        <Button Name="FilesInUseCloseRadioButton" X="300" Y="-65" Width="-11" Height="23" TabStop="yes" FontId="0" HideWhenDisabled="yes" HexStyle="0x000009">#(loc.FilesInUseCloseRadioButton)</Button>
+        <Button Name="FilesInUseDontCloseRadioButton" X="300" Y="-45" Width="-11" Height="23" TabStop="yes" FontId="0" HideWhenDisabled="yes" HexStyle="0x000009">#(loc.FilesInUseDontCloseRadioButton)</Button>
 
-      <Button Name="FilesInUseOkButton" X="-91" Y="-11" Width="75" Height="23" TabStop="yes" FontId="0" HideWhenDisabled="yes">#(loc.FilesInUseOkButton)</Button>
-      <Button Name="FilesInUseCancelButton" X="-11" Y="-11" Width="75" Height="23" TabStop="yes" FontId="0">#(loc.FilesInUseCancelButton)</Button>
-      <Image X="0" Y="0" Width="620" Height="418" ImageFile="bg.png" />
+        <Button Name="FilesInUseOkButton" X="-91" Y="-11" Width="75" Height="23" TabStop="yes" FontId="0" HideWhenDisabled="yes">#(loc.FilesInUseOkButton)</Button>
+        <Button Name="FilesInUseCancelButton" X="-11" Y="-11" Width="75" Height="23" TabStop="yes" FontId="0">#(loc.FilesInUseCancelButton)</Button>
+        <Image Name="BackgroundImage" X="0" Y="0" Width="620" Height="418" ImageFile="bg.png" />
     </Page>
     <Page Name="Progress">
-        <Image X="0" Y="0" Width="620" Height="418" ImageFile="bg.png" />
+        <Image Name="BackgroundImage" X="0" Y="0" Width="620" Height="418" ImageFile="bg.png" />
         <Text X="0" Y="0" Width="660" Height="75" FontId="1" />
 
-        <Text X="11" Y="80" Width="-11" Height="30" FontId="2" DisablePrefix="yes">#(loc.ProgressHeader)</Text>
-        <Text X="11" Y="121" Width="70" Height="17" FontId="3" DisablePrefix="yes">#(loc.ProgressLabel)</Text>
+        <Text Name="ProgressHeader" X="11" Y="80" Width="-11" Height="30" FontId="2" DisablePrefix="yes">#(loc.ProgressHeader)</Text>
+        <Text Name="ProgressLabel" X="11" Y="121" Width="70" Height="17" FontId="3" DisablePrefix="yes">#(loc.ProgressLabel)</Text>
         <Text Name="OverallProgressPackageText" X="85" Y="121" Width="-11" Height="17" FontId="3" DisablePrefix="yes">#(loc.OverallProgressPackageText)</Text>
         <Progressbar Name="OverallCalculatedProgressbar" X="11" Y="143" Width="-11" Height="15" />
         <Button Name="ProgressCancelButton" X="-11" Y="-11" Width="75" Height="23" TabStop="yes" FontId="0">#(loc.ProgressCancelButton)</Button>
     </Page>
     <Page Name="Modify">
-        <Image X="0" Y="0" Width="620" Height="418" ImageFile="bg.png" />
+        <Image Name="BackgroundImage" X="0" Y="0" Width="620" Height="418" ImageFile="bg.png" />
         <Text X="0" Y="0" Width="660" Height="75" FontId="1" />
 
-        <Text X="11" Y="80" Width="-11" Height="30" FontId="2" DisablePrefix="yes">#(loc.ModifyHeader)</Text>
+        <Text Name="ModifyHeader" X="11" Y="80" Width="-11" Height="30" FontId="2" DisablePrefix="yes">#(loc.ModifyHeader)</Text>
         <Button Name="RepairButton" X="-171" Y="-11" Width="75" Height="23" TabStop="yes" FontId="0" HideWhenDisabled="yes">#(loc.ModifyRepairButton)</Button>
         <Button Name="UninstallButton" X="-91" Y="-11" Width="75" Height="23" TabStop="yes" FontId="0">#(loc.ModifyUninstallButton)</Button>
         <Button Name="ModifyCancelButton" X="-11" Y="-11" Width="75" Height="23" TabStop="yes" FontId="0">#(loc.ModifyCloseButton)</Button>
     </Page>
     <Page Name="Success">
-        <Image X="0" Y="0" Width="620" Height="418" ImageFile="bg.png" />
+        <Image Name="BackgroundImage" X="0" Y="0" Width="620" Height="418" ImageFile="bg.png" />
         <Text X="0" Y="0" Width="660" Height="75" FontId="1" />
 
         <Text Name="SuccessHeader" X="11" Y="80"  Width="-11" Height="30" FontId="2" HideWhenDisabled="yes" DisablePrefix="yes">#(loc.SuccessHeader)</Text>
@@ -99,7 +99,7 @@
         <Button Name="SuccessCancelButton" X="-11" Y="-11" Width="75" Height="23" TabStop="yes" FontId="0">#(loc.SuccessCloseButton)</Button>
     </Page>
     <Page Name="Failure">
-        <Image X="0" Y="0" Width="620" Height="418" ImageFile="bg.png" />
+        <Image Name="BackgroundImage" X="0" Y="0" Width="620" Height="418" ImageFile="bg.png" />
         <Text X="0" Y="0" Width="660" Height="75" FontId="1" />
 
         <Text Name="FailureHeader" X="11" Y="80" Width="-11" Height="30" FontId="2" HideWhenDisabled="yes" DisablePrefix="yes">#(loc.FailureHeader)</Text>


### PR DESCRIPTION
Starts by porting over https://github.com/dotnet/core-sdk/pull/1012. Accessibility Insights also reported that some bounds didn't fit inside the parent. I also ran into some issues with tabbing that I fixed.

@johnbeisner I think the tab stops need to be ported to core-sdk, not sure if the bounds problem exists there too.

/cc @merriemcgaw @joeloff @livarcocc @dleeapho