### PR TITLE
Build WindowsDesktop from WinForms and WPF directly, skip DotNet-Trusted

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -1,10 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Dependencies>
   <ProductDependencies>
-    <Dependency Name="Microsoft.Private.CoreFx.NETCoreApp" Version="4.6.0-preview6.19260.3">
-      <Uri>https://github.com/dotnet/corefx</Uri>
-      <Sha>87b2e237fafbdfb01f03f16558f3fa17f8288f91</Sha>
-    </Dependency>
     <Dependency Name="Microsoft.NETCore.Platforms" Version="3.0.0-preview6.19260.3">
       <Uri>https://github.com/dotnet/corefx</Uri>
       <Sha>87b2e237fafbdfb01f03f16558f3fa17f8288f91</Sha>
@@ -12,6 +8,90 @@
     <Dependency Name="Microsoft.NETCore.Targets" Version="2.0.0" Pinned="true">
       <Uri>https://github.com/dotnet/corefx</Uri>
       <Sha>8321c729934c0f8be754953439b88e6e1c120c24</Sha>
+    </Dependency>
+    <Dependency Name="Microsoft.Private.CoreFx.NETCoreApp" Version="4.6.0-preview6.19260.3">
+      <Uri>https://github.com/dotnet/corefx</Uri>
+      <Sha>ef02cf17b5cdb57d5277b158cd3afba047df4d1b</Sha>
+    </Dependency>
+    <Dependency Name="Microsoft.Win32.Registry" Version="4.6.0-preview6.19260.3">
+      <Uri>https://github.com/dotnet/corefx</Uri>
+      <Sha>da36ea268c778200dc676d294667eb76146e1a01</Sha>
+    </Dependency>
+    <Dependency Name="Microsoft.Win32.SystemEvents" Version="4.6.0-preview6.19260.3">
+      <Uri>https://github.com/dotnet/corefx</Uri>
+      <Sha>da36ea268c778200dc676d294667eb76146e1a01</Sha>
+    </Dependency>
+    <Dependency Name="Microsoft.Windows.Compatibility" Version="3.0.0-preview6.19260.3">
+      <Uri>https://github.com/dotnet/corefx</Uri>
+      <Sha>da36ea268c778200dc676d294667eb76146e1a01</Sha>
+    </Dependency>
+    <Dependency Name="System.CodeDom" Version="4.6.0-preview6.19260.3">
+      <Uri>https://github.com/dotnet/corefx</Uri>
+      <Sha>da36ea268c778200dc676d294667eb76146e1a01</Sha>
+    </Dependency>
+    <Dependency Name="System.Configuration.ConfigurationManager" Version="4.6.0-preview6.19260.3">
+      <Uri>https://github.com/dotnet/corefx</Uri>
+      <Sha>da36ea268c778200dc676d294667eb76146e1a01</Sha>
+    </Dependency>
+    <Dependency Name="System.Diagnostics.EventLog" Version="4.6.0-preview6.19260.3">
+      <Uri>https://github.com/dotnet/corefx</Uri>
+      <Sha>da36ea268c778200dc676d294667eb76146e1a01</Sha>
+    </Dependency>
+    <Dependency Name="System.DirectoryServices" Version="4.6.0-preview6.19260.3">
+      <Uri>https://github.com/dotnet/corefx</Uri>
+      <Sha>da36ea268c778200dc676d294667eb76146e1a01</Sha>
+    </Dependency>
+    <Dependency Name="System.Drawing.Common" Version="4.6.0-preview6.19260.3">
+      <Uri>https://github.com/dotnet/corefx</Uri>
+      <Sha>da36ea268c778200dc676d294667eb76146e1a01</Sha>
+    </Dependency>
+    <Dependency Name="System.IO.FileSystem.AccessControl" Version="4.6.0-preview6.19260.3">
+      <Uri>https://github.com/dotnet/corefx</Uri>
+      <Sha>da36ea268c778200dc676d294667eb76146e1a01</Sha>
+    </Dependency>
+    <Dependency Name="System.Resources.Extensions" Version="4.6.0-preview6.19260.3">
+      <Uri>https://github.com/dotnet/corefx</Uri>
+      <Sha>da36ea268c778200dc676d294667eb76146e1a01</Sha>
+    </Dependency>
+    <Dependency Name="System.IO.Packaging" Version="4.6.0-preview6.19260.3">
+      <Uri>https://github.com/dotnet/corefx</Uri>
+      <Sha>da36ea268c778200dc676d294667eb76146e1a01</Sha>
+    </Dependency>
+    <Dependency Name="System.Security.AccessControl" Version="4.6.0-preview6.19260.3">
+      <Uri>https://github.com/dotnet/corefx</Uri>
+      <Sha>da36ea268c778200dc676d294667eb76146e1a01</Sha>
+    </Dependency>
+    <Dependency Name="System.Security.Cryptography.Cng" Version="4.6.0-preview6.19260.3">
+      <Uri>https://github.com/dotnet/corefx</Uri>
+      <Sha>da36ea268c778200dc676d294667eb76146e1a01</Sha>
+    </Dependency>
+    <Dependency Name="System.Security.Cryptography.Pkcs" Version="4.6.0-preview6.19260.3">
+      <Uri>https://github.com/dotnet/corefx</Uri>
+      <Sha>da36ea268c778200dc676d294667eb76146e1a01</Sha>
+    </Dependency>
+    <Dependency Name="System.Security.Cryptography.ProtectedData" Version="4.6.0-preview6.19260.3">
+      <Uri>https://github.com/dotnet/corefx</Uri>
+      <Sha>da36ea268c778200dc676d294667eb76146e1a01</Sha>
+    </Dependency>
+    <Dependency Name="System.Security.Cryptography.Xml" Version="4.6.0-preview6.19260.3">
+      <Uri>https://github.com/dotnet/corefx</Uri>
+      <Sha>da36ea268c778200dc676d294667eb76146e1a01</Sha>
+    </Dependency>
+    <Dependency Name="System.Security.Permissions" Version="4.6.0-preview6.19260.3">
+      <Uri>https://github.com/dotnet/corefx</Uri>
+      <Sha>da36ea268c778200dc676d294667eb76146e1a01</Sha>
+    </Dependency>
+    <Dependency Name="System.Security.Principal.Windows" Version="4.6.0-preview6.19260.3">
+      <Uri>https://github.com/dotnet/corefx</Uri>
+      <Sha>da36ea268c778200dc676d294667eb76146e1a01</Sha>
+    </Dependency>
+    <Dependency Name="System.Threading.AccessControl" Version="4.6.0-preview6.19260.3">
+      <Uri>https://github.com/dotnet/corefx</Uri>
+      <Sha>da36ea268c778200dc676d294667eb76146e1a01</Sha>
+    </Dependency>
+    <Dependency Name="System.Windows.Extensions" Version="4.6.0-preview6.19260.3">
+      <Uri>https://github.com/dotnet/corefx</Uri>
+      <Sha>da36ea268c778200dc676d294667eb76146e1a01</Sha>
     </Dependency>
     <Dependency Name="NETStandard.Library" Version="2.1.0-prerelease.19259.7">
       <Uri>https://github.com/dotnet/standard</Uri>
@@ -21,9 +101,17 @@
       <Uri>https://github.com/dotnet/coreclr</Uri>
       <Sha>48431cc037776ca359de36bf71bda8c154cc2aa9</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Private.WindowsDesktop.App" Version="3.0.0-preview6-27710-10">
-      <Uri>https://dev.azure.com/devdiv/DevDiv/_git/DotNet-Trusted</Uri>
-      <Sha>8cff4053239d3436b36f5602d0bd2e61df223f5d</Sha>
+    <Dependency Name="Microsoft.Private.Winforms" Version="4.8.0-preview6.19257.1" CoherentParentDependency="Microsoft.DotNet.Wpf.DncEng">
+      <Uri>https://github.com/dotnet/winforms</Uri>
+      <Sha>98469c5ef23bb546454f7983b122fa6edde41e7a</Sha>
+    </Dependency>
+    <Dependency Name="Microsoft.DotNet.Wpf.GitHub" Version="4.8.0-preview6.19257.5" CoherentParentDependency="Microsoft.DotNet.Wpf.DncEng">
+      <Uri>https://github.com/dotnet/wpf</Uri>
+      <Sha>a0cf8b895d481d4f6bc77ba3d944078b81091998</Sha>
+    </Dependency>
+    <Dependency Name="Microsoft.DotNet.Wpf.DncEng" Version="4.8.0-preview6.19258.6">
+      <Uri>https://dev.azure.com/dnceng/internal/_git/dotnet-wpf-int</Uri>
+      <Sha>a7f5978b0c658dd41fd441186c44996d9fe0bfb5</Sha>
     </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -8,15 +8,39 @@
   <!--Package versions-->
   <PropertyGroup>
     <!-- corefx -->
-    <MicrosoftPrivateCoreFxNETCoreAppPackageVersion>4.6.0-preview6.19260.3</MicrosoftPrivateCoreFxNETCoreAppPackageVersion>
     <MicrosoftNETCorePlatformsPackageVersion>3.0.0-preview6.19260.3</MicrosoftNETCorePlatformsPackageVersion>
     <MicrosoftNETCoreTargetsPackageVersion>2.0.0</MicrosoftNETCoreTargetsPackageVersion>
+    <MicrosoftPrivateCoreFxNETCoreAppPackageVersion>4.6.0-preview6.19260.3</MicrosoftPrivateCoreFxNETCoreAppPackageVersion>
+    <MicrosoftWin32RegistryVersion>4.6.0-preview6.19260.3</MicrosoftWin32RegistryVersion>
+    <MicrosoftWin32SystemEventsVersion>4.6.0-preview6.19260.3</MicrosoftWin32SystemEventsVersion>
+    <MicrosoftWindowsCompatibilityPackageVersion>3.0.0-preview6.19260.3</MicrosoftWindowsCompatibilityPackageVersion>
+    <SystemCodeDomVersion>4.6.0-preview6.19260.3</SystemCodeDomVersion>
+    <SystemConfigurationConfigurationManagerVersion>4.6.0-preview6.19260.3</SystemConfigurationConfigurationManagerVersion>
+    <SystemDiagnosticsEventLogVersion>4.6.0-preview6.19260.3</SystemDiagnosticsEventLogVersion>
+    <SystemDirectoryServicesVersion>4.6.0-preview6.19260.3</SystemDirectoryServicesVersion>
+    <SystemDrawingCommonVersion>4.6.0-preview6.19260.3</SystemDrawingCommonVersion>
+    <SystemIOFileSystemAccessControlVersion>4.6.0-preview6.19260.3</SystemIOFileSystemAccessControlVersion>
+    <SystemIOPackagingVersion>4.6.0-preview6.19260.3</SystemIOPackagingVersion>
+    <SystemResourcesExtensionsPackageVersion>4.6.0-preview6.19260.3</SystemResourcesExtensionsPackageVersion>
+    <SystemSecurityAccessControlVersion>4.6.0-preview6.19260.3</SystemSecurityAccessControlVersion>
+    <SystemSecurityCryptographyCngVersion>4.6.0-preview6.19260.3</SystemSecurityCryptographyCngVersion>
+    <SystemSecurityCryptographyPkcsVersion>4.6.0-preview6.19260.3</SystemSecurityCryptographyPkcsVersion>
+    <SystemSecurityCryptographyProtectedDataVersion>4.6.0-preview6.19260.3</SystemSecurityCryptographyProtectedDataVersion>
+    <SystemSecurityCryptographyXmlVersion>4.6.0-preview6.19260.3</SystemSecurityCryptographyXmlVersion>
+    <SystemSecurityPermissionsVersion>4.6.0-preview6.19260.3</SystemSecurityPermissionsVersion>
+    <SystemSecurityPrincipalWindowsVersion>4.6.0-preview6.19260.3</SystemSecurityPrincipalWindowsVersion>
+    <SystemThreadingAccessControlVersion>4.6.0-preview6.19260.3</SystemThreadingAccessControlVersion>
+    <SystemWindowsExtensionsPackageVersion>4.6.0-preview6.19260.3</SystemWindowsExtensionsPackageVersion>
     <!-- standard -->
     <NETStandardLibraryPackageVersion>2.1.0-prerelease.19259.7</NETStandardLibraryPackageVersion>
     <!-- coreclr -->
     <MicrosoftNETCoreRuntimeCoreCLRPackageVersion>3.0.0-preview6-27710-71</MicrosoftNETCoreRuntimeCoreCLRPackageVersion>
-    <!-- dotnet-trusted -->
-    <MicrosoftPrivateWindowsDesktopAppPackageVersion>3.0.0-preview6-27710-10</MicrosoftPrivateWindowsDesktopAppPackageVersion>
+    <!-- winforms -->
+    <MicrosoftPrivateWinformsPackageVersion>4.8.0-preview6.19257.1</MicrosoftPrivateWinformsPackageVersion>
+    <!-- wpf -->
+    <MicrosoftDotNetWpfGitHubPackageVersion>4.8.0-preview6.19257.5</MicrosoftDotNetWpfGitHubPackageVersion>
+    <!-- wpf-int -->
+    <MicrosoftDotNetWpfDncEngPackageVersion>4.8.0-preview6.19258.6</MicrosoftDotNetWpfDncEngPackageVersion>
     <!-- Not auto-updated. -->
     <MicrosoftBclJsonSourcesPackageVersion>4.6.0-preview.19072.2</MicrosoftBclJsonSourcesPackageVersion>
   </PropertyGroup>

--- a/src/pkg/packaging-tools/framework.dependency.targets
+++ b/src/pkg/packaging-tools/framework.dependency.targets
@@ -335,6 +335,10 @@
           BeforeTargets="GetFilesToPackage"
           DependsOnTargets="PrepareForCrossGen;GetCrossGenSymbolsFiles" />
 
+  <Target Name="GetReferenceFilenames"
+          Returns="@(Reference -> '%(Filename)')"
+          DependsOnTargets="ResolveNuGetPackages" />
+
   <!-- Target overrides (can't be shared with pkgproj) -->
 
   <Target Name="Build" DependsOnTargets="GenerateHashVersionsFile;GetFilesToPackage" />

--- a/src/pkg/packaging-tools/framework.dependency.targets
+++ b/src/pkg/packaging-tools/framework.dependency.targets
@@ -67,7 +67,7 @@
           DependsOnTargets="GetDependencyVersionFiles"
           Condition="'$(FrameworkPackageName)' != ''">
     <Error
-      Condition="!Exists('%(DependencyVersionFile.Identity)')"
+      Condition="'@(DependencyVersionFile)' != '' AND !Exists('%(DependencyVersionFile.Identity)')"
       Text="'%(Name)' version file does not exist: %(Identity)" />
 
     <ItemGroup>
@@ -77,6 +77,8 @@
       <_VersionsFileLines Include="@(DependencyVersionFile ->'%(Name) %(Content)')" />
     </ItemGroup>
 
+    <!-- GetDependencyVersionFiles may or may not create the intermediate dir. Ensure it exists. -->
+    <MakeDir Directories="$(IntermediateOutputPath)" />
     <WriteLinesToFile Lines="@(_VersionsFileLines)"
                        File="$(IntermediateOutputPath)\$(FrameworkPackageName).versions.txt"
                        Overwrite="true"/>

--- a/src/pkg/packaging-tools/framework.dependency.targets
+++ b/src/pkg/packaging-tools/framework.dependency.targets
@@ -114,7 +114,7 @@
   <!--
     Get paths from packages that are needed for crossgen. Only relevant for runtime-specific builds.
   -->
-  <Target Name="GetCrossgenPackagePaths"
+  <Target Name="GetCorePackagePaths"
           Condition="'$(NuGetRuntimeIdentifier)' != ''"
           DependsOnTargets="ResolveNuGetPackages">
     <PropertyGroup>
@@ -127,6 +127,24 @@
       <_winmdPackageDir>$(PackagesDir)$(MicrosoftTargetingPackPrivateWinRTPackage.ToLowerInvariant())/$(MicrosoftTargetingPackPrivateWinRTPackageVersion)/</_winmdPackageDir>
     </PropertyGroup>
 
+    <PropertyGroup>
+      <_crossDir Condition="'$(TargetArchitecture)' == 'arm' AND '$(OS)' == 'Windows_NT'">/x86_arm</_crossDir>
+      <_crossDir Condition="'$(TargetArchitecture)' == 'arm' AND '$(OS)' != 'Windows_NT'">/x64_arm</_crossDir>
+      <_crossDir Condition="'$(TargetArchitecture)' == 'arm64'">/x64_arm64</_crossDir>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <_requiredProperty Include="_runtimePackageDir;_jitPackageDir;_corefxPackageDir;_winmdPackageDir" />
+    </ItemGroup>
+
+    <Message Text="%(_requiredProperty.Identity): $(%(_requiredProperty.Identity))" />
+    <Error Condition="'$(%(_requiredProperty.Identity))' == ''" Text="Required property %(_requiredProperty.Identity) was not set." />
+    <Error Condition="!Exists('$(%(_requiredProperty.Identity))')" Text="Required property %(_requiredProperty.Identity) with value '$(%(_requiredProperty.Identity))' does not exist." />
+  </Target>
+
+  <Target Name="GetCrossgenToolPaths"
+          Condition="'$(NuGetRuntimeIdentifier)' != ''"
+          DependsOnTargets="GetCorePackagePaths">
     <ItemGroup>
       <!-- Find crossgen tool assets in package cache to allow ExcludeAssets=All. -->
       <_runtimeCLR Include="$(_runtimePackageDir)**/$(LibraryFilePrefix)coreclr$(LibraryFileExtension)" />
@@ -135,12 +153,6 @@
       <_fxSystemRuntime Include="$(_corefxPackageDir)**/System.Runtime.dll" />
       <_windowsWinMD Include="$(_winmdPackageDir)**/Windows.winmd" />
     </ItemGroup>
-
-    <PropertyGroup>
-      <_crossDir Condition="'$(TargetArchitecture)' == 'arm' AND '$(OS)' == 'Windows_NT'">/x86_arm</_crossDir>
-      <_crossDir Condition="'$(TargetArchitecture)' == 'arm' AND '$(OS)' != 'Windows_NT'">/x64_arm</_crossDir>
-      <_crossDir Condition="'$(TargetArchitecture)' == 'arm64'">/x64_arm64</_crossDir>
-    </PropertyGroup>
 
     <PropertyGroup Condition="'@(_runtimeCLR)' != ''">
       <_crossGenPath>$(_runtimePackageDir)tools$(_crossDir)/crossgen$(ApplicationFileExtension)</_crossGenPath>
@@ -165,26 +177,45 @@
     </PropertyGroup>
     
     <ItemGroup>
-      <_requiredProperty Include="_runtimePackageDir;_coreLibDirectory;_crossGenPath;_jitPath;_fxLibDirectory;_windowsWinMDDirectory" />
+      <_requiredProperty Include="_coreLibDirectory;_crossGenPath;_jitPath;_fxLibDirectory;_windowsWinMDDirectory" />
     </ItemGroup>
 
     <Message Text="%(_requiredProperty.Identity): $(%(_requiredProperty.Identity))" />
     <Error Condition="'$(%(_requiredProperty.Identity))' == ''" Text="Required property %(_requiredProperty.Identity) was not set." />
     <Error Condition="!Exists('$(%(_requiredProperty.Identity))')" Text="Required property %(_requiredProperty.Identity) with value '$(%(_requiredProperty.Identity))' does not exist." />
+
+    <ItemGroup>
+      <!--
+        The following path must be passed to crossgen to locate all dependencies. Include it first
+        so in case of conflicts, DLLs are found in the framework being crossgenned.
+      -->
+      <_crossgenPlatformDirectories Include="%(_filesToCrossGen.RootDir)%(_filesToCrossGen.Directory)" />
+      <!-- the following path *must* be passed to crossgen as it has the CoreLib.ni.dll, it will not use the IL copy. -->
+      <_crossgenPlatformDirectories Include="$(_runtimeDirectory)" />
+      <!-- the following need not be passed to crossgen but we do so to be safe. -->
+      <_crossgenPlatformDirectories Include="$(_coreLibDirectory)" />
+      <!-- The following is necessary to crossgen WindowsDesktop. For NETCoreApp it's automatic because we're crossgenning CoreFX bits. -->
+      <_crossgenPlatformDirectories Include="$(_fxLibDirectory)" />
+    </ItemGroup>
+
+    <PropertyGroup>
+      <!-- Use PathSeparator so that we get a ':' on unix and ';' on windows
+           Escape the value so that the ';' doesn't result multiple lines when writing to the RSP file -->
+      <_pathSeparatorEscaped>$([MSBuild]::Escape($([System.IO.Path]::PathSeparator.ToString())))</_pathSeparatorEscaped>
+      <_crossgenPlatformAssemblies>@(_crossgenPlatformDirectories->'%(Identity)', '$(_pathSeparatorEscaped)')</_crossgenPlatformAssemblies>
+    </PropertyGroup>
   </Target>
 
   <!-- Prepares all items for cross-gen and replaces package file items with their cross-gen'ed equivalents -->
   <Target Name="PrepareForCrossGen"
           Condition="'$(NuGetRuntimeIdentifier)' != '' AND '$(DisableCrossgen)' != 'true'"
           DependsOnTargets="
-            GetCrossgenPackagePaths;
+            GetCorePackagePaths;
             GetFilesFromPackages">
     <PropertyGroup>
       <_crossGenIntermediatePath>$(IntermediateOutputPath)/crossgen</_crossGenIntermediatePath>
     </PropertyGroup>
-    <!-- Ensure crossgen is executable.  See https://github.com/NuGet/Home/issues/4424 -->
-    <Exec Command="chmod u+x $(_crossGenPath)"
-          Condition="'$(OSGroup)' != 'Windows_NT'" />
+    
     <ItemGroup>
       <!--
         Skip crossgen for some files, including:
@@ -217,32 +248,24 @@
       <_crossGenedFilesToPackage Include="@(_filesToCrossGen->'%(CrossGenedPath)')" />
       <FilesToPackage Include="@(_crossGenedFilesToPackage)" />
     </ItemGroup>
+  </Target>
 
-    <ItemGroup>
-      <!--
-        The following path must be passed to crossgen to locate all dependencies. Include it first
-        so in case of conflicts, DLLs are found in the framework being crossgenned.
-      -->
-      <_crossgenPlatformDirectories Include="%(_filesToCrossGen.RootDir)%(_filesToCrossGen.Directory)" />
-      <!-- the following path *must* be passed to crossgen as it has the CoreLib.ni.dll, it will not use the IL copy. -->
-      <_crossgenPlatformDirectories Include="$(_runtimeDirectory)" />
-      <!-- the following need not be passed to crossgen but we do so to be safe. -->
-      <_crossgenPlatformDirectories Include="$(_coreLibDirectory)" />
-      <!-- The following is necessary to crossgen WindowsDesktop. For NETCoreApp it's automatic because we're crossgenning CoreFX bits. -->
-      <_crossgenPlatformDirectories Include="$(_fxLibDirectory)" />
-    </ItemGroup>
-
-    <PropertyGroup>
-      <!-- Use PathSeparator so that we get a ':' on unix and ';' on windows
-           Escape the value so that the ';' doesn't result multiple lines when writing to the RSP file -->
-      <_pathSeparatorEscaped>$([MSBuild]::Escape($([System.IO.Path]::PathSeparator.ToString())))</_pathSeparatorEscaped>
-      <_crossgenPlatformAssemblies>@(_crossgenPlatformDirectories->'%(Identity)', '$(_pathSeparatorEscaped)')</_crossgenPlatformAssemblies>
-    </PropertyGroup>
+  <!-- Ensure crossgen is executable. See https://github.com/NuGet/Home/issues/4424 -->
+  <Target Name="EnsureCrossGenIsExecutable"
+          Condition="'$(OSGroup)' != 'Windows_NT'"
+          DependsOnTargets="GetCrossgenToolPaths">
+    <Exec
+      Command="chmod u+x $(_crossGenPath)"
+      Condition="'$(OSGroup)' != 'Windows_NT' AND Exists('$(_crossGenPath)')" />
   </Target>
 
   <Target Name="CrossGen"
           BeforeTargets="Build"
-          DependsOnTargets="CreateCrossGenImages;CreateCrossGenSymbols" />
+          DependsOnTargets="
+            GetCrossgenToolPaths;
+            EnsureCrossGenIsExecutable;
+            CreateCrossGenImages;
+            CreateCrossGenSymbols" />
 
   <Target Name="CreateCrossGenImages"
           DependsOnTargets="PrepareForCrossGen"

--- a/src/pkg/packaging-tools/framework.packaging.targets
+++ b/src/pkg/packaging-tools/framework.packaging.targets
@@ -329,7 +329,18 @@
   <Target Name="GenerateSharedFramework"
           Condition="'$(GenerateSharedFramework)' == 'true'">
     <PropertyGroup>
-      <SharedFrameworkIntermediateOutputPath>$(IntermediateOutputPath)sfx/</SharedFrameworkIntermediateOutputPath>
+      <!--
+        For the sfx intermediate path, use 'bin/obj/sfx/', without OSPlatformConfig (RID +
+        Release/Debug). This is to save on path chars, which are at a premium. if the Git clone root
+        is even a little deep, Windows max path is a big problem. Package caches are a particular
+        problem due to long IDs, long versions, and deep resource DLLs with big names.
+
+        The OSPlatformConfig is normally in the intermediate path because it allows building
+        different configurations without cleaning the repo in between. This can be valuable for dev
+        builds. Not including OSPlatformConfig is ok in this target because the intermediate dir is
+        always deleted before it's used.
+      -->
+      <SharedFrameworkIntermediateOutputPath>$(BaseIntermediateOutputPath)sfx/$(ShortFrameworkName)/</SharedFrameworkIntermediateOutputPath>
     </PropertyGroup>
 
     <!-- Delete layout directory and sfx NuGet cache to ensure freshness. -->

--- a/src/pkg/packaging-tools/framework.packaging.targets
+++ b/src/pkg/packaging-tools/framework.packaging.targets
@@ -382,8 +382,93 @@
     </PropertyGroup>
   </Target>
 
+  <!-- Closure verification targets for WindowsDesktop. -->
+  <PropertyGroup>
+    <!-- Avoid MSBuild quirk: AfterTargets failure doesn't cause the build to fail. -->
+    <BuildDependsOn>$(BuildDependsOn);VerifyClosure;VerifyDuplicateTypes</BuildDependsOn>
+  </PropertyGroup>
+
+  <Target Name="GetClosureFiles">
+    <!-- Set up ClosureFile items organized by file-set. -->
+    <ItemGroup>
+      <ExistingLibraryFile
+        Include="@(File)"
+        Condition="
+          Exists('%(FullPath)') AND
+          (
+            '%(Extension)' == '.dll' OR
+            '%(Extension)' == '$(LibraryFileExtension)'
+          )"/>
+
+      <ClosureFile
+        Include="@(ExistingLibraryFile)"
+        Condition="'%(ExistingLibraryFile.TargetPath)' == 'ref/$(TargetFramework)'"
+        FileSet="reference" />
+
+      <ClosureFile
+        Include="@(ExistingLibraryFile)"
+        Condition="
+          '%(ExistingLibraryFile.TargetPath)' == 'runtimes/$(PackageTargetRuntime)/lib/$(TargetFramework)' OR
+          '%(ExistingLibraryFile.TargetPath)' == 'runtimes/$(PackageTargetRuntime)/native'"
+        FileSet="runtime" />
+
+      <!-- Remove resource files. -->
+      <ClosureFile
+        Remove="@(ClosureFile)"
+        Condition="'%(ClosureFile.DestinationSubDirectory)' != ''" />
+    </ItemGroup>
+  </Target>
+
+  <Target Name="VerifyClosure"
+          DependsOnTargets="GetClosureFiles"
+          Condition="'$(SkipValidatePackage)' != 'true'"
+          Inputs="%(ClosureFile.FileSet)"
+          Outputs="batching-on-FileSet-metadata">
+    <ItemGroup>
+      <_closureFileNames Include="@(ClosureFile->'%(FileName)')" Original="%(Identity)" />
+
+      <_closureFileNamesFiltered Include="@(_closureFileNames)" Exclude="@(ExcludeFromClosure)"/>
+      <_closureFileFiltered Include="@(_closureFileNamesFiltered->'%(Original)')"/>
+    </ItemGroup>
+
+    <Message Importance="High" Text="Verifying closure of $(Id) %(ClosureFile.FileSet) assemblies" />
+    <VerifyClosure
+      Sources="@(_closureFileFiltered)"
+      IgnoredReferences="@(IgnoredReference)"
+      DependencyGraphFilePath="$(PackageReportDir)$(Id)$(NuspecSuffix)-%(ClosureFile.FileSet).dgml" />
+  </Target>
+
+  <Target Name="VerifyDuplicateTypes"
+          DependsOnTargets="GetClosureFiles"
+          Condition="'$(SkipValidatePackage)' != 'true'"
+          Inputs="%(ClosureFile.FileSet)"
+          Outputs="batching-on-FileSet-metadata">
+    <PropertyGroup>
+      <_fileSet>%(ClosureFile.FileSet)</_fileSet>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <_dupTypeFileName Include="@(ClosureFile->'%(FileName)')" Original="%(Identity)" />
+      <_dupTypeFileName
+        Include="@(FrameworkClosureFile->'%(FileName)')"
+        Exclude="@(_dupTypeFileName)"
+        Condition="'$(_fileSet)' == '%(FrameworkClosureFile.FileSet)'"
+        Original="%(Identity)" />
+
+      <_dupTypeFileNamesFiltered Include="@(_dupTypeFileName)" Exclude="@(ExcludeFromDuplicateTypes)"/>
+      <_dupTypeFileFiltered Include="@(_dupTypeFileNamesFiltered->'%(Original)')"/>
+    </ItemGroup>
+
+    <Message Importance="High" Text="Verifying no duplicate types in $(Id) %(ClosureFile.FileSet) assemblies" />
+    <VerifyTypes
+      Sources="@(_dupTypeFileFiltered)"
+      IgnoredTypes="@(IgnoredDuplicateType)" />
+  </Target>
+
   <!-- Target overrides (can't be shared with other package projects) -->
 
-  <Target Name="GetPackageReport" />
+  <Import
+    Project="$(MSBuildThisFileDirectory)skip.GetPackageReport.targets"
+    Condition="'$(SkipValidatePackage)' == 'true'"/>
 
 </Project>

--- a/src/pkg/packaging-tools/framework.packaging.targets
+++ b/src/pkg/packaging-tools/framework.packaging.targets
@@ -329,7 +329,7 @@
   <Target Name="GenerateSharedFramework"
           Condition="'$(GenerateSharedFramework)' == 'true'">
     <PropertyGroup>
-      <SharedFrameworkIntermediateOutputPath>$(IntermediateOutputPath)sharedFx/</SharedFrameworkIntermediateOutputPath>
+      <SharedFrameworkIntermediateOutputPath>$(IntermediateOutputPath)sfx/</SharedFrameworkIntermediateOutputPath>
     </PropertyGroup>
 
     <!-- Delete layout directory and sfx NuGet cache to ensure freshness. -->

--- a/src/pkg/packaging-tools/sharedFramework/sharedFramework.csproj
+++ b/src/pkg/packaging-tools/sharedFramework/sharedFramework.csproj
@@ -31,8 +31,8 @@
     <DisableImplicitNuGetFallbackFolder>true</DisableImplicitNuGetFallbackFolder>
     <!-- Don't error due to lack of runtime-specific deps, we're referencing those directly -->
     <EnsureRuntimePackageDependencies>false</EnsureRuntimePackageDependencies>
-    <!-- Use a project-local packages folder -->
-    <RestorePackagesPath>$(IntermediateOutputPath)packages</RestorePackagesPath>
+    <!-- Use a project-local packages folder. 'p' rather than 'packages': stay under char limit. -->
+    <RestorePackagesPath>$(IntermediateOutputPath)p</RestorePackagesPath>
     <!-- Do not build or nor build in publish output or deps -->
     <NoBuild>true</NoBuild>
     <CopyBuildOutputToPublishDirectory>false</CopyBuildOutputToPublishDirectory>

--- a/src/pkg/packaging-tools/sharedFramework/sharedFramework.csproj
+++ b/src/pkg/packaging-tools/sharedFramework/sharedFramework.csproj
@@ -31,7 +31,7 @@
     <DisableImplicitNuGetFallbackFolder>true</DisableImplicitNuGetFallbackFolder>
     <!-- Don't error due to lack of runtime-specific deps, we're referencing those directly -->
     <EnsureRuntimePackageDependencies>false</EnsureRuntimePackageDependencies>
-    <!-- Use a project-local packages folder. 'p' rather than 'packages': stay under char limit. -->
+    <!-- Use a project-local packages folder. 'p', not 'packages': max path breathing room. -->
     <RestorePackagesPath>$(IntermediateOutputPath)p</RestorePackagesPath>
     <!-- Do not build or nor build in publish output or deps -->
     <NoBuild>true</NoBuild>

--- a/src/pkg/packaging-tools/skip.GetPackageReport.targets
+++ b/src/pkg/packaging-tools/skip.GetPackageReport.targets
@@ -1,0 +1,5 @@
+<Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <Target Name="GetPackageReport" />
+
+</Project>

--- a/src/pkg/projects/dir.targets
+++ b/src/pkg/projects/dir.targets
@@ -45,9 +45,17 @@
       <NonWindowsSymbolFile Include="@(NonWindowsNativeFile -> '%(Identity)$(SymbolFileExtension)')" />
       <ExistingNonWindowsSymbolFile Include="@(NonWindowsSymbolFile)" Condition="Exists('%(Identity)')" />
 
-      <File Include="@(ExistingWindowsSymbolFile);@(ExistingNonWindowsSymbolFile)">
-        <IsSymbolFile>true</IsSymbolFile>
-      </File>
+      <!--
+        These files might be directly redisted, and already in File. Duplicates cause validation
+        errors, so don't add files that are already known.
+      -->
+      <DiscoveredSymbolFile
+        Include="@(ExistingWindowsSymbolFile);@(ExistingNonWindowsSymbolFile)"
+        IsSymbolFile="true" />
+      
+      <NormalizedFile Include="$([MSBuild]::NormalizePath('%(File.Identity)'))" />
+
+      <File Include="@(DiscoveredSymbolFile)" Exclude="@(NormalizedFile)" />
     </ItemGroup>
 
     <PropertyGroup>

--- a/src/pkg/projects/netcoreapp/src/netcoreapp.depproj
+++ b/src/pkg/projects/netcoreapp/src/netcoreapp.depproj
@@ -27,7 +27,7 @@
        only relevant for runtime-specific builds -->
   <Target Name="GetPackagePaths"
           Condition="'$(NuGetRuntimeIdentifier)' != ''"
-          DependsOnTargets="GetCrossgenPackagePaths" />
+          DependsOnTargets="GetCorePackagePaths" />
 
   <Target Name="GetDependencyVersionFiles" DependsOnTargets="GetPackagePaths;ResolveNuGetPackages">
     <ItemGroup>
@@ -55,7 +55,7 @@
   <!-- Fetches all the runtime items from the packages that we want to redist -->
   <Target Name="GetRuntimeFilesFromPackages"
           BeforeTargets="GetRuntimeFilesToPackage"
-          DependsOnTargets="GetCrossgenPackagePaths">
+          DependsOnTargets="GetCorePackagePaths">
     <ItemGroup Condition="'$(NuGetRuntimeIdentifier)' != ''">
       <_ToolsToPackage Include="$(_runtimePackageDir)tools/**/*.*"/>
       <FilesToPackage Include="@(_ToolsToPackage)">

--- a/src/pkg/projects/windowsdesktop/pkg/Microsoft.WindowsDesktop.App.pkgproj
+++ b/src/pkg/projects/windowsdesktop/pkg/Microsoft.WindowsDesktop.App.pkgproj
@@ -12,6 +12,12 @@
     <GenerateNetCoreAppRuntimeConfig>true</GenerateNetCoreAppRuntimeConfig>
 
     <GenerateCompressedArchive>true</GenerateCompressedArchive>
+
+    <!--
+      Only build WindowsDesktop shared framework if this is on Windows and we know WD assets are
+      available. This lets us skip them on the non-Windows official build legs.
+    -->
+    <BuildOnUnknownPlatforms>false</BuildOnUnknownPlatforms>
   </PropertyGroup>
 
   <!-- Identity / Reference package content -->

--- a/src/pkg/projects/windowsdesktop/pkg/Microsoft.WindowsDesktop.App.pkgproj
+++ b/src/pkg/projects/windowsdesktop/pkg/Microsoft.WindowsDesktop.App.pkgproj
@@ -18,13 +18,50 @@
       available. This lets us skip them on the non-Windows official build legs.
     -->
     <BuildOnUnknownPlatforms>false</BuildOnUnknownPlatforms>
+
+    <TargetFrameworkName>netcoreapp</TargetFrameworkName>
+    <TargetFrameworkVersion>3.0</TargetFrameworkVersion>
+    <TargetFramework>$(TargetFrameworkName)$(TargetFrameworkVersion)</TargetFramework>
+
+    <!--
+      Turn on package validation to validate the dependency closure. Important because the
+      WPF/WinForms packages don't declare their transitive dependencies and the depproj has to fill
+      it in correctly. Being wrong means dependency failures at runtime.
+    -->
+    <SkipValidatePackage>false</SkipValidatePackage>
   </PropertyGroup>
 
-  <!-- Identity / Reference package content -->
-  <ItemGroup Condition="'$(PackageTargetRuntime)' == ''">
-    <!-- reference RID specific packages to generate lineup -->
-    <ProjectReference Include="@(RuntimeProject)" />
+  <ItemGroup>
+    <ExcludeFromDuplicateTypes Include="PresentationFramework.Aero" />
+    <ExcludeFromDuplicateTypes Include="PresentationFramework.Aero2" />
+    <ExcludeFromDuplicateTypes Include="PresentationFramework.AeroLite" />
+    <ExcludeFromDuplicateTypes Include="PresentationFramework.Classic" />
+    <ExcludeFromDuplicateTypes Include="PresentationFramework.Luna" />
+    <ExcludeFromDuplicateTypes Include="PresentationFramework.Royale" />
+  </ItemGroup>
+  
+  <ItemGroup>
+    <!-- There is a known cycle. More info at https://github.com/dotnet/wpf/issues/607 -->
+    <IgnoredReference Include="PresentationFramework" />
+    <IgnoredReference Include="ReachFramework" />
+    <IgnoredReference Include="System.Printing" />
+
+    <!-- We don't have a ref assembly for DirectWriteForwarder -->
+    <IgnoredReference Condition="'$(PackageTargetRuntime)' == ''" Include="DirectWriteForwarder" />
   </ItemGroup>
 
+  <Target Name="GetNETCoreAppIgnoredReference" BeforeTargets="VerifyClosure">
+    <MSBuild
+      Projects="../../netcoreapp/src/netcoreapp.depproj"
+      Properties="Configuration=netcoreapp"
+      Targets="GetReferenceFilenames">
+      <Output TaskParameter="TargetOutputs"  ItemName="IgnoredReference" />
+    </MSBuild>
+  </Target>
+
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+
+  <!-- Don't validate this package as it doesn't actually represent a framework. -->
+  <Target Name="ValidateFrameworkPackage" />
+
 </Project>

--- a/src/pkg/projects/windowsdesktop/src/windowsdesktop.depproj
+++ b/src/pkg/projects/windowsdesktop/src/windowsdesktop.depproj
@@ -3,17 +3,60 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Private.WindowsDesktop.App" Version="$(MicrosoftPrivateWindowsDesktopAppPackageVersion)" />
+    <PackageReference Include="Microsoft.DotNet.Wpf.DncEng" Version="$(MicrosoftDotNetWpfDncEngPackageVersion)" />
+    <PackageReference Include="Microsoft.DotNet.Wpf.GitHub" Version="$(MicrosoftDotNetWpfGitHubPackageVersion)" />
+    <PackageReference Include="Microsoft.Private.Winforms" Version="$(MicrosoftPrivateWinformsPackageVersion)" />
+
+    <PackageReference Include="Microsoft.Win32.Registry" Version="$(MicrosoftWin32RegistryVersion)" />
+    <PackageReference Include="Microsoft.Win32.SystemEvents" Version="$(MicrosoftWin32SystemEventsVersion)" />
+    <PackageReference Include="System.CodeDom" Version="$(SystemCodeDomVersion)" />
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="$(SystemConfigurationConfigurationManagerVersion)" />
+    <PackageReference Include="System.Drawing.Common" Version="$(SystemDrawingCommonVersion)" />
+    <PackageReference Include="System.IO.Packaging" Version="$(SystemIOPackagingVersion)" />
+    <PackageReference Include="System.Resources.Extensions" Version="$(SystemResourcesExtensionsPackageVersion)" />
+    <PackageReference Include="System.Security.AccessControl" Version="$(SystemSecurityAccessControlVersion)" />
+    <PackageReference Include="System.Security.Cryptography.Cng" Version="$(SystemSecurityCryptographyCngVersion)" />
+    <PackageReference Include="System.Security.Cryptography.Pkcs" Version="$(SystemSecurityCryptographyPkcsVersion)" />
+    <PackageReference Include="System.Security.Cryptography.ProtectedData" Version="$(SystemSecurityCryptographyProtectedDataVersion)" />
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="$(SystemSecurityCryptographyXmlVersion)" />
+    <PackageReference Include="System.Security.Permissions" Version="$(SystemSecurityPermissionsVersion)" />
+    <PackageReference Include="System.Security.Principal.Windows" Version="$(SystemSecurityPrincipalWindowsVersion)" />
+    <PackageReference Include="System.Windows.Extensions" Version="$(SystemWindowsExtensionsPackageVersion)" />
   </ItemGroup>
 
-  <Target Name="GetDependencyVersionFiles" DependsOnTargets="ResolveNuGetPackages">
+  <ItemGroup>
+    <RuntimeOnlyPackageReference Include="System.Diagnostics.EventLog" Version="$(SystemDiagnosticsEventLogVersion)" />
+    <RuntimeOnlyPackageReference Include="System.DirectoryServices" Version="$(SystemDirectoryServicesVersion)" />
+    <RuntimeOnlyPackageReference Include="System.IO.FileSystem.AccessControl" Version="$(SystemIOFileSystemAccessControlVersion)" />
+    <RuntimeOnlyPackageReference Include="System.Threading.AccessControl" Version="$(SystemThreadingAccessControlVersion)" />
+
+    <PackageReference Include="@(RuntimeOnlyPackageReference)" ExcludeAssets="Compile" />
+  </ItemGroup>
+
+  <!-- Pick up unconventional WPF runtime package natives in lib\<rid>. -->
+  <Target Name="GetLibNativeFilePackagePaths"
+          BeforeTargets="GetFilesFromPackages"
+          Condition="'$(NuGetRuntimeIdentifier)' != ''">
     <ItemGroup>
-      <DependencyVersionFile
-        Include="$(PackagesDir)$([System.String]::new('%(Reference.NuGetPackageId)').ToLowerInvariant())/%(Reference.NuGetPackageVersion)/version.txt"
-        Condition="$([System.String]::new('%(Reference.Identity)').ToLowerInvariant().Contains('system.xaml.dll'))"
-        Name="dotnet-trusted" />
+      <_lowercasePackageId
+        Include="$([System.String]::new('runtime.$(NuGetRuntimeIdentifier).%(PackageReference.Identity)').ToLowerInvariant())"
+        NuGetPackageId="%(PackageReference.Identity)"
+        Version="%(PackageReference.Version)" />
+
+      <_packageNativeDir Include="@(_lowercasePackageId -> '$(PackagesDir)%(Identity)/%(Version)/lib/$(NuGetRuntimeIdentifier)/')" />
+
+      <ReferenceCopyLocalPaths
+        Include="%(_packageNativeDir.Identity)**/*.*"
+        IsNative="true"
+        NuGetPackageId="%(_packageNativeDir.NuGetPackageId)" />
     </ItemGroup>
   </Target>
+
+  <!--
+    Version.txt files aren't provided in some packages. However, they're not necessary anymore:
+    dependency information is now in Version.Details.xml and BAR. Stub the target to ignore.
+  -->
+  <Target Name="GetDependencyVersionFiles" />
 
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>


### PR DESCRIPTION
Resolves https://github.com/dotnet/core-setup/issues/5219.

Changes Core-Setup to depend on WinForms, WPF, and WPF-int directly for WindowsDesktop assets. Removes the dependency on DotNet-Trusted.

A few differences in the packages:
* `Microsoft.WindowsDesktop.App.Ref` now includes the intellisense XML files for the CoreFX bits being redistributed.
* In the WD runtime package, `Microsoft.Win32.SystemEvents.dll` is now redisted from `Microsoft.Win32.SystemEvents`, not `runtime.<rid>.Microsoft.Private.CoreFx.NETCoreApp`. @ericstj helped look through this and it turns out the change is a fix--DN-T was packing the wrong thing. (The infra in core-setup is more focused on this use case so it's easier to get exactly what I'm pointing at.)
* `Microsoft.WindowsDesktop.App.versions.txt` only has the Core-Setup commit in it now. WPF/WinForms don't produce the `version.txt` files that are typically gathered to create this, but it isn't important anymore: the info is in BAR and `Version.Details.xml`.

Also turns off `BuildOnUnknownPlatforms` for the WD shared framework to prevent unusual/confusing packages from being made: fixes https://github.com/dotnet/core-setup/issues/5820.

Based on https://maestro-prod.westus2.cloudapp.azure.com/3/https:%2F%2Fgithub.com%2Fdotnet%2Fcore-sdk/latest/graph, DN-T will be out of the product build graph after this!

@zsd4yr @vatsan-madhavan PTAL too.