### PR TITLE
Switch from *-temp to BYOC agent pools

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -234,6 +234,7 @@ jobs:
   - template: /eng/common/templates/job/publish-build-assets.yml
     parameters:
       pool:
-        name: dotnet-internal-temp
+        name: NetCoreInternal-Int-Pool
+        queue: buildpool.windows.10.amd64.vs2017
       dependsOn:
         - Finalize_Publish

--- a/eng/jobs/bash-build.yml
+++ b/eng/jobs/bash-build.yml
@@ -25,9 +25,11 @@ jobs:
         name: dnceng-freebsd-internal
       ${{ if ne(parameters.displayName, 'Build_FreeBSD_x64') }}:
         ${{ if eq(variables['System.TeamProject'], 'public') }}:
-          name: dnceng-linux-external-temp
+          name: NetCorePublic-Int-Pool
+          queue: buildpool.ubuntu.1604.amd64.open
         ${{ if ne(variables['System.TeamProject'], 'public') }}:
-          name: dnceng-linux-internal-temp
+          name: NetCoreInternal-Int-Pool
+          queue: buildpool.ubuntu.1604.amd64
     strategy: ${{ parameters.strategy }}
     variables:
 
@@ -153,6 +155,20 @@ jobs:
               outputRidArg: /p:OutputRid=${{ rid }}-${{ parameters.targetArchitecture }}
               packageStepDescription: Runtime Deps installers
               packagingArgs: /p:BuildDistroIndependentInstallers=false
+
+    # Files may be owned by root because builds don't set user ID. The next AzDO step runs 'find' in
+    # the source tree, which fails due to permissions in the 'NetCore*-Int-Pool' queues. This step
+    # prevents the failure by using chown to clean up our source tree.
+    - script: |
+        set -x
+        docker run --rm \
+          -v "$(Agent.BuildDirectory):/root/build" \
+          -w /root/build \
+          ${{ parameters.dockerImage }} \
+          bash -c "chown -R $(id -u):$(id -g) *"
+      displayName: Update file ownership from root to build agent account
+      continueOnError: true
+      condition: succeededOrFailed()
 
     - task: CopyFiles@2
       displayName: Copy logs to stage

--- a/eng/jobs/finalize-publish.yml
+++ b/eng/jobs/finalize-publish.yml
@@ -7,12 +7,12 @@ jobs:
     # Run after all dependent legs are executed
     dependsOn: ${{ parameters.DependsOn }}
     pool:
-      # For public or PR jobs, use the hosted pool.  For internal jobs use the internal pool.
-      # Will eventually change this to two BYOC pools.
+      # Use a hosted pool when possible.
       ${{ if eq(variables['System.TeamProject'], 'public') }}:
         name: Hosted VS2017
       ${{ if ne(variables['System.TeamProject'], 'public') }}:
-        name: dotnet-internal-temp
+        name: NetCoreInternal-Int-Pool
+        queue: buildpool.windows.10.amd64.vs2017
     # Double the default timeout. Publishing is subject to huge delays due to contention on the dotnet-core blob feed
     timeoutInMinutes: 120
     workspace:

--- a/eng/jobs/windows-build.yml
+++ b/eng/jobs/windows-build.yml
@@ -10,15 +10,16 @@ jobs:
   - job: ${{ parameters.displayName }}
     displayName: ${{ parameters.displayName }}
     pool:
-      # For public or PR jobs, use the hosted pool.  For internal jobs use the internal pool.
-      # Will eventually change this to two BYOC pools.
+      # Use a hosted pool when possible.
       ${{ if eq(variables['System.TeamProject'], 'public') }}:
         ${{ if contains(parameters.targetArchitecture, 'arm') }}:
-          name: dotnet-external-temp
+          name: NetCorePublic-Int-Pool
+          queue: buildpool.windows.10.amd64.vs2017.open
         ${{ if not(contains(parameters.targetArchitecture, 'arm')) }}:
           name: Hosted VS2017
       ${{ if ne(variables['System.TeamProject'], 'public') }}:
-        name: dotnet-internal-temp
+        name: NetCoreInternal-Int-Pool
+        queue: buildpool.windows.10.amd64.vs2017
     strategy:
       matrix: 
         debug:


### PR DESCRIPTION
The `*-temp` pools are being deleted Friday, so we need to switch to these new ones.

The only difference I saw in my public and internal test builds was a new type of failure caused by `root` ownership of some files in the source dir. I added a post-build `chown` workaround for this.