### PR TITLE
Fix copy/paste error

### DIFF
--- a/dependencies.props
+++ b/dependencies.props
@@ -42,7 +42,7 @@
   <!-- Package versions used as toolsets -->
   <PropertyGroup>
     <FeedTasksPackage>Microsoft.DotNet.Build.Tasks.Feed</FeedTasksPackage>
-    <FeedTasksPackageVersion>2.2.0-beta.19204.16</FeedTasksPackageVersion>
+    <FeedTasksPackageVersion>2.2.0-beta.19208.9</FeedTasksPackageVersion>
   </PropertyGroup>
 
   <!-- Publish symbol build task package -->


### PR DESCRIPTION
On https://github.com/dotnet/core-setup/pull/5749 I copied an incorrect version by mistake. The correct version has the things core-setup needs to actually publish correctly