### PR TITLE
Get pre-crossgen files for the platform manifest

### DIFF
--- a/src/pkg/projects/dir.targets
+++ b/src/pkg/projects/dir.targets
@@ -146,13 +146,31 @@
                    '$(BuildFullPlatformManifest)' == 'true'">true</IncludeAllRuntimePackagesInPlatformManifest>
     </PropertyGroup>
 
-    <MSBuild Projects="@(ProjectReference)"
-             Condition="'%(ProjectReference.PackageTargetRuntime)' == '$(PackageRID)' OR
-                        '%(ProjectReference.BuidOnRID)' == '$(PackageRID)' OR
-                        ('$(IncludeAllRuntimePackagesInPlatformManifest)' == 'true' AND
-                         '%(ProjectReference.PackageTargetRuntime)' != '' AND
-                         '%(ProjectReference.ExcludeFromPlatformManifest)' != 'true')"
+    <ItemGroup>
+      <ProjectReferencesWithSharedFrameworkRuntimeFiles
+        Include="@(ProjectReference)"
+        Condition="
+          '%(ProjectReference.PackageTargetRuntime)' == '$(PackageRID)' OR
+          '%(ProjectReference.BuidOnRID)' == '$(PackageRID)' OR
+          ('$(IncludeAllRuntimePackagesInPlatformManifest)' == 'true' AND
+          '%(ProjectReference.PackageTargetRuntime)' != '' AND
+          '%(ProjectReference.ExcludeFromPlatformManifest)' != 'true')"/>
+    </ItemGroup>
+
+    <MSBuild Projects="@(ProjectReferencesWithSharedFrameworkRuntimeFiles)"
              Targets="GetPackageFiles">
+      <Output TaskParameter="TargetOutputs" ItemName="SharedFrameworkRuntimeFiles" />
+    </MSBuild>
+
+    <ItemGroup Condition="'$(GetPreCrossgenFilesForManifest)' == 'true'">
+      <SharedFrameworkRuntimeFiles
+        Remove="@(SharedFrameworkRuntimeFiles)"
+        Condition="'%(SharedFrameworkRuntimeFiles.CrossGenedPath)' != ''" />
+    </ItemGroup>
+
+    <MSBuild Projects="@(ProjectReferencesWithSharedFrameworkRuntimeFiles)"
+             Targets="GetPreCrossgenFilesFromReferences"
+             Condition="'$(GetPreCrossgenFilesForManifest)' == 'true'">
       <Output TaskParameter="TargetOutputs" ItemName="SharedFrameworkRuntimeFiles" />
     </MSBuild>
 

--- a/src/pkg/projects/netcoreapp/pkg/Microsoft.NETCore.App.pkgproj
+++ b/src/pkg/projects/netcoreapp/pkg/Microsoft.NETCore.App.pkgproj
@@ -7,6 +7,12 @@
     <BuildTargetPath>build/$(NETCoreAppFramework)</BuildTargetPath>
     <PlatformManifestTargetPath>$(BuildTargetPath)</PlatformManifestTargetPath>
     <FileVersionPropsTargetPath>$(BuildTargetPath)</FileVersionPropsTargetPath>
+
+    <!--
+      Instead of the crossgen'd files, get pre-crossgen files to generate the manifest with. This
+      works around an issue where crossgen strips the version information.
+    -->
+    <GetPreCrossgenFilesForManifest>true</GetPreCrossgenFilesForManifest>
   </PropertyGroup>
 
   <!-- Identity / Reference package content -->
@@ -24,6 +30,18 @@
       <TargetPath>$(BuildTargetPath)</TargetPath>
     </File>
   </ItemGroup>
+
+  <Target Name="GetPreCrossgenFilesFromReferences"
+          DependsOnTargets="SplitProjectReferences"
+          Outputs="@(_PreCrossgenFiles)">
+    <MSBuild
+      Targets="GetPreCrossgenFilesForManifest"
+      Projects="@(_NonPkgProjProjectReference)">
+      <Output
+        TaskParameter="TargetOutputs"
+        ItemName="_PreCrossgenFiles" />
+    </MSBuild>
+  </Target>
 
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/pkg/projects/netcoreapp/src/netcoreapp.depproj
+++ b/src/pkg/projects/netcoreapp/src/netcoreapp.depproj
@@ -264,5 +264,9 @@
           DependsOnTargets="GetRuntimeFilesFromPackages;PrepareForCrossGen;GetCrossGenSymbolsFiles">
   </Target>
 
+  <Target Name="GetPreCrossgenFilesForManifest"
+          DependsOnTargets="PrepareForCrossGen"
+          Outputs="@(_filesToCrossGen)" />
+
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>


### PR DESCRIPTION
Workaround for crossgen stripping versions from binaries.

For https://github.com/dotnet/core-setup/issues/5665.

When generating a netcoreapp platform manifest, the `GenerateFileVersionProps` calls into the pkgproj to fetch the pre-crossgen files rather than post-crossgen. The MSBuild and targets chain is based on `GetPackageFiles`.

I tried it on win-x64 and it fixes the 0.0.0.0 versions. I'm doing some before/after package diffs next to make sure it doesn't affect anything else.

/cc @dougbu @JunTaoLuo 