### PR TITLE
Add <functional> include to coreclr.h

### DIFF
--- a/src/corehost/cli/hostpolicy/coreclr.h
+++ b/src/corehost/cli/hostpolicy/coreclr.h
@@ -11,6 +11,7 @@
 #include <cstdint>
 #include <memory>
 #include <vector>
+#include <functional>
 
 class coreclr_property_bag_t;
 


### PR DESCRIPTION
Due to a header reorganization in VS 2019.1, none of the headers included in coreclr.h transitively include <functional>. So, directly include the functional header in coreclr.h since we use the `std::function` type that is defined in said header.