### PR TITLE
Fix _jitPackageDir ref to include cross build jit

### DIFF
--- a/src/pkg/projects/netcoreapp/src/netcoreapp.depproj
+++ b/src/pkg/projects/netcoreapp/src/netcoreapp.depproj
@@ -63,7 +63,7 @@
         <TargetPath>tools/%(RecursiveDir)</TargetPath>
         <IsNative>true</IsNative>
       </FilesToPackage>
-      <FilesToPackage Condition="'$(_crossDir)' != ''" Include="$(_jitPackagePath)/runtimes$(_crossDir)/native/*.*">
+      <FilesToPackage Condition="'$(_crossDir)' != ''" Include="$(_jitPackageDir)runtimes$(_crossDir)/native/*.*">
         <TargetPath>runtimes$(_crossDir)/native</TargetPath>
         <IsNative>true</IsNative>
       </FilesToPackage>


### PR DESCRIPTION
Fixes https://github.com/dotnet/core-setup/issues/5969.

Refactor went wrong, causing `x64_arm64` (for example) to get missed because `_jitPackagePath` was replaced by `_jitPackageDir`. Verified fix with a local `/p:TargetArchitecture=arm64` build.