### PR TITLE
Move command line parsing into separate file (out of fx_muxer.cpp)

### DIFF
--- a/src/corehost/cli/fxr/CMakeLists.txt
+++ b/src/corehost/cli/fxr/CMakeLists.txt
@@ -24,6 +24,7 @@ set(SOURCES
     ../fx_definition.cpp
     ../fx_reference.cpp
     ../version.cpp
+    ./command_line.cpp
     ./corehost_init.cpp
     ./hostfxr.cpp
     ./fx_ver.cpp
@@ -49,6 +50,7 @@ set(HEADERS
     ../roll_forward_option.h
     ../roll_fwd_on_no_candidate_fx_option.h
     ../version.h
+    ./command_line.h
     ./corehost_init.h
     ./fx_ver.h
     ./fx_muxer.h

--- a/src/corehost/cli/fxr/command_line.cpp
+++ b/src/corehost/cli/fxr/command_line.cpp
@@ -1,0 +1,311 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#include "command_line.h"
+#include <error_codes.h>
+#include "framework_info.h"
+#include <pal.h>
+#include "sdk_info.h"
+#include <trace.h>
+#include <utils.h>
+
+namespace
+{
+    struct host_option
+    {
+        pal::string_t option;
+        pal::string_t argument;
+        pal::string_t description;
+        bool framework_dependent;
+    };
+
+    bool is_sdk_dir_present(const pal::string_t& dotnet_root)
+    {
+        pal::string_t sdk_path = dotnet_root;
+        append_path(&sdk_path, _X("sdk"));
+        return pal::directory_exists(sdk_path);
+    }
+
+    std::vector<host_option> get_known_opts(bool exec_mode, host_mode_t mode, bool for_cli_usage = false)
+    {
+        std::vector<host_option> known_opts = { { _X("--additionalprobingpath"), _X("<path>"), _X("Path containing probing policy and assemblies to probe for.") } };
+        if (for_cli_usage || exec_mode || mode == host_mode_t::split_fx || mode == host_mode_t::apphost)
+        {
+            known_opts.push_back({ _X("--depsfile"), _X("<path>"), _X("Path to <application>.deps.json file.")});
+            known_opts.push_back({ _X("--runtimeconfig"), _X("<path>"), _X("Path to <application>.runtimeconfig.json file.")});
+        }
+
+        if (for_cli_usage || mode == host_mode_t::muxer || mode == host_mode_t::apphost)
+        {
+            // If mode=host_mode_t::apphost, these are only used when the app is framework-dependent.
+            known_opts.push_back({ _X("--fx-version"), _X("<version>"), _X("Version of the installed Shared Framework to use to run the application.") });
+            known_opts.push_back({ _X("--roll-forward"), _X("<value>"), _X("Roll forward to framework version (LatestPatch, Minor, LatestMinor, Major, LatestMajor, Disable)") });
+            known_opts.push_back({ _X("--additional-deps"), _X("<path>"), _X("Path to additional deps.json file.") });
+
+            if (!for_cli_usage)
+            {
+                // Intentionally leave this one out of for_cli_usage since we don't want to show it in command line help (it's deprecated).
+                known_opts.push_back({ _X("--roll-forward-on-no-candidate-fx"), _X("<n>"), _X("<obsolete>") });
+            }
+        }
+
+        return known_opts;
+    }
+
+    bool parse_known_args(
+        const int argc,
+        const pal::char_t* argv[],
+        const std::vector<host_option>& known_opts,
+        // Although multimap would provide this functionality the order of kv, values are
+        // not preserved in C++ < C++0x
+        opt_map_t* opts,
+        int* num_args)
+    {
+        int arg_i = *num_args;
+        while (arg_i < argc)
+        {
+            pal::string_t arg = argv[arg_i];
+            pal::string_t arg_lower = pal::to_lower(arg);
+            if (std::find_if(known_opts.begin(), known_opts.end(),
+                [&](const host_option& hostoption) { return arg_lower == hostoption.option; })
+                == known_opts.end())
+            {
+                // Unknown argument.
+                break;
+            }
+
+            // Known argument, so expect one more arg (value) to be present.
+            if (arg_i + 1 >= argc)
+            {
+                return false;
+            }
+
+            trace::verbose(_X("Parsed known arg %s = %s"), arg.c_str(), argv[arg_i + 1]);
+            (*opts)[arg_lower].push_back(argv[arg_i + 1]);
+
+            // Increment for both the option and its value.
+            arg_i += 2;
+        }
+
+        *num_args = arg_i;
+
+        return true;
+    }
+
+    int parse_args(
+        const host_startup_info_t &host_info,
+        int argoff,
+        int argc,
+        const pal::char_t *argv[],
+        bool exec_mode,
+        host_mode_t mode,
+        /*out*/ int *new_argoff,
+        /*out*/ pal::string_t &app_candidate,
+        /*out*/ opt_map_t &opts)
+    {
+        std::vector<host_option> known_opts = get_known_opts(exec_mode, mode);
+
+        // Parse the known arguments if any.
+        int num_parsed = 0;
+        if (!parse_known_args(argc - argoff, &argv[argoff], known_opts, &opts, &num_parsed))
+        {
+            trace::error(_X("Failed to parse supported options or their values:"));
+            for (const auto& arg : known_opts)
+            {
+                trace::error(_X("  %-37s  %s"), (arg.option + _X(" ") + arg.argument).c_str(), arg.description.c_str());
+            }
+            return StatusCode::InvalidArgFailure;
+        }
+
+        app_candidate = host_info.app_path;
+        *new_argoff = argoff + num_parsed;
+        bool doesAppExist = false;
+        if (mode == host_mode_t::apphost)
+        {
+            doesAppExist = pal::realpath(&app_candidate);
+        }
+        else
+        {
+            trace::verbose(_X("Using the provided arguments to determine the application to execute."));
+            if (*new_argoff >= argc)
+            {
+                command_line::print_muxer_usage(!is_sdk_dir_present(host_info.dotnet_root));
+                return StatusCode::InvalidArgFailure;
+            }
+
+            app_candidate = argv[*new_argoff];
+
+            bool is_app_managed = ends_with(app_candidate, _X(".dll"), false) || ends_with(app_candidate, _X(".exe"), false);
+            if (!is_app_managed)
+            {
+                trace::verbose(_X("Application '%s' is not a managed executable."), app_candidate.c_str());
+                if (!exec_mode)
+                {
+                    // Route to CLI.
+                    return StatusCode::AppArgNotRunnable;
+                }
+            }
+
+            doesAppExist = pal::realpath(&app_candidate);
+            if (!doesAppExist)
+            {
+                trace::verbose(_X("Application '%s' does not exist."), app_candidate.c_str());
+                if (!exec_mode)
+                {
+                    // Route to CLI.
+                    return StatusCode::AppArgNotRunnable;
+                }
+            }
+
+            if (!is_app_managed && doesAppExist)
+            {
+                assert(exec_mode == true);
+                trace::error(_X("dotnet exec needs a managed .dll or .exe extension. The application specified was '%s'"), app_candidate.c_str());
+                return StatusCode::InvalidArgFailure;
+            }
+        }
+
+        // App is managed executable.
+        if (!doesAppExist)
+        {
+            trace::error(_X("The application to execute does not exist: '%s'"), app_candidate.c_str());
+            return StatusCode::InvalidArgFailure;
+        }
+
+        return StatusCode::Success;
+    }
+}
+
+pal::string_t command_line::get_last_known_arg(
+    const opt_map_t& opts,
+    const pal::string_t& opt_key,
+    const pal::string_t& de_fault)
+{
+    if (opts.count(opt_key))
+    {
+        const auto& val = opts.find(opt_key)->second;
+        return val[val.size() - 1];
+    }
+    return de_fault;
+}
+
+int command_line::parse_args_for_mode(
+    host_mode_t mode,
+    const host_startup_info_t &host_info,
+    const int argc,
+    const pal::char_t *argv[],
+    /*out*/ int *new_argoff,
+    /*out*/ pal::string_t &app_candidate,
+    /*out*/ opt_map_t &opts)
+{
+    int result;
+    if (mode == host_mode_t::split_fx)
+    {
+        // Invoked as corehost
+        trace::verbose(_X("--- Executing in split/FX mode..."));
+        result = parse_args(host_info, 1, argc, argv, false, mode, new_argoff, app_candidate, opts);
+    }
+    else if (mode == host_mode_t::apphost)
+    {
+        // Invoked from the application base.
+        trace::verbose(_X("--- Executing in a native executable mode..."));
+        result = parse_args(host_info, 1, argc, argv, false, mode, new_argoff, app_candidate, opts);
+    }
+    else
+    {
+        // Invoked as the dotnet.exe muxer.
+        assert(mode == host_mode_t::muxer);
+        trace::verbose(_X("--- Executing in muxer mode..."));
+
+        if (argc <= 1)
+        {
+            command_line::print_muxer_usage(!is_sdk_dir_present(host_info.dotnet_root));
+            return StatusCode::InvalidArgFailure;
+        }
+
+        if (pal::strcasecmp(_X("exec"), argv[1]) == 0)
+        {
+            // arg offset 2 for dotnet, exec
+            result = parse_args(host_info, 2, argc, argv, true, mode, new_argoff, app_candidate, opts);
+        }
+        else
+        {
+            // arg offset 1 for dotnet
+            result = parse_args(host_info, 1, argc, argv, false, mode, new_argoff, app_candidate, opts);
+        }
+    }
+
+    return result;
+}
+
+int command_line::parse_args_for_sdk_command(
+    const host_startup_info_t& host_info,
+    const int argc,
+    const pal::char_t* argv[],
+    /*out*/ int *new_argoff,
+    /*out*/ pal::string_t &app_candidate,
+    /*out*/ opt_map_t &opts)
+{
+    // arg offset 1 for dotnet
+    return parse_args(host_info, 1, argc, argv, false, host_mode_t::muxer, new_argoff, app_candidate, opts);
+}
+
+void command_line::print_muxer_info(const pal::string_t &dotnet_root)
+{
+    trace::println();
+    trace::println(_X("Host (useful for support):"));
+    trace::println(_X("  Version: %s"), _STRINGIFY(HOST_FXR_PKG_VER));
+
+    pal::string_t commit = _STRINGIFY(REPO_COMMIT_HASH);
+    trace::println(_X("  Commit:  %s"), commit.substr(0, 10).c_str());
+
+    trace::println();
+    trace::println(_X(".NET Core SDKs installed:"));
+    if (!sdk_info::print_all_sdks(dotnet_root, _X("  ")))
+    {
+        trace::println(_X("  No SDKs were found."));
+    }
+
+    trace::println();
+    trace::println(_X(".NET Core runtimes installed:"));
+    if (!framework_info::print_all_frameworks(dotnet_root, _X("  ")))
+    {
+        trace::println(_X("  No runtimes were found."));
+    }
+
+    trace::println();
+    trace::println(_X("To install additional .NET Core runtimes or SDKs:"));
+    trace::println(_X("  %s"), DOTNET_CORE_DOWNLOAD_URL);
+}
+
+void command_line::print_muxer_usage(bool is_sdk_present)
+{
+    std::vector<host_option> known_opts = get_known_opts(true, host_mode_t::invalid, /*for_cli_usage*/ true);
+
+    if (!is_sdk_present)
+    {
+        trace::println();
+        trace::println(_X("Usage: dotnet [host-options] [path-to-application]"));
+        trace::println();
+        trace::println(_X("path-to-application:"));
+        trace::println(_X("  The path to an application .dll file to execute."));
+    }
+    trace::println();
+    trace::println(_X("host-options:"));
+
+    for (const auto& arg : known_opts)
+    {
+        trace::println(_X("  %-30s  %s"), (arg.option + _X(" ") + arg.argument).c_str(), arg.description.c_str());
+    }
+    trace::println(_X("  --list-runtimes                 Display the installed runtimes"));
+    trace::println(_X("  --list-sdks                     Display the installed SDKs"));
+
+    if (!is_sdk_present)
+    {
+        trace::println();
+        trace::println(_X("Common Options:"));
+        trace::println(_X("  -h|--help                           Displays this help."));
+        trace::println(_X("  --info                              Display .NET Core information."));
+    }
+}

--- a/src/corehost/cli/fxr/command_line.h
+++ b/src/corehost/cli/fxr/command_line.h
@@ -9,8 +9,6 @@
 #include <host_startup_info.h>
 #include <pal.h>
 
-typedef std::unordered_map<pal::string_t, std::vector<pal::string_t>> opt_map_t;
-
 enum class known_options
 {
     additional_probing_path,
@@ -24,13 +22,23 @@ enum class known_options
     __last // Sentinel value
 };
 
+struct known_options_hash
+{
+    inline size_t operator()(const known_options& opt) const
+    {
+        return static_cast<size_t>(opt);
+    }
+};
+
+typedef std::unordered_map<known_options, std::vector<pal::string_t>, known_options_hash> opt_map_t;
+
 namespace command_line
 {
-    pal::string_t get_last_known_arg(
+    const pal::string_t& get_option_name(known_options opt);
+    pal::string_t get_option_value(
         const opt_map_t& opts,
         known_options opt,
         const pal::string_t& de_fault);
-    const pal::string_t& get_option_flag(known_options opt);
 
     // Returns '0' on success, 'AppArgNotRunnable' if should be routed to CLI, otherwise error code.
     int parse_args_for_mode(

--- a/src/corehost/cli/fxr/command_line.h
+++ b/src/corehost/cli/fxr/command_line.h
@@ -1,0 +1,42 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#ifndef __COMMAND_LINE_H__
+#define __COMMAND_LINE_H__
+
+#include <host_interface.h>
+#include <host_startup_info.h>
+#include <pal.h>
+
+typedef std::unordered_map<pal::string_t, std::vector<pal::string_t>> opt_map_t;
+
+namespace command_line
+{
+    pal::string_t get_last_known_arg(
+        const opt_map_t& opts,
+        const pal::string_t& opt_key,
+        const pal::string_t& de_fault);
+
+    // Returns '0' on success, 'AppArgNotRunnable' if should be routed to CLI, otherwise error code.
+    int parse_args_for_mode(
+        host_mode_t mode,
+        const host_startup_info_t& host_info,
+        const int argc,
+        const pal::char_t* argv[],
+        /*out*/ int *new_argoff,
+        /*out*/ pal::string_t &app_candidate,
+        /*out*/ opt_map_t &opts);
+    int parse_args_for_sdk_command(
+        const host_startup_info_t& host_info,
+        const int argc,
+        const pal::char_t* argv[],
+        /*out*/ int *new_argoff,
+        /*out*/ pal::string_t &app_candidate,
+        /*out*/ opt_map_t &opts);
+
+    void print_muxer_info(const pal::string_t &dotnet_root);
+    void print_muxer_usage(bool is_sdk_present);
+};
+
+#endif // __COMMAND_LINE_H__

--- a/src/corehost/cli/fxr/command_line.h
+++ b/src/corehost/cli/fxr/command_line.h
@@ -11,12 +11,26 @@
 
 typedef std::unordered_map<pal::string_t, std::vector<pal::string_t>> opt_map_t;
 
+enum class known_options
+{
+    additional_probing_path,
+    deps_file,
+    runtime_config,
+    fx_version,
+    roll_forward,
+    additional_deps,
+    roll_forward_on_no_candidate_fx,
+
+    __last // Sentinel value
+};
+
 namespace command_line
 {
     pal::string_t get_last_known_arg(
         const opt_map_t& opts,
-        const pal::string_t& opt_key,
+        known_options opt,
         const pal::string_t& de_fault);
+    const pal::string_t& get_option_flag(known_options opt);
 
     // Returns '0' on success, 'AppArgNotRunnable' if should be routed to CLI, otherwise error code.
     int parse_args_for_mode(

--- a/src/corehost/cli/fxr/fx_muxer.cpp
+++ b/src/corehost/cli/fxr/fx_muxer.cpp
@@ -213,72 +213,6 @@ void get_runtime_config_paths_from_app(const pal::string_t& app, pal::string_t* 
     get_runtime_config_paths(path, name, cfg, dev_cfg);
 }
 
-bool is_sdk_dir_present(const pal::string_t& dotnet_root)
-{
-    pal::string_t sdk_path = dotnet_root;
-    append_path(&sdk_path, _X("sdk"));
-    return pal::directory_exists(sdk_path);
-}
-
-void muxer_info(pal::string_t dotnet_root)
-{
-    trace::println();
-    trace::println(_X("Host (useful for support):"));
-    trace::println(_X("  Version: %s"), _STRINGIFY(HOST_FXR_PKG_VER));
-
-    pal::string_t commit = _STRINGIFY(REPO_COMMIT_HASH);
-    trace::println(_X("  Commit:  %s"), commit.substr(0, 10).c_str());
-
-    trace::println();
-    trace::println(_X(".NET Core SDKs installed:"));
-    if (!sdk_info::print_all_sdks(dotnet_root, _X("  ")))
-    {
-        trace::println(_X("  No SDKs were found."));
-    }
-
-    trace::println();
-    trace::println(_X(".NET Core runtimes installed:"));
-    if (!framework_info::print_all_frameworks(dotnet_root, _X("  ")))
-    {
-        trace::println(_X("  No runtimes were found."));
-    }
-
-    trace::println();
-    trace::println(_X("To install additional .NET Core runtimes or SDKs:"));
-    trace::println(_X("  %s"), DOTNET_CORE_DOWNLOAD_URL);
-}
-
-void fx_muxer_t::muxer_usage(bool is_sdk_present)
-{
-    std::vector<host_option> known_opts = fx_muxer_t::get_known_opts(true, host_mode_t::invalid, /*for_cli_usage*/ true);
-
-    if (!is_sdk_present)
-    {
-        trace::println();
-        trace::println(_X("Usage: dotnet [host-options] [path-to-application]"));
-        trace::println();
-        trace::println(_X("path-to-application:"));
-        trace::println(_X("  The path to an application .dll file to execute."));
-    }
-    trace::println();
-    trace::println(_X("host-options:"));
-
-    for (const auto& arg : known_opts)
-    {
-        trace::println(_X("  %-30s  %s"), (arg.option + _X(" ") + arg.argument).c_str(), arg.description.c_str());
-    }
-    trace::println(_X("  --list-runtimes                 Display the installed runtimes"));
-    trace::println(_X("  --list-sdks                     Display the installed SDKs"));
-
-    if (!is_sdk_present)
-    {
-        trace::println();
-        trace::println(_X("Common Options:"));
-        trace::println(_X("  -h|--help                           Displays this help."));
-        trace::println(_X("  --info                              Display .NET Core information."));
-    }
-}
-
 // Convert "path" to realpath (merging working dir if needed) and append to "realpaths" out param.
 void append_probe_realpath(const pal::string_t& path, std::vector<pal::string_t>* realpaths, const pal::string_t& tfm)
 {
@@ -321,116 +255,6 @@ void append_probe_realpath(const pal::string_t& path, std::vector<pal::string_t>
             trace::verbose(_X("Ignoring additional probing path %s as it does not exist."), probe_path.c_str());
         }
     }
-}
-
-std::vector<host_option> fx_muxer_t::get_known_opts(bool exec_mode, host_mode_t mode, bool for_cli_usage)
-{
-    std::vector<host_option> known_opts = { { _X("--additionalprobingpath"), _X("<path>"), _X("Path containing probing policy and assemblies to probe for.") } };
-    if (for_cli_usage || exec_mode || mode == host_mode_t::split_fx || mode == host_mode_t::apphost)
-    {
-        known_opts.push_back({ _X("--depsfile"), _X("<path>"), _X("Path to <application>.deps.json file.")});
-        known_opts.push_back({ _X("--runtimeconfig"), _X("<path>"), _X("Path to <application>.runtimeconfig.json file.")});
-    }
-
-    if (for_cli_usage || mode == host_mode_t::muxer || mode == host_mode_t::apphost)
-    {
-        // If mode=host_mode_t::apphost, these are only used when the app is framework-dependent.
-        known_opts.push_back({ _X("--fx-version"), _X("<version>"), _X("Version of the installed Shared Framework to use to run the application.") });
-        known_opts.push_back({ _X("--roll-forward"), _X("<value>"), _X("Roll forward to framework version (LatestPatch, Minor, LatestMinor, Major, LatestMajor, Disable)") });
-        known_opts.push_back({ _X("--additional-deps"), _X("<path>"), _X("Path to additional deps.json file.") });
-
-        if (!for_cli_usage)
-        {
-            // Intentionally leave this one out of for_cli_usage since we don't want to show it in command line help (it's deprecated).
-            known_opts.push_back({ _X("--roll-forward-on-no-candidate-fx"), _X("<n>"), _X("<obsolete>") });
-        }
-    }
-
-    return known_opts;
-}
-
-// Returns '0' on success, 'AppArgNotRunnable' if should be routed to CLI, otherwise error code.
-int fx_muxer_t::parse_args(
-    const host_startup_info_t& host_info,
-    int argoff,
-    int argc,
-    const pal::char_t* argv[],
-    bool exec_mode,
-    host_mode_t mode,
-    int* new_argoff,
-    pal::string_t& app_candidate,
-    opt_map_t& opts)
-{
-    std::vector<host_option> known_opts = get_known_opts(exec_mode, mode);
-
-    // Parse the known arguments if any.
-    int num_parsed = 0;
-    if (!parse_known_args(argc - argoff, &argv[argoff], known_opts, &opts, &num_parsed))
-    {
-        trace::error(_X("Failed to parse supported options or their values:"));
-        for (const auto& arg : known_opts)
-        {
-            trace::error(_X("  %-37s  %s"), (arg.option + _X(" ") + arg.argument).c_str(), arg.description.c_str());
-        }
-        return StatusCode::InvalidArgFailure;
-    }
-
-    app_candidate = host_info.app_path;
-    *new_argoff = argoff + num_parsed;
-    bool doesAppExist = false;
-    if (mode == host_mode_t::apphost)
-    {
-        doesAppExist = pal::realpath(&app_candidate);
-    }
-    else
-    {
-        trace::verbose(_X("Using the provided arguments to determine the application to execute."));
-        if (*new_argoff >= argc)
-        {
-            muxer_usage(!is_sdk_dir_present(host_info.dotnet_root));
-            return StatusCode::InvalidArgFailure;
-        }
-
-        app_candidate = argv[*new_argoff];
-
-        bool is_app_managed = ends_with(app_candidate, _X(".dll"), false) || ends_with(app_candidate, _X(".exe"), false);
-        if (!is_app_managed)
-        {
-            trace::verbose(_X("Application '%s' is not a managed executable."), app_candidate.c_str());
-            if (!exec_mode)
-            {
-                // Route to CLI.
-                return StatusCode::AppArgNotRunnable;
-            }
-        }
-
-        doesAppExist = pal::realpath(&app_candidate);
-        if (!doesAppExist)
-        {
-            trace::verbose(_X("Application '%s' does not exist."), app_candidate.c_str());
-            if (!exec_mode)
-            {
-                // Route to CLI.
-                return StatusCode::AppArgNotRunnable;
-            }
-        }
-
-        if (!is_app_managed && doesAppExist)
-        {
-            assert(exec_mode == true);
-            trace::error(_X("dotnet exec needs a managed .dll or .exe extension. The application specified was '%s'"), app_candidate.c_str());
-            return StatusCode::InvalidArgFailure;
-        }
-    }
-
-    // App is managed executable.
-    if (!doesAppExist)
-    {
-        trace::error(_X("The application to execute does not exist: '%s'"), app_candidate.c_str());
-        return StatusCode::InvalidArgFailure;
-    }
-
-    return StatusCode::Success;
 }
 
 namespace
@@ -542,9 +366,9 @@ namespace
         pal::string_t opts_additional_deps = _X("--additional-deps");
         pal::string_t opts_runtime_config = _X("--runtimeconfig");
 
-        pal::string_t runtime_config = get_last_known_arg(opts, opts_runtime_config, _X(""));
+        pal::string_t runtime_config = command_line::get_last_known_arg(opts, opts_runtime_config, _X(""));
 
-        pal::string_t deps_file = get_last_known_arg(opts, opts_deps_file, _X(""));
+        pal::string_t deps_file = command_line::get_last_known_arg(opts, opts_deps_file, _X(""));
         if (!deps_file.empty() && !pal::realpath(&deps_file))
         {
             trace::error(_X("The specified deps.json [%s] does not exist"), deps_file.c_str());
@@ -566,7 +390,7 @@ namespace
         // The conflicts will be resolved by following the priority rank described above (from 1 to 5, lower number wins over higher number).
         // The env var condition is verified in the config file processing
 
-        pal::string_t roll_forward = get_last_known_arg(opts, opts_roll_forward, _X(""));
+        pal::string_t roll_forward = command_line::get_last_known_arg(opts, opts_roll_forward, _X(""));
         if (roll_forward.length() > 0)
         {
             auto val = roll_forward_option_from_string(roll_forward);
@@ -579,7 +403,7 @@ namespace
             override_settings.set_roll_forward(val);
         }
 
-        pal::string_t roll_fwd_on_no_candidate_fx = get_last_known_arg(opts, opts_roll_fwd_on_no_candidate_fx, _X(""));
+        pal::string_t roll_fwd_on_no_candidate_fx = command_line::get_last_known_arg(opts, opts_roll_fwd_on_no_candidate_fx, _X(""));
         if (roll_fwd_on_no_candidate_fx.length() > 0)
         {
             if (override_settings.has_roll_forward)
@@ -607,7 +431,7 @@ namespace
         if (is_framework_dependent)
         {
             // Apply the --fx-version option to the first framework
-            pal::string_t fx_version_specified = get_last_known_arg(opts, opts_fx_version, _X(""));
+            pal::string_t fx_version_specified = command_line::get_last_known_arg(opts, opts_fx_version, _X(""));
             if (fx_version_specified.length() > 0)
             {
                 // This will also set roll forward defaults on the ref
@@ -615,7 +439,7 @@ namespace
             }
 
             // Determine additional deps
-            pal::string_t additional_deps = get_last_known_arg(opts, opts_additional_deps, _X(""));
+            pal::string_t additional_deps = command_line::get_last_known_arg(opts, opts_additional_deps, _X(""));
             additional_deps_serialized = additional_deps;
             if (additional_deps_serialized.empty())
             {
@@ -654,43 +478,43 @@ namespace
 
         return StatusCode::Success;
     }
-}
 
-int fx_muxer_t::read_config_and_execute(
-    const pal::string_t& host_command,
-    const host_startup_info_t& host_info,
-    const pal::string_t& app_candidate,
-    const opt_map_t& opts,
-    int new_argc,
-    const pal::char_t** new_argv,
-    host_mode_t mode,
-    pal::char_t out_buffer[],
-    int32_t buffer_size,
-    int32_t* required_buffer_size)
-{
-    pal::string_t hostpolicy_dir;
-    std::unique_ptr<corehost_init_t> init;
-    int rc = get_init_info_for_app(
-        host_command,
-        host_info,
-        app_candidate,
-        opts,
-        mode,
-        hostpolicy_dir,
-        init);
-    if (rc != StatusCode::Success)
+    int read_config_and_execute(
+        const pal::string_t& host_command,
+        const host_startup_info_t& host_info,
+        const pal::string_t& app_candidate,
+        const opt_map_t& opts,
+        int new_argc,
+        const pal::char_t** new_argv,
+        host_mode_t mode,
+        pal::char_t out_buffer[],
+        int32_t buffer_size,
+        int32_t* required_buffer_size)
+    {
+        pal::string_t hostpolicy_dir;
+        std::unique_ptr<corehost_init_t> init;
+        int rc = get_init_info_for_app(
+            host_command,
+            host_info,
+            app_candidate,
+            opts,
+            mode,
+            hostpolicy_dir,
+            init);
+        if (rc != StatusCode::Success)
+            return rc;
+
+        if (host_command.size() == 0)
+        {
+            rc = execute_app(hostpolicy_dir, init.get(), new_argc, new_argv);
+        }
+        else
+        {
+            rc = execute_host_command(hostpolicy_dir, init.get(), new_argc, new_argv, out_buffer, buffer_size, required_buffer_size);
+        }
+
         return rc;
-
-    if (host_command.size() == 0)
-    {
-        rc = execute_app(hostpolicy_dir, init.get(), new_argc, new_argv);
     }
-    else
-    {
-        rc = execute_host_command(hostpolicy_dir, init.get(), new_argc, new_argv, out_buffer, buffer_size, required_buffer_size);
-    }
-
-    return rc;
 }
 
 /**
@@ -712,45 +536,10 @@ int fx_muxer_t::execute(
     int new_argoff;
     pal::string_t app_candidate;
     opt_map_t opts;
-    int result;
-
-    if (mode == host_mode_t::split_fx)
+    int result = command_line::parse_args_for_mode(mode, host_info, argc, argv, &new_argoff, app_candidate, opts);
+    if (static_cast<StatusCode>(result) == AppArgNotRunnable)
     {
-        // Invoked as corehost
-        trace::verbose(_X("--- Executing in split/FX mode..."));
-        result = parse_args(host_info, 1, argc, argv, false, mode, &new_argoff, app_candidate, opts);
-    }
-    else if (mode == host_mode_t::apphost)
-    {
-        // Invoked from the application base.
-        trace::verbose(_X("--- Executing in a native executable mode..."));
-        result = parse_args(host_info, 1, argc, argv, false, mode, &new_argoff, app_candidate, opts);
-    }
-    else
-    {
-        // Invoked as the dotnet.exe muxer.
-        assert(mode == host_mode_t::muxer);
-        trace::verbose(_X("--- Executing in muxer mode..."));
-
-        if (argc <= 1)
-        {
-            muxer_usage(!is_sdk_dir_present(host_info.dotnet_root));
-            return StatusCode::InvalidArgFailure;
-        }
-
-        if (pal::strcasecmp(_X("exec"), argv[1]) == 0)
-        {
-            result = parse_args(host_info, 2, argc, argv, true, mode, &new_argoff, app_candidate, opts); // arg offset 2 for dotnet, exec
-        }
-        else
-        {
-            result = parse_args(host_info, 1, argc, argv, false, mode, &new_argoff, app_candidate, opts); // arg offset 1 for dotnet
-
-            if (static_cast<StatusCode>(result) == AppArgNotRunnable)
-            {
-                return handle_cli(host_info, argc, argv);
-            }
-        }
+        return handle_cli(host_info, argc, argv);
     }
 
     if (!result)
@@ -1124,29 +913,6 @@ int fx_muxer_t::close_host_context(host_context_t *context)
     return StatusCode::Success;
 }
 
-int fx_muxer_t::handle_exec(
-    const host_startup_info_t& host_info,
-    const pal::string_t& app_candidate,
-    const opt_map_t& opts,
-    int argc,
-    const pal::char_t* argv[],
-    int argoff,
-    host_mode_t mode)
-{
-    return handle_exec_host_command(
-        pal::string_t(),
-        host_info,
-        app_candidate,
-        opts,
-        argc,
-        argv,
-        argoff,
-        mode,
-        nullptr,
-        0,
-        nullptr);
-}
-
 int fx_muxer_t::handle_exec_host_command(
     const pal::string_t& host_command,
     const host_startup_info_t& host_info,
@@ -1219,12 +985,12 @@ int fx_muxer_t::handle_cli(
             pal::strcasecmp(_X("-?"), argv[1]) == 0 ||
             pal::strcasecmp(_X("/?"), argv[1]) == 0)
         {
-            muxer_usage(false);
+            command_line::print_muxer_usage(false);
             return StatusCode::InvalidArgFailure;
         }
         else if (pal::strcasecmp(_X("--info"), argv[1]) == 0)
         {
-            muxer_info(host_info.dotnet_root);
+            command_line::print_muxer_info(host_info.dotnet_root);
             return StatusCode::Success;
         }
 
@@ -1252,17 +1018,27 @@ int fx_muxer_t::handle_cli(
     int new_argoff;
     pal::string_t app_candidate;
     opt_map_t opts;
-
-    int result = parse_args(host_info, 1, new_argv.size(), new_argv.data(), false, host_mode_t::muxer, &new_argoff, app_candidate, opts); // arg offset 1 for dotnet
+    int result = command_line::parse_args_for_sdk_command(host_info, new_argv.size(), new_argv.data(), &new_argoff, app_candidate, opts);
     if (!result)
     {
         // Transform dotnet [exec] [--additionalprobingpath path] [--depsfile file] [dll] [args] -> dotnet [dll] [args]
-        result = handle_exec(host_info, app_candidate, opts, new_argv.size(), new_argv.data(), new_argoff, host_mode_t::muxer);
+        result = handle_exec_host_command(
+            pal::string_t{} /*host_command*/,
+            host_info,
+            app_candidate,
+            opts,
+            new_argv.size(),
+            new_argv.data(),
+            new_argoff,
+            host_mode_t::muxer,
+            nullptr /*result_buffer*/,
+            0 /*buffer_size*/,
+            nullptr/*required_buffer_size*/);
     }
 
     if (pal::strcasecmp(_X("--info"), argv[1]) == 0)
     {
-        muxer_info(host_info.dotnet_root);
+        command_line::print_muxer_info(host_info.dotnet_root);
     }
 
     return result;

--- a/src/corehost/cli/fxr/fx_muxer.cpp
+++ b/src/corehost/cli/fxr/fx_muxer.cpp
@@ -358,9 +358,9 @@ namespace
         /*out*/ pal::string_t &hostpolicy_dir,
         /*out*/ std::unique_ptr<corehost_init_t> &init)
     {
-        pal::string_t runtime_config = command_line::get_last_known_arg(opts, known_options::runtime_config, _X(""));
+        pal::string_t runtime_config = command_line::get_option_value(opts, known_options::runtime_config, _X(""));
 
-        pal::string_t deps_file = command_line::get_last_known_arg(opts, known_options::deps_file, _X(""));
+        pal::string_t deps_file = command_line::get_option_value(opts, known_options::deps_file, _X(""));
         if (!deps_file.empty() && !pal::realpath(&deps_file))
         {
             trace::error(_X("The specified deps.json [%s] does not exist"), deps_file.c_str());
@@ -382,27 +382,27 @@ namespace
         // The conflicts will be resolved by following the priority rank described above (from 1 to 5, lower number wins over higher number).
         // The env var condition is verified in the config file processing
 
-        pal::string_t roll_forward = command_line::get_last_known_arg(opts, known_options::roll_forward, _X(""));
+        pal::string_t roll_forward = command_line::get_option_value(opts, known_options::roll_forward, _X(""));
         if (roll_forward.length() > 0)
         {
             auto val = roll_forward_option_from_string(roll_forward);
             if (val == roll_forward_option::__Last)
             {
-                trace::error(_X("Invalid value for command line argument '%s'"), command_line::get_option_flag(known_options::roll_forward).c_str());
+                trace::error(_X("Invalid value for command line argument '%s'"), command_line::get_option_name(known_options::roll_forward).c_str());
                 return StatusCode::InvalidArgFailure;
             }
 
             override_settings.set_roll_forward(val);
         }
 
-        pal::string_t roll_fwd_on_no_candidate_fx = command_line::get_last_known_arg(opts, known_options::roll_forward_on_no_candidate_fx, _X(""));
+        pal::string_t roll_fwd_on_no_candidate_fx = command_line::get_option_value(opts, known_options::roll_forward_on_no_candidate_fx, _X(""));
         if (roll_fwd_on_no_candidate_fx.length() > 0)
         {
             if (override_settings.has_roll_forward)
             {
                 trace::error(_X("It's invalid to use both '%s' and '%s' command line options."),
-                    command_line::get_option_flag(known_options::roll_forward).c_str(),
-                    command_line::get_option_flag(known_options::roll_forward_on_no_candidate_fx).c_str());
+                    command_line::get_option_name(known_options::roll_forward).c_str(),
+                    command_line::get_option_name(known_options::roll_forward_on_no_candidate_fx).c_str());
                 return StatusCode::InvalidArgFailure;
             }
 
@@ -425,7 +425,7 @@ namespace
         if (is_framework_dependent)
         {
             // Apply the --fx-version option to the first framework
-            pal::string_t fx_version_specified = command_line::get_last_known_arg(opts, known_options::fx_version, _X(""));
+            pal::string_t fx_version_specified = command_line::get_option_value(opts, known_options::fx_version, _X(""));
             if (fx_version_specified.length() > 0)
             {
                 // This will also set roll forward defaults on the ref
@@ -433,7 +433,7 @@ namespace
             }
 
             // Determine additional deps
-            pal::string_t additional_deps = command_line::get_last_known_arg(opts, known_options::additional_deps, _X(""));
+            pal::string_t additional_deps = command_line::get_option_value(opts, known_options::additional_deps, _X(""));
             additional_deps_serialized = additional_deps;
             if (additional_deps_serialized.empty())
             {
@@ -457,7 +457,7 @@ namespace
             }
         }
 
-        const pal::string_t &opts_probe_path = command_line::get_option_flag(known_options::additional_probing_path);
+        const known_options opts_probe_path = known_options::additional_probing_path;
         std::vector<pal::string_t> spec_probe_paths = opts.count(opts_probe_path) ? opts.find(opts_probe_path)->second : std::vector<pal::string_t>();
         std::vector<pal::string_t> probe_realpaths = get_probe_realpaths(fx_definitions, spec_probe_paths);
 

--- a/src/corehost/cli/fxr/fx_muxer.cpp
+++ b/src/corehost/cli/fxr/fx_muxer.cpp
@@ -358,17 +358,9 @@ namespace
         /*out*/ pal::string_t &hostpolicy_dir,
         /*out*/ std::unique_ptr<corehost_init_t> &init)
     {
-        pal::string_t opts_fx_version = _X("--fx-version");
-        pal::string_t opts_roll_forward = _X("--roll-forward");
-        pal::string_t opts_roll_fwd_on_no_candidate_fx = _X("--roll-forward-on-no-candidate-fx");
-        pal::string_t opts_deps_file = _X("--depsfile");
-        pal::string_t opts_probe_path = _X("--additionalprobingpath");
-        pal::string_t opts_additional_deps = _X("--additional-deps");
-        pal::string_t opts_runtime_config = _X("--runtimeconfig");
+        pal::string_t runtime_config = command_line::get_last_known_arg(opts, known_options::runtime_config, _X(""));
 
-        pal::string_t runtime_config = command_line::get_last_known_arg(opts, opts_runtime_config, _X(""));
-
-        pal::string_t deps_file = command_line::get_last_known_arg(opts, opts_deps_file, _X(""));
+        pal::string_t deps_file = command_line::get_last_known_arg(opts, known_options::deps_file, _X(""));
         if (!deps_file.empty() && !pal::realpath(&deps_file))
         {
             trace::error(_X("The specified deps.json [%s] does not exist"), deps_file.c_str());
@@ -390,25 +382,27 @@ namespace
         // The conflicts will be resolved by following the priority rank described above (from 1 to 5, lower number wins over higher number).
         // The env var condition is verified in the config file processing
 
-        pal::string_t roll_forward = command_line::get_last_known_arg(opts, opts_roll_forward, _X(""));
+        pal::string_t roll_forward = command_line::get_last_known_arg(opts, known_options::roll_forward, _X(""));
         if (roll_forward.length() > 0)
         {
             auto val = roll_forward_option_from_string(roll_forward);
             if (val == roll_forward_option::__Last)
             {
-                trace::error(_X("Invalid value for command line argument '%s'"), opts_roll_forward.c_str());
+                trace::error(_X("Invalid value for command line argument '%s'"), command_line::get_option_flag(known_options::roll_forward).c_str());
                 return StatusCode::InvalidArgFailure;
             }
 
             override_settings.set_roll_forward(val);
         }
 
-        pal::string_t roll_fwd_on_no_candidate_fx = command_line::get_last_known_arg(opts, opts_roll_fwd_on_no_candidate_fx, _X(""));
+        pal::string_t roll_fwd_on_no_candidate_fx = command_line::get_last_known_arg(opts, known_options::roll_forward_on_no_candidate_fx, _X(""));
         if (roll_fwd_on_no_candidate_fx.length() > 0)
         {
             if (override_settings.has_roll_forward)
             {
-                trace::error(_X("It's invalid to use both '%s' and '%s' command line options."), opts_roll_forward.c_str(), opts_roll_fwd_on_no_candidate_fx.c_str());
+                trace::error(_X("It's invalid to use both '%s' and '%s' command line options."),
+                    command_line::get_option_flag(known_options::roll_forward).c_str(),
+                    command_line::get_option_flag(known_options::roll_forward_on_no_candidate_fx).c_str());
                 return StatusCode::InvalidArgFailure;
             }
 
@@ -431,7 +425,7 @@ namespace
         if (is_framework_dependent)
         {
             // Apply the --fx-version option to the first framework
-            pal::string_t fx_version_specified = command_line::get_last_known_arg(opts, opts_fx_version, _X(""));
+            pal::string_t fx_version_specified = command_line::get_last_known_arg(opts, known_options::fx_version, _X(""));
             if (fx_version_specified.length() > 0)
             {
                 // This will also set roll forward defaults on the ref
@@ -439,7 +433,7 @@ namespace
             }
 
             // Determine additional deps
-            pal::string_t additional_deps = command_line::get_last_known_arg(opts, opts_additional_deps, _X(""));
+            pal::string_t additional_deps = command_line::get_last_known_arg(opts, known_options::additional_deps, _X(""));
             additional_deps_serialized = additional_deps;
             if (additional_deps_serialized.empty())
             {
@@ -463,6 +457,7 @@ namespace
             }
         }
 
+        const pal::string_t &opts_probe_path = command_line::get_option_flag(known_options::additional_probing_path);
         std::vector<pal::string_t> spec_probe_paths = opts.count(opts_probe_path) ? opts.find(opts_probe_path)->second : std::vector<pal::string_t>();
         std::vector<pal::string_t> probe_realpaths = get_probe_realpaths(fx_definitions, spec_probe_paths);
 

--- a/src/corehost/cli/fxr/fx_muxer.h
+++ b/src/corehost/cli/fxr/fx_muxer.h
@@ -2,13 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-class corehost_init_t;
-class runtime_config_t;
-class fx_definition_t;
-struct fx_ver_t;
-struct host_startup_info_t;
-
 #include <corehost_context_contract.h>
+#include "command_line.h"
 #include "error_codes.h"
 #include "fx_definition.h"
 #include "host_context.h"
@@ -43,24 +38,6 @@ public:
     static const host_context_t* get_active_host_context();
     static int close_host_context(host_context_t *context);
 private:
-    static int parse_args(
-        const host_startup_info_t& host_info,
-        int argoff,
-        int argc,
-        const pal::char_t* argv[],
-        bool exec_mode,
-        host_mode_t mode,
-        int* new_argoff,
-        pal::string_t& app_candidate,
-        opt_map_t& opts);
-    static int handle_exec(
-        const host_startup_info_t& host_info,
-        const pal::string_t& app_candidate,
-        const opt_map_t& opts,
-        int argc,
-        const pal::char_t* argv[],
-        int argoff,
-        host_mode_t mode);
     static int handle_exec_host_command(
         const pal::string_t& host_command,
         const host_startup_info_t& host_info,
@@ -77,20 +54,4 @@ private:
         const host_startup_info_t& host_info,
         int argc,
         const pal::char_t* argv[]);
-    static std::vector<host_option> get_known_opts(
-        bool exec_mode,
-        host_mode_t mode,
-        bool for_cli_usage = false);
-    static int read_config_and_execute(
-        const pal::string_t& host_command,
-        const host_startup_info_t& host_info,
-        const pal::string_t& app_candidate,
-        const opt_map_t& opts,
-        int new_argc,
-        const pal::char_t** new_argv,
-        host_mode_t mode,
-        pal::char_t out_buffer[],
-        int32_t buffer_size,
-        int32_t* required_buffer_size);
-    static void muxer_usage(bool is_sdk_present);
 };

--- a/src/corehost/common/utils.cpp
+++ b/src/corehost/common/utils.cpp
@@ -200,59 +200,6 @@ const pal::char_t* get_arch()
 #endif
 }
 
-pal::string_t get_last_known_arg(
-    const opt_map_t& opts,
-    const pal::string_t& opt_key,
-    const pal::string_t& de_fault)
-{
-    if (opts.count(opt_key))
-    {
-        const auto& val = opts.find(opt_key)->second;
-        return val[val.size() - 1];
-    }
-    return de_fault;
-}
-
-bool parse_known_args(
-    const int argc,
-    const pal::char_t* argv[],
-    const std::vector<host_option>& known_opts,
-    // Although multimap would provide this functionality the order of kv, values are
-    // not preserved in C++ < C++0x
-    opt_map_t* opts,
-    int* num_args)
-{
-    int arg_i = *num_args;
-    while (arg_i < argc)
-    {
-        pal::string_t arg = argv[arg_i];
-        pal::string_t arg_lower = pal::to_lower(arg);
-        if (std::find_if(known_opts.begin(), known_opts.end(),
-            [&](const host_option& hostoption) { return arg_lower == hostoption.option; })
-            == known_opts.end())
-        {
-            // Unknown argument.
-            break;
-        }
-
-        // Known argument, so expect one more arg (value) to be present.
-        if (arg_i + 1 >= argc)
-        {
-            return false;
-        }
-
-        trace::verbose(_X("Parsed known arg %s = %s"), arg.c_str(), argv[arg_i + 1]);
-        (*opts)[arg_lower].push_back(argv[arg_i + 1]);
-
-        // Increment for both the option and its value.
-        arg_i += 2;
-    }
-
-    *num_args = arg_i;
-
-    return true;
-}
-
 // Try to match 0xEF 0xBB 0xBF byte sequence (no endianness here.)
 bool skip_utf8_bom(pal::istream_t* stream)
 {

--- a/src/corehost/common/utils.h
+++ b/src/corehost/common/utils.h
@@ -7,13 +7,6 @@
 
 #include "pal.h"
 #include "trace.h"
-struct host_option
-{
-    pal::string_t option;
-    pal::string_t argument;
-    pal::string_t description;
-    bool framework_dependent;
-};
 
 #define _STRINGIFY(s) _X(s)
 #if defined(_WIN32)
@@ -27,8 +20,6 @@ struct host_option
 #define DOTNET_CORE_DOWNLOAD_URL _X("https://aka.ms/dotnet-download")
 
 #define RUNTIME_STORE_DIRECTORY_NAME _X("store")
-
-typedef std::unordered_map<pal::string_t, std::vector<pal::string_t>> opt_map_t;
 
 bool ends_with(const pal::string_t& value, const pal::string_t& suffix, bool match_case);
 bool starts_with(const pal::string_t& value, const pal::string_t& prefix, bool match_case);
@@ -44,16 +35,6 @@ void remove_trailing_dir_seperator(pal::string_t* dir);
 void replace_char(pal::string_t* path, pal::char_t match, pal::char_t repl);
 pal::string_t get_replaced_char(const pal::string_t& path, pal::char_t match, pal::char_t repl);
 const pal::char_t* get_arch();
-pal::string_t get_last_known_arg(
-    const opt_map_t& opts,
-    const pal::string_t& opt_key,
-    const pal::string_t& de_fault);
-bool parse_known_args(
-    const int argc,
-    const pal::char_t* argv[],
-    const std::vector<host_option>& known_opts,
-    opt_map_t* opts,
-    int* num_args);
 bool skip_utf8_bom(pal::istream_t* stream);
 bool get_env_shared_store_dirs(std::vector<pal::string_t>* dirs, const pal::string_t& arch, const pal::string_t& tfm);
 bool get_global_shared_store_dirs(std::vector<pal::string_t>* dirs, const pal::string_t& arch, const pal::string_t& tfm);


### PR DESCRIPTION
Move definitions for known host options into one place (`command_line.cpp`).
This should not represent a functional change.

The first commit is just largely just copying/moving functions into different files and the second commit modifies some of the moved functions. I still haven't figured out an easy way to review code that was just moved around, but this is generally where things came from and went:

Previously in `fx_muxer.cpp`, now in `command_line.cpp`:
- `fx_muxer_t::parse_args` -> `parse_args` (anonymous namespace)
- `fx_muxer_t::get_known_opts` -> `get_known_opts` (anonymous namespace)
- `fx_muxer_t::muxer_usage` -> `command_line::print_muxer_usage`
- `is_sdk_dir_present` -> `is_sdk_dir_present` (anonymous namespace)
- `muxer_info` -> `command_line::print_muxer_info`
- part of `fx_muxer_t::execute` (dealing with parsing) -> `command_line::parse_args_for_mode`

Previously in `utils.cpp`, now in `command_line.cpp`:
- `host_option` -> `host_option` (anonymous namespace, removed `framework_dependent` field)
- `get_last_known_arg` -> `command_line::get_last_known_arg`
- `parse_known_args` -> `parse_known_args` (anonymous namespace)