### PR TITLE
Enforce that DLL/EXEs in platform manifest have a FileVersion

### DIFF
--- a/src/pkg/projects/dir.targets
+++ b/src/pkg/projects/dir.targets
@@ -163,7 +163,8 @@
                               PackageVersion="$(Version)"
                               PlatformManifestFile="$(PlatformManifestFile)"
                               PropsFile="$(PropsFile)"
-                              PreferredPackages="$(Id);@(RuntimeDependency)" />
+                              PreferredPackages="$(Id);@(RuntimeDependency)"
+                              PermitDllAndExeFilesLackingFileVersion="$(PermitDllAndExeFilesLackingFileVersion)" />
   </Target>
 
   <Target Name="IncludeFileVersionPropsFile"

--- a/src/pkg/projects/dir.targets
+++ b/src/pkg/projects/dir.targets
@@ -158,6 +158,14 @@
       <Output TaskParameter="TargetOutputs" ItemName="SharedFrameworkRuntimeFiles" />
     </MSBuild>
 
+    <!--
+      Workaround: zero-versioned Microsoft.VisualBasic.dll in non-Windows CoreFX transport package.
+      See https://github.com/dotnet/corefx/issues/36630
+    -->
+    <PropertyGroup Condition="'$(OSGroup)' != 'Windows_NT'">
+      <PermitDllAndExeFilesLackingFileVersion>true</PermitDllAndExeFilesLackingFileVersion>
+    </PropertyGroup>
+
     <GenerateFileVersionProps Files="@(SharedFrameworkRuntimeFiles)"
                               PackageId="$(Id)"
                               PackageVersion="$(Version)"

--- a/src/pkg/projects/windowsdesktop/dir.props
+++ b/src/pkg/projects/windowsdesktop/dir.props
@@ -4,5 +4,16 @@
 
   <PropertyGroup>
     <FrameworkPackageName>Microsoft.WindowsDesktop.App</FrameworkPackageName>
+
+    <!--
+      Disable FileVersion check for WindowsDesktop. Files with no FileVersion, as of writing:
+
+      runtimes\win-x86\native\PenImc_cor3.dll
+      runtimes\win-x86\native\PresentationNative_cor3.dll
+      runtimes\win-x86\native\wpfgfx_cor3.dll
+      runtimes\win-x86\lib\netcoreapp3.0\DirectWriteForwarder.dll
+      runtimes\win-x86\lib\netcoreapp3.0\System.Printing.dll
+    -->
+    <PermitDllAndExeFilesLackingFileVersion>true</PermitDllAndExeFilesLackingFileVersion>
   </PropertyGroup>
 </Project>

--- a/tools-local/tasks/GenerateFileVersionProps.cs
+++ b/tools-local/tasks/GenerateFileVersionProps.cs
@@ -2,18 +2,21 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using Microsoft.Build.Framework;
-using System.IO;
-using System.Collections.Generic;
 using Microsoft.Build.Construction;
+using Microsoft.Build.Framework;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
 
 namespace Microsoft.DotNet.Build.Tasks
 {
     public partial class GenerateFileVersionProps : BuildTask
     {
-        const string PlatformManifestsItem = "PackageConflictPlatformManifests";
-        const string PreferredPackagesProperty = "PackageConflictPreferredPackages";
+        private const string PlatformManifestsItem = "PackageConflictPlatformManifests";
+        private const string PreferredPackagesProperty = "PackageConflictPreferredPackages";
+        private static readonly Version ZeroVersion = new Version(0, 0, 0, 0);
+
 
         [Required]
         public ITaskItem[] Files { get; set; }
@@ -32,6 +35,12 @@ namespace Microsoft.DotNet.Build.Tasks
 
         [Required]
         public string PreferredPackages { get; set; }
+
+        /// <summary>
+        /// The task normally enforces that all DLL and EXE files have a non-0.0.0.0 FileVersion.
+        /// This flag disables the check.
+        /// </summary>
+        public bool PermitDllAndExeFilesLackingFileVersion { get; set; }
 
         public override bool Execute()
         {
@@ -90,6 +99,28 @@ namespace Microsoft.DotNet.Build.Tasks
                 }
             }
 
+            // Check for versionless files after all duplicate filenames are resolved, rather than
+            // logging errors immediately upon encountering a versionless file. There may be
+            // duplicate filenames where only one has a version, and this is ok. The highest version
+            // is used.
+            if (!PermitDllAndExeFilesLackingFileVersion)
+            {
+                var versionlessFiles = fileVersions
+                    .Where(p =>
+                        p.Key.EndsWith(".exe", StringComparison.OrdinalIgnoreCase) ||
+                        p.Key.EndsWith(".dll", StringComparison.OrdinalIgnoreCase))
+                    .Where(p => (p.Value.FileVersion ?? ZeroVersion) == ZeroVersion)
+                    .Select(p => p.Value.File.ItemSpec)
+                    .ToArray();
+
+                if (versionlessFiles.Any())
+                {
+                    Log.LogError(
+                        $"Missing FileVersion in {versionlessFiles.Length} shared framework files:" +
+                        string.Concat(versionlessFiles.Select(f => Environment.NewLine + f)));
+                }
+            }
+
             var props = ProjectRootElement.Create();
             var itemGroup = props.AddItemGroup();
             // set the platform manifest when the platform is not being published as part of the app
@@ -132,7 +163,8 @@ namespace Microsoft.DotNet.Build.Tasks
                 return new FileVersionData()
                 {
                     AssemblyVersion = FileUtilities.GetAssemblyName(filePath)?.Version,
-                    FileVersion = FileUtilities.GetFileVersion(filePath)
+                    FileVersion = FileUtilities.GetFileVersion(filePath),
+                    File = file
                 };
             }
             else
@@ -147,13 +179,14 @@ namespace Microsoft.DotNet.Build.Tasks
                 {
                     // FileVersionInfo will return 0.0.0.0 if a file doesn't have a version.
                     // match that behavior
-                    fileVersion = new Version(0, 0, 0, 0);
+                    fileVersion = ZeroVersion;
                 }
 
                 return new FileVersionData()
                 {
                     AssemblyVersion = assemblyVersion,
-                    FileVersion = fileVersion
+                    FileVersion = fileVersion,
+                    File = file
                 };
             }
         }
@@ -162,6 +195,7 @@ namespace Microsoft.DotNet.Build.Tasks
         {
             public Version AssemblyVersion { get; set; }
             public Version FileVersion { get; set; }
+            public ITaskItem File { get; set; }
         }
     }
 }


### PR DESCRIPTION
Prevent https://github.com/dotnet/core-setup/issues/5665 from occurring again by making sure no DLL/EXE FileVersions are `0.0.0.0`.

Not enabled for WindowsDesktop. There are some files to investigate there. We might need to have a baseline to enable the check there if there are valid reasons for the files not to have versions.

I rebased it back before the crossgen issue was fixed and it was able to detect the issues ([full list](https://gist.github.com/dagood/fe57f26c8d7bd9211b2732bed8924b00)):

```
C:\git\core-setup\src\pkg\projects\dir.targets(159,5): error : Missing FileVersion in 121 shared framework files: [C:\git\core-setup\src\pkg\projects\netcoreapp\pkg\Microsoft.NETCore.App.pkgproj]
C:\git\core-setup\src\pkg\projects\dir.targets(159,5): error : C:\git\core-setup\packages/transport.runtime.linux-x64.Microsoft.NETCore.Runtime.CoreCLR\3.0.0-preview4-27602-72\runtimes\linux-x64\native\System.Private.CoreLib.dll [C:\git\core-setup\src\pkg\projects\netcoreapp\pkg\Microsoft.NETCore.App.pkgproj]
C:\git\core-setup\src\pkg\projects\dir.targets(159,5): error : C:\git\core-setup\bin/win-x64.Debug\\crossgen/netcoreapp/win-x64/runtimes/win-x64/lib/netcoreapp3.0/Microsoft.CSharp.dll [C:\git\core-setup\src\pkg\projects\netcoreapp\pkg\Microsoft.NETCore.App.pkgproj]
```