### PR TITLE
Fix reorder warnings in code

### DIFF
--- a/src/corehost/cli/apphost/bundle/bundle_runner.h
+++ b/src/corehost/cli/apphost/bundle/bundle_runner.h
@@ -16,10 +16,10 @@ namespace bundle
     {
     public:
         bundle_runner_t(const pal::string_t& bundle_path)
-            :m_bundle_path(bundle_path),
-            m_bundle_stream(nullptr),
-            m_manifest(nullptr),
-            m_num_embedded_files(0)
+            : m_bundle_stream(nullptr)
+            , m_manifest(nullptr)
+            , m_num_embedded_files(0)
+            , m_bundle_path(bundle_path)
         {
         }
 

--- a/src/corehost/cli/deps_format.h
+++ b/src/corehost/cli/deps_format.h
@@ -29,8 +29,8 @@ public:
     typedef str_to_vector_map_t rid_fallback_graph_t;
 
     deps_json_t()
-        : m_valid(false)
-        , m_file_exists(false)
+        : m_file_exists(false)
+        , m_valid(false)
     {
     }
 

--- a/src/corehost/cli/fx_reference.h
+++ b/src/corehost/cli/fx_reference.h
@@ -14,14 +14,14 @@ class fx_reference_t
 {
 public:
     fx_reference_t()
-        : fx_name(_X(""))
-        , fx_version(_X(""))
-        , fx_version_number()
-        , has_patch_roll_fwd(false)
+        : has_patch_roll_fwd(false)
         , patch_roll_fwd(false)
         , has_roll_fwd_on_no_candidate_fx(false)
-        , use_exact_version(false)
         , roll_fwd_on_no_candidate_fx((roll_fwd_on_no_candidate_fx_option)0)
+        , use_exact_version(false)
+        , fx_name(_X(""))
+        , fx_version(_X(""))
+        , fx_version_number()
         { }
 
     const pal::string_t& get_fx_name() const

--- a/src/corehost/cli/fxr/corehost_init.cpp
+++ b/src/corehost/cli/fxr/corehost_init.cpp
@@ -21,17 +21,17 @@ corehost_init_t::corehost_init_t(
     const std::vector<pal::string_t>& probe_paths,
     const host_mode_t mode,
     const fx_definition_vector_t& fx_definitions)
-    : m_host_command(host_command)
-    , m_host_info_host_path(host_info.host_path)
-    , m_host_info_dotnet_root(host_info.dotnet_root)
-    , m_host_info_app_path(host_info.app_path)
+    : m_tfm(get_app(fx_definitions).get_runtime_config().get_tfm())
     , m_deps_file(deps_file)
     , m_additional_deps_serialized(additional_deps_serialized)
     , m_is_framework_dependent(get_app(fx_definitions).get_runtime_config().get_is_framework_dependent())
     , m_probe_paths(probe_paths)
     , m_host_mode(mode)
     , m_host_interface()
-    , m_tfm(get_app(fx_definitions).get_runtime_config().get_tfm())
+    , m_host_command(host_command)
+    , m_host_info_host_path(host_info.host_path)
+    , m_host_info_dotnet_root(host_info.dotnet_root)
+    , m_host_info_app_path(host_info.app_path)
 {
     make_cstr_arr(m_probe_paths, &m_probe_paths_cstr);
 

--- a/src/corehost/cli/hostpolicy/args.cpp
+++ b/src/corehost/cli/hostpolicy/args.cpp
@@ -6,14 +6,14 @@
 #include <utils.h>
 
 arguments_t::arguments_t()
-    : managed_application(_X(""))
-    , host_mode(host_mode_t::invalid)
+    : host_mode(host_mode_t::invalid)
     , host_path(_X(""))
     , app_root(_X(""))
+    , deps_path(_X(""))
+    , core_servicing(_X(""))
+    , managed_application(_X(""))
     , app_argc(0)
     , app_argv(nullptr)
-    , core_servicing(_X(""))
-    , deps_path(_X(""))
 {
 }
 

--- a/src/corehost/cli/hostpolicy/args.h
+++ b/src/corehost/cli/hostpolicy/args.h
@@ -38,8 +38,8 @@ struct probe_config_t
         : probe_dir(probe_dir)
         , probe_deps_json(probe_deps_json)
         , fx_level(fx_level)
-        , only_serviceable_assets(only_serviceable_assets)
         , only_runtime_assets(only_runtime_assets)
+        , only_serviceable_assets(only_serviceable_assets)
         , probe_publish_dir(probe_publish_dir)
     {
     }

--- a/src/corehost/cli/hostpolicy/breadcrumbs.cpp
+++ b/src/corehost/cli/hostpolicy/breadcrumbs.cpp
@@ -9,9 +9,9 @@
 #include "breadcrumbs.h"
 
 breadcrumb_writer_t::breadcrumb_writer_t(bool enabled, const std::unordered_set<pal::string_t> &files)
-    : m_status(false)
+    : m_files(files)
     , m_enabled(enabled)
-    , m_files(files)
+    , m_status(false)
 {
     if (enabled && !pal::get_default_breadcrumb_store(&m_breadcrumb_store))
     {

--- a/src/corehost/cli/hostpolicy/deps_resolver.h
+++ b/src/corehost/cli/hostpolicy/deps_resolver.h
@@ -49,10 +49,10 @@ public:
         bool is_framework_dependent)
         : m_fx_definitions(fx_definitions)
         , m_app_dir(args.app_root)
-        , m_managed_app(args.managed_application)
-        , m_is_framework_dependent(is_framework_dependent)
-        , m_core_servicing(args.core_servicing)
         , m_host_mode(args.host_mode)
+        , m_managed_app(args.managed_application)
+        , m_core_servicing(args.core_servicing)
+        , m_is_framework_dependent(is_framework_dependent)
     {
         int lowest_framework = m_fx_definitions.size() - 1;
         int root_framework = -1;

--- a/src/corehost/cli/ijwhost/bootstrap_thunk_chunk.cpp
+++ b/src/corehost/cli/ijwhost/bootstrap_thunk_chunk.cpp
@@ -8,7 +8,7 @@
 //=================================================================================
 // Ctor
 bootstrap_thunk_chunk::bootstrap_thunk_chunk(size_t numThunks, pal::dll_t dll)
-    : m_numThunks(numThunks), m_dll(dll), m_next(NULL)
+    : m_dll(dll), m_numThunks(numThunks), m_next(NULL)
 {
 #ifdef _DEBUG
     memset(m_thunks, 0, m_numThunks * sizeof(bootstrap_thunk));

--- a/src/settings.cmake
+++ b/src/settings.cmake
@@ -158,6 +158,7 @@ if(WIN32)
     add_compile_options(/DEBUG)
     add_compile_options(/GS)
     add_compile_options(/W1)
+    add_compile_options(/we5038) # make reorder warnings into errors
     add_compile_options(/Zc:inline)
     add_compile_options(/fp:precise)
     add_compile_options(/EHsc)
@@ -189,6 +190,7 @@ if(WIN32)
     set(CMAKE_EXE_LINKER_FLAGS_RELWITHDEBINFO "${CMAKE_EXE_LINKER_FLAGS_RELWITHDEBINFO} /NODEFAULTLIB:libucrt.lib /DEFAULTLIB:ucrt.lib")
 else()
     add_compile_options(-Wno-unused-local-typedef)
+    add_compile_options(-Werror=reorder)
 endif()
 
 # Older CMake doesn't support CMAKE_CXX_STANDARD and GCC/Clang need a switch to enable C++ 11


### PR DESCRIPTION
Fix all the errors produced by clang after adding -Werror=reorder to
src/settings.cmake.

The member initialization list is always evaluated in the order the
members are delcared in the class. So modify the member initialization
lists to match the order in which they will be evaluated.