### PR TITLE
[release/2.1] Move runtime-deps to openssl 1.1: support SLES 15 without legacy

### DIFF
--- a/src/pkg/packaging/rpm/dotnet-runtime-deps-rpm_config_sles.12-x64.json
+++ b/src/pkg/packaging/rpm/dotnet-runtime-deps-rpm_config_sles.12-x64.json
@@ -30,7 +30,7 @@
     },
     
     "rpm_dependencies":[{
-        "package_name": "libopenssl1_0_0",
+        "package_name": "libopenssl1_1",
         "package_version": ""
     },
     {


### PR DESCRIPTION
#### Description

SLES 12 has both libopenssl1_0_0 and libopenssl1_1, but SLES 15 moved 1_0_0 to the legacy module: https://www.suse.com/releasenotes/x86_64/SUSE-SLES/15/#fate-323920

Changing the RPM to 1_1 allows a single RPM to work by default with both SLES 12 and SLES 15.

#### Customer Impact

Adds support to install on SLES 15 without enabling legacy module.

#### Regression?

No.

#### Risk

Not significant.

When a SLES 12 user installs a new version, they *may* be upgraded from openssl 1.0 to openssl 1.1. This is not expected to break anything (.NET Core is compatible) but the change will be documented to raise awareness.

If openssl 1.1 somehow doesn't work, openssl 1.0 can still be used with some manual setup.