### PR TITLE
Enable component activation tests

### DIFF
--- a/src/test/Assets/TestProjects/ComponentWithNoDependencies/ComponentWithNoDependencies.csproj
+++ b/src/test/Assets/TestProjects/ComponentWithNoDependencies/ComponentWithNoDependencies.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFramework>$(NETCoreAppFramework)</TargetFramework>
     <RuntimeFrameworkVersion>$(MNAVersion)</RuntimeFrameworkVersion>
+    <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
Make ComponentWithNoDependencies test project generate a runtime config
on build to use in component activation tests.