### PR TITLE
Remove redundant std::move()

### DIFF
--- a/src/corehost/cli/json/casablanca/src/utilities/asyncrt_utils.cpp
+++ b/src/corehost/cli/json/casablanca/src/utilities/asyncrt_utils.cpp
@@ -483,13 +483,13 @@ utility::string_t __cdecl conversions::to_string_t(const std::string &s)
 #endif
 }
 
-std::string __cdecl conversions::to_utf8string(std::string value) { return std::move(value); }
+std::string __cdecl conversions::to_utf8string(std::string value) { return value; }
 
 std::string __cdecl conversions::to_utf8string(const utf16string &value) { return utf16_to_utf8(value); }
 
 utf16string __cdecl conversions::to_utf16string(const std::string &value) { return utf8_to_utf16(value); }
 
-utf16string __cdecl conversions::to_utf16string(utf16string value) { return std::move(value); }
+utf16string __cdecl conversions::to_utf16string(utf16string value) { return value; }
 
 static bool is_digit(utility::char_t c) { return c >= _XPLATSTR('0') && c <= _XPLATSTR('9'); }
 


### PR DESCRIPTION
This is essentially a port of:
https://github.com/Microsoft/cpprestsdk/commit/f0637654fc0e6752d60f483138cbc8aef4ff0b75#diff-8e55486b33944293c131ee21fe87ff37

clang (and gcc, but I didn't test that) complains about std::move being
redundant because the compiler can already infer it.

I had to add `add_compile_options(-Werror=redundant-move)` to see the warning/failure.