### PR TITLE
Use Pinned attribute for Microsoft.NETCore.Targets dependency

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -9,9 +9,10 @@
       <Uri>https://github.com/dotnet/corefx</Uri>
       <Sha>d6a30736858f91b297fdd3ed4e3d1dfde67bdbdb</Sha>
     </Dependency>
-    <PinnedDependency Name="Microsoft.NETCore.Targets" Version="2.0.0">
+    <Dependency Name="Microsoft.NETCore.Targets" Version="2.0.0" Pinned="true">
       <Uri>https://github.com/dotnet/corefx</Uri>
-    </PinnedDependency>
+      <Sha>8321c729934c0f8be754953439b88e6e1c120c24</Sha>
+    </Dependency>
     <Dependency Name="NETStandard.Library" Version="2.1.0-prerelease.19168.1">
       <Uri>https://github.com/dotnet/standard</Uri>
       <Sha>fc4a92712cff169e451bc097b2dc57590fd5de36</Sha>


### PR DESCRIPTION
Reapplies https://github.com/dotnet/core-setup/pull/5547 (reverted by https://github.com/dotnet/core-setup/pull/5557) after figuring out the official build error. (`Sha` was missing.)