### PR TITLE
Single-file: Avoid exception-throw in startup path

### DIFF
--- a/src/corehost/cli/apphost/bundle/bundle_runner.h
+++ b/src/corehost/cli/apphost/bundle/bundle_runner.h
@@ -39,7 +39,7 @@ namespace bundle
         void reopen_host_for_reading();
         static void seek(FILE* stream, long offset, int origin);
 
-        void process_manifest_footer(int64_t& header_offset);
+        bool process_manifest_footer(int64_t& header_offset);
         void process_manifest_header(int64_t header_offset);
 
         void determine_extraction_dir();

--- a/src/corehost/cli/apphost/bundle/manifest.cpp
+++ b/src/corehost/cli/apphost/bundle/manifest.cpp
@@ -56,13 +56,6 @@ manifest_footer_t* manifest_footer_t::read(FILE* stream)
 
     bundle_runner_t::read(footer, num_bytes_read(), stream);
 
-    if (!footer->is_valid())
-    {
-        trace::info(_X("This executable is not recognized as a bundle."));
-
-        throw StatusCode::AppHostExeNotBundle;
-    }
-
     return footer;
 }
 


### PR DESCRIPTION
This commit implements two changes:

1) If the current AppHost is not a bundle, process_manifest_footer() returns a bool value to indicate the same, rather than throwing StatusCode::AppHostExeNotBundle. This ensures that we do not throw every time a non-bundled app-host runs, which is undesirable (especially while debugging).

2) If a single-file app is simultaneously started multiple times, the apphost begins extracting files for each instantiation. However, once one of the runs complete the extraction process, other runs will use the files extracted to the committed-directory. The AppHost tries to clean up the redundantly extracted files and directories. However, if there is an I/O error while doing so, the process is now allowed to continue execution, instead of failing.

These changes are carved out of https://github.com/dotnet/core-setup/pull/6576 in order to ensure that the fixes are available the next preview.