### PR TITLE
Depend on M.NC.Platforms 2.1.3 instead of 2.2.0

### DIFF
--- a/dependencies.props
+++ b/dependencies.props
@@ -16,7 +16,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <MicrosoftNETCorePlatformsPackageVersion>2.2.0</MicrosoftNETCorePlatformsPackageVersion>
+    <MicrosoftNETCorePlatformsPackageVersion>2.1.3</MicrosoftNETCorePlatformsPackageVersion>
     <MicrosoftNETCoreTargetsPackageVersion>2.0.0</MicrosoftNETCoreTargetsPackageVersion>
     <MicrosoftPrivateCoreFxNETCoreAppPackageVersion>4.5.220-servicing-27414-05</MicrosoftPrivateCoreFxNETCoreAppPackageVersion>
     <MicrosoftNETCoreRuntimeCoreCLRPackageVersion>2.2.3-servicing-27414-05</MicrosoftNETCoreRuntimeCoreCLRPackageVersion>
@@ -54,8 +54,14 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <!-- Depend on 2.2 CoreFx packages, except for M.NC.Platforms, where we depend on 2.1 -->
     <RemoteDependencyBuildInfo Include="CoreFx">
       <BuildInfoPath>$(BaseDotNetBuildInfo)corefx/$(DependencyBranch)</BuildInfoPath>
+      <CurrentRef>$(CoreFxCurrentRef)</CurrentRef>
+      <DisabledPackages>Microsoft.NETCore.Platforms</DisabledPackages>
+    </RemoteDependencyBuildInfo>
+    <RemoteDependencyBuildInfo Include="CoreFx">
+      <BuildInfoPath>$(BaseDotNetBuildInfo)corefx/release/2.1</BuildInfoPath>
       <CurrentRef>$(CoreFxCurrentRef)</CurrentRef>
     </RemoteDependencyBuildInfo>
     <RemoteDependencyBuildInfo Include="CoreClr">


### PR DESCRIPTION
The latest version of M.NC.Platforms from CoreFx release/2.2 is from November, whereas the Platforms package in 2.1 has been updated a couple of times since then (at will be updated again for the next 2.1 release). We should depend on the latest version of that package in Core-Setup 2.x, which means depending on the 2.1 version in both release/2.x branches. This should fix the update step so that we depend on the right version of the package.

We still need to decide whether or not we need to sim-ship the package out of both CoreFx 2.x branches, as many external folks depend on M.NC.Platforms 2.2.0 today.

@ericstj @dagood PTAL

https://github.com/dotnet/core-setup/issues/5562