### PR TITLE
Create zip file for WindowsDesktop sfx

### DIFF
--- a/src/pkg/packaging-tools/framework.packaging.targets
+++ b/src/pkg/packaging-tools/framework.packaging.targets
@@ -13,12 +13,14 @@
             GenerateDeb;
             GenerateRpm;
             GenerateMsi;
-            GeneratePkg" />
+            GeneratePkg;
+            GenerateCompressedArchive" />
 
   <Target Name="GenerateDeb" DependsOnTargets="TestDebuild;CreateDeb" Condition="'$(BuildDebPackage)' == 'true'"/>
   <Target Name="GenerateRpm" DependsOnTargets="TestFPMTool;CreateRpm" Condition="'$(BuildRpmPackage)' == 'true'"/>
   <Target Name="GenerateMsi" DependsOnTargets="CreateMsi" Condition="'$(GenerateMSI)' == 'true'"/>
   <Target Name="GeneratePkg" DependsOnTargets="CreatePkg" Condition="'$(GeneratePkg)' == 'true'"/>
+  <Target Name="GenerateCompressedArchive" DependsOnTargets="CreateCompressedArchive" Condition="'$(GenerateCompressedArchive)' == 'true'"/>
 
   <!--
     Create Debian package.
@@ -144,6 +146,21 @@
             GetInstallerProperties;
             RunLightLinker">
     <Message Text="Created '$(InstallerFile)'" Importance="High" />
+  </Target>
+
+  <Target Name="CreateCompressedArchive"
+          DependsOnTargets="
+            GetInstallerProperties;
+            GenerateZip"/>
+
+  <UsingTask TaskName="ZipFileCreateFromDirectory" AssemblyFile="$(BuildToolsTaskDir)Microsoft.DotNet.Build.Tasks.dll"/>
+
+  <Target Name="GenerateZip"
+          Condition="'$(OSGroup)' == 'Windows_NT'">
+    <ZipFileCreateFromDirectory
+      SourceDirectory="$(SharedFrameworkLayoutDir)"
+      DestinationArchive="$(CompressedArchiveFile)"
+      OverwriteDestination="true" />
   </Target>
 
   <!--

--- a/src/pkg/packaging-tools/packaging-tools.targets
+++ b/src/pkg/packaging-tools/packaging-tools.targets
@@ -53,6 +53,7 @@
       <!-- Location to place the installer, in bin. -->
       <InstallerFileNameWithoutExtension>$(InstallerName)-$(InstallerBuildPart)</InstallerFileNameWithoutExtension>
       <InstallerFile>$(AssetOutputPath)$(InstallerFileNameWithoutExtension)$(InstallerExtension)</InstallerFile>
+      <CompressedArchiveFile>$(AssetOutputPath)$(InstallerFileNameWithoutExtension)$(CompressedFileExtension)</CompressedArchiveFile>
     </PropertyGroup>
   </Target>
 

--- a/src/pkg/projects/windowsdesktop/pkg/Microsoft.WindowsDesktop.App.pkgproj
+++ b/src/pkg/projects/windowsdesktop/pkg/Microsoft.WindowsDesktop.App.pkgproj
@@ -10,6 +10,8 @@
 
     <GenerateSharedFramework>true</GenerateSharedFramework>
     <GenerateNetCoreAppRuntimeConfig>true</GenerateNetCoreAppRuntimeConfig>
+
+    <GenerateCompressedArchive>true</GenerateCompressedArchive>
   </PropertyGroup>
 
   <!-- Identity / Reference package content -->


### PR DESCRIPTION
This zip in particular is needed to unblock core-sdk uptake.

Implementation is very rough: the zip file creation target only works for the sfx in particular, and is only enabled for WindowsDesktop specifically.

In a local build, produces `windowsdesktop-runtime-3.0.0-preview5-27612-0-win-x64.zip` with sfx contents the same as the DN-T `dotnet-extensions...` zip.

Filed https://github.com/dotnet/core-setup/issues/5817 to clean this up and create compressed archives more broadly.