### PR TITLE
Bundler Test: Run using AppHost

### DIFF
--- a/src/test/Microsoft.DotNet.Build.Bundle.Tests/BundleAndExtract.cs
+++ b/src/test/Microsoft.DotNet.Build.Bundle.Tests/BundleAndExtract.cs
@@ -26,9 +26,11 @@ namespace Microsoft.DotNet.CoreSetup.Test.BundleTests.BundleExtract
 
             var dotnet = fixture.SdkDotnet;
             var appDll = fixture.TestProject.AppDll;
+            var hostName = Path.GetFileName(fixture.TestProject.AppExe);
+            var publishDir = fixture.TestProject.OutputDirectory;
 
             // Run the App normally
-            dotnet.Exec(appDll)
+           Command.Create(Path.Combine(publishDir, hostName))
                 .CaptureStdErr()
                 .CaptureStdOut()
                 .Execute()
@@ -37,7 +39,6 @@ namespace Microsoft.DotNet.CoreSetup.Test.BundleTests.BundleExtract
                 .And
                 .HaveStdOutContaining("Wow! We now say hello to the big world and you.");
 
-
             // Create a directory for bundle/extraction output.
             // This directory shouldn't be within TestProject.OutputDirectory, since the bundler
             // will (attempt to) embed all files below the TestProject.OutputDirectory tree into one file.
@@ -45,12 +46,11 @@ namespace Microsoft.DotNet.CoreSetup.Test.BundleTests.BundleExtract
             Directory.CreateDirectory(singleFileDir);
 
             // Bundle to a single-file
-            string hostName = Path.GetFileName(fixture.TestProject.AppExe);
             string bundleDll = Path.Combine(sharedTestState.RepoDirectories.Artifacts,
                                             "Microsoft.DotNet.Build.Bundle",
                                             "netcoreapp2.0",
                                             "Microsoft.DotNet.Build.Bundle.dll");
-            string[] bundleArgs = { "--source", fixture.TestProject.OutputDirectory,
+            string[] bundleArgs = { "--source", publishDir,
                                     "--apphost", hostName,
                                     "--output", singleFileDir };
 


### PR DESCRIPTION
The bundler test runs a self-contained-published test app twice:
once before and once after bundling.

The initial run (to sanity check the project) was done using
the dotnet host obtained from the SDK. However, the SDK dotnet seems
to be a X64 binary, which failed to run the test-app published for x86.
https://dev.azure.com/dnceng/public/_build/results?buildId=134281&view=logs

This change fixes the problem by invoking both runs using the published AppHost.
