### PR TITLE
Add a basic lockable class that avoids using concrt on Windows

### DIFF
--- a/src/corehost/common/pal.h
+++ b/src/corehost/common/pal.h
@@ -37,6 +37,7 @@
 #include <cstdlib>
 #include <unistd.h>
 #include <libgen.h>
+#include <mutex>
 #include <sys/stat.h>
 #include <sys/types.h>
 
@@ -119,6 +120,23 @@ namespace pal
     typedef HMODULE dll_t;
     typedef FARPROC proc_t;
 
+    // Lockable object backed by CRITICAL_SECTION such that it does not pull in ConcRT.
+    class mutex_t
+    {
+    public:
+        mutex_t();
+        ~mutex_t();
+
+        mutex_t(const mutex_t&) = delete;
+        mutex_t& operator=(const mutex_t&) = delete;
+
+        void lock();
+        void unlock();
+
+    private:
+        CRITICAL_SECTION _impl;
+    };
+
     inline string_t exe_suffix() { return _X(".exe"); }
 
     inline int cstrcasecmp(const char* str1, const char* str2) { return ::_stricmp(str1, str2); }
@@ -172,6 +190,7 @@ namespace pal
     typedef int hresult_t;
     typedef void* dll_t;
     typedef void* proc_t;
+    typedef std::mutex mutex_t;
 
     inline string_t exe_suffix() { return _X(""); }
 

--- a/src/corehost/common/pal.windows.cpp
+++ b/src/corehost/common/pal.windows.cpp
@@ -693,3 +693,24 @@ bool pal::are_paths_equal_with_normalized_casing(const string_t& path1, const st
     // On Windows, paths are case-insensitive
     return (strcasecmp(path1.c_str(), path2.c_str()) == 0);
 }
+
+pal::mutex_t::mutex_t()
+    : _impl{ }
+{
+    ::InitializeCriticalSection(&_impl);
+}
+
+pal::mutex_t::~mutex_t()
+{
+    ::DeleteCriticalSection(&_impl);
+}
+
+void pal::mutex_t::lock()
+{
+    ::EnterCriticalSection(&_impl);
+}
+
+void pal::mutex_t::unlock()
+{
+    ::LeaveCriticalSection(&_impl);
+}

--- a/src/corehost/common/trace.cpp
+++ b/src/corehost/common/trace.cpp
@@ -14,7 +14,7 @@
 //  COREHOST_TRACE=1 COREHOST_TRACE_VERBOSITY=1          implies g_trace_verbosity = 1.  // Trace "enabled".  error() messages will be produced
 static int g_trace_verbosity = 0;
 static FILE * g_trace_file = stderr;
-static std::mutex g_trace_mutex;
+static pal::mutex_t g_trace_mutex;
 thread_local static trace::error_writer_fn g_error_writer = nullptr;
 
 //
@@ -51,7 +51,7 @@ bool trace::enable()
     }
     else
     {
-        std::lock_guard<std::mutex> lock(g_trace_mutex);
+        std::lock_guard<pal::mutex_t> lock(g_trace_mutex);
 
         g_trace_file = stderr;
         if (pal::getenv(_X("COREHOST_TRACEFILE"), &tracefile_str))
@@ -95,7 +95,7 @@ void trace::verbose(const pal::char_t* format, ...)
 {
     if (g_trace_verbosity > 3)
     {
-        std::lock_guard<std::mutex> lock(g_trace_mutex);
+        std::lock_guard<pal::mutex_t> lock(g_trace_mutex);
 
         va_list args;
         va_start(args, format);
@@ -108,7 +108,7 @@ void trace::info(const pal::char_t* format, ...)
 {
     if (g_trace_verbosity > 2)
     {
-        std::lock_guard<std::mutex> lock(g_trace_mutex);
+        std::lock_guard<pal::mutex_t> lock(g_trace_mutex);
 
         va_list args;
         va_start(args, format);
@@ -119,7 +119,7 @@ void trace::info(const pal::char_t* format, ...)
 
 void trace::error(const pal::char_t* format, ...)
 {
-    std::lock_guard<std::mutex> lock(g_trace_mutex);
+    std::lock_guard<pal::mutex_t> lock(g_trace_mutex);
 
     // Always print errors
     va_list args;
@@ -156,7 +156,7 @@ void trace::error(const pal::char_t* format, ...)
 
 void trace::println(const pal::char_t* format, ...)
 {
-    std::lock_guard<std::mutex> lock(g_trace_mutex);
+    std::lock_guard<pal::mutex_t> lock(g_trace_mutex);
 
     va_list args;
     va_start(args, format);
@@ -173,7 +173,7 @@ void trace::warning(const pal::char_t* format, ...)
 {
     if (g_trace_verbosity > 1)
     {
-        std::lock_guard<std::mutex> lock(g_trace_mutex);
+        std::lock_guard<pal::mutex_t> lock(g_trace_mutex);
 
         va_list args;
         va_start(args, format);
@@ -184,7 +184,7 @@ void trace::warning(const pal::char_t* format, ...)
 
 void trace::flush()
 {
-    std::lock_guard<std::mutex> lock(g_trace_mutex);
+    std::lock_guard<pal::mutex_t> lock(g_trace_mutex);
 
     pal::file_flush(g_trace_file);
     pal::err_flush();


### PR DESCRIPTION
Lockable class directly uses CRITICAL_SECTION on Windows, typedef-ed to be std::mutex on non-Windows.
Switch tracing to use new lockable class so that concrt is not pulled in for every component

Fixes #4814