### PR TITLE
Revert "Use correct way to pin dependencies"

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -9,9 +9,9 @@
       <Uri>https://github.com/dotnet/corefx</Uri>
       <Sha>d6a30736858f91b297fdd3ed4e3d1dfde67bdbdb</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.Targets" Version="2.0.0" Pinned="true">
+    <PinnedDependency Name="Microsoft.NETCore.Targets" Version="2.0.0">
       <Uri>https://github.com/dotnet/corefx</Uri>
-    </Dependency>
+    </PinnedDependency>
     <Dependency Name="NETStandard.Library" Version="2.1.0-prerelease.19168.1">
       <Uri>https://github.com/dotnet/standard</Uri>
       <Sha>fc4a92712cff169e451bc097b2dc57590fd5de36</Sha>


### PR DESCRIPTION
Reverts dotnet/core-setup#5547

Seems to cause an official build failure:
https://dev.azure.com/dnceng/internal/_build/results?buildId=132798&view=logs

```
  Starting build metadata push to the Build Asset Registry...
  Getting a collection of dependencies from 'eng/Version.Details.xml' in repo 'F:/vsagent/7/s'...
  Reading 'eng/Version.Details.xml' in repo 'F:/vsagent/7/s' and branch ''...
  Reading 'eng/Version.Details.xml' from repo 'F:/vsagent/7/s' and branch '' succeeded!
F:\vsagent\7\s\.packages\microsoft.dotnet.arcade.sdk\1.0.0-beta.19171.6\tools\SdkTasks\PublishBuildAssets.proj(30,5): error : NullReferenceException: Object reference not set to an instance of an object.
F:\vsagent\7\s\.packages\microsoft.dotnet.arcade.sdk\1.0.0-beta.19171.6\tools\SdkTasks\PublishBuildAssets.proj(30,5): error :    at Microsoft.DotNet.DarcLib.GitFileManager.<GetDependencyDetails>g__BuildDependencies|30_0(XmlNodeList dependencies, <>c__DisplayClass30_0& ) in /_/src/Microsoft.DotNet.Darc/src/DarcLib/Helpers/GitFileManager.cs:line 770
F:\vsagent\7\s\.packages\microsoft.dotnet.arcade.sdk\1.0.0-beta.19171.6\tools\SdkTasks\PublishBuildAssets.proj(30,5): error :    at Microsoft.DotNet.DarcLib.GitFileManager.GetDependencyDetails(XmlDocument document, String branch, Boolean includePinned) in /_/src/Microsoft.DotNet.Darc/src/DarcLib/Helpers/GitFileManager.cs:line 734
F:\vsagent\7\s\.packages\microsoft.dotnet.arcade.sdk\1.0.0-beta.19171.6\tools\SdkTasks\PublishBuildAssets.proj(30,5): error :    at Microsoft.DotNet.DarcLib.GitFileManager.ParseVersionDetailsXmlAsync(String repoUri, String branch, Boolean includePinned) in /_/src/Microsoft.DotNet.Darc/src/DarcLib/Helpers/GitFileManager.cs:line 86
F:\vsagent\7\s\.packages\microsoft.dotnet.arcade.sdk\1.0.0-beta.19171.6\tools\SdkTasks\PublishBuildAssets.proj(30,5): error :    at Microsoft.DotNet.DarcLib.Local.GetDependenciesAsync(String name, Boolean includePinned) in /_/src/Microsoft.DotNet.Darc/src/DarcLib/Actions/Local.cs:line 115
F:\vsagent\7\s\.packages\microsoft.dotnet.arcade.sdk\1.0.0-beta.19171.6\tools\SdkTasks\PublishBuildAssets.proj(30,5): error :    at Microsoft.DotNet.Maestro.Tasks.PushMetadataToBuildAssetRegistry.GetBuildDependenciesAsync(IMaestroApi client, CancellationToken cancellationToken) in /_/src/Maestro/Microsoft.DotNet.Maestro.Tasks/src/PushMetadataToBuildAssetRegistry.cs:line 103
F:\vsagent\7\s\.packages\microsoft.dotnet.arcade.sdk\1.0.0-beta.19171.6\tools\SdkTasks\PublishBuildAssets.proj(30,5): error :    at Microsoft.DotNet.Maestro.Tasks.PushMetadataToBuildAssetRegistry.PushMetadataAsync(CancellationToken cancellationToken) in /_/src/Maestro/Microsoft.DotNet.Maestro.Tasks/src/PushMetadataToBuildAssetRegistry.cs:line 76
F:\vsagent\7\s\.packages\microsoft.dotnet.arcade.sdk\1.0.0-beta.19171.6\tools\SdkTasks\PublishBuildAssets.proj(30,5): error : 

Build FAILED.
```