### PR TITLE
Setup batch build

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,6 +1,9 @@
 trigger:
-- master
-- release/3.0
+  batch: true
+  branches:
+    include:
+      - master
+      - release/3.0
 
 pr:
 - master

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -2,8 +2,8 @@ trigger:
   batch: true
   branches:
     include:
-      - master
-      - release/3.0
+    - master
+    - release/3.0
 
 pr:
 - master


### PR DESCRIPTION
Core-setup builds take a long time to publish and they hold the dotnet-core feed lock while doing so.

To make matters worse, the internal builds aren't batched. At this moment there are 9 builds running for the master branch. Each will hold the feed lock for about 1 hour.

If there is no requirement against making these build batched we should batch 'em.