### PR TITLE
Build WindowsDesktop targeting pack installer and package assets for Linux and macOS

### DIFF
--- a/src/pkg/projects/windowsdesktop/pkg/dir.props
+++ b/src/pkg/projects/windowsdesktop/pkg/dir.props
@@ -15,12 +15,6 @@
     <FrameworkListFrameworkName>$(FrameworkPackageName)</FrameworkListFrameworkName>
   </PropertyGroup>
 
-  <PropertyGroup>
-    <BuildDebPackage>false</BuildDebPackage>
-    <BuildRpmPackage>false</BuildRpmPackage>
-    <GeneratePkg>false</GeneratePkg>
-  </PropertyGroup>
-
   <!-- Redistribute package content from other nuget packages. -->
   <ItemGroup>
     <ProjectReference Include="..\src\windowsdesktop.depproj">


### PR DESCRIPTION
The SDK currently expects the same targeting packs to available regardless of platform, and there's no known reason to omit WindowsDesktop bits from non-Windows. The WindowsDesktop targets only run on Windows, but it's possible to avoid the targets and compile against the reference DLLs directly.