### PR TITLE
Add ability to disable GUI host errors

### DIFF
--- a/src/corehost/corehost.cpp
+++ b/src/corehost/corehost.cpp
@@ -293,9 +293,20 @@ int main(const int argc, const pal::char_t* argv[])
 #if defined(_WIN32) && defined(FEATURE_APPHOST)
     if (get_windows_graphical_user_interface_bit())
     {
-        // If this is a GUI application, buffer errors to display them later. Without this any errors are effectively lost
-        // unless the caller explicitly redirects stderr. This leads to bad experience of running the GUI app and nothing happening.
-        trace::set_error_writer(buffering_trace_writer);
+        pal::string_t env_value;
+        bool gui_errors_disabled = false;
+
+        if (pal::getenv(_X("DOTNET_DISABLE_GUI_ERRORS"), &env_value))
+        {
+            gui_errors_disabled = pal::xtoi(env_value.c_str()) == 1;
+        }
+
+        if (!gui_errors_disabled)
+        {
+            // If this is a GUI application, buffer errors to display them later. Without this any errors are effectively lost
+            // unless the caller explicitly redirects stderr. This leads to bad experience of running the GUI app and nothing happening.
+            trace::set_error_writer(buffering_trace_writer);
+        }
     }
 #endif
 

--- a/src/corehost/corehost.cpp
+++ b/src/corehost/corehost.cpp
@@ -303,9 +303,14 @@ int main(const int argc, const pal::char_t* argv[])
 
         if (!gui_errors_disabled)
         {
+            trace::verbose(_X("Redirecting errors to custom writer."));
             // If this is a GUI application, buffer errors to display them later. Without this any errors are effectively lost
             // unless the caller explicitly redirects stderr. This leads to bad experience of running the GUI app and nothing happening.
             trace::set_error_writer(buffering_trace_writer);
+        }
+        else
+        {
+            trace::verbose(_X("Gui errors disabled, keeping errors in stderr."));
         }
     }
 #endif

--- a/src/test/HostActivationTests/Constants.cs
+++ b/src/test/HostActivationTests/Constants.cs
@@ -42,6 +42,11 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
             public const string EnvironmentVariable = "DOTNET_ROLL_FORWARD_TO_PRERELEASE";
         }
 
+        public static class DisableGuiErrors
+        {
+            public const string EnvironmentVariable = "DOTNET_DISABLE_GUI_ERRORS";
+        }
+
         public static class TestOnlyEnvironmentVariables
         {
             public const string DefaultInstallPath = "_DOTNET_TEST_DEFAULT_INSTALL_PATH";

--- a/src/test/HostActivationTests/StandaloneAppActivation.cs
+++ b/src/test/HostActivationTests/StandaloneAppActivation.cs
@@ -333,6 +333,8 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
             MarkAppHostAsGUI(appExe);
 
             Command command = Command.Create(appExe)
+                .EnvironmentVariable("COREHOST_TRACE", "1")
+                .CaptureStdOut()
                 .CaptureStdErr()
                 .EnvironmentVariable(Constants.DisableGuiErrors.EnvironmentVariable, "1")
                 .Start();

--- a/src/test/HostActivationTests/StandaloneAppActivation.cs
+++ b/src/test/HostActivationTests/StandaloneAppActivation.cs
@@ -314,6 +314,48 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
                 .And.FileContains(traceFilePath, "This executable is not bound to a managed DLL to execute.");
         }
 
+        [Fact]
+        public void Running_AppHost_with_GUI_Doesnt_Report_Errors_In_Window_When_Disabled()
+        {
+            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                // GUI app host is only supported on Windows.
+                return;
+            }
+
+            var fixture = sharedTestState.StandaloneAppFixture_Published
+                .Copy();
+
+            string appExe = fixture.TestProject.AppExe;
+
+            // Mark the apphost as GUI, but don't bind it to anything - this will cause it to fail
+            UseBuiltAppHost(appExe);
+            MarkAppHostAsGUI(appExe);
+
+            Command command = Command.Create(appExe)
+                .CaptureStdErr()
+                .EnvironmentVariable(Constants.DisableGuiErrors.EnvironmentVariable, "1")
+                .Start();
+
+            CommandResult commandResult = command.WaitForExit(fExpectedToFail: false, timeoutMilliseconds: 30000);
+            if (commandResult.ExitCode == -1)
+            {
+                try
+                {
+                    // Try to kill the process - it may be up with a dialog, or have some other issue.
+                    command.Process.Kill();
+                }
+                catch
+                {
+                    // Ignore exceptions, we don't know what's going on with the process.
+                }
+
+                Assert.True(false, "The process failed to exit in the alloted time, it's possible it has a dialog up which should not be there.");
+            }
+
+            commandResult.Should().HaveStdErrContaining("This executable is not bound to a managed DLL to execute.");
+        }
+
 #if WINDOWS
         private delegate bool EnumThreadWindowsDelegate(IntPtr hWnd, IntPtr lParam);
 


### PR DESCRIPTION
By default if the host runs a GUI application, it will report errors as a popup dialog. This is very useful for normal activation, but it is when executed from automation. The popup dialog blocks the process exit indefinitely.

This change adds environment variable `DOTNET_DISABLE_GUI_ERRORS`. If it's set to `1`, then even if the application is marked as GUI, all hosting errors will be reported to `stderr` and no UI popup will occur.

Fixes #5739 