### PR TITLE
Update Microsoft.NetCore.Targets dependency to latest 3.0.0 version

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -5,9 +5,9 @@
       <Uri>https://github.com/dotnet/corefx</Uri>
       <Sha>11eba7947e9736109c588a1cfcb77987cb80f570</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.Targets" Version="2.0.0" Pinned="true">
+    <Dependency Name="Microsoft.NETCore.Targets" Version="3.0.0-preview6.19270.15">
       <Uri>https://github.com/dotnet/corefx</Uri>
-      <Sha>8321c729934c0f8be754953439b88e6e1c120c24</Sha>
+      <Sha>11eba7947e9736109c588a1cfcb77987cb80f570</Sha>
     </Dependency>
     <Dependency Name="Microsoft.Private.CoreFx.NETCoreApp" Version="4.6.0-preview6.19270.15">
       <Uri>https://github.com/dotnet/corefx</Uri>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -9,7 +9,7 @@
   <PropertyGroup>
     <!-- corefx -->
     <MicrosoftNETCorePlatformsPackageVersion>3.0.0-preview6.19270.15</MicrosoftNETCorePlatformsPackageVersion>
-    <MicrosoftNETCoreTargetsPackageVersion>2.0.0</MicrosoftNETCoreTargetsPackageVersion>
+    <MicrosoftNETCoreTargetsPackageVersion>3.0.0-preview6.19270.15</MicrosoftNETCoreTargetsPackageVersion>
     <MicrosoftPrivateCoreFxNETCoreAppPackageVersion>4.6.0-preview6.19270.15</MicrosoftPrivateCoreFxNETCoreAppPackageVersion>
     <MicrosoftWin32RegistryVersion>4.6.0-preview6.19270.15</MicrosoftWin32RegistryVersion>
     <MicrosoftWin32SystemEventsVersion>4.6.0-preview6.19270.15</MicrosoftWin32SystemEventsVersion>


### PR DESCRIPTION
Reacts to https://github.com/dotnet/corefx/pull/37600 - allows Core-Setup to depend on the latest version of the `Targets` package from 3.0.0, rather than being pinned on the 2.0.0 version.

CC @dagood @joperezr @ericstj 