### PR TITLE
[release/3.0] Fix FixLayoutPermissions ordering for AppHost +x permission in installers

### DIFF
--- a/src/pkg/packaging-tools/framework.packaging.targets
+++ b/src/pkg/packaging-tools/framework.packaging.targets
@@ -167,7 +167,9 @@
     Create macOS pkg installer.
   -->
   <Target Name="CreatePkg"
-          DependsOnTargets="GetInstallerProperties">
+          DependsOnTargets="
+            GetInstallerProperties;
+            FixLayoutPermissions">
     <PropertyGroup>
       <_pkgArgs></_pkgArgs>
       <_pkgArgs>$(_pkgArgs) --root $(PackLayoutDir)</_pkgArgs>
@@ -184,7 +186,9 @@
     Create installer layout. Used for RPM or Debian package creation.
   -->
   <Target Name="CreateInstallerLayout"
-          DependsOnTargets="CopyFilesToLayout;FixLayoutPermissions" />
+          DependsOnTargets="
+            FixLayoutPermissions;
+            CopyFilesToLayout" />
 
   <Target Name="CopyFilesToLayout">
     <PropertyGroup>


### PR DESCRIPTION
#### Description

Ports https://github.com/dotnet/core-setup/pull/6003 to `release/3.0` to address https://github.com/dotnet/cli/issues/11231.
 
This change sets the execute bit for the apphost in the macOS installer so it has correct permissions when placed in the final location.

A fix in the CLI tooling is also possible, but it's riskier because it would involve calling something like `chmod u+x` on every publish. A Core-Setup fix is preferred.

#### Customer Impact

If the execute bit isn't set on the app host, .NET Core apps can't run. This affects macOS when the SDK is installed via the SDK `pkg` bundle.

#### Regression?

This is a regression caused by a change in how the apphost is packaged. When the AppHost was consumed by the SDK via NuGet, NuGet handled the execute bit. Now that a macOS package is used, Core-Setup is responsible for setting it, but it wasn't implemented.

#### Risk

Minimal. This PR takes a step that has already existed and been successful in the build and applies it to the macOS packaging flow. The change has been verified with local macOS, Ubuntu, and Fedora builds for `pkg`/`deb`/`rpm`.

@dsplaisted @wli3 @peterhuene @wtgodbe @dleeapho 