### PR TITLE
Run tests on Windows jobs using '-test' alias

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -205,6 +205,7 @@ jobs:
   parameters:
     buildFullPlatformManifest: true
     displayName: Build_Windows_x86
+    skipTests: true
     targetArchitecture: x86
 
 - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:

--- a/eng/jobs/windows-build.yml
+++ b/eng/jobs/windows-build.yml
@@ -104,6 +104,13 @@ jobs:
       displayName: Build sharedframework layout
       condition: succeeded()
 
+    - ${{ if ne(parameters.skipTests, 'true') }}:
+      - script: build.cmd
+          -test
+          -- '$(CommonMSBuildArgs)
+          /bl:$(Build.SourcesDirectory)\test.binlog'
+        displayName: Test
+
     - ${{ if and(ne(parameters.displayName,'Build_Windows_x86'), ne(parameters.displayName,'Build_Windows_x64')) }}:
       - script: build.cmd -packaging
             -- '$(CommonMSBuildArgs)


### PR DESCRIPTION
Use new `-test` alias from https://github.com/dotnet/core-setup/pull/5564 to run tests on x86/x64 Windows jobs. They don't run on arm/arm64 Windows.