### PR TITLE
Package Microsoft.DotNet.Build.Bundle as a tool

### DIFF
--- a/src/managed/Microsoft.DotNet.Build.Bundle/Microsoft.DotNet.Build.Bundle.csproj
+++ b/src/managed/Microsoft.DotNet.Build.Bundle/Microsoft.DotNet.Build.Bundle.csproj
@@ -4,6 +4,7 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp2.0</TargetFramework>
     <Description>.Net Core Single File Bundler</Description>
+    <IsTool>true</IsTool>
   </PropertyGroup>
 
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), CommonManaged.props))\CommonManaged.props" />

--- a/src/managed/Microsoft.DotNet.Build.Bundle/Sdk.props
+++ b/src/managed/Microsoft.DotNet.Build.Bundle/Sdk.props
@@ -12,7 +12,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 <Project ToolsVersion="14.0">
 
   <PropertyGroup>
-    <MicrosoftDotnetBundle>$(MSBuildThisFileDirectory)..\lib\netcoreapp2.0\Microsoft.DotNet.Build.Bundle.dll</MicrosoftDotnetBundle>
+    <MicrosoftDotnetBundle>$(MSBuildThisFileDirectory)..\tools\Microsoft.DotNet.Build.Bundle.dll</MicrosoftDotnetBundle>
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
Package Microsoft.DotNet.Build.Bundle as a tool similar to ILLink.Tasks
so that it can be consumed by the ToolSet repo.
(https://github.com/dotnet/toolset/pull/541)

Packaging the bundler as a lib causes version compatibility check failures.
