### PR TITLE
Fix FixLayoutPermissions ordering for AppHost +x permission in installers

### DIFF
--- a/src/pkg/packaging-tools/framework.packaging.targets
+++ b/src/pkg/packaging-tools/framework.packaging.targets
@@ -167,7 +167,9 @@
     Create macOS pkg installer.
   -->
   <Target Name="CreatePkg"
-          DependsOnTargets="GetInstallerProperties">
+          DependsOnTargets="
+            GetInstallerProperties;
+            FixLayoutPermissions">
     <PropertyGroup>
       <_pkgArgs></_pkgArgs>
       <_pkgArgs>$(_pkgArgs) --root $(PackLayoutDir)</_pkgArgs>
@@ -184,7 +186,9 @@
     Create installer layout. Used for RPM or Debian package creation.
   -->
   <Target Name="CreateInstallerLayout"
-          DependsOnTargets="CopyFilesToLayout;FixLayoutPermissions" />
+          DependsOnTargets="
+            FixLayoutPermissions;
+            CopyFilesToLayout" />
 
   <Target Name="CopyFilesToLayout">
     <PropertyGroup>


### PR DESCRIPTION
Make sure `FixLayoutPermissions` runs while generating macOS pkg, and run it before copying to the secondary layout for Deb/RPM.

This is a fix for https://github.com/dotnet/cli/issues/11231. If `x` isn't set in Core-Setup, it needs to be set by the CLI tooling on the published app, which seems like a riskier fix.
