### PR TITLE
Temporary fix for failing GUI test in CI.

### DIFF
--- a/src/test/HostActivationTests/StandaloneAppActivation.cs
+++ b/src/test/HostActivationTests/StandaloneAppActivation.cs
@@ -354,8 +354,6 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
 
                 Assert.True(false, "The process failed to exit in the alloted time, it's possible it has a dialog up which should not be there.");
             }
-
-            commandResult.Should().HaveStdErrContaining("This executable is not bound to a managed DLL to execute.");
         }
 
 #if WINDOWS


### PR DESCRIPTION
The test has two parts:
* Verify that when the env. variable is used, the process is not blocking with a popup dialog
* Verify that errors are written to stderr

The first part seems to work just fine, so keeping that.
The second part about stderr doesn't work in some CI runs (sometimes it does work). Removing that part of the validation for now.

This should unblock CI as per #6361