### PR TITLE
Test on Windows x86 in CI

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -205,7 +205,6 @@ jobs:
   parameters:
     buildFullPlatformManifest: true
     displayName: Build_Windows_x86
-    skipTests: true
     targetArchitecture: x86
 
 - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:


### PR DESCRIPTION
Now that https://github.com/dotnet/core-setup/pull/5571 and https://github.com/dotnet/core-setup/pull/5574 are merged, re-enable Windows x86 tests in CI.