### PR TITLE
[release/2.1] Remove item metadata attributes for MSBuild 14

### DIFF
--- a/src/pkg/packaging/deb/package.targets
+++ b/src/pkg/packaging/deb/package.targets
@@ -344,14 +344,14 @@
         In every runtime deps Deb package, include alternatives known to work with .NET Core.
         Specifying these as "or" dependencies lets us create one package that works on many distros.
       -->
-      <SharedFrameworkTokenValue
-        Include="%SSL_DEPENDENCY_LIST%"
-        ReplacementString="libssl1.0.0 | libssl1.0.2 | libssl1.1" />
+      <SharedFrameworkTokenValue Include="%SSL_DEPENDENCY_LIST%">
+        <ReplacementString>libssl1.0.0 | libssl1.0.2 | libssl1.1</ReplacementString>
+      </SharedFrameworkTokenValue>
 
       <KnownLibIcuVersion Include="63;60;57;55;52" />
-      <SharedFrameworkTokenValue
-        Include="%LIBICU_DEPENDENCY_LIST%"
-        ReplacementString="libicu | @(KnownLibIcuVersion -> 'libicu%(Identity)', ' | ')" />
+      <SharedFrameworkTokenValue Include="%LIBICU_DEPENDENCY_LIST%">
+        <ReplacementString>libicu | @(KnownLibIcuVersion -> 'libicu%(Identity)', ' | ')</ReplacementString>
+      </SharedFrameworkTokenValue>
     </ItemGroup>
 
     <ReplaceFileContents InputFile="$(ConfigJsonFile)"


### PR DESCRIPTION
The official build uses MSBuild 14 on Windows. When it tries to parse this file using arbitrary attribute names to add metadata to items, it fails. This was introduced in https://github.com/dotnet/core-setup/pull/6246 because it was only tested on Linux, where a newer MSBuild is used because it's built with .NET Core.