### PR TITLE
Fix intermittent failures in light.exe

### DIFF
--- a/src/pkg/packaging/windows/sharedframework/generatebundle.ps1
+++ b/src/pkg/packaging/windows/sharedframework/generatebundle.ps1
@@ -79,6 +79,8 @@ function RunLightForBundle
     Write-Host Running light for bundle..
     $AuthWsxRoot =  Join-Path $PackagingRoot "windows\sharedframework"
 
+    Start-Sleep 1
+
     .\light.exe -nologo `
         -cultures:en-us `
         bundle.wixobj `
@@ -104,6 +106,10 @@ if([string]::IsNullOrEmpty($WixRoot))
 {
     Exit -1
 }
+
+$WixTempPath = Join-Path $WixRoot "wix_temp"
+New-Item -ItemType Directory -Path $WixTempPath -Force | Out-Null
+$env:WIX_TEMP = $WixTempPath
 
 if(-Not (RunCandleForBundle))
 {


### PR DESCRIPTION
This is a workaround for an issue I recently started to see locally. The light.exe would fail with "The process cannot access the file because it is being used by another process". Debugging into it, it fails to move a file from temp to the output (the final exe output file).

There are two issues here:
* It uses the OS temp folder (TMP variable) which people typically don't have excluded from antivirus and thus the antivirus can lock the file for a bit. This is fixed by setting the `WIX_TEMP` env. variable to a location in the obj tree.
* Even with the above it still sometimes fails. The only workaround I found is simply  wait for a bit before running light. I don't know why this happens, but the simple sleep 1 second fixes it. It's probably not worth the effort to try to figure out why.