### PR TITLE
Remove the --roll-forward-on-no-candidate-fx from command line help

### DIFF
--- a/src/corehost/cli/fxr/fx_muxer.cpp
+++ b/src/corehost/cli/fxr/fx_muxer.cpp
@@ -198,10 +198,10 @@ void fx_muxer_t::muxer_usage(bool is_sdk_present)
 
     for (const auto& arg : known_opts)
     {
-        trace::println(_X("  %-37s  %s"), (arg.option + _X(" ") + arg.argument).c_str(), arg.description.c_str());
+        trace::println(_X("  %-30s  %s"), (arg.option + _X(" ") + arg.argument).c_str(), arg.description.c_str());
     }
-    trace::println(_X("  --list-runtimes                        Display the installed runtimes"));
-    trace::println(_X("  --list-sdks                            Display the installed SDKs"));
+    trace::println(_X("  --list-runtimes                 Display the installed runtimes"));
+    trace::println(_X("  --list-sdks                     Display the installed SDKs"));
 
     if (!is_sdk_present)
     {
@@ -268,10 +268,15 @@ std::vector<host_option> fx_muxer_t::get_known_opts(bool exec_mode, host_mode_t 
     if (get_all_options || mode == host_mode_t::muxer || mode == host_mode_t::apphost)
     {
         // If mode=host_mode_t::apphost, these are only used when the app is framework-dependent.
-        known_opts.push_back({ _X("--fx-version"), _X("<version>"), _X("Version of the installed Shared Framework to use to run the application.")});
-        known_opts.push_back({ _X("--roll-forward"), _X("<value>"), _X("Roll forward to framework version (LatestPatch, Minor, LatestMinor, Major, LatestMajor, Disable)")});
-        known_opts.push_back({ _X("--roll-forward-on-no-candidate-fx"), _X("<n>"), _X("Roll forward on no candidate framework (0=off, 1=roll minor, 2=roll major & minor).")});
-        known_opts.push_back({ _X("--additional-deps"), _X("<path>"), _X("Path to additional deps.json file.")});
+        known_opts.push_back({ _X("--fx-version"), _X("<version>"), _X("Version of the installed Shared Framework to use to run the application.") });
+        known_opts.push_back({ _X("--roll-forward"), _X("<value>"), _X("Roll forward to framework version (LatestPatch, Minor, LatestMinor, Major, LatestMajor, Disable)") });
+        known_opts.push_back({ _X("--additional-deps"), _X("<path>"), _X("Path to additional deps.json file.") });
+
+        if (!get_all_options)
+        {
+            // Intentionally leave this one out of get_all_options since we don't want to show it in command line help (it's deprecated).
+            known_opts.push_back({ _X("--roll-forward-on-no-candidate-fx"), _X("<n>"), _X("<obsolete>") });
+        }
     }
 
     return known_opts;

--- a/src/corehost/cli/fxr/fx_muxer.cpp
+++ b/src/corehost/cli/fxr/fx_muxer.cpp
@@ -183,7 +183,7 @@ void muxer_info(pal::string_t dotnet_root)
 
 void fx_muxer_t::muxer_usage(bool is_sdk_present)
 {
-    std::vector<host_option> known_opts = fx_muxer_t::get_known_opts(true, host_mode_t::invalid, true);
+    std::vector<host_option> known_opts = fx_muxer_t::get_known_opts(true, host_mode_t::invalid, /*for_cli_usage*/ true);
 
     if (!is_sdk_present)
     {
@@ -256,25 +256,25 @@ void append_probe_realpath(const pal::string_t& path, std::vector<pal::string_t>
     }
 }
 
-std::vector<host_option> fx_muxer_t::get_known_opts(bool exec_mode, host_mode_t mode, bool get_all_options)
+std::vector<host_option> fx_muxer_t::get_known_opts(bool exec_mode, host_mode_t mode, bool for_cli_usage)
 {
     std::vector<host_option> known_opts = { { _X("--additionalprobingpath"), _X("<path>"), _X("Path containing probing policy and assemblies to probe for.") } };
-    if (get_all_options || exec_mode || mode == host_mode_t::split_fx || mode == host_mode_t::apphost)
+    if (for_cli_usage || exec_mode || mode == host_mode_t::split_fx || mode == host_mode_t::apphost)
     {
         known_opts.push_back({ _X("--depsfile"), _X("<path>"), _X("Path to <application>.deps.json file.")});
         known_opts.push_back({ _X("--runtimeconfig"), _X("<path>"), _X("Path to <application>.runtimeconfig.json file.")});
     }
 
-    if (get_all_options || mode == host_mode_t::muxer || mode == host_mode_t::apphost)
+    if (for_cli_usage || mode == host_mode_t::muxer || mode == host_mode_t::apphost)
     {
         // If mode=host_mode_t::apphost, these are only used when the app is framework-dependent.
         known_opts.push_back({ _X("--fx-version"), _X("<version>"), _X("Version of the installed Shared Framework to use to run the application.") });
         known_opts.push_back({ _X("--roll-forward"), _X("<value>"), _X("Roll forward to framework version (LatestPatch, Minor, LatestMinor, Major, LatestMajor, Disable)") });
         known_opts.push_back({ _X("--additional-deps"), _X("<path>"), _X("Path to additional deps.json file.") });
 
-        if (!get_all_options)
+        if (!for_cli_usage)
         {
-            // Intentionally leave this one out of get_all_options since we don't want to show it in command line help (it's deprecated).
+            // Intentionally leave this one out of for_cli_usage since we don't want to show it in command line help (it's deprecated).
             known_opts.push_back({ _X("--roll-forward-on-no-candidate-fx"), _X("<n>"), _X("<obsolete>") });
         }
     }

--- a/src/corehost/cli/fxr/fx_muxer.h
+++ b/src/corehost/cli/fxr/fx_muxer.h
@@ -75,7 +75,7 @@ private:
     static std::vector<host_option> get_known_opts(
         bool exec_mode,
         host_mode_t mode,
-        bool get_all_options = false);
+        bool for_cli_usage = false);
     static int read_config_and_execute(
         const pal::string_t& host_command,
         const host_startup_info_t& host_info,


### PR DESCRIPTION
The setting is now deprecated so we don't want to show it in the command line help (it still works though).
