### PR TITLE
Test-only product behavior support

### DIFF
--- a/src/corehost/common/pal.unix.cpp
+++ b/src/corehost/common/pal.unix.cpp
@@ -305,7 +305,7 @@ bool pal::get_dotnet_self_registered_dir(pal::string_t* recv)
 
     //  ***Used only for testing***
     pal::string_t environment_override;
-    if (pal::getenv(_X("_DOTNET_TEST_GLOBALLY_REGISTERED_PATH"), &environment_override))
+    if (test_only_getenv(_X("_DOTNET_TEST_GLOBALLY_REGISTERED_PATH"), &environment_override))
     {
         recv->assign(environment_override);
         return true;
@@ -316,7 +316,7 @@ bool pal::get_dotnet_self_registered_dir(pal::string_t* recv)
 
     //  ***Used only for testing***
     pal::string_t environment_install_location_override;
-    if (pal::getenv(_X("_DOTNET_TEST_INSTALL_LOCATION_FILE_PATH"), &environment_install_location_override))
+    if (test_only_getenv(_X("_DOTNET_TEST_INSTALL_LOCATION_FILE_PATH"), &environment_install_location_override))
     {
         install_location_file_path = environment_install_location_override;
     }
@@ -361,7 +361,7 @@ bool pal::get_default_installation_dir(pal::string_t* recv)
 {
     //  ***Used only for testing***
     pal::string_t environmentOverride;
-    if (pal::getenv(_X("_DOTNET_TEST_DEFAULT_INSTALL_PATH"), &environmentOverride))
+    if (test_only_getenv(_X("_DOTNET_TEST_DEFAULT_INSTALL_PATH"), &environmentOverride))
     {
         recv->assign(environmentOverride);
         return true;

--- a/src/corehost/common/pal.windows.cpp
+++ b/src/corehost/common/pal.windows.cpp
@@ -223,7 +223,7 @@ bool pal::get_default_installation_dir(pal::string_t* recv)
 {
     //  ***Used only for testing***
     pal::string_t environmentOverride;
-    if (pal::getenv(_X("_DOTNET_TEST_DEFAULT_INSTALL_PATH"), &environmentOverride))
+    if (test_only_getenv(_X("_DOTNET_TEST_DEFAULT_INSTALL_PATH"), &environmentOverride))
     {
         recv->assign(environmentOverride);
         return true;
@@ -260,7 +260,7 @@ bool pal::get_dotnet_self_registered_dir(pal::string_t* recv)
 
     //  ***Used only for testing***
     pal::string_t environmentOverride;
-    if (pal::getenv(_X("_DOTNET_TEST_GLOBALLY_REGISTERED_PATH"), &environmentOverride))
+    if (test_only_getenv(_X("_DOTNET_TEST_GLOBALLY_REGISTERED_PATH"), &environmentOverride))
     {
         recv->assign(environmentOverride);
         return true;
@@ -273,7 +273,7 @@ bool pal::get_dotnet_self_registered_dir(pal::string_t* recv)
     pal::string_t dotnet_key_path = pal::string_t(_X("SOFTWARE\\dotnet"));
 
     pal::string_t environmentRegistryPathOverride;
-    if (pal::getenv(_X("_DOTNET_TEST_REGISTRY_PATH"), &environmentRegistryPathOverride))
+    if (test_only_getenv(_X("_DOTNET_TEST_REGISTRY_PATH"), &environmentRegistryPathOverride))
     {
         pal::string_t hkcuPrefix = _X("HKEY_CURRENT_USER\\");
         if (environmentRegistryPathOverride.substr(0, hkcuPrefix.length()) == hkcuPrefix)

--- a/src/corehost/common/utils.cpp
+++ b/src/corehost/common/utils.cpp
@@ -477,7 +477,7 @@ bool test_only_getenv(const pal::char_t* name, pal::string_t* recv)
     //  - Default value is 'd' (stands for disabled) - test only behavior is disabled
     //  - To enable test-only behaviors set it to 'e' (stands for enabled)
     constexpr size_t EMBED_SIZE = sizeof(TEST_ONLY_MARKER) / sizeof(TEST_ONLY_MARKER[0]);
-    static char embed[EMBED_SIZE] = TEST_ONLY_MARKER;
+    volatile static char embed[EMBED_SIZE] = TEST_ONLY_MARKER;
 
     if (embed[0] != 'e')
     {

--- a/src/corehost/common/utils.cpp
+++ b/src/corehost/common/utils.cpp
@@ -463,3 +463,26 @@ pal::string_t get_dotnet_root_from_fxr_path(const pal::string_t &fxr_path)
     pal::string_t fxr_root = get_directory(fxr_dir);
     return get_directory(get_directory(fxr_root));
 }
+
+#define TEST_ONLY_MARKER "d38cc827-e34f-4453-9df4-1e796e9f1d07"
+
+// Retrieves environment variable which is only used for testing.
+// This will only work if there's also a _dotnet_test_only_enabled file next to the current module
+// (which means next to dotnet.exe, apphost.exe, hostfxr.dll and so on, whichever is being tested)
+bool test_only_getenv(const pal::char_t* name, pal::string_t* recv)
+{
+    // This is a static variable which is embeded in the product binary (somewhere).
+    // The marker values is a GUID so that it's unique and can be found by doing a simple search on the file
+    // The first character is used as the decider:
+    //  - Default value is 'd' (stands for disabled) - test only behavior is disabled
+    //  - To enable test-only behaviors set it to 'e' (stands for enabled)
+    constexpr size_t EMBED_SIZE = sizeof(TEST_ONLY_MARKER) / sizeof(TEST_ONLY_MARKER[0]);
+    static char embed[EMBED_SIZE] = TEST_ONLY_MARKER;
+
+    if (embed[0] != 'e')
+    {
+        return false;
+    }
+
+    return pal::getenv(name, recv);
+}

--- a/src/corehost/common/utils.cpp
+++ b/src/corehost/common/utils.cpp
@@ -467,8 +467,8 @@ pal::string_t get_dotnet_root_from_fxr_path(const pal::string_t &fxr_path)
 #define TEST_ONLY_MARKER "d38cc827-e34f-4453-9df4-1e796e9f1d07"
 
 // Retrieves environment variable which is only used for testing.
-// This will only work if there's also a _dotnet_test_only_enabled file next to the current module
-// (which means next to dotnet.exe, apphost.exe, hostfxr.dll and so on, whichever is being tested)
+// This will return the value of the variable only if the product binary is stamped
+// with test-only marker.
 bool test_only_getenv(const pal::char_t* name, pal::string_t* recv)
 {
     // This is a static variable which is embeded in the product binary (somewhere).

--- a/src/corehost/common/utils.h
+++ b/src/corehost/common/utils.h
@@ -68,8 +68,8 @@ void get_runtime_config_paths(const pal::string_t& path, const pal::string_t& na
 pal::string_t get_dotnet_root_from_fxr_path(const pal::string_t &fxr_path);
 
 // Retrieves environment variable which is only used for testing.
-// This will only work if there's also a _dotnet_test_only_enabled file next to the current module
-// (which means next to dotnet.exe, apphost.exe, hostfxr.dll and so on, whichever is being tested)
+// This will return the value of the variable only if the product binary is stamped
+// with test-only marker.
 bool test_only_getenv(const pal::char_t* name, pal::string_t* recv);
 
 // Helper class to make it easy to propagate error writer to the hostpolicy

--- a/src/corehost/common/utils.h
+++ b/src/corehost/common/utils.h
@@ -67,6 +67,11 @@ pal::string_t get_deps_from_app_binary(const pal::string_t& app_base, const pal:
 void get_runtime_config_paths(const pal::string_t& path, const pal::string_t& name, pal::string_t* cfg, pal::string_t* dev_cfg);
 pal::string_t get_dotnet_root_from_fxr_path(const pal::string_t &fxr_path);
 
+// Retrieves environment variable which is only used for testing.
+// This will only work if there's also a _dotnet_test_only_enabled file next to the current module
+// (which means next to dotnet.exe, apphost.exe, hostfxr.dll and so on, whichever is being tested)
+bool test_only_getenv(const pal::char_t* name, pal::string_t* recv);
+
 // Helper class to make it easy to propagate error writer to the hostpolicy
 class propagate_error_writer_t
 {

--- a/src/test/HostActivationTests/FrameworkResolution/MultipleHives.cs
+++ b/src/test/HostActivationTests/FrameworkResolution/MultipleHives.cs
@@ -72,14 +72,17 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.FrameworkResolution
 
         private CommandResult RunTest(Func<RuntimeConfig, RuntimeConfig> runtimeConfig)
         {
-            return RunTest(
-                SharedState.DotNetMainHive,
-                SharedState.FrameworkReferenceApp,
-                new TestSettings()
-                    .WithRuntimeConfigCustomizer(runtimeConfig)
-                    .WithEnvironment(Constants.TestOnlyEnvironmentVariables.GloballyRegisteredPath, SharedState.DotNetGlobalHive.BinPath),
-                // Must enable multi-level lookup otherwise multiple hives are not enabled
-                multiLevelLookup: true);
+            using (TestOnlyProductBehavior.Enable(SharedState.DotNetMainHive.GreatestVersionHostFxrFilePath))
+            {
+                return RunTest(
+                    SharedState.DotNetMainHive,
+                    SharedState.FrameworkReferenceApp,
+                    new TestSettings()
+                        .WithRuntimeConfigCustomizer(runtimeConfig)
+                        .WithEnvironment(Constants.TestOnlyEnvironmentVariables.GloballyRegisteredPath, SharedState.DotNetGlobalHive.BinPath),
+                    // Must enable multi-level lookup otherwise multiple hives are not enabled
+                    multiLevelLookup: true);
+            }
         }
 
         public class SharedTestState : SharedTestStateBase

--- a/src/test/HostActivationTests/MultilevelSDKLookup.cs
+++ b/src/test/HostActivationTests/MultilevelSDKLookup.cs
@@ -38,6 +38,8 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
 
         private const string _dotnetSdkDllMessageTerminator = "dotnet.dll]";
 
+        private readonly IDisposable _testOnlyProductBehaviorMarker;
+
         public MultilevelSDKLookup()
         {
             // The dotnetMultilevelSDKLookup dir will contain some folders and files that will be
@@ -73,10 +75,14 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
             // Trace messages used to identify from which folder the SDK was picked
             _exeSelectedMessage = $"Using dotnet SDK dll=[{_exeSdkBaseDir}";
             _regSelectedMessage = $"Using dotnet SDK dll=[{_regSdkBaseDir}";
+
+            _testOnlyProductBehaviorMarker = TestOnlyProductBehavior.Enable(DotNet.GreatestVersionHostFxrFilePath);
         }
 
         public void Dispose()
         {
+            _testOnlyProductBehaviorMarker?.Dispose();
+
             if (!TestArtifact.PreserveTestRuns())
             {
                 Directory.Delete(_multilevelDir, true);
@@ -510,7 +516,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
                 return;
             }
 
-            using (var registeredInstallLocationOverride = new RegisteredInstallLocationOverride())
+            using (var registeredInstallLocationOverride = new RegisteredInstallLocationOverride(DotNet.GreatestVersionHostFxrFilePath))
             {
                 registeredInstallLocationOverride.SetInstallLocation(_regDir, RepoDirectories.BuildArchitecture);
 

--- a/src/test/HostActivationTests/MultilevelSharedFxLookup.cs
+++ b/src/test/HostActivationTests/MultilevelSharedFxLookup.cs
@@ -42,6 +42,8 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
         private readonly string _builtDotnet;
         private readonly string _hostPolicyDllName;
 
+        private readonly IDisposable _testOnlyProductBehaviorMarker;
+
         public MultilevelSharedFxLookup()
         {
             // From the artifacts dir, it's possible to find where the sharedFrameworkPublish folder is. We need
@@ -111,10 +113,14 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
             _regSelectedMessage = $"The expected {_hostPolicyDllName} directory is [{_regSharedFxBaseDir}";
 
             _exeFoundUberFxMessage = $"Chose FX version [{_exeSharedUberFxBaseDir}";
+
+            _testOnlyProductBehaviorMarker = TestOnlyProductBehavior.Enable(fixture.BuiltDotnet.GreatestVersionHostFxrFilePath);
         }
 
         public void Dispose()
         {
+            _testOnlyProductBehaviorMarker?.Dispose();
+
             SharedFxLookupPortableAppFixture.Dispose();
 
             if (!TestProject.PreserveTestRuns())

--- a/src/test/HostActivationTests/NativeHostApis.cs
+++ b/src/test/HostActivationTests/NativeHostApis.cs
@@ -133,9 +133,10 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
 
         private class SdkResolutionFixture
         {
+            private readonly string _builtDotnet;
             private readonly TestProjectFixture _fixture;
 
-            public DotNetCli Dotnet => _fixture.BuiltDotnet;
+            public DotNetCli Dotnet { get; }
             public string AppDll => _fixture.TestProject.AppDll;
             public string ExeDir => Path.Combine(_fixture.TestProject.ProjectDirectory, "ed");
             public string ProgramFiles => Path.Combine(ExeDir, "pf");
@@ -151,6 +152,9 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
 
             public SdkResolutionFixture(SharedTestState state)
             {
+                _builtDotnet = Path.Combine(TestArtifact.TestArtifactsPath, "sharedFrameworkPublish");
+                Dotnet = new DotNetCli(_builtDotnet);
+
                 _fixture = state.HostApiInvokerAppFixture.Copy();
 
                 Directory.CreateDirectory(WorkingDir);

--- a/src/test/HostActivationTests/NativeHostApis.cs
+++ b/src/test/HostActivationTests/NativeHostApis.cs
@@ -200,15 +200,18 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
                 Path.Combine(f.SelfRegisteredGlobalSdkDir, "15.1.4-preview"),
             });
 
-            f.Dotnet.Exec(f.AppDll, new[] { "hostfxr_get_available_sdks", f.ExeDir })
-                .EnvironmentVariable("TEST_MULTILEVEL_LOOKUP_PROGRAM_FILES", f.ProgramFiles)
-                .EnvironmentVariable("TEST_MULTILEVEL_LOOKUP_SELF_REGISTERED", f.SelfRegistered)
-                .CaptureStdOut()
-                .CaptureStdErr()
-                .Execute()
-                .Should().Pass()
-                .And.HaveStdOutContaining("hostfxr_get_available_sdks:Success")
-                .And.HaveStdOutContaining($"hostfxr_get_available_sdks sdks:[{expectedList}]");
+            using (TestOnlyProductBehavior.Enable(f.Dotnet.GreatestVersionHostFxrFilePath))
+            {
+                f.Dotnet.Exec(f.AppDll, new[] { "hostfxr_get_available_sdks", f.ExeDir })
+                    .EnvironmentVariable("TEST_MULTILEVEL_LOOKUP_PROGRAM_FILES", f.ProgramFiles)
+                    .EnvironmentVariable("TEST_MULTILEVEL_LOOKUP_SELF_REGISTERED", f.SelfRegistered)
+                    .CaptureStdOut()
+                    .CaptureStdErr()
+                    .Execute()
+                    .Should().Pass()
+                    .And.HaveStdOutContaining("hostfxr_get_available_sdks:Success")
+                    .And.HaveStdOutContaining($"hostfxr_get_available_sdks sdks:[{expectedList}]");
+            }
         }
 
         [Fact]

--- a/src/test/HostActivationTests/NativeHosting/Nethost.cs
+++ b/src/test/HostActivationTests/NativeHosting/Nethost.cs
@@ -191,7 +191,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.NativeHosting
         [Fact]
         public void TestOnlyDisabledByDefault()
         {
-            // Intentionally not enabling test-only behavior. This test validates that even if the test-oly env. variable is set
+            // Intentionally not enabling test-only behavior. This test validates that even if the test-only env. variable is set
             // it will not take effect on its own by default.
             // To make sure the test is reliable, copy the product binary again into the test folder where we run it from.
             // This is to make sure that we're using the unmodified product binary. If some previous test

--- a/src/test/HostActivationTests/NativeHosting/Nethost.cs
+++ b/src/test/HostActivationTests/NativeHosting/Nethost.cs
@@ -188,6 +188,20 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.NativeHosting
             }
         }
 
+        [Fact]
+        public void TestOnlyDisabledByDefault()
+        {
+            // Intentionally not enabling test-only behavior. This test validates that even if the test-oly env. variable is set
+            // it will not take effect on its own by default.
+            Command.Create(sharedState.NativeHostPath, GetHostFxrPath)
+                .CaptureStdErr()
+                .CaptureStdOut()
+                .EnvironmentVariable("COREHOST_TRACE", "1")
+                .EnvironmentVariable(Constants.TestOnlyEnvironmentVariables.GloballyRegisteredPath, sharedState.ValidInstallRoot)
+                .Execute()
+                .Should().NotHaveStdErrContaining($"Using global installation location [{sharedState.ValidInstallRoot}] as runtime location.");
+        }
+
         public class SharedTestState : SharedTestStateBase
         {
             public string HostFxrPath { get; }

--- a/src/test/HostActivationTests/NativeHosting/Nethost.cs
+++ b/src/test/HostActivationTests/NativeHosting/Nethost.cs
@@ -188,23 +188,6 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.NativeHosting
             }
         }
 
-        [Fact]
-        public void TestOnlyProductBehaviorDisabledByDefault()
-        {
-            // This is using one of the test-only product behaviors, the ability to redirect default install path
-            // but that's just a sample - the goal of the test is to verify that when not explicitly enabled
-            // test-only product behaviors are not working.
-            Command.Create(sharedState.NativeHostPath, $"{GetHostFxrPath}")
-                .CaptureStdErr()
-                .CaptureStdOut()
-                .EnvironmentVariable("COREHOST_TRACE", "1")
-                .EnvironmentVariable( // Test-only redirection, this should not kick in
-                    Constants.TestOnlyEnvironmentVariables.DefaultInstallPath,
-                    sharedState.ValidInstallRoot)
-                .Execute()
-                .Should().NotHaveStdErrContaining(sharedState.ValidInstallRoot);
-        }
-
         public class SharedTestState : SharedTestStateBase
         {
             public string HostFxrPath { get; }

--- a/src/test/HostActivationTests/NativeHosting/Nethost.cs
+++ b/src/test/HostActivationTests/NativeHosting/Nethost.cs
@@ -193,6 +193,14 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.NativeHosting
         {
             // Intentionally not enabling test-only behavior. This test validates that even if the test-oly env. variable is set
             // it will not take effect on its own by default.
+            // To make sure the test is reliable, copy the product binary again into the test folder where we run it from.
+            // This is to make sure that we're using the unmodified product binary. If some previous test
+            // enabled test-only product behavior on the binary and didn't correctly cleanup, this test would fail.
+            File.Copy(
+                Path.Combine(sharedState.RepoDirectories.CorehostPackages, RuntimeInformationExtensions.GetSharedLibraryFileNameForCurrentPlatform("nethost")),
+                sharedState.NethostPath,
+                overwrite: true);
+
             Command.Create(sharedState.NativeHostPath, GetHostFxrPath)
                 .CaptureStdErr()
                 .CaptureStdOut()

--- a/src/test/HostActivationTests/NativeHosting/SharedTestStateBase.cs
+++ b/src/test/HostActivationTests/NativeHosting/SharedTestStateBase.cs
@@ -11,6 +11,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.NativeHosting
     {
         public string BaseDirectory { get; }
         public string NativeHostPath { get; }
+        public string NethostPath { get; }
         public RepoDirectoriesProvider RepoDirectories { get; }
 
         public SharedTestStateBase()
@@ -30,9 +31,10 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.NativeHosting
             // user-friendly way of linking against nethost (instead of dlopen/LoadLibrary and dlsym/GetProcAddress).
             // On Windows, we can delay load through a linker option, but on other platforms load is required on start.
             string nethostName = RuntimeInformationExtensions.GetSharedLibraryFileNameForCurrentPlatform("nethost");
+            NethostPath = Path.Combine(Path.GetDirectoryName(NativeHostPath), nethostName);
             File.Copy(
                 Path.Combine(RepoDirectories.CorehostPackages, nethostName),
-                Path.Combine(Path.GetDirectoryName(NativeHostPath), nethostName));
+                NethostPath);
         }
 
         public void Dispose()

--- a/src/test/HostActivationTests/PortableAppActivation.cs
+++ b/src/test/HostActivationTests/PortableAppActivation.cs
@@ -263,7 +263,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
                 // Replace the hash with the managed DLL name.
                 var hash = sha256.ComputeHash(Encoding.UTF8.GetBytes("foobar"));
                 var hashStr = BitConverter.ToString(hash).Replace("-", "").ToLower();
-                AppHostExtensions.SearchAndReplace(appDirHostExe, Encoding.UTF8.GetBytes(hashStr), Encoding.UTF8.GetBytes(appDllName), true);
+                FileUtils.SearchAndReplace(appDirHostExe, Encoding.UTF8.GetBytes(hashStr), Encoding.UTF8.GetBytes(appDllName), true);
             }
             File.Copy(appDirHostExe, appExe, true);
 
@@ -323,14 +323,14 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
                 // Replace the hash with the managed DLL name.
                 var hash = sha256.ComputeHash(Encoding.UTF8.GetBytes("foobar"));
                 var hashStr = BitConverter.ToString(hash).Replace("-", "").ToLower();
-                AppHostExtensions.SearchAndReplace(appDirHostExe, Encoding.UTF8.GetBytes(hashStr), Encoding.UTF8.GetBytes(appDllName), true);
+                FileUtils.SearchAndReplace(appDirHostExe, Encoding.UTF8.GetBytes(hashStr), Encoding.UTF8.GetBytes(appDllName), true);
             }
             File.Copy(appDirHostExe, appExe, true);
 
             // Get the framework location that was built
             string builtDotnet = fixture.BuiltDotnet.BinPath;
 
-            using (var registeredInstallLocationOverride = new RegisteredInstallLocationOverride())
+            using (var registeredInstallLocationOverride = new RegisteredInstallLocationOverride(appExe))
             {
                 string architecture = fixture.CurrentRid.Split('-')[1];
                 if (useRegisteredLocation)

--- a/src/test/HostActivationTests/RegisteredInstallLocationOverride.cs
+++ b/src/test/HostActivationTests/RegisteredInstallLocationOverride.cs
@@ -20,10 +20,12 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
         private readonly RegistryKey key;
         private readonly string keyName;
 
-        // Linux/macOS only
+        private IDisposable _testOnlyProductBehavior;
 
-        public RegisteredInstallLocationOverride()
+        public RegisteredInstallLocationOverride(string productBinaryPath)
         {
+            _testOnlyProductBehavior = TestOnlyProductBehavior.Enable(productBinaryPath);
+
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
                 // To test registered installs, we need a registry key which is:
@@ -89,6 +91,11 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
                 {
                     File.Delete(PathValueOverride);
                 }
+            }
+
+            if (_testOnlyProductBehavior != null)
+            {
+                _testOnlyProductBehavior.Dispose();
             }
         }
     }

--- a/src/test/HostActivationTests/StandaloneAppActivation.cs
+++ b/src/test/HostActivationTests/StandaloneAppActivation.cs
@@ -163,7 +163,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
             string appDll = fixture.TestProject.AppDll;
             string appDllName = Path.GetFileName(appDll);
             string relativeDllPath = Path.Combine(relativeNewPath, appDllName);
-            AppHostExtensions.SearchAndReplace(appExe, Encoding.UTF8.GetBytes(appDllName), Encoding.UTF8.GetBytes(relativeDllPath), true);
+            FileUtils.SearchAndReplace(appExe, Encoding.UTF8.GetBytes(appDllName), Encoding.UTF8.GetBytes(relativeDllPath), true);
 
             Command.Create(appExe)
                 .CaptureStdErr()
@@ -433,7 +433,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
                 // Replace the hash with the managed DLL name.
                 var hash = sha256.ComputeHash(Encoding.UTF8.GetBytes("foobar"));
                 var hashStr = BitConverter.ToString(hash).Replace("-", "").ToLower();
-                AppHostExtensions.SearchAndReplace(appDirHostExe, Encoding.UTF8.GetBytes(hashStr), Encoding.UTF8.GetBytes(appDll), true);
+                FileUtils.SearchAndReplace(appDirHostExe, Encoding.UTF8.GetBytes(hashStr), Encoding.UTF8.GetBytes(appDll), true);
             }
             File.Copy(appDirHostExe, appExe, true);
         }

--- a/src/test/HostActivationTests/TestOnlyProductBehavior.cs
+++ b/src/test/HostActivationTests/TestOnlyProductBehavior.cs
@@ -1,0 +1,64 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.IO;
+
+namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
+{
+    public static class TestOnlyProductBehavior
+    {
+        private static readonly byte[] OriginalTestOnlyMarker = StringToByteArray("d38cc827-e34f-4453-9df4-1e796e9f1d07");
+        private static readonly byte[] EnabledTestOnlyMarker  = StringToByteArray("e38cc827-e34f-4453-9df4-1e796e9f1d07");
+
+        private static byte[] StringToByteArray(string value)
+        {
+            byte[] result = new byte[value.Length];
+            for (int i = 0; i < value.Length; i++)
+            {
+                result[i] = (byte)value[i];
+            }
+
+            return result;
+        }
+
+        public static IDisposable Enable(string productBinaryPath)
+        {
+            if (!File.Exists(productBinaryPath))
+            {
+                throw new Exception($"Could not find product binary {productBinaryPath} to enable test only behavior on.");
+            }
+
+            if (FileUtils.SearchInFile(productBinaryPath, OriginalTestOnlyMarker) == -1)
+            {
+                // The marker is already enabled (probably by another call to TestOnlyProductBehavior)
+                // We allow this to be able to nest the enable calls seamlessly - so that tests don't have to track
+                // which helper does what.
+                return null;
+            }
+
+            TestFileBackup backup = new TestFileBackup(Path.GetDirectoryName(productBinaryPath), Path.GetFileNameWithoutExtension(productBinaryPath));
+            backup.Backup(productBinaryPath);
+            IDisposable returnDisposable = null;
+
+            try
+            {
+                FileUtils.SearchAndReplace(
+                    productBinaryPath,
+                    OriginalTestOnlyMarker,
+                    EnabledTestOnlyMarker,
+                    terminateWithNul: false);
+            }
+            finally
+            {
+                if (backup != null)
+                {
+                    backup.Dispose();
+                }
+            }
+
+            return returnDisposable;
+        }
+    }
+}

--- a/src/test/HostActivationTests/TestOnlyProductBehavior.cs
+++ b/src/test/HostActivationTests/TestOnlyProductBehavior.cs
@@ -49,6 +49,8 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
                     OriginalTestOnlyMarker,
                     EnabledTestOnlyMarker,
                     terminateWithNul: false);
+                returnDisposable = backup;
+                backup = null;
             }
             finally
             {

--- a/src/test/TestUtils/AppHostExtensions.cs
+++ b/src/test/TestUtils/AppHostExtensions.cs
@@ -3,116 +3,12 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.IO;
 using System.IO.MemoryMappedFiles;
 
 namespace Microsoft.DotNet.CoreSetup.Test
 {
     public static class AppHostExtensions
     {
-        // See: https://en.wikipedia.org/wiki/Knuth%E2%80%93Morris%E2%80%93Pratt_algorithm
-        static int[] ComputeKMP_FailureFunction(byte[] pattern)
-        {
-            int[] table = new int[pattern.Length];
-            if (pattern.Length >= 1)
-            {
-                table[0] = -1;
-            }
-            if (pattern.Length >= 2)
-            {
-                table[1] = 0;
-            }
-
-            int pos = 2;
-            int cnd = 0;
-            while (pos < pattern.Length)
-            {
-                if (pattern[pos - 1] == pattern[cnd])
-                {
-                    table[pos] = cnd + 1;
-                    cnd++;
-                    pos++;
-                }
-                else if (cnd > 0)
-                {
-                    cnd = table[cnd];
-                }
-                else
-                {
-                    table[pos] = 0;
-                    pos++;
-                }
-            }
-            return table;
-        }
-
-        // See: https://en.wikipedia.org/wiki/Knuth%E2%80%93Morris%E2%80%93Pratt_algorithm
-        static unsafe int KMP_Search(byte[] pattern, byte* bytes, int length)
-        {
-            int m = 0;
-            int i = 0;
-            int[] table = ComputeKMP_FailureFunction(pattern);
-
-            while (m + i < length)
-            {
-                if (pattern[i] == bytes[m + i])
-                {
-                    if (i == pattern.Length - 1)
-                    {
-                        return m;
-                    }
-                    i++;
-                }
-                else
-                {
-                    if (table[i] > -1)
-                    {
-                        m = m + i - table[i];
-                        i = table[i];
-                    }
-                    else
-                    {
-                        m++;
-                        i = 0;
-                    }
-                }
-            }
-
-            return -1;
-        }
-
-        public static unsafe int SearchAndReplace(string filePath, byte[] search, byte[] replace, bool terminateWithNul)
-        {
-            // Create stream because CreateFromFile(string, ...) uses FileShare.None which is too strict
-            using (var fileStream = new FileStream(filePath, FileMode.Open, FileAccess.ReadWrite, FileShare.Read, 4096, false))
-            {
-                using (var mappedFile = MemoryMappedFile.CreateFromFile(
-                    fileStream, null, fileStream.Length, MemoryMappedFileAccess.ReadWrite, HandleInheritability.None, true))
-                {
-                    using (var accessor = mappedFile.CreateViewAccessor(0, 0, MemoryMappedFileAccess.ReadWrite))
-                    {
-                        var safeBuffer = accessor.SafeMemoryMappedViewHandle;
-                        int offset = KMP_Search(search, (byte*)safeBuffer.DangerousGetHandle(), (int)safeBuffer.ByteLength);
-                        if (offset < 0)
-                        {
-                            Console.WriteLine("The search pattern was not found in the file.");
-                            return -1;
-                        }
-                        foreach (var b in replace)
-                        {
-                            accessor.Write(offset++, b);
-                        }
-                        // Terminate with '\0'
-                        if (terminateWithNul)
-                        {
-                            accessor.Write(offset++, (byte) 0);
-                        }
-                        return 0;
-                    }
-                }
-            }
-        }
-
         /// <summary>
         /// The first two bytes of a PE file are a constant signature.
         /// </summary>

--- a/src/test/TestUtils/DotNetCli.cs
+++ b/src/test/TestUtils/DotNetCli.cs
@@ -14,6 +14,9 @@ namespace Microsoft.DotNet.Cli.Build
         public string BinPath { get; }
         public string GreatestVersionSharedFxPath { get; }
         public string GreatestVersionHostFxrPath { get; } 
+        public string GreatestVersionHostFxrFilePath { get => Path.Combine(
+            GreatestVersionHostFxrPath,
+            RuntimeInformationExtensions.GetSharedLibraryFileNameForCurrentPlatform("hostfxr")); }
         public string DotnetExecutablePath
         {
             get

--- a/src/test/TestUtils/FileUtils.cs
+++ b/src/test/TestUtils/FileUtils.cs
@@ -1,0 +1,131 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.IO;
+using System.IO.MemoryMappedFiles;
+
+namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
+{
+    public static class FileUtils
+    {
+        // See: https://en.wikipedia.org/wiki/Knuth%E2%80%93Morris%E2%80%93Pratt_algorithm
+        static int[] ComputeKMP_FailureFunction(byte[] pattern)
+        {
+            int[] table = new int[pattern.Length];
+            if (pattern.Length >= 1)
+            {
+                table[0] = -1;
+            }
+            if (pattern.Length >= 2)
+            {
+                table[1] = 0;
+            }
+
+            int pos = 2;
+            int cnd = 0;
+            while (pos < pattern.Length)
+            {
+                if (pattern[pos - 1] == pattern[cnd])
+                {
+                    table[pos] = cnd + 1;
+                    cnd++;
+                    pos++;
+                }
+                else if (cnd > 0)
+                {
+                    cnd = table[cnd];
+                }
+                else
+                {
+                    table[pos] = 0;
+                    pos++;
+                }
+            }
+            return table;
+        }
+
+        // See: https://en.wikipedia.org/wiki/Knuth%E2%80%93Morris%E2%80%93Pratt_algorithm
+        static unsafe int KMP_Search(byte[] pattern, byte* bytes, int length)
+        {
+            int m = 0;
+            int i = 0;
+            int[] table = ComputeKMP_FailureFunction(pattern);
+
+            while (m + i < length)
+            {
+                if (pattern[i] == bytes[m + i])
+                {
+                    if (i == pattern.Length - 1)
+                    {
+                        return m;
+                    }
+                    i++;
+                }
+                else
+                {
+                    if (table[i] > -1)
+                    {
+                        m = m + i - table[i];
+                        i = table[i];
+                    }
+                    else
+                    {
+                        m++;
+                        i = 0;
+                    }
+                }
+            }
+
+            return -1;
+        }
+
+        public static unsafe void SearchAndReplace(string filePath, byte[] search, byte[] replace, bool terminateWithNul)
+        {
+            // Create stream because CreateFromFile(string, ...) uses FileShare.None which is too strict
+            using (var fileStream = new FileStream(filePath, FileMode.Open, FileAccess.ReadWrite, FileShare.Read, 4096, false))
+            {
+                using (var mappedFile = MemoryMappedFile.CreateFromFile(
+                    fileStream, null, fileStream.Length, MemoryMappedFileAccess.ReadWrite, HandleInheritability.None, true))
+                {
+                    using (var accessor = mappedFile.CreateViewAccessor(0, 0, MemoryMappedFileAccess.ReadWrite))
+                    {
+                        var safeBuffer = accessor.SafeMemoryMappedViewHandle;
+                        int offset = KMP_Search(search, (byte*)safeBuffer.DangerousGetHandle(), (int)safeBuffer.ByteLength);
+                        if (offset < 0)
+                        {
+                            throw new Exception("The search pattern was not found in the file.");
+                        }
+                        foreach (var b in replace)
+                        {
+                            accessor.Write(offset++, b);
+                        }
+                        // Terminate with '\0'
+                        if (terminateWithNul)
+                        {
+                            accessor.Write(offset++, (byte)0);
+                        }
+                    }
+                }
+            }
+        }
+
+        public static unsafe int SearchInFile(string filePath, byte[] search)
+        {
+            // Create stream because CreateFromFile(string, ...) uses FileShare.None which is too strict
+            using (var fileStream = new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.Read, 4096, false))
+            {
+                using (var mappedFile = MemoryMappedFile.CreateFromFile(
+                    fileStream, null, fileStream.Length, MemoryMappedFileAccess.Read, HandleInheritability.None, true))
+                {
+                    using (var accessor = mappedFile.CreateViewAccessor(0, 0, MemoryMappedFileAccess.Read))
+                    {
+                        var safeBuffer = accessor.SafeMemoryMappedViewHandle;
+                        return KMP_Search(search, (byte*)safeBuffer.DangerousGetHandle(), (int)safeBuffer.ByteLength);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/test/TestUtils/TestFileBackup.cs
+++ b/src/test/TestUtils/TestFileBackup.cs
@@ -12,7 +12,7 @@ namespace Microsoft.DotNet.CoreSetup.Test
         void Backup(string path);
     }
 
-    public class TestFileBackup : ITestFileBackup
+    public class TestFileBackup : ITestFileBackup, IDisposable
     {
         private readonly string _basePath;
         private readonly string _backupPath;

--- a/src/test/TestUtils/TestFileBackup.cs
+++ b/src/test/TestUtils/TestFileBackup.cs
@@ -1,0 +1,79 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.IO;
+
+namespace Microsoft.DotNet.CoreSetup.Test
+{
+    public interface ITestFileBackup
+    {
+        void Backup(string path);
+    }
+
+    public class TestFileBackup : ITestFileBackup
+    {
+        private readonly string _basePath;
+        private readonly string _backupPath;
+
+        public TestFileBackup(string basePath, string backupName = "test")
+        {
+            _basePath = Path.GetFullPath(basePath);
+            _backupPath = Path.Combine(_basePath, $".{backupName}.backup");
+
+            if (Directory.Exists(_backupPath))
+            {
+                throw new Exception($"The backup directory already exists. Please make sure that all customizers are correctly disposed.");
+            }
+        }
+
+        public void Backup(string path)
+        {
+            path = Path.GetFullPath(path);
+            if (!path.StartsWith(_basePath))
+            {
+                throw new Exception($"Trying to backup file {path} which is outside of the backup root {_basePath}.");
+            }
+
+            if (!Directory.Exists(_backupPath))
+            {
+                Directory.CreateDirectory(_backupPath);
+            }
+
+            string backupFile = Path.Combine(_backupPath, path.Substring(_basePath.Length + 1));
+            string containingDirectory = Path.GetDirectoryName(backupFile);
+            if (!Directory.Exists(containingDirectory))
+            {
+                Directory.CreateDirectory(containingDirectory);
+                if (!File.Exists(backupFile))
+                {
+                    File.Copy(path, backupFile);
+                }
+            }
+        }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(_backupPath))
+            {
+                CopyOverDirectory(_backupPath, _basePath);
+
+                Directory.Delete(_backupPath, recursive: true);
+            }
+        }
+
+        private static void CopyOverDirectory(string source, string destination)
+        {
+            foreach (string directory in Directory.GetDirectories(source))
+            {
+                CopyOverDirectory(directory, Path.Combine(destination, Path.GetFileName(directory)));
+            }
+
+            foreach (string file in Directory.GetFiles(source))
+            {
+                File.Copy(file, Path.Combine(destination, Path.GetFileName(file)), overwrite: true);
+            }
+        }
+    }
+}

--- a/src/test/TestUtils/TestFileBackup.cs
+++ b/src/test/TestUtils/TestFileBackup.cs
@@ -46,10 +46,11 @@ namespace Microsoft.DotNet.CoreSetup.Test
             if (!Directory.Exists(containingDirectory))
             {
                 Directory.CreateDirectory(containingDirectory);
-                if (!File.Exists(backupFile))
-                {
-                    File.Copy(path, backupFile);
-                }
+            }
+
+            if (!File.Exists(backupFile))
+            {
+                File.Copy(path, backupFile);
             }
         }
 


### PR DESCRIPTION
Implement test-only product behavior support

The product uses special test-only environment variables to enable specific behaviors to allow for easier testing. These should not be enabled by default.

This change implements a guard which only enables the special env. variables if test-only behaviors are enabled.
The mechanism uses static variable in the product binary, so the tests must patch the binary itself to enable the special behavior.