### PR TITLE
Add missing closedir() in readdir()

### DIFF
--- a/src/corehost/common/pal.unix.cpp
+++ b/src/corehost/common/pal.unix.cpp
@@ -647,6 +647,8 @@ static void readdir(const pal::string_t& path, const pal::string_t& pattern, boo
                 files.push_back(filepath);
             }
         }
+
+        closedir(dir);
     }
 }
 


### PR DESCRIPTION
The readdir function calls opendir() but never closedir(), leaking the
DIR resource.