### PR TITLE
Temporary fix for BAR publish failing on a warning

### DIFF
--- a/eng/common/sdk-task.ps1
+++ b/eng/common/sdk-task.ps1
@@ -12,7 +12,7 @@ Param(
 
 $ci = $true
 $binaryLog = $true
-$warnAsError = $true
+$warnAsError = $false
 
 . $PSScriptRoot\tools.ps1
 


### PR DESCRIPTION
Pushing to BAR is failing due to:

```
F:\vsagent\7\s\.packages\microsoft.dotnet.arcade.sdk\1.0.0-beta.19176.14\tools\SdkTasks\PublishBuildAssets.proj(30,5):
  error : Asset 'Microsoft.NETCore.Targets@2.0.0' not found in BAR, ignoring.
```

This will be fixed properly by https://github.com/dotnet/arcade-services/pull/282. @jcagme suggested changing this line to stop treating the warning as an error until then. Once the fix comes through, Maestro++ will automatically overwrite/revert this change.