### PR TITLE
Omit trailing path separator in TPA

### DIFF
--- a/src/corehost/cli/hostpolicy.cpp
+++ b/src/corehost/cli/hostpolicy.cpp
@@ -102,7 +102,6 @@ namespace
             }
 
             probe_paths.tpa.append(corelib_path);
-            probe_paths.tpa.push_back(PATH_SEPARATOR);
 
             pal::string_t clrjit_path = probe_paths.clrjit;
             if (clrjit_path.empty())

--- a/src/test/HostActivationTests/PortableAppActivation.cs
+++ b/src/test/HostActivationTests/PortableAppActivation.cs
@@ -363,6 +363,25 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
             }
         }
 
+        [Fact]
+        public void ComputedTPADoesntEndWithPathSeparator()
+        {
+            var fixture = sharedTestState.PortableAppFixture_Built
+                .Copy();
+
+            var dotnet = fixture.BuiltDotnet;
+            var appDll = fixture.TestProject.AppDll;
+
+            dotnet.Exec(appDll)
+                .EnvironmentVariable("COREHOST_TRACE", "1")
+                .CaptureStdErr()
+                .CaptureStdOut()
+                .Execute()
+                .Should().Pass()
+                .And.HaveStdErrMatching($"Property TRUSTED_PLATFORM_ASSEMBLIES = .*[^{Path.PathSeparator}]$", System.Text.RegularExpressions.RegexOptions.Multiline);
+        }
+
+
         private string MoveDepsJsonToSubdirectory(TestProjectFixture testProjectFixture)
         {
             var subdirectory = Path.Combine(testProjectFixture.TestProject.ProjectDirectory, "d");


### PR DESCRIPTION
In 2.* the trailing separator was removed by the runtime. After refactorings in the runtime it's no longer the case. This is technically a breaking change since in 2.* the `AppDomain.GetData("TRUSTED_PLATFORM_ASSEMBLIES")` returns string which doesn't have trailing path separator. In 3.0 it has.

It's cleaner to fix this in `hostpolicy` because there's no reason for runtime to "tweak" runtime property values before they are reported via `GetData`. TPA is not special in any way either. The trailing path separator serves no purpose anyway, so it's perfectly fine to remove it. And there's no reason to keep the change from 2.* in the codebase.

Fixes #5553 