### PR TITLE
Revert GetRuntimeFilesFromPackages target order

### DIFF
--- a/src/pkg/packaging-tools/framework.dependency.targets
+++ b/src/pkg/packaging-tools/framework.dependency.targets
@@ -331,7 +331,10 @@
 
   <Target Name="GetRuntimeFilesToPackage"
           BeforeTargets="GetFilesToPackage"
-          DependsOnTargets="PrepareForCrossGen;GetCrossGenSymbolsFiles" />
+          DependsOnTargets="GetRuntimeFilesFromPackages;PrepareForCrossGen;GetCrossGenSymbolsFiles" />
+
+  <!-- Stub target to override if a depproj wants to package some runtime files. -->
+  <Target Name="GetRuntimeFilesFromPackages" />
 
   <!-- Target overrides (can't be shared with pkgproj) -->
 

--- a/src/pkg/projects/netcoreapp/src/netcoreapp.depproj
+++ b/src/pkg/projects/netcoreapp/src/netcoreapp.depproj
@@ -52,9 +52,10 @@
       Text="Failed to locate coreclr version.txt file." />
   </Target>
 
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+
   <!-- Fetches all the runtime items from the packages that we want to redist -->
   <Target Name="GetRuntimeFilesFromPackages"
-          BeforeTargets="GetRuntimeFilesToPackage"
           DependsOnTargets="GetCrossgenPackagePaths">
     <ItemGroup Condition="'$(NuGetRuntimeIdentifier)' != ''">
       <_ToolsToPackage Include="$(_runtimePackageDir)tools/**/*.*"/>
@@ -69,6 +70,4 @@
       </FilesToPackage>
     </ItemGroup>
   </Target>
-
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>


### PR DESCRIPTION
Potential fix for https://github.com/dotnet/core-setup/issues/5969.