### PR TITLE
Simplify nethost API for getting hostfxr path

### DIFF
--- a/src/corehost/cli/nethost/nethost.cpp
+++ b/src/corehost/cli/nethost/nethost.cpp
@@ -41,13 +41,11 @@ NETHOST_API int NETHOST_CALLTYPE get_hostfxr_path(
     size_t len = fxr_path.length();
     size_t required_size = len + 1; // null terminator
 
-    if (buffer == nullptr || *buffer_size < required_size)
-    {
-        *buffer_size = required_size;
-        return StatusCode::HostApiBufferTooSmall;
-    }
-
+    size_t input_buffer_size = *buffer_size;
     *buffer_size = required_size;
+    if (buffer == nullptr || input_buffer_size < required_size)
+        return StatusCode::HostApiBufferTooSmall;
+
     fxr_path.copy(buffer, len);
     buffer[len] = '\0';
     return StatusCode::Success;

--- a/src/corehost/cli/nethost/nethost.cpp
+++ b/src/corehost/cli/nethost/nethost.cpp
@@ -19,7 +19,7 @@ namespace
 }
 
 NETHOST_API int NETHOST_CALLTYPE get_hostfxr_path(
-    char_t * result_buffer,
+    char_t * buffer,
     size_t * buffer_size,
     const char_t * assembly_path)
 {
@@ -41,14 +41,14 @@ NETHOST_API int NETHOST_CALLTYPE get_hostfxr_path(
     size_t len = fxr_path.length();
     size_t required_size = len + 1; // null terminator
 
-    if (result_buffer == nullptr || *buffer_size < required_size)
+    if (buffer == nullptr || *buffer_size < required_size)
     {
         *buffer_size = required_size;
         return StatusCode::HostApiBufferTooSmall;
     }
 
     *buffer_size = required_size;
-    fxr_path.copy(result_buffer, len);
-    result_buffer[len] = '\0';
+    fxr_path.copy(buffer, len);
+    buffer[len] = '\0';
     return StatusCode::Success;
 }

--- a/src/corehost/cli/nethost/nethost.cpp
+++ b/src/corehost/cli/nethost/nethost.cpp
@@ -18,13 +18,12 @@ namespace
     }
 }
 
-NETHOST_API int NETHOST_CALLTYPE nethost_get_hostfxr_path(
+NETHOST_API int NETHOST_CALLTYPE get_hostfxr_path(
     char_t * result_buffer,
-    size_t buffer_size,
-    size_t * out_buffer_required_size,
+    size_t * buffer_size,
     const char_t * assembly_path)
 {
-    if (out_buffer_required_size == nullptr)
+    if (buffer_size == nullptr)
         return StatusCode::InvalidArgFailure;
 
     trace::setup();
@@ -42,10 +41,13 @@ NETHOST_API int NETHOST_CALLTYPE nethost_get_hostfxr_path(
     size_t len = fxr_path.length();
     size_t required_size = len + 1; // null terminator
 
-    *out_buffer_required_size = required_size;
-    if (result_buffer == nullptr || buffer_size < required_size)
+    if (result_buffer == nullptr || *buffer_size < required_size)
+    {
+        *buffer_size = required_size;
         return StatusCode::HostApiBufferTooSmall;
+    }
 
+    *buffer_size = required_size;
     fxr_path.copy(result_buffer, len);
     result_buffer[len] = '\0';
     return StatusCode::Success;

--- a/src/corehost/cli/nethost/nethost.h
+++ b/src/corehost/cli/nethost/nethost.h
@@ -35,13 +35,13 @@
 // Get the path to the hostfxr library
 //
 // Parameters:
-//   result_buffer
+//   buffer
 //     Buffer that will be populated with the hostfxr path, including a null terminator.
 //
 //   buffer_size
-//     [in] Size of result_buffer in char_t units.
-//     [out] Size of result_buffer used in char_t units. If the input value is too small
-//           or result_buffer is nullptr, this is populated with the minimum required size
+//     [in] Size of buffer in char_t units.
+//     [out] Size of buffer used in char_t units. If the input value is too small
+//           or buffer is nullptr, this is populated with the minimum required size
 //           in char_t units for a buffer to hold the hostfxr path
 //
 //   assembly_path
@@ -52,14 +52,14 @@
 //
 // Return value:
 //   0 on success, otherwise failure
-//   0x80008098 - result_buffer is too small (HostApiBufferTooSmall)
+//   0x80008098 - buffer is too small (HostApiBufferTooSmall)
 //
 // Remarks:
 //   The full search for the hostfxr library is done on every call. To minimize the need
-//   to call this function multiple times, pass a large result_buffer (e.g. PATH_MAX).
+//   to call this function multiple times, pass a large buffer (e.g. PATH_MAX).
 //
 extern "C" NETHOST_API int NETHOST_CALLTYPE get_hostfxr_path(
-    char_t * result_buffer,
+    char_t * buffer,
     size_t * buffer_size,
     const char_t * assembly_path);
 

--- a/src/corehost/cli/nethost/nethost.h
+++ b/src/corehost/cli/nethost/nethost.h
@@ -39,10 +39,10 @@
 //     Buffer that will be populated with the hostfxr path, including a null terminator.
 //
 //   buffer_size
-//     Size of result_buffer in char_t units
-//
-//   out_buffer_required_size
-//     Minimum required size in char_t units for a buffer to hold the hostfxr path
+//     [in] Size of result_buffer in char_t units.
+//     [out] Size of result_buffer used in char_t units. If the input value is too small
+//           or result_buffer is nullptr, this is populated with the minimum required size
+//           in char_t units for a buffer to hold the hostfxr path
 //
 //   assembly_path
 //     Optional. Path to the compenent's assembly. Whether or not this is specified
@@ -58,10 +58,9 @@
 //   The full search for the hostfxr library is done on every call. To minimize the need
 //   to call this function multiple times, pass a large result_buffer (e.g. PATH_MAX).
 //
-extern "C" NETHOST_API int NETHOST_CALLTYPE nethost_get_hostfxr_path(
+extern "C" NETHOST_API int NETHOST_CALLTYPE get_hostfxr_path(
     char_t * result_buffer,
-    size_t buffer_size,
-    size_t * out_buffer_required_size,
+    size_t * buffer_size,
     const char_t * assembly_path);
 
 #endif // __NETHOST_H__

--- a/src/corehost/cli/test/nativehost/nativehost.cpp
+++ b/src/corehost/cli/test/nativehost/nativehost.cpp
@@ -30,7 +30,7 @@ int main(const int argc, const pal::char_t *argv[])
     }
 
     const pal::char_t *command = argv[1];
-    if (pal::strcmp(command, _X("nethost_get_hostfxr_path")) == 0)
+    if (pal::strcmp(command, _X("get_hostfxr_path")) == 0)
     {
         const pal::char_t *assembly_path = nullptr;
         if (argc >= 3)
@@ -47,23 +47,23 @@ int main(const int argc, const pal::char_t *argv[])
 #endif
 
         pal::string_t fxr_path;
-        size_t len = 0;
-        int res = nethost_get_hostfxr_path(nullptr, 0, &len, assembly_path);
+        size_t len = fxr_path.size();
+        int res = get_hostfxr_path(nullptr, &len, assembly_path);
         if (res == StatusCode::HostApiBufferTooSmall)
         {
             fxr_path.resize(len);
-            res = nethost_get_hostfxr_path(&fxr_path[0], fxr_path.size(), &len, assembly_path);
+            res = get_hostfxr_path(&fxr_path[0], &len, assembly_path);
         }
 
         if (res == StatusCode::Success)
         {
-            std::cout << "nethost_get_hostfxr_path succeeded" << std::endl;
+            std::cout << "get_hostfxr_path succeeded" << std::endl;
             std::cout << "hostfxr_path: " << tostr(pal::to_lower(fxr_path)).data() << std::endl;
             return 0;
         }
         else
         {
-            std::cout << "nethost_get_hostfxr_path failed: " << std::hex << std::showbase << res << std::endl;
+            std::cout << "get_hostfxr_path failed: " << std::hex << std::showbase << res << std::endl;
             return 1;
         }
     }

--- a/src/test/HostActivationTests/NativeHosting/Nethost.cs
+++ b/src/test/HostActivationTests/NativeHosting/Nethost.cs
@@ -13,7 +13,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.NativeHosting
 {
     public class Nethost : IClassFixture<Nethost.SharedTestState>
     {
-        private const string GetHostFxrPath = "nethost_get_hostfxr_path";
+        private const string GetHostFxrPath = "get_hostfxr_path";
         private const int CoreHostLibMissingFailure = unchecked((int)0x80008083);
 
         private static readonly string HostFxrName = RuntimeInformationExtensions.GetSharedLibraryFileNameForCurrentPlatform("hostfxr");


### PR DESCRIPTION
- Remove `nethost_` prefix on exported function
- Collapse buffer size / required size into one inout parameter