### PR TITLE
Add ijwhost.lib to host package.

### DIFF
--- a/src/corehost/cli/ijwhost/Exports.def
+++ b/src/corehost/cli/ijwhost/Exports.def
@@ -1,3 +1,3 @@
 EXPORTS
-    _CorDllMain            PRIVATE
+    _CorDllMain
     GetTokenForVTableEntry PRIVATE

--- a/src/pkg/projects/Microsoft.NETCore.DotNetAppHost/runtime.Windows_NT.Microsoft.NETCore.DotNetAppHost.props
+++ b/src/pkg/projects/Microsoft.NETCore.DotNetAppHost/runtime.Windows_NT.Microsoft.NETCore.DotNetAppHost.props
@@ -4,6 +4,7 @@
     <ArchitectureSpecificNativeFile Include="$(DotNetHostBinDir)/apphost.exe" />
     <ArchitectureSpecificNativeFile Include="$(DotNetHostBinDir)/comhost.dll" />
     <ArchitectureSpecificNativeFile Include="$(DotNetHostBinDir)/ijwhost.dll" />
+    <ArchitectureSpecificNativeFile Include="$(DotNetHostBinDir)/ijwhost.lib" />
 
     <File Include="@(ArchitectureSpecificNativeFile)">
       <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>

--- a/src/pkg/projects/dir.targets
+++ b/src/pkg/projects/dir.targets
@@ -33,7 +33,9 @@
     <ItemGroup>
       <WindowsNativeFile Include="@(File)"
                          Condition="'%(File.Extension)' == '.dll' OR '%(File.Extension)' == '.exe'" />
-      <WindowsSymbolFile Include="@(File -> '%(RootDir)%(Directory)%(Filename).pdb')" />
+      <!-- Don't include *.pdb for export libraries -->
+      <WindowsSymbolFile Include="@(File -> '%(RootDir)%(Directory)%(Filename).pdb')"
+                         Condition="'%(File.Extension)' != '.lib'" />
       <!-- Crossgened files (on windows) have both a *.pdb and a *.ni.pdb symbol file.  Include the *.ni.pdb file as well if it exists. -->
       <WindowsSymbolFile Include="@(File -> '%(RootDir)%(Directory)%(Filename).ni.pdb')" />
       <ExistingWindowsSymbolFile Include="@(WindowsSymbolFile)" Condition="Exists('%(Identity)')" />


### PR DESCRIPTION
I forgot to include the `ijwhost.lib` exports lib in the Microsoft.NETCore.DotNetAppHost package. C++/CLI will need this in the package for aquisition via NuGet.