### PR TITLE
Increase GUI test timeout and add more diagnostics.

### DIFF
--- a/src/test/HostActivationTests/StandaloneAppActivation.cs
+++ b/src/test/HostActivationTests/StandaloneAppActivation.cs
@@ -324,7 +324,10 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
         {
             IntPtr windowHandle = IntPtr.Zero;
             StringBuilder diagMessages = new StringBuilder();
-            while (timeout > 0)
+
+            int longTimeout = timeout * 3;
+            int timeRemaining = longTimeout;
+            while (timeRemaining > 0)
             {
                 foreach (ProcessThread thread in process.Threads)
                 {
@@ -344,13 +347,19 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
                 }
 
                 Thread.Sleep(100);
-                timeout -= 100;
+                timeRemaining -= 100;
             }
 
             Assert.True(
                 windowHandle != IntPtr.Zero,
-                $"Waited {timeout} milliseconds for the popup window on process {process.Id}, but none was found." +
+                $"Waited {longTimeout} milliseconds for the popup window on process {process.Id}, but none was found." +
                 $"{Environment.NewLine}{diagMessages.ToString()}");
+
+            Assert.True(
+                timeRemaining > (longTimeout - timeout),
+                $"Waited {longTimeout - timeRemaining} milliseconds for the popup window on process {process.Id}. " +
+                $"It did show and was detected as HWND {windowHandle}, but it took too long. Consider extending the timeout period for this test.");
+
             return windowHandle;
         }
 #else


### PR DESCRIPTION
Since we don't have enough info to know why the tests were failing before, for now I'm increasing the timeout and adding better diagnostics.

The one failure mentioned in #6117 is interesting in that there are two tests which do the same thing (only small variation), and only one failed while the other worked. Which supports the theory of too short timeout.

Fixes #6117 