### PR TITLE
Framework list updates: add WindowsDesktop Profile, include list in runtime packages

### DIFF
--- a/src/pkg/projects/dir.targets
+++ b/src/pkg/projects/dir.targets
@@ -191,20 +191,13 @@
                    '$(BuildFullPlatformManifest)' == 'true'">true</IncludeAllRuntimePackagesInPlatformManifest>
     </PropertyGroup>
 
-    <!--
-      Set FrameworkListTargetPath to empty string to skip framework list generation. When
-      BuildFullPlatformManifest is set, list generation  attempts to read post-crossgen files from
-      other platforms, which don't exist on the current machine. (Generating the framework list is
-      also not necessary here and a waste of time.)
-    -->
     <MSBuild Projects="@(ProjectReference)"
              Condition="'%(ProjectReference.PackageTargetRuntime)' == '$(PackageRID)' OR
                         '%(ProjectReference.BuidOnRID)' == '$(PackageRID)' OR
                         ('$(IncludeAllRuntimePackagesInPlatformManifest)' == 'true' AND
                          '%(ProjectReference.PackageTargetRuntime)' != '' AND
                          '%(ProjectReference.ExcludeFromPlatformManifest)' != 'true')"
-             Targets="GetPackageFiles"
-             Properties="FrameworkListTargetPath=">
+             Targets="GetPackageFiles">
       <Output TaskParameter="TargetOutputs" ItemName="SharedFrameworkRuntimeFiles" />
     </MSBuild>
 
@@ -250,7 +243,12 @@
   <Target Name="IncludeFrameworkListFile"
           BeforeTargets="GetFiles"
           DependsOnTargets="GetSymbolPackageFiles"
-          Condition="'$(FrameworkListTargetPath)' != ''">
+          Condition="
+            '$(FrameworkListTargetPath)' != '' AND
+            (
+              '$(PackageTargetRuntime)' == '' OR
+              '$(PackageTargetRuntime)' == '$(PackageRID)'
+            )">
     <PropertyGroup>
       <FrameworkListFile>$(IntermediateOutputPath)FrameworkList.xml</FrameworkListFile>
     </PropertyGroup>

--- a/src/pkg/projects/dir.targets
+++ b/src/pkg/projects/dir.targets
@@ -191,13 +191,20 @@
                    '$(BuildFullPlatformManifest)' == 'true'">true</IncludeAllRuntimePackagesInPlatformManifest>
     </PropertyGroup>
 
+    <!--
+      Set FrameworkListTargetPath to empty string to skip framework list generation. When
+      BuildFullPlatformManifest is set, list generation  attempts to read post-crossgen files from
+      other platforms, which don't exist on the current machine. (Generating the framework list is
+      also not necessary here and a waste of time.)
+    -->
     <MSBuild Projects="@(ProjectReference)"
              Condition="'%(ProjectReference.PackageTargetRuntime)' == '$(PackageRID)' OR
                         '%(ProjectReference.BuidOnRID)' == '$(PackageRID)' OR
                         ('$(IncludeAllRuntimePackagesInPlatformManifest)' == 'true' AND
                          '%(ProjectReference.PackageTargetRuntime)' != '' AND
                          '%(ProjectReference.ExcludeFromPlatformManifest)' != 'true')"
-             Targets="GetPackageFiles">
+             Targets="GetPackageFiles"
+             Properties="FrameworkListTargetPath=">
       <Output TaskParameter="TargetOutputs" ItemName="SharedFrameworkRuntimeFiles" />
     </MSBuild>
 

--- a/src/pkg/projects/dir.targets
+++ b/src/pkg/projects/dir.targets
@@ -56,6 +56,12 @@
     </ItemGroup>
 
     <ItemGroup>
+      <!-- Normalize file paths up front (preserving metadata) for easier duplicate detection. -->
+      <File NormalizedIdentity="$([MSBuild]::NormalizePath('%(Identity)'))" />
+      <FileNormalized Include="@(File -> '%(NormalizedIdentity)')" RemoveMetadata="NormalizedIdentity" />
+      <File Remove="@(File)" />
+      <File Include="@(FileNormalized)" />
+
       <WindowsNativeFile Include="@(File)"
                          Condition="'%(File.Extension)' == '.dll' OR '%(File.Extension)' == '.exe'" />
       <!-- Don't include *.pdb for export libraries or headers -->
@@ -70,17 +76,21 @@
       <NonWindowsSymbolFile Include="@(NonWindowsNativeFile -> '%(Identity)$(SymbolFileExtension)')" />
       <ExistingNonWindowsSymbolFile Include="@(NonWindowsSymbolFile)" Condition="Exists('%(Identity)')" />
 
-      <!--
-        These files might be directly redisted, and already in File. Duplicates cause validation
-        errors, so don't add files that are already known.
-      -->
-      <DiscoveredSymbolFile
-        Include="@(ExistingWindowsSymbolFile);@(ExistingNonWindowsSymbolFile)"
-        IsSymbolFile="true" />
-      
-      <NormalizedFile Include="$([MSBuild]::NormalizePath('%(File.Identity)'))" />
+      <DiscoveredSymbolFile Include="@(ExistingWindowsSymbolFile);@(ExistingNonWindowsSymbolFile)" />
+    </ItemGroup>
 
-      <File Include="@(DiscoveredSymbolFile)" Exclude="@(NormalizedFile)" />
+    <!-- Remove any duplicates in symbol files found by the above searches. -->
+    <RemoveDuplicates Inputs="@(DiscoveredSymbolFile)">
+      <Output TaskParameter="Filtered" ItemName="FilteredDiscoveredSymbolFile"/>
+    </RemoveDuplicates>
+
+    <ItemGroup>
+      <!--
+        Discovered symbol files might already be in File, without IsSymbolFile set. Make sure we
+        keep the discovered one and apply IsSymbolFile=true.
+      -->
+      <File Remove="@(FilteredDiscoveredSymbolFile)" />
+      <File Include="@(FilteredDiscoveredSymbolFile)" IsSymbolFile="true" />
     </ItemGroup>
 
     <PropertyGroup>
@@ -232,7 +242,8 @@
 
   <Target Name="IncludeFrameworkListFile"
           BeforeTargets="GetFiles"
-          Condition="'$(PackageTargetRuntime)' == '' AND '$(FrameworkListTargetPath)' != ''">
+          DependsOnTargets="GetSymbolPackageFiles"
+          Condition="'$(FrameworkListTargetPath)' != ''">
     <PropertyGroup>
       <FrameworkListFile>$(IntermediateOutputPath)FrameworkList.xml</FrameworkListFile>
     </PropertyGroup>
@@ -250,6 +261,7 @@
 
     <CreateFrameworkListFile
       Files="@(File)"
+      FileProfiles="@(FrameworkListFileProfile)"
       TargetFile="$(FrameworkListFile)"
       TargetFilePrefixes="ref/;runtimes/"
       RootAttributes="@(FrameworkListRootAttributes)" />

--- a/src/pkg/projects/netcoreapp/pkg/legacy/Microsoft.NETCore.App.pkgproj
+++ b/src/pkg/projects/netcoreapp/pkg/legacy/Microsoft.NETCore.App.pkgproj
@@ -8,6 +8,8 @@
       Microsoft.NETCore.App.Internal.
     -->
     <BuildLineupPackage>false</BuildLineupPackage>
+
+    <FrameworkListTargetPath>data/</FrameworkListTargetPath>
   </PropertyGroup>
 
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />

--- a/src/pkg/projects/windowsdesktop/pkg/Microsoft.WindowsDesktop.App.pkgproj
+++ b/src/pkg/projects/windowsdesktop/pkg/Microsoft.WindowsDesktop.App.pkgproj
@@ -8,21 +8,7 @@
     <PlatformManifestTargetPath>$(BuildTargetPath)</PlatformManifestTargetPath>
     <FileVersionPropsTargetPath>$(BuildTargetPath)</FileVersionPropsTargetPath>
 
-    <!--
-      Only try to create the framework list if both:
-
-      - This is a runtime package. Only the runtime package (eventually runtime pack) and targeting
-        pack need this list, not the legacy identity package.
-
-      - The build platform is the same as the target arch. Package validation (currently unique to
-        WindowsDesktop) runs the GetPackageFiles target on each architecture. This causes e.g. an
-        x64 build that targets x86. After the File paths are transformed to find the R2R files (even
-        though crossgen didn't run!), the new paths don't exist, causing failures during
-        CreateFrameworkListFile.
-    -->
-    <FrameworkListTargetPath Condition="
-      '$(PackageTargetRuntime)' != '' AND
-      '$(TargetArchitecture)' == '$(Platform)'">data/</FrameworkListTargetPath>
+    <FrameworkListTargetPath>data/</FrameworkListTargetPath>
 
     <GenerateSharedFramework>true</GenerateSharedFramework>
     <GenerateNetCoreAppRuntimeConfig>true</GenerateNetCoreAppRuntimeConfig>

--- a/src/pkg/projects/windowsdesktop/pkg/Microsoft.WindowsDesktop.App.pkgproj
+++ b/src/pkg/projects/windowsdesktop/pkg/Microsoft.WindowsDesktop.App.pkgproj
@@ -8,6 +8,22 @@
     <PlatformManifestTargetPath>$(BuildTargetPath)</PlatformManifestTargetPath>
     <FileVersionPropsTargetPath>$(BuildTargetPath)</FileVersionPropsTargetPath>
 
+    <!--
+      Only try to create the framework list if both:
+
+      - This is a runtime package. Only the runtime package (eventually runtime pack) and targeting
+        pack need this list, not the legacy identity package.
+
+      - The build platform is the same as the target arch. Package validation (currently unique to
+        WindowsDesktop) runs the GetPackageFiles target on each architecture. This causes e.g. an
+        x64 build that targets x86. After the File paths are transformed to find the R2R files (even
+        though crossgen didn't run!), the new paths don't exist, causing failures during
+        CreateFrameworkListFile.
+    -->
+    <FrameworkListTargetPath Condition="
+      '$(PackageTargetRuntime)' != '' AND
+      '$(TargetArchitecture)' == '$(Platform)'">data/</FrameworkListTargetPath>
+
     <GenerateSharedFramework>true</GenerateSharedFramework>
     <GenerateNetCoreAppRuntimeConfig>true</GenerateNetCoreAppRuntimeConfig>
 

--- a/src/pkg/projects/windowsdesktop/pkg/dir.props
+++ b/src/pkg/projects/windowsdesktop/pkg/dir.props
@@ -21,7 +21,7 @@
     <GeneratePkg>false</GeneratePkg>
   </PropertyGroup>
 
-  <ItemGroup>
+  <ItemGroup Condition="'$(PackageTargetRuntime)' == ''">
     <FrameworkListFileProfile Include="Accessibility.dll" Profile="WindowsForms;WPF" />
     <FrameworkListFileProfile Include="D3DCompiler_47_cor3.dll" Profile="WPF" />
     <FrameworkListFileProfile Include="DirectWriteForwarder.dll" Profile="WPF" />

--- a/src/pkg/projects/windowsdesktop/pkg/dir.props
+++ b/src/pkg/projects/windowsdesktop/pkg/dir.props
@@ -21,6 +21,72 @@
     <GeneratePkg>false</GeneratePkg>
   </PropertyGroup>
 
+  <ItemGroup>
+    <FrameworkListFileProfile Include="Accessibility.dll" Profile="WindowsForms;WPF" />
+    <FrameworkListFileProfile Include="D3DCompiler_47_cor3.dll" Profile="WPF" />
+    <FrameworkListFileProfile Include="DirectWriteForwarder.dll" Profile="WPF" />
+    <FrameworkListFileProfile Include="Microsoft.Win32.Registry.dll" Profile="WindowsForms;WPF" />
+    <FrameworkListFileProfile Include="Microsoft.Win32.SystemEvents.dll" Profile="WindowsForms;WPF" />
+    <FrameworkListFileProfile Include="PenImc_cor3.dll" Profile="WPF" />
+    <FrameworkListFileProfile Include="PresentationCore-CommonResources.dll" Profile="WPF" />
+    <FrameworkListFileProfile Include="PresentationCore.dll" Profile="WPF" />
+    <FrameworkListFileProfile Include="PresentationFramework-SystemCore.dll" Profile="WPF" />
+    <FrameworkListFileProfile Include="PresentationFramework-SystemData.dll" Profile="WPF" />
+    <FrameworkListFileProfile Include="PresentationFramework-SystemDrawing.dll" Profile="WPF" />
+    <FrameworkListFileProfile Include="PresentationFramework-SystemXml.dll" Profile="WPF" />
+    <FrameworkListFileProfile Include="PresentationFramework-SystemXmlLinq.dll" Profile="WPF" />
+    <FrameworkListFileProfile Include="PresentationFramework.Aero.dll" Profile="WPF" />
+    <FrameworkListFileProfile Include="PresentationFramework.Aero2.dll" Profile="WPF" />
+    <FrameworkListFileProfile Include="PresentationFramework.AeroLite.dll" Profile="WPF" />
+    <FrameworkListFileProfile Include="PresentationFramework.Classic.dll" Profile="WPF" />
+    <FrameworkListFileProfile Include="PresentationFramework.dll" Profile="WPF" />
+    <FrameworkListFileProfile Include="PresentationFramework.Luna.dll" Profile="WPF" />
+    <FrameworkListFileProfile Include="PresentationFramework.Royale.dll" Profile="WPF" />
+    <FrameworkListFileProfile Include="PresentationNative_cor3.dll" Profile="WPF" />
+    <FrameworkListFileProfile Include="PresentationUI.dll" Profile="WPF" />
+    <FrameworkListFileProfile Include="ReachFramework.dll" Profile="WPF" />
+    <FrameworkListFileProfile Include="System.CodeDom.dll" Profile="WindowsForms;WPF" />
+    <FrameworkListFileProfile Include="System.Configuration.ConfigurationManager.dll" Profile="WindowsForms;WPF" />
+    <FrameworkListFileProfile Include="System.Design.dll" Profile="WindowsForms" />
+    <FrameworkListFileProfile Include="System.Diagnostics.EventLog.dll" Profile="WindowsForms;WPF" />
+    <FrameworkListFileProfile Include="System.DirectoryServices.dll" Profile="WindowsForms;WPF" />
+    <FrameworkListFileProfile Include="System.Drawing.Common.dll" Profile="WindowsForms" />
+    <FrameworkListFileProfile Include="System.Drawing.Design.dll" Profile="WindowsForms" />
+    <FrameworkListFileProfile Include="System.Drawing.Design.Primitives.dll" Profile="WindowsForms" />
+    <FrameworkListFileProfile Include="System.Drawing.dll" Profile="WindowsForms" />
+    <FrameworkListFileProfile Include="System.IO.FileSystem.AccessControl.dll" Profile="WindowsForms;WPF" />
+    <FrameworkListFileProfile Include="System.IO.Packaging.dll" Profile="WindowsForms;WPF" />
+    <FrameworkListFileProfile Include="System.Media.SoundPlayer.dll" Profile="WindowsForms;WPF" />
+    <FrameworkListFileProfile Include="System.Printing.dll" Profile="WPF" />
+    <FrameworkListFileProfile Include="System.Resources.Extensions.dll" Profile="WindowsForms;WPF" />
+    <FrameworkListFileProfile Include="System.Security.AccessControl.dll" Profile="WindowsForms;WPF" />
+    <FrameworkListFileProfile Include="System.Security.Cryptography.Cng.dll" Profile="WindowsForms;WPF" />
+    <FrameworkListFileProfile Include="System.Security.Cryptography.Pkcs.dll" Profile="WindowsForms;WPF" />
+    <FrameworkListFileProfile Include="System.Security.Cryptography.ProtectedData.dll" Profile="WindowsForms;WPF" />
+    <FrameworkListFileProfile Include="System.Security.Cryptography.Xml.dll" Profile="WindowsForms;WPF" />
+    <FrameworkListFileProfile Include="System.Security.Permissions.dll" Profile="WindowsForms;WPF" />
+    <FrameworkListFileProfile Include="System.Security.Principal.Windows.dll" Profile="WindowsForms;WPF" />
+    <FrameworkListFileProfile Include="System.Threading.AccessControl.dll" Profile="WindowsForms;WPF" />
+    <FrameworkListFileProfile Include="System.Windows.Controls.Ribbon.dll" Profile="WPF" />
+    <FrameworkListFileProfile Include="System.Windows.Extensions.dll" Profile="WindowsForms;WPF" />
+    <FrameworkListFileProfile Include="System.Windows.Forms.Design.dll" Profile="WindowsForms" />
+    <FrameworkListFileProfile Include="System.Windows.Forms.Design.Editors.dll" Profile="WindowsForms" />
+    <FrameworkListFileProfile Include="System.Windows.Forms.dll" Profile="WindowsForms" />
+    <FrameworkListFileProfile Include="System.Windows.Input.Manipulations.dll" Profile="WPF" />
+    <FrameworkListFileProfile Include="System.Windows.Presentation.dll" Profile="WPF" />
+    <FrameworkListFileProfile Include="System.Xaml.dll" Profile="WPF" />
+    <FrameworkListFileProfile Include="UIAutomationClient.dll" Profile="WPF" />
+    <FrameworkListFileProfile Include="UIAutomationClientSideProviders.dll" Profile="WPF" />
+    <FrameworkListFileProfile Include="UIAutomationProvider.dll" Profile="WPF" />
+    <FrameworkListFileProfile Include="UIAutomationTypes.dll" Profile="WPF" />
+    <FrameworkListFileProfile Include="vcruntime140_cor3.dll" Profile="WPF" />
+    <FrameworkListFileProfile Include="WindowsBase.dll" Profile="WPF" />
+    <FrameworkListFileProfile Include="WPFgfx_cor3.dll" Profile="WPF" />
+
+    <!-- If any of these files has resource dlls, use the file's profile. -->
+    <FrameworkListFileProfile Include="@(FrameworkListFileProfile -> '%(Filename).resources%(Extension)')" />
+  </ItemGroup>
+
   <!-- Redistribute package content from other nuget packages. -->
   <ItemGroup>
     <ProjectReference Include="..\src\windowsdesktop.depproj">


### PR DESCRIPTION
Sets `Profile` attribute to WindowsDesktop DLLs based on the table from https://github.com/dotnet/core-setup/issues/6210. I didn't look into ways to detect this automatically yet.

I guessed on classifications for `System.Drawing.dll`, `System.IO.Packaging.dll`, `System.Resources.Extensions.dll`, `D3DCompiler_47_cor3.dll`, and `vcruntime140_cor3.dll` because they weren't in the table, PTAL @vatsan-madhavan @zsd4yr @ericstj 

Adds `Type` and `Path` attributes, and generates a framework list for each runtime package, for https://github.com/dotnet/core-setup/issues/6409. (The heavier modifications in this PR are to make sure symbol files aren't included in these, since they don't end up in the non-symbol package.)

`Type`/`Path` are generated for *all* framework lists, including the targeting packs. I figure this might be useful for something, so I didn't code in something to disable it (yet).

I uploaded all the framework lists here:
~https://gist.github.com/dagood/59680abf2dd952e25563f045ae86fc8f~ (old)
[frameworklists.zip](https://github.com/dotnet/core-setup/files/3238049/frameworklists.zip)

/cc @dsplaisted @nguerrera @livarcocc