### PR TITLE
[release/3.0] Revert "Skip System.Windows.Forms crossgen"

### DIFF
--- a/src/pkg/packaging-tools/framework.dependency.targets
+++ b/src/pkg/packaging-tools/framework.dependency.targets
@@ -192,15 +192,12 @@
         System.Runtime.WindowsRuntime is only supported on Windows.
 
         Resource DLLs in 'cs/', 'de/', ... subdirectories.
-
-        System.Windows.Forms. If crossgen'd, the Win32Manifest resource can't be found.
       -->
       <_filesToCrossGen
         Include="@(FilesToPackage)"
         Condition="
           '%(FilesToPackage.IsNative)' != 'true' AND
           '%(FileName)' != 'System.Private.CoreLib' AND
-          '%(FileName)' != 'System.Windows.Forms' AND
           '%(FileName)' != 'mscorlib' AND
           '%(Extension)' == '.dll' AND
           '%(FilesToPackage.DestinationSubDirectory)' == '' AND
@@ -212,14 +209,6 @@
         <CrossGenedPath>$(CrossGenOutputPath)/%(TargetPath)/%(FileName)%(Extension)</CrossGenedPath>
         <CrossGenSymbolSemaphorePath>$(_crossGenIntermediatePath)/%(FileName).symbol.semaphore</CrossGenSymbolSemaphorePath>
       </_filesToCrossGen>
-
-      <!--
-        We need to include System.Windows.Forms as a platform assembly even if we don't crossgen it,
-        in some cases.
-      -->
-      <WinFormsPlatformDirectory
-        Include="%(FilesToPackage.RootDir)%(FilesToPackage.Directory)"
-        Condition="'%(FilesToPackage.FileName)' == 'System.Windows.Forms'" />
 
       <FilesToPackage Remove="@(_filesToCrossGen)" />
 
@@ -296,25 +285,16 @@
           DependsOnTargets="CreateCrossGenImages"
           Inputs="%(_filesToCrossGen.CrossGenedPath)"
           Outputs="%(_filesToCrossGen.CrossGenSymbolSemaphorePath)">
-    <ItemGroup>
-      <_crossgenSymbolsPlatformDirectories Include="%(_filesToCrossGen.CrossGenedDirectory)" />
-      <_crossgenSymbolsPlatformDirectories Include="@(WinFormsPlatformDirectory)" />
-      <_crossgenSymbolsPlatformDirectories Include="$(_coreLibDirectory)" />
-      <_crossgenSymbolsPlatformDirectories Include="$(_fxLibDirectory)" />
-    </ItemGroup>
-
     <PropertyGroup>
       <_crossGenSymbolsResponseFile>$(_crossGenIntermediatePath)/%(_filesToCrossGen.FileName).symbols.rsp</_crossGenSymbolsResponseFile>
       <_crossGenSymbolsOptionName Condition="'$(OS)' == 'Windows_NT'">CreatePDB</_crossGenSymbolsOptionName>
       <_crossGenSymbolsOptionName Condition="'$(_crossGenSymbolsOptionName)' == ''">CreatePerfMap</_crossGenSymbolsOptionName>
       <_crossGenSymbolsOutputDirectory>$(CrossGenSymbolsOutputPath)/%(_filesToCrossGen.TargetPath)</_crossGenSymbolsOutputDirectory>
-
-      <_crossgenSymbolsPlatformAssemblies>@(_crossgenSymbolsPlatformDirectories->'%(Identity)', '$(_pathSeparatorEscaped)')</_crossgenSymbolsPlatformAssemblies>
     </PropertyGroup>
 
     <ItemGroup>
       <_crossGenSymbolsArgs Include="-readytorun" />
-      <_crossGenSymbolsArgs Include="-platform_assemblies_paths $(_crossgenSymbolsPlatformAssemblies)" />
+      <_crossGenSymbolsArgs Include="-platform_assemblies_paths %(_filesToCrossGen.CrossGenedDirectory)$(_pathSeparatorEscaped)$(_coreLibDirectory)$(_pathSeparatorEscaped)$(_fxLibDirectory)" />
       <_crossGenSymbolsArgs Include="-Platform_Winmd_Paths $(_windowsWinMDDirectory)" Condition="'$(OsEnvironment)'=='Windows_NT'"/>
       <_crossGenSymbolsArgs Include="-$(_crossGenSymbolsOptionName)" />
       <_crossGenSymbolsArgs Include="$(_crossGenSymbolsOutputDirectory)" />


### PR DESCRIPTION
Reverts dotnet/core-setup#6128

This workaround was never added to `master`, so it only needs to be reverted in `release/3.0`. This avoids confusion/merge conflicts during future auto-merges from `master` => `release/3.0`, and makes sure we don't forget to remove the change.

The underlying crossgen issue was fixed: https://github.com/dotnet/coreclr/issues/24301.