### PR TITLE
[release/2.2] Move runtime-deps to openssl 1.1: support SLES 15 without legacy

### DIFF
--- a/src/pkg/packaging/rpm/dotnet-runtime-deps-rpm_config_sles.12-x64.json
+++ b/src/pkg/packaging/rpm/dotnet-runtime-deps-rpm_config_sles.12-x64.json
@@ -30,7 +30,7 @@
     },
     
     "rpm_dependencies":[{
-        "package_name": "libopenssl1_0_0",
+        "package_name": "libopenssl1_1",
         "package_version": ""
     },
     {


### PR DESCRIPTION
See https://github.com/dotnet/core-setup/pull/6250.