### PR TITLE
Add trace flush to error writer propagation

### DIFF
--- a/src/corehost/cli/fxr/fx_muxer.cpp
+++ b/src/corehost/cli/fxr/fx_muxer.cpp
@@ -68,9 +68,6 @@ static int execute_app(
     if (code != StatusCode::Success)
         return code;
 
-    // Previous hostfxr trace messages must be printed before calling trace::setup in hostpolicy
-    trace::flush();
-
     {
         propagate_error_writer_t propagate_error_writer_to_corehost(host_contract.set_error_writer);
 
@@ -101,9 +98,6 @@ static int execute_host_command(
     int code = load_hostpolicy(impl_dll_dir, &corehost, host_contract, "corehost_main_with_output_buffer", &host_main);
     if (code != StatusCode::Success)
         return code;
-
-    // Previous hostfxr trace messages must be printed before calling trace::setup in hostpolicy
-    trace::flush();
 
     {
         propagate_error_writer_t propagate_error_writer_to_corehost(host_contract.set_error_writer);
@@ -724,9 +718,6 @@ namespace
             trace::error(_X("This component must target .NET Core 3.0 or a higher version."));
             return code;
         }
-
-        // Previous hostfxr trace messages must be printed before calling trace::setup in hostpolicy
-        trace::flush();
 
         {
             propagate_error_writer_t propagate_error_writer_to_corehost(host_contract.set_error_writer);

--- a/src/corehost/common/utils.h
+++ b/src/corehost/common/utils.h
@@ -79,6 +79,11 @@ private:
 public:
     propagate_error_writer_t(set_error_writer_fn set_error_writer)
     {
+        // Previous trace messages from the caller module must be printed before calling trace::setup in calee module
+        // The two modules have different trace util instances and thus don't share file IO buffers
+        // not flashing may lead to writing traces from before the call after the call due to module mismatch.
+        trace::flush();
+
         m_set_error_writer = set_error_writer;
         m_error_writer_set = false;
 

--- a/src/corehost/common/utils.h
+++ b/src/corehost/common/utils.h
@@ -79,9 +79,9 @@ private:
 public:
     propagate_error_writer_t(set_error_writer_fn set_error_writer)
     {
-        // Previous trace messages from the caller module must be printed before calling trace::setup in calee module
+        // Previous trace messages from the caller module must be printed before calling trace::setup in callee module
         // The two modules have different trace util instances and thus don't share file IO buffers
-        // not flashing may lead to writing traces from before the call after the call due to module mismatch.
+        // Not flushing may lead to traces from before the call being written after the call due to module mismatch.
         trace::flush();
 
         m_set_error_writer = set_error_writer;

--- a/src/corehost/corehost.cpp
+++ b/src/corehost/corehost.cpp
@@ -209,12 +209,11 @@ int exe_start(const int argc, const pal::char_t* argv[])
 
         hostfxr_set_error_writer_fn set_error_writer_fn = (hostfxr_set_error_writer_fn)pal::get_symbol(fxr, "hostfxr_set_error_writer");
 
-        // Previous corehost trace messages must be printed before calling trace::setup in hostfxr
-        trace::flush();
+        {
+            propagate_error_writer_t propagate_error_writer_to_hostfxr(set_error_writer_fn);
 
-        propagate_error_writer_t propagate_error_writer_to_hostfxr(set_error_writer_fn);
-
-        rc = main_fn_v2(argc, argv, host_path_cstr, dotnet_root_cstr, app_path_cstr);
+            rc = main_fn_v2(argc, argv, host_path_cstr, dotnet_root_cstr, app_path_cstr);
+        }
     }
     else
     {


### PR DESCRIPTION
Removes small amount of code duplication. Makes sure that the behavior is consistent across all cross-module calls.