### PR TITLE
Add Versions.props comments: stop merge conflicts

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -7,13 +7,18 @@
   </PropertyGroup>
   <!--Package versions-->
   <PropertyGroup>
+    <!-- corefx -->
     <MicrosoftPrivateCoreFxNETCoreAppPackageVersion>4.6.0-preview4.19204.4</MicrosoftPrivateCoreFxNETCoreAppPackageVersion>
     <MicrosoftNETCorePlatformsPackageVersion>3.0.0-preview4.19204.4</MicrosoftNETCorePlatformsPackageVersion>
     <MicrosoftNETCoreTargetsPackageVersion>2.0.0</MicrosoftNETCoreTargetsPackageVersion>
+    <!-- standard -->
     <NETStandardLibraryPackageVersion>2.1.0-prerelease.19203.1</NETStandardLibraryPackageVersion>
+    <!-- coreclr -->
     <MicrosoftNETCoreRuntimeCoreCLRPackageVersion>3.0.0-preview4-27604-73</MicrosoftNETCoreRuntimeCoreCLRPackageVersion>
-    <MicrosoftBclJsonSourcesPackageVersion>4.6.0-preview.19072.2</MicrosoftBclJsonSourcesPackageVersion>
+    <!-- dotnet-trusted -->
     <MicrosoftWindowsDesktopAppPackageVersion>3.0.0-preview4-27604-23</MicrosoftWindowsDesktopAppPackageVersion>
+    <!-- Not auto-updated. -->
+    <MicrosoftBclJsonSourcesPackageVersion>4.6.0-preview.19072.2</MicrosoftBclJsonSourcesPackageVersion>
   </PropertyGroup>
   <!--Package names-->
   <PropertyGroup>


### PR DESCRIPTION
Add simple repo source comments to Versions.props. This prevents a common merge conflict by avoiding adjacent-line updates by the various PRs coming in.

I tried this before using blank newlines, but Maestro++ removed them.
