### PR TITLE
Fix build break: update PublishRid list for Deb consolidation

### DIFF
--- a/publish/dir.props
+++ b/publish/dir.props
@@ -46,11 +46,6 @@
 
   <ItemGroup>
     <PublishRid Include="ubuntu.14.04-x64" />
-    <PublishRid Include="ubuntu.16.04-x64" />
-    <PublishRid Include="ubuntu.18.04-x64" />
-    <PublishRid Include="ubuntu.19.04-x64" />
-    <PublishRid Include="debian.8-x64" />
-    <PublishRid Include="debian.9-x64" />
     <PublishRid Include="linux-x64" />
     <PublishRid Include="win-x86" />
     <PublishRid Include="win-x64" />


### PR DESCRIPTION
Fixes https://github.com/dotnet/core-setup/issues/6212.

We don't build distro/release-specific Debian packages anymore, so only one Debian-packaging build is necessary. https://github.com/dotnet/core-setup/pull/6070 removed the extra builds but didn't update `PublishRid`s, causing official build failure.