### PR TITLE
[release/2.1] Create dotnet-runtime-deps for Ubuntu 19.04

### DIFF
--- a/buildpipeline/Core-Setup-Linux-BT.json
+++ b/buildpipeline/Core-Setup-Linux-BT.json
@@ -410,6 +410,44 @@
       "enabled": true,
       "continueOnError": false,
       "alwaysRun": false,
+      "displayName": "Package Runtime Dep - Ubuntu 19.04",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "filename": "docker",
+        "arguments": "$(CommonDockerCommandToBuildRuntimeDepDebPackage) /p:OutputRid=ubuntu.19.04-$(PB_TargetArchitecture) $(PB_AdditionalMSBuildArguments)",
+        "workingFolder": "",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "environment": {},
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Publish Runtime Dep - Ubuntu 19.04",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "filename": "docker",
+        "arguments": "$(CommonDockerCommandToPublishRuntimeDepDebPackage) /p:OutputRid=ubuntu.19.04-$(PB_TargetArchitecture) $(PB_AdditionalMSBuildArguments)",
+        "workingFolder": "",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "environment": {},
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
       "displayName": "Package Runtime Dep - Debian 8",
       "timeoutInMinutes": 0,
       "task": {

--- a/publish/dir.props
+++ b/publish/dir.props
@@ -47,6 +47,7 @@
     <PublishRid Include="ubuntu.16.04-x64" />
     <PublishRid Include="ubuntu.17.10-x64" />
     <PublishRid Include="ubuntu.18.04-x64" />
+    <PublishRid Include="ubuntu.19.04-x64" />
     <PublishRid Include="debian.8-x64" />
     <PublishRid Include="debian.9-x64" />
     <PublishRid Include="linuxmint.7-x64" />

--- a/src/pkg/packaging/deb/dotnet-runtime-deps-debian_config_ubuntu.19.04-x64.json
+++ b/src/pkg/packaging/deb/dotnet-runtime-deps-debian_config_ubuntu.19.04-x64.json
@@ -1,0 +1,46 @@
+{
+    "maintainer_name":".NET Core Team",
+    "maintainer_email": "dotnetpackages@dotnetfoundation.org",
+
+    "package_name": "%RUNTIME_DEPS_DEBIAN_PACKAGE_NAME%",
+    "install_root": "/usr/share/dotnet",
+
+    "short_description": "%RUNTIME_DEPS_DEBIAN_PACKAGE_NAME% %RUNTIME_DEPS_VERSION%",
+    "long_description": ".NET Core is a development platform that you can use to build command-line applications, microservices and modern websites. This package installs all the system dependencies for .NET Core Runtime.",
+    "homepage": "https://dot.net/core",
+
+    "release":{
+        "package_version":"1.0.0.0",
+        "package_revision":"%RUNTIME_DEPS_REVISION%",
+        "urgency" : "low",
+        "changelog_message" : "https://github.com/dotnet/core/tree/master/release-notes"
+    },
+
+    "control": {
+        "priority":"standard",
+        "section":"libs",
+        "architecture":"amd64"
+    },
+
+    "copyright": "2018 Microsoft",
+    "license": {
+        "type": "MIT and ASL 2.0 and BSD",
+        "full_text": "Copyright (c) 2018 Microsoft\nPermission is hereby granted, free of charge, to any person obtaining a copy\nof this software and associated documentation files (the \"Software\"), to deal\nin the Software without restriction, including without limitation the rights\nto use, copy, modify, merge, publish, distribute, sublicense, and/or sell\ncopies of the Software, and to permit persons to whom the Software is\nfurnished to do so, subject to the following conditions:\nThe above copyright notice and this permission notice shall be included in all\ncopies or substantial portions of the Software.\nTHE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR\nIMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,\nFITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE\nAUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER\nLIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,\nOUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE\nSOFTWARE."
+    },
+
+    "debian_dependencies":{
+        "libc6":{},
+        "libgcc1":{},
+        "libgssapi-krb5-2":{},
+        "liblttng-ust0":{},
+        "libstdc++6":{},
+        "zlib1g":{},
+        "libssl1.1" : {},
+        "libicu63": {} 
+    },
+
+    "debian_ignored_dependencies" : [
+        "liblldb-3.5",
+        "liblldb-3.6"
+    ]
+}


### PR DESCRIPTION
#### Description
Adds `dotnet-runtime-deps-2.1` package for Ubuntu 19.04 to the `release/2.1` official build. This is a copy of the the 18.04 infra with the necessary dependency changes for SSL and ICU.

See https://github.com/dotnet/core-setup/issues/5852. This will need to be ported to 2.2/3.0/master.

#### Customer Impact
Without this package, users running Ubuntu 19.04 will be unable to install .NET Core from the Microsoft Debian package feed.

#### Regression?
No, new distro release bringup.

#### Risk
Minimal. The official build could break, although it's unlikely. No risk if something's wrong with the Debian package this ends up producing: we can choose not to ship it after the full build.

---

/cc @mmitche @vivmishra 

Dev build of the deps package: 
[dotnet-runtime-deps-2.1.11-servicing-27617-0-ubuntu.19.04-x64.zip](https://github.com/dotnet/core-setup/files/3090790/dotnet-runtime-deps-2.1.11-servicing-27617-0-ubuntu.19.04-x64.zip)

```
# dpkg-deb -I dotnet-runtime-deps-2.1.11-servicing-27617-0-ubuntu.19.04-x64.deb
 new Debian package, version 2.0.
 size 2122 bytes: control archive=617 bytes.
     595 bytes,    11 lines      control
     174 bytes,     2 lines      md5sums
 Package: dotnet-runtime-deps-2.1
 Version: 2.1.11~servicing-27617-0-1
 Architecture: amd64
 Maintainer: .NET Core Team <dotnetpackages@dotnetfoundation.org>
 Installed-Size: 26
 Depends: libgcc1, liblttng-ust0, libc6, zlib1g, libstdc++6, libssl1.1, libgssapi-krb5-2, libicu63
 Section: libs
 Priority: standard
 Homepage: https://dot.net/core
 Description: dotnet-runtime-deps-2.1 2.1.11~servicing-27617-0
  .NET Core is a development platform that you can use to build command-line applications, microservices and modern websites. This package installs all the system dependencies for .NET Core Runtime.
```