### PR TITLE
[release/3.0] Fix _jitPackageDir ref to include cross build jit

### DIFF
--- a/src/pkg/projects/netcoreapp/src/netcoreapp.depproj
+++ b/src/pkg/projects/netcoreapp/src/netcoreapp.depproj
@@ -63,7 +63,7 @@
         <TargetPath>tools/%(RecursiveDir)</TargetPath>
         <IsNative>true</IsNative>
       </FilesToPackage>
-      <FilesToPackage Condition="'$(_crossDir)' != ''" Include="$(_jitPackagePath)/runtimes$(_crossDir)/native/*.*">
+      <FilesToPackage Condition="'$(_crossDir)' != ''" Include="$(_jitPackageDir)runtimes$(_crossDir)/native/*.*">
         <TargetPath>runtimes$(_crossDir)/native</TargetPath>
         <IsNative>true</IsNative>
       </FilesToPackage>


### PR DESCRIPTION
Ports https://github.com/dotnet/core-setup/pull/5987 to `release/3.0` via cherry-pick.