### PR TITLE
Specify calling convention for hostfxr/hostpolicy exports

### DIFF
--- a/src/corehost/cli/comhost/comhost.cpp
+++ b/src/corehost/cli/comhost/comhost.cpp
@@ -69,7 +69,7 @@ namespace
             delegate
         );
     }
-    
+
     void report_com_error_info(const GUID& guid, pal::string_t errs)
     {
         ICreateErrorInfo *cei;
@@ -112,10 +112,10 @@ COM_API HRESULT STDMETHODCALLTYPE DllGetClassObject(
     {
         trace::setup();
         reset_redirected_error_writer();
-        
+
         error_writer_scope_t writer_scope(redirected_error_writer);
 
-        int ec = get_com_delegate(hostfxr_delegate_type::com_activation, &app_path, &act);
+        int ec = get_com_delegate(hostfxr_delegate_type::hdt_com_activation, &app_path, &act);
         if (ec != StatusCode::Success)
         {
             report_com_error_info(rclsid, std::move(get_redirected_error_string()));
@@ -329,7 +329,7 @@ COM_API HRESULT STDMETHODCALLTYPE DllRegisterServer(void)
     HRESULT hr;
     pal::string_t app_path;
     com_delegate_fn reg;
-    RETURN_IF_FAILED(get_com_delegate(hostfxr_delegate_type::com_register, &app_path, &reg));
+    RETURN_IF_FAILED(get_com_delegate(hostfxr_delegate_type::hdt_com_register, &app_path, &reg));
 
     com_activation_context cxt
     {
@@ -373,7 +373,7 @@ COM_API HRESULT STDMETHODCALLTYPE DllUnregisterServer(void)
     HRESULT hr;
     pal::string_t app_path;
     com_delegate_fn unreg;
-    RETURN_IF_FAILED(get_com_delegate(hostfxr_delegate_type::com_unregister, &app_path, &unreg));
+    RETURN_IF_FAILED(get_com_delegate(hostfxr_delegate_type::hdt_com_unregister, &app_path, &unreg));
 
     com_activation_context cxt
     {

--- a/src/corehost/cli/coreclr_delegates.h
+++ b/src/corehost/cli/coreclr_delegates.h
@@ -1,0 +1,34 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#ifndef __CORECLR_DELEGATES_H__
+#define __CORECLR_DELEGATES_H__
+
+#include <stdint.h>
+
+#if defined(_WIN32)
+    #define CORECLR_DELEGATE_CALLTYPE __stdcall
+    #ifdef _WCHAR_T_DEFINED
+        typedef wchar_t char_t;
+    #else
+        typedef unsigned short char_t;
+    #endif
+#else
+    #define CORECLR_DELEGATE_CALLTYPE
+    typedef char char_t;
+#endif
+
+// Signature of delegate returned by coreclr_delegate_type::load_assembly_and_get_function_pointer
+typedef int (CORECLR_DELEGATE_CALLTYPE *load_assembly_and_get_function_pointer_fn)(
+    const char_t *assembly_path      /* Fully qualified path to assembly */,
+    const char_t *type_name          /* Assembly qualified type name */,
+    const char_t *method_name        /* Public static method name compatible with delegateType */,
+    const char_t *delegate_type_name /* Assembly qualified delegate type name or null */,
+    void         *reserved           /* Extensibility parameter (currently unused and must be 0) */,
+    /*out*/ void **delegate          /* Pointer where to store the function pointer result */);
+
+// Signature of delegate returned by load_assembly_and_get_function_pointer_fn when delegate_type_name == null (default)
+typedef int (CORECLR_DELEGATE_CALLTYPE *component_entry_point_fn)(void *arg, int32_t arg_size_in_bytes);
+
+#endif // __CORECLR_DELEGATES_H__

--- a/src/corehost/cli/corehost_context_contract.h
+++ b/src/corehost/cli/corehost_context_contract.h
@@ -6,6 +6,7 @@
 #define __COREHOST_CONTEXT_CONTRACT_H__
 
 #include "host_interface.h"
+#include "hostpolicy.h"
 #include <pal.h>
 
 enum intialization_options_t : int32_t
@@ -41,21 +42,21 @@ static_assert(offsetof(corehost_initialize_request_t, config_values) == 3 * size
 struct corehost_context_contract
 {
     size_t version;
-    int (__cdecl *get_property_value)(
+    int (HOSTPOLICY_CALLTYPE *get_property_value)(
         const pal::char_t* key,
         /*out*/ const pal::char_t** value);
-    int (__cdecl *set_property_value)(
+    int (HOSTPOLICY_CALLTYPE *set_property_value)(
         const pal::char_t* key,
         const pal::char_t* value);
-    int (__cdecl *get_properties)(
+    int (HOSTPOLICY_CALLTYPE *get_properties)(
         /*inout*/ size_t *count,
         /*out*/ const pal::char_t** keys,
         /*out*/ const pal::char_t** values);
-    int (__cdecl *load_runtime)();
-    int (__cdecl *run_app)(
+    int (HOSTPOLICY_CALLTYPE *load_runtime)();
+    int (HOSTPOLICY_CALLTYPE *run_app)(
         const int argc,
         const pal::char_t* argv[]);
-    int (__cdecl *get_runtime_delegate)(
+    int (HOSTPOLICY_CALLTYPE *get_runtime_delegate)(
         coreclr_delegate_type type,
         /*out*/ void** delegate);
 };
@@ -67,17 +68,5 @@ static_assert(offsetof(corehost_context_contract, load_runtime) == 4 * sizeof(si
 static_assert(offsetof(corehost_context_contract, run_app) == 5 * sizeof(size_t), "Struct offset breaks backwards compatibility");
 static_assert(offsetof(corehost_context_contract, get_runtime_delegate) == 6 * sizeof(size_t), "Struct offset breaks backwards compatibility");
 #pragma pack(pop)
-
-/// Signature of delegate returned by coreclr_delegate_type::load_assembly_and_get_function_pointer
-typedef int (STDMETHODCALLTYPE *LoadAssemblyAndGetFunctionPointer)(
-    const pal::char_t * assemblyPathNative /* Fully qualified path to assembly */,
-    const pal::char_t * typeNameNative     /* Assembly qualified type name */,
-    const pal::char_t * methodNameNative   /* Public static method name compatible with delegateType */,
-    const pal::char_t * delegateTypeNative /* Assembly qualified delegate type name or null */,
-    void *              reserved           /* Extensibility parameter (currently unused and must be 0) */,
-    /*out*/ void **     delegate           /* Pointer where to store the function pointer result */);
-
-/// Signature of delegate returned by LoadAssemblyAndGetFunctionPointer when delegateTypeNative == null (default)
-typedef int (STDMETHODCALLTYPE *ComponentEntryPointDelegate)(void *arg, int32_t argSize);
 
 #endif // __COREHOST_CONTEXT_CONTRACT_H__

--- a/src/corehost/cli/corehost_context_contract.h
+++ b/src/corehost/cli/corehost_context_contract.h
@@ -43,22 +43,22 @@ struct corehost_context_contract
 {
     size_t version;
     int (HOSTPOLICY_CALLTYPE *get_property_value)(
-        const pal::char_t* key,
-        /*out*/ const pal::char_t** value);
+        const pal::char_t *key,
+        /*out*/ const pal::char_t **value);
     int (HOSTPOLICY_CALLTYPE *set_property_value)(
-        const pal::char_t* key,
-        const pal::char_t* value);
+        const pal::char_t *key,
+        const pal::char_t *value);
     int (HOSTPOLICY_CALLTYPE *get_properties)(
         /*inout*/ size_t *count,
-        /*out*/ const pal::char_t** keys,
-        /*out*/ const pal::char_t** values);
+        /*out*/ const pal::char_t **keys,
+        /*out*/ const pal::char_t **values);
     int (HOSTPOLICY_CALLTYPE *load_runtime)();
     int (HOSTPOLICY_CALLTYPE *run_app)(
         const int argc,
-        const pal::char_t* argv[]);
+        const pal::char_t **argv);
     int (HOSTPOLICY_CALLTYPE *get_runtime_delegate)(
         coreclr_delegate_type type,
-        /*out*/ void** delegate);
+        /*out*/ void **delegate);
 };
 static_assert(offsetof(corehost_context_contract, version) == 0 * sizeof(size_t), "Struct offset breaks backwards compatibility");
 static_assert(offsetof(corehost_context_contract, get_property_value) == 1 * sizeof(size_t), "Struct offset breaks backwards compatibility");

--- a/src/corehost/cli/fxr/CMakeLists.txt
+++ b/src/corehost/cli/fxr/CMakeLists.txt
@@ -44,6 +44,7 @@ set(HEADERS
     ../deps_format.h
     ../deps_entry.h
     ../host_startup_info.h
+    ../hostpolicy.h
     ../runtime_config.h
     ../json/casablanca/include/cpprest/json.h
     ../fx_definition.h

--- a/src/corehost/cli/fxr/fx_muxer.cpp
+++ b/src/corehost/cli/fxr/fx_muxer.cpp
@@ -13,6 +13,7 @@
 
 #include <cpprest/json.h>
 #include <corehost_context_contract.h>
+#include <hostpolicy.h>
 #include "corehost_init.h"
 #include "deps_format.h"
 #include "framework_info.h"
@@ -27,9 +28,6 @@
 #include "sdk_info.h"
 #include "sdk_resolver.h"
 #include "roll_fwd_on_no_candidate_fx_option.h"
-
-using corehost_main_fn = int(*) (const int argc, const pal::char_t* argv[]);
-using corehost_main_with_output_buffer_fn = int(*) (const int argc, const pal::char_t* argv[], pal::char_t buffer[], int32_t buffer_size, int32_t* required_buffer_size);
 
 namespace
 {

--- a/src/corehost/cli/fxr/hostfxr.cpp
+++ b/src/corehost/cli/fxr/hostfxr.cpp
@@ -585,17 +585,17 @@ namespace
     {
         switch (type)
         {
-        case hostfxr_delegate_type::com_activation:
+        case hostfxr_delegate_type::hdt_com_activation:
             return coreclr_delegate_type::com_activation;
-        case hostfxr_delegate_type::load_in_memory_assembly:
+        case hostfxr_delegate_type::hdt_load_in_memory_assembly:
             return coreclr_delegate_type::load_in_memory_assembly;
-        case hostfxr_delegate_type::winrt_activation:
+        case hostfxr_delegate_type::hdt_winrt_activation:
             return coreclr_delegate_type::winrt_activation;
-        case hostfxr_delegate_type::com_register:
+        case hostfxr_delegate_type::hdt_com_register:
             return coreclr_delegate_type::com_register;
-        case hostfxr_delegate_type::com_unregister:
+        case hostfxr_delegate_type::hdt_com_unregister:
             return coreclr_delegate_type::com_unregister;
-        case hostfxr_delegate_type::load_assembly_and_get_function_pointer:
+        case hostfxr_delegate_type::hdt_load_assembly_and_get_function_pointer:
             return coreclr_delegate_type::load_assembly_and_get_function_pointer;
         }
         return coreclr_delegate_type::invalid;

--- a/src/corehost/cli/fxr/hostfxr.cpp
+++ b/src/corehost/cli/fxr/hostfxr.cpp
@@ -24,7 +24,7 @@ namespace
     }
 }
 
-SHARED_API int hostfxr_main_startupinfo(const int argc, const pal::char_t* argv[], const pal::char_t* host_path, const pal::char_t* dotnet_root, const pal::char_t* app_path)
+SHARED_API int HOSTFXR_CALLTYPE hostfxr_main_startupinfo(const int argc, const pal::char_t* argv[], const pal::char_t* host_path, const pal::char_t* dotnet_root, const pal::char_t* app_path)
 {
     trace_hostfxr_entry_point(_X("hostfxr_main_startupinfo"));
 
@@ -33,7 +33,7 @@ SHARED_API int hostfxr_main_startupinfo(const int argc, const pal::char_t* argv[
     return fx_muxer_t::execute(pal::string_t(), argc, argv, startup_info, nullptr, 0, nullptr);
 }
 
-SHARED_API int hostfxr_main(const int argc, const pal::char_t* argv[])
+SHARED_API int HOSTFXR_CALLTYPE hostfxr_main(const int argc, const pal::char_t* argv[])
 {
     trace_hostfxr_entry_point(_X("hostfxr_main"));
 
@@ -86,7 +86,7 @@ SHARED_API int hostfxr_main(const int argc, const pal::char_t* argv[])
 //   Windows     - UTF-16 (pal::char_t is 2 byte wchar_t)
 //   Unix        - UTF-8  (pal::char_t is 1 byte char)
 //
-SHARED_API int32_t hostfxr_resolve_sdk(
+SHARED_API int32_t HOSTFXR_CALLTYPE hostfxr_resolve_sdk(
     const pal::char_t* exe_dir,
     const pal::char_t* working_dir,
     pal::char_t buffer[],
@@ -144,7 +144,7 @@ enum class hostfxr_resolve_sdk2_result_key_t : int32_t
     global_json_path = 1,
 };
 
-typedef void (*hostfxr_resolve_sdk2_result_fn)(
+typedef void (HOSTFXR_CALLTYPE *hostfxr_resolve_sdk2_result_fn)(
     hostfxr_resolve_sdk2_result_key_t key,
     const pal::char_t* value);
 
@@ -200,7 +200,7 @@ typedef void (*hostfxr_resolve_sdk2_result_fn)(
 //   Windows     - UTF-16 (pal::char_t is 2 byte wchar_t)
 //   Unix        - UTF-8  (pal::char_t is 1 byte char)
 //
-SHARED_API int32_t hostfxr_resolve_sdk2(
+SHARED_API int32_t HOSTFXR_CALLTYPE hostfxr_resolve_sdk2(
     const pal::char_t* exe_dir,
     const pal::char_t* working_dir,
     int32_t flags,
@@ -248,7 +248,7 @@ SHARED_API int32_t hostfxr_resolve_sdk2(
 }
 
 
-typedef void (*hostfxr_get_available_sdks_result_fn)(
+typedef void (HOSTFXR_CALLTYPE *hostfxr_get_available_sdks_result_fn)(
     int32_t sdk_count,
     const pal::char_t *sdk_dirs[]);
 
@@ -274,7 +274,7 @@ typedef void (*hostfxr_get_available_sdks_result_fn)(
 //   Windows     - UTF-16 (pal::char_t is 2 byte wchar_t)
 //   Unix        - UTF-8  (pal::char_t is 1 byte char)
 //
-SHARED_API int32_t hostfxr_get_available_sdks(
+SHARED_API int32_t HOSTFXR_CALLTYPE hostfxr_get_available_sdks(
     const pal::char_t* exe_dir,
     hostfxr_get_available_sdks_result_fn result)
 {
@@ -348,7 +348,7 @@ SHARED_API int32_t hostfxr_get_available_sdks(
 //   Windows     - UTF-16 (pal::char_t is 2 byte wchar_t)
 //   Unix        - UTF-8  (pal::char_t is 1 byte char)
 //
-SHARED_API int32_t hostfxr_get_native_search_directories(const int argc, const pal::char_t* argv[], pal::char_t buffer[], int32_t buffer_size, int32_t* required_buffer_size)
+SHARED_API int32_t HOSTFXR_CALLTYPE hostfxr_get_native_search_directories(const int argc, const pal::char_t* argv[], pal::char_t buffer[], int32_t buffer_size, int32_t* required_buffer_size)
 {
     trace_hostfxr_entry_point(_X("hostfxr_get_native_search_directories"));
 
@@ -364,8 +364,6 @@ SHARED_API int32_t hostfxr_get_native_search_directories(const int argc, const p
     int rc = fx_muxer_t::execute(_X("get-native-search-directories"), argc, argv, startup_info, buffer, buffer_size, required_buffer_size);
     return rc;
 }
-
-typedef void(*hostfxr_error_writer_fn)(const pal::char_t* message);
 
 //
 // Sets a callback which is to be used to write errors to.
@@ -390,7 +388,7 @@ typedef void(*hostfxr_error_writer_fn)(const pal::char_t* message);
 // will be propagated to hostpolicy for the duration of the call. This means that errors from
 // both hostfxr and hostpolicy will be reporter through the same error writer.
 //
-SHARED_API hostfxr_error_writer_fn hostfxr_set_error_writer(hostfxr_error_writer_fn error_writer)
+SHARED_API hostfxr_error_writer_fn HOSTFXR_CALLTYPE hostfxr_set_error_writer(hostfxr_error_writer_fn error_writer)
 {
     return trace::set_error_writer(error_writer);
 }
@@ -460,7 +458,7 @@ namespace
 //
 // This function does not load the runtime.
 //
-SHARED_API int32_t __cdecl hostfxr_initialize_for_dotnet_command_line(
+SHARED_API int32_t HOSTFXR_CALLTYPE hostfxr_initialize_for_dotnet_command_line(
     int argc,
     const pal::char_t *argv[],
     const hostfxr_initialize_parameters * parameters,
@@ -533,7 +531,7 @@ SHARED_API int32_t __cdecl hostfxr_initialize_for_dotnet_command_line(
 // initializations. In the case of Success_DifferentRuntimeProperties, it is left to the consumer to verify that
 // the difference in properties is acceptable.
 //
-SHARED_API int32_t __cdecl hostfxr_initialize_for_runtime_config(
+SHARED_API int32_t HOSTFXR_CALLTYPE hostfxr_initialize_for_runtime_config(
     const pal::char_t *runtime_config_path,
     const hostfxr_initialize_parameters *parameters,
     /*out*/ hostfxr_handle *host_context_handle)
@@ -570,7 +568,7 @@ SHARED_API int32_t __cdecl hostfxr_initialize_for_runtime_config(
 //
 // This function will not return until the managed application exits.
 //
-SHARED_API int32_t __cdecl hostfxr_run_app(const hostfxr_handle host_context_handle)
+SHARED_API int32_t HOSTFXR_CALLTYPE hostfxr_run_app(const hostfxr_handle host_context_handle)
 {
     trace_hostfxr_entry_point(_X("hostfxr_run_app"));
 
@@ -620,7 +618,7 @@ namespace
 //
 // The host_context_handle must have been initialized using hostfxr_initialize_for_runtime_config.
 //
-SHARED_API int32_t __cdecl hostfxr_get_runtime_delegate(
+SHARED_API int32_t HOSTFXR_CALLTYPE hostfxr_get_runtime_delegate(
     const hostfxr_handle host_context_handle,
     hostfxr_delegate_type type,
     /*out*/ void **delegate)
@@ -662,7 +660,7 @@ SHARED_API int32_t __cdecl hostfxr_get_runtime_delegate(
 // If host_context_handle is nullptr and an active host context exists, this function will get the
 // property value for the active host context.
 //
-SHARED_API int32_t __cdecl hostfxr_get_runtime_property_value(
+SHARED_API int32_t HOSTFXR_CALLTYPE hostfxr_get_runtime_property_value(
     const hostfxr_handle host_context_handle,
     const pal::char_t *name,
     /*out*/ const pal::char_t **value)
@@ -727,7 +725,7 @@ SHARED_API int32_t __cdecl hostfxr_get_runtime_property_value(
 // If the property already exists in the host context, it will be overwritten. If value is nullptr, the
 // property will be removed.
 //
-SHARED_API int32_t __cdecl hostfxr_set_runtime_property_value(
+SHARED_API int32_t HOSTFXR_CALLTYPE hostfxr_set_runtime_property_value(
     const hostfxr_handle host_context_handle,
     const pal::char_t *name,
     const pal::char_t *value)
@@ -778,7 +776,7 @@ SHARED_API int32_t __cdecl hostfxr_set_runtime_property_value(
 // If host_context_handle is nullptr and an active host context exists, this function will get the
 // properties for the active host context.
 //
-SHARED_API int32_t __cdecl hostfxr_get_runtime_properties(
+SHARED_API int32_t HOSTFXR_CALLTYPE hostfxr_get_runtime_properties(
     const hostfxr_handle host_context_handle,
     /*inout*/ size_t * count,
     /*out*/ const pal::char_t **keys,
@@ -843,7 +841,7 @@ SHARED_API int32_t __cdecl hostfxr_get_runtime_properties(
 // Return value:
 //     The error code result.
 //
-SHARED_API int32_t __cdecl hostfxr_close(const hostfxr_handle host_context_handle)
+SHARED_API int32_t HOSTFXR_CALLTYPE hostfxr_close(const hostfxr_handle host_context_handle)
 {
     trace_hostfxr_entry_point(_X("hostfxr_close"));
 

--- a/src/corehost/cli/fxr/hostpolicy_resolver.h
+++ b/src/corehost/cli/fxr/hostpolicy_resolver.h
@@ -9,12 +9,7 @@
 #include <host_interface.h>
 #include <error_codes.h>
 #include <corehost_context_contract.h>
-
-using corehost_load_fn = int(*) (const host_interface_t* init);
-using corehost_unload_fn = int(*) ();
-using corehost_error_writer_fn = void(*) (const pal::char_t* message);
-using corehost_set_error_writer_fn = corehost_error_writer_fn(*) (corehost_error_writer_fn error_writer);
-using corehost_initialize_fn = int(*)(const corehost_initialize_request_t* init_request, int32_t options, corehost_context_contract* handle);
+#include <hostpolicy.h>
 
 struct hostpolicy_contract_t
 {

--- a/src/corehost/cli/hostfxr.h
+++ b/src/corehost/cli/hostfxr.h
@@ -22,12 +22,12 @@
 
 enum hostfxr_delegate_type
 {
-    com_activation,
-    load_in_memory_assembly,
-    winrt_activation,
-    com_register,
-    com_unregister,
-    load_assembly_and_get_function_pointer
+    hdt_com_activation,
+    hdt_load_in_memory_assembly,
+    hdt_winrt_activation,
+    hdt_com_register,
+    hdt_com_unregister,
+    hdt_load_assembly_and_get_function_pointer
 };
 
 typedef int32_t(HOSTFXR_CALLTYPE *hostfxr_main_fn)(const int argc, const char_t **argv);

--- a/src/corehost/cli/hostfxr.h
+++ b/src/corehost/cli/hostfxr.h
@@ -42,21 +42,21 @@ typedef void(HOSTFXR_CALLTYPE *hostfxr_error_writer_fn)(const char_t *message);
 typedef hostfxr_error_writer_fn(HOSTFXR_CALLTYPE *hostfxr_set_error_writer_fn)(hostfxr_error_writer_fn error_writer);
 
 typedef void* hostfxr_handle;
-typedef struct hostfxr_initialize_parameters
+struct hostfxr_initialize_parameters
 {
     size_t size;
     const char_t *host_path;
     const char_t *dotnet_root;
-} hostfxr_initialize_parameters;
+};
 
 typedef int32_t(HOSTFXR_CALLTYPE *hostfxr_initialize_for_dotnet_command_line_fn)(
     int argc,
     const char_t **argv,
-    const hostfxr_initialize_parameters *parameters,
+    const struct hostfxr_initialize_parameters *parameters,
     /*out*/ hostfxr_handle *host_context_handle);
 typedef int32_t(HOSTFXR_CALLTYPE *hostfxr_initialize_for_runtime_config_fn)(
     const char_t *runtime_config_path,
-    const hostfxr_initialize_parameters*parameters,
+    const struct hostfxr_initialize_parameters *parameters,
     /*out*/ hostfxr_handle *host_context_handle);
 
 typedef int32_t(HOSTFXR_CALLTYPE *hostfxr_get_runtime_property_value_fn)(

--- a/src/corehost/cli/hostfxr.h
+++ b/src/corehost/cli/hostfxr.h
@@ -2,21 +2,25 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#ifndef _COREHOST_CLI_HOSTFXR_H_
-#define _COREHOST_CLI_HOSTFXR_H_
+#ifndef __HOSTFXR_H__
+#define __HOSTFXR_H__
 
-#include <pal.h>
+#include <stddef.h>
+#include <stdint.h>
 
-// Forward declaration of required custom feature APIs
-using hostfxr_main_fn = int32_t(*)(const int argc, const pal::char_t* argv[]);
-using hostfxr_main_startupinfo_fn = int32_t(*)(
-    const int argc,
-    const pal::char_t* argv[],
-    const pal::char_t* host_path,
-    const pal::char_t* dotnet_root,
-    const pal::char_t* app_path);
+#if defined(_WIN32)
+    #define HOSTFXR_CALLTYPE __cdecl
+    #ifdef _WCHAR_T_DEFINED
+        typedef wchar_t char_t;
+    #else
+        typedef unsigned short char_t;
+    #endif
+#else
+    #define HOSTFXR_CALLTYPE
+    typedef char char_t;
+#endif
 
-enum class hostfxr_delegate_type
+enum hostfxr_delegate_type
 {
     com_activation,
     load_in_memory_assembly,
@@ -26,54 +30,55 @@ enum class hostfxr_delegate_type
     load_assembly_and_get_function_pointer
 };
 
-using hostfxr_main_fn = int32_t(*)(const int argc, const pal::char_t* argv[]);
-using hostfxr_main_startupinfo_fn = int32_t(*)(
+typedef int32_t(HOSTFXR_CALLTYPE *hostfxr_main_fn)(const int argc, const char_t **argv);
+typedef int32_t(HOSTFXR_CALLTYPE *hostfxr_main_startupinfo_fn)(
     const int argc,
-    const pal::char_t* argv[],
-    const pal::char_t* host_path,
-    const pal::char_t* dotnet_root,
-    const pal::char_t* app_path);
-using hostfxr_error_writer_fn = void(*)(const pal::char_t* message);
-using hostfxr_set_error_writer_fn = hostfxr_error_writer_fn(*)(hostfxr_error_writer_fn error_writer);
+    const char_t **argv,
+    const char_t *host_path,
+    const char_t *dotnet_root,
+    const char_t *app_path);
 
-using hostfxr_handle = void*;
-struct hostfxr_initialize_parameters
+typedef void(HOSTFXR_CALLTYPE *hostfxr_error_writer_fn)(const char_t *message);
+typedef hostfxr_error_writer_fn(HOSTFXR_CALLTYPE *hostfxr_set_error_writer_fn)(hostfxr_error_writer_fn error_writer);
+
+typedef void* hostfxr_handle;
+typedef struct hostfxr_initialize_parameters
 {
     size_t size;
-    const pal::char_t *host_path;
-    const pal::char_t *dotnet_root;
-};
+    const char_t *host_path;
+    const char_t *dotnet_root;
+} hostfxr_initialize_parameters;
 
-using hostfxr_initialize_for_dotnet_command_line_fn = int32_t(__cdecl *)(
+typedef int32_t(HOSTFXR_CALLTYPE *hostfxr_initialize_for_dotnet_command_line_fn)(
     int argc,
-    const pal::char_t *argv[],
+    const char_t **argv,
     const hostfxr_initialize_parameters *parameters,
     /*out*/ hostfxr_handle *host_context_handle);
-using hostfxr_initialize_for_runtime_config_fn = int32_t(__cdecl *)(
-    const pal::char_t *runtime_config_path,
+typedef int32_t(HOSTFXR_CALLTYPE *hostfxr_initialize_for_runtime_config_fn)(
+    const char_t *runtime_config_path,
     const hostfxr_initialize_parameters*parameters,
     /*out*/ hostfxr_handle *host_context_handle);
 
-using hostfxr_get_runtime_property_value_fn = int32_t(__cdecl *)(
+typedef int32_t(HOSTFXR_CALLTYPE *hostfxr_get_runtime_property_value_fn)(
     const hostfxr_handle host_context_handle,
-    const pal::char_t *name,
-    /*out*/ const pal::char_t **value);
-using hostfxr_set_runtime_property_value_fn = int32_t(__cdecl *)(
+    const char_t *name,
+    /*out*/ const char_t **value);
+typedef int32_t(HOSTFXR_CALLTYPE *hostfxr_set_runtime_property_value_fn)(
     const hostfxr_handle host_context_handle,
-    const pal::char_t *name,
-    const pal::char_t *value);
-using hostfxr_get_runtime_properties_fn = int32_t(__cdecl *)(
+    const char_t *name,
+    const char_t *value);
+typedef int32_t(HOSTFXR_CALLTYPE *hostfxr_get_runtime_properties_fn)(
     const hostfxr_handle host_context_handle,
     /*inout*/ size_t * count,
-    /*out*/ const pal::char_t **keys,
-    /*out*/ const pal::char_t **values);
+    /*out*/ const char_t **keys,
+    /*out*/ const char_t **values);
 
-using hostfxr_run_app_fn = int32_t(__cdecl *)(const hostfxr_handle host_context_handle);
-using hostfxr_get_runtime_delegate_fn = int32_t(__cdecl *)(
+typedef int32_t(HOSTFXR_CALLTYPE *hostfxr_run_app_fn)(const hostfxr_handle host_context_handle);
+typedef int32_t(HOSTFXR_CALLTYPE *hostfxr_get_runtime_delegate_fn)(
     const hostfxr_handle host_context_handle,
-    hostfxr_delegate_type type,
+    enum hostfxr_delegate_type type,
     /*out*/ void **delegate);
 
-using hostfxr_close_fn = int32_t(__cdecl *)(const hostfxr_handle host_context_handle);
+typedef int32_t(HOSTFXR_CALLTYPE *hostfxr_close_fn)(const hostfxr_handle host_context_handle);
 
-#endif //_COREHOST_CLI_HOSTFXR_H_
+#endif //__HOSTFXR_H__

--- a/src/corehost/cli/hostpolicy.h
+++ b/src/corehost/cli/hostpolicy.h
@@ -22,13 +22,13 @@ typedef int(HOSTPOLICY_CALLTYPE *corehost_unload_fn) ();
 
 typedef int(HOSTPOLICY_CALLTYPE *corehost_main_fn) (
     const int argc,
-    const pal::char_t* argv[]);
+    const pal::char_t **argv);
 typedef int(HOSTPOLICY_CALLTYPE *corehost_main_with_output_buffer_fn) (
     const int argc,
-    const pal::char_t* argv[],
-    pal::char_t buffer[],
+    const pal::char_t **argv,
+    pal::char_t *buffer,
     int32_t buffer_size,
-    int32_t* required_buffer_size);
+    int32_t *required_buffer_size);
 
 typedef void(HOSTPOLICY_CALLTYPE *corehost_error_writer_fn) (const pal::char_t *message);
 typedef corehost_error_writer_fn(HOSTPOLICY_CALLTYPE *corehost_set_error_writer_fn) (corehost_error_writer_fn error_writer);

--- a/src/corehost/cli/hostpolicy.h
+++ b/src/corehost/cli/hostpolicy.h
@@ -1,0 +1,39 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#ifndef __HOSTPOLICY_H__
+#define __HOSTPOLICY_H__
+
+#include "corehost_context_contract.h"
+#include "host_interface.h"
+#include <pal.h>
+
+#if defined(_WIN32)
+    #define HOSTPOLICY_CALLTYPE __cdecl
+#else
+    #define HOSTPOLICY_CALLTYPE
+#endif
+
+typedef int(HOSTPOLICY_CALLTYPE *corehost_load_fn) (const host_interface_t *init);
+typedef int(HOSTPOLICY_CALLTYPE *corehost_unload_fn) ();
+
+typedef int(HOSTPOLICY_CALLTYPE *corehost_main_fn) (
+    const int argc,
+    const pal::char_t* argv[]);
+typedef int(HOSTPOLICY_CALLTYPE *corehost_main_with_output_buffer_fn) (
+    const int argc,
+    const pal::char_t* argv[],
+    pal::char_t buffer[],
+    int32_t buffer_size,
+    int32_t* required_buffer_size);
+
+typedef void(HOSTPOLICY_CALLTYPE *corehost_error_writer_fn) (const pal::char_t *message);
+typedef corehost_error_writer_fn(HOSTPOLICY_CALLTYPE *corehost_set_error_writer_fn) (corehost_error_writer_fn error_writer);
+
+typedef int(HOSTPOLICY_CALLTYPE *corehost_initialize_fn)(
+    const corehost_initialize_request_t *init_request,
+    int32_t options,
+    corehost_context_contract *handle);
+
+#endif //__HOSTPOLICY_H__

--- a/src/corehost/cli/hostpolicy.h
+++ b/src/corehost/cli/hostpolicy.h
@@ -5,7 +5,6 @@
 #ifndef __HOSTPOLICY_H__
 #define __HOSTPOLICY_H__
 
-#include "corehost_context_contract.h"
 #include "host_interface.h"
 #include <pal.h>
 
@@ -14,6 +13,9 @@
 #else
     #define HOSTPOLICY_CALLTYPE
 #endif
+
+struct corehost_initialize_request_t;
+struct corehost_context_contract;
 
 typedef int(HOSTPOLICY_CALLTYPE *corehost_load_fn) (const host_interface_t *init);
 typedef int(HOSTPOLICY_CALLTYPE *corehost_unload_fn) ();

--- a/src/corehost/cli/hostpolicy/CMakeLists.txt
+++ b/src/corehost/cli/hostpolicy/CMakeLists.txt
@@ -44,6 +44,7 @@ set(HEADERS
     ./hostpolicy_context.h
     ./hostpolicy_init.h
     ../corehost_context_contract.h
+    ../hostpolicy.h
     ../runtime_config.h
     ../json/casablanca/include/cpprest/json.h
     ../fxr/fx_ver.h

--- a/src/corehost/cli/hostpolicy/hostpolicy.cpp
+++ b/src/corehost/cli/hostpolicy/hostpolicy.cpp
@@ -284,7 +284,7 @@ void trace_hostpolicy_entrypoint_invocation(const pal::string_t& entryPointName)
 // If hostpolicy is already initalized, the library will not be
 // reinitialized.
 //
-SHARED_API int corehost_load(host_interface_t* init)
+SHARED_API int __cdecl corehost_load(host_interface_t* init)
 {
     assert(init != nullptr);
     std::lock_guard<std::mutex> lock{ g_init_lock };
@@ -362,7 +362,7 @@ int corehost_main_init(
     return corehost_init(hostpolicy_init, argc, argv, location, args);
 }
 
-SHARED_API int corehost_main(const int argc, const pal::char_t* argv[])
+SHARED_API int __cdecl corehost_main(const int argc, const pal::char_t* argv[])
 {
     arguments_t args;
     int rc = corehost_main_init(g_init, argc, argv, _X("corehost_main"), args);
@@ -381,7 +381,7 @@ SHARED_API int corehost_main(const int argc, const pal::char_t* argv[])
     return run_app(args.app_argc, args.app_argv);
 }
 
-SHARED_API int corehost_main_with_output_buffer(const int argc, const pal::char_t* argv[], pal::char_t buffer[], int32_t buffer_size, int32_t* required_buffer_size)
+SHARED_API int __cdecl corehost_main_with_output_buffer(const int argc, const pal::char_t* argv[], pal::char_t buffer[], int32_t buffer_size, int32_t* required_buffer_size)
 {
     arguments_t args;
     int rc = corehost_main_init(g_init, argc, argv, _X("corehost_main_with_output_buffer"), args);
@@ -738,7 +738,7 @@ SHARED_API int __cdecl corehost_initialize(const corehost_initialize_request_t *
     return rc;
 }
 
-SHARED_API int corehost_unload()
+SHARED_API int __cdecl corehost_unload()
 {
     {
         std::lock_guard<std::mutex> lock{ g_context_lock };
@@ -758,12 +758,12 @@ SHARED_API int corehost_unload()
     return StatusCode::Success;
 }
 
-typedef void(*corehost_resolve_component_dependencies_result_fn)(
+typedef void(__cdecl *corehost_resolve_component_dependencies_result_fn)(
     const pal::char_t* assembly_paths,
     const pal::char_t* native_search_paths,
     const pal::char_t* resource_search_paths);
 
-SHARED_API int corehost_resolve_component_dependencies(
+SHARED_API int __cdecl corehost_resolve_component_dependencies(
     const pal::char_t *component_main_assembly_path,
     corehost_resolve_component_dependencies_result_fn result)
 {
@@ -881,7 +881,7 @@ SHARED_API int corehost_resolve_component_dependencies(
 }
 
 
-typedef void(*corehost_error_writer_fn)(const pal::char_t* message);
+typedef void(__cdecl *corehost_error_writer_fn)(const pal::char_t* message);
 
 //
 // Sets a callback which is to be used to write errors to.
@@ -902,7 +902,7 @@ typedef void(*corehost_error_writer_fn)(const pal::char_t* message);
 // Each call to the error writer is sort of like writing a single line (the EOL character is omitted).
 // Multiple calls to the error writer may occure for one failure.
 //
-SHARED_API corehost_error_writer_fn corehost_set_error_writer(corehost_error_writer_fn error_writer)
+SHARED_API corehost_error_writer_fn __cdecl corehost_set_error_writer(corehost_error_writer_fn error_writer)
 {
     return trace::set_error_writer(error_writer);
 }

--- a/src/corehost/cli/hostpolicy/hostpolicy.cpp
+++ b/src/corehost/cli/hostpolicy/hostpolicy.cpp
@@ -17,6 +17,7 @@
 #include "breadcrumbs.h"
 #include <host_startup_info.h>
 #include <corehost_context_contract.h>
+#include <hostpolicy.h>
 #include "hostpolicy_context.h"
 
 namespace
@@ -284,7 +285,7 @@ void trace_hostpolicy_entrypoint_invocation(const pal::string_t& entryPointName)
 // If hostpolicy is already initalized, the library will not be
 // reinitialized.
 //
-SHARED_API int __cdecl corehost_load(host_interface_t* init)
+SHARED_API int HOSTPOLICY_CALLTYPE corehost_load(host_interface_t* init)
 {
     assert(init != nullptr);
     std::lock_guard<std::mutex> lock{ g_init_lock };
@@ -362,7 +363,7 @@ int corehost_main_init(
     return corehost_init(hostpolicy_init, argc, argv, location, args);
 }
 
-SHARED_API int __cdecl corehost_main(const int argc, const pal::char_t* argv[])
+SHARED_API int HOSTPOLICY_CALLTYPE corehost_main(const int argc, const pal::char_t* argv[])
 {
     arguments_t args;
     int rc = corehost_main_init(g_init, argc, argv, _X("corehost_main"), args);
@@ -381,7 +382,7 @@ SHARED_API int __cdecl corehost_main(const int argc, const pal::char_t* argv[])
     return run_app(args.app_argc, args.app_argv);
 }
 
-SHARED_API int __cdecl corehost_main_with_output_buffer(const int argc, const pal::char_t* argv[], pal::char_t buffer[], int32_t buffer_size, int32_t* required_buffer_size)
+SHARED_API int HOSTPOLICY_CALLTYPE corehost_main_with_output_buffer(const int argc, const pal::char_t* argv[], pal::char_t buffer[], int32_t buffer_size, int32_t* required_buffer_size)
 {
     arguments_t args;
     int rc = corehost_main_init(g_init, argc, argv, _X("corehost_main_with_output_buffer"), args);
@@ -617,7 +618,7 @@ namespace
 // initializations. In the case of Success_DifferentRuntimeProperties, it is left to the consumer to verify that
 // the difference in properties is acceptable.
 //
-SHARED_API int __cdecl corehost_initialize(const corehost_initialize_request_t *init_request, int32_t options, /*out*/ corehost_context_contract *context_contract)
+SHARED_API int HOSTPOLICY_CALLTYPE corehost_initialize(const corehost_initialize_request_t *init_request, int32_t options, /*out*/ corehost_context_contract *context_contract)
 {
     if (context_contract == nullptr)
         return StatusCode::InvalidArgFailure;
@@ -738,7 +739,7 @@ SHARED_API int __cdecl corehost_initialize(const corehost_initialize_request_t *
     return rc;
 }
 
-SHARED_API int __cdecl corehost_unload()
+SHARED_API int HOSTPOLICY_CALLTYPE corehost_unload()
 {
     {
         std::lock_guard<std::mutex> lock{ g_context_lock };
@@ -758,12 +759,12 @@ SHARED_API int __cdecl corehost_unload()
     return StatusCode::Success;
 }
 
-typedef void(__cdecl *corehost_resolve_component_dependencies_result_fn)(
+typedef void(HOSTPOLICY_CALLTYPE *corehost_resolve_component_dependencies_result_fn)(
     const pal::char_t* assembly_paths,
     const pal::char_t* native_search_paths,
     const pal::char_t* resource_search_paths);
 
-SHARED_API int __cdecl corehost_resolve_component_dependencies(
+SHARED_API int HOSTPOLICY_CALLTYPE corehost_resolve_component_dependencies(
     const pal::char_t *component_main_assembly_path,
     corehost_resolve_component_dependencies_result_fn result)
 {
@@ -880,9 +881,6 @@ SHARED_API int __cdecl corehost_resolve_component_dependencies(
     return 0;
 }
 
-
-typedef void(__cdecl *corehost_error_writer_fn)(const pal::char_t* message);
-
 //
 // Sets a callback which is to be used to write errors to.
 //
@@ -902,7 +900,7 @@ typedef void(__cdecl *corehost_error_writer_fn)(const pal::char_t* message);
 // Each call to the error writer is sort of like writing a single line (the EOL character is omitted).
 // Multiple calls to the error writer may occure for one failure.
 //
-SHARED_API corehost_error_writer_fn __cdecl corehost_set_error_writer(corehost_error_writer_fn error_writer)
+SHARED_API corehost_error_writer_fn HOSTPOLICY_CALLTYPE corehost_set_error_writer(corehost_error_writer_fn error_writer)
 {
     return trace::set_error_writer(error_writer);
 }

--- a/src/corehost/cli/ijwhost/ijwhost.cpp
+++ b/src/corehost/cli/ijwhost/ijwhost.cpp
@@ -24,7 +24,7 @@
 pal::hresult_t get_load_in_memory_assembly_delegate(pal::dll_t handle, load_in_memory_assembly_fn* delegate)
 {
     return load_fxr_and_get_delegate(
-        hostfxr_delegate_type::load_in_memory_assembly,
+        hostfxr_delegate_type::hdt_load_in_memory_assembly,
         [handle](const pal::string_t& host_path, pal::string_t* config_path_out)
         {
             pal::string_t mod_path;

--- a/src/corehost/cli/test/mockhostpolicy/mockhostpolicy.cpp
+++ b/src/corehost/cli/test/mockhostpolicy/mockhostpolicy.cpp
@@ -29,12 +29,12 @@ void print_strarr(const char* prefix, const strarr_t& arr)
     }
 }
 
-SHARED_API int corehost_load(host_interface_t* init)
+SHARED_API int __cdecl corehost_load(host_interface_t* init)
 {
     trace::setup();
 
     trace::verbose(_X("--- Invoked hostpolicy mock - corehost_load"));
-    
+
     std::cout << "--- Invoked hostpolicy mock - corehost_load" << std::endl;
     std::cout << "mock version: " << init->version_hi << " " << init->version_lo << std::endl;
     if (init->config_keys.len == 0)
@@ -74,8 +74,8 @@ SHARED_API int corehost_load(host_interface_t* init)
     {
         for (size_t i = 0; i < init->fx_names.len; i++)
         {
-            std::cout << "mock frameworks: " 
-                << tostr(init->fx_names.arr[i]).data() << " " 
+            std::cout << "mock frameworks: "
+                << tostr(init->fx_names.arr[i]).data() << " "
                 << tostr(init->fx_found_versions.arr[i]).data() << " [requested: "
                 << tostr(init->fx_requested_versions.arr[i]).data() << "] [path: "
                 << tostr(init->fx_dirs.arr[i]).data() << "]"
@@ -86,20 +86,20 @@ SHARED_API int corehost_load(host_interface_t* init)
     return StatusCode::Success;
 }
 
-SHARED_API int corehost_main(const int argc, const pal::char_t* argv[])
+SHARED_API int __cdecl corehost_main(const int argc, const pal::char_t* argv[])
 {
     trace::verbose(_X("--- Invoked hostpolicy mock - corehost_main"));
     return StatusCode::Success;
 }
 
-SHARED_API int corehost_unload()
+SHARED_API int __cdecl corehost_unload()
 {
     trace::verbose(_X("--- Invoked hostpolicy mock - corehost_unload"));
     return StatusCode::Success;
 }
 
 using corehost_error_writer_fn = void(*)(const pal::char_t* message);
-SHARED_API corehost_error_writer_fn corehost_set_error_writer(corehost_error_writer_fn error_writer)
+SHARED_API corehost_error_writer_fn __cdecl corehost_set_error_writer(corehost_error_writer_fn error_writer)
 {
     trace::verbose(_X("--- Invoked hostpolicy mock - corehost_set_error_writer"));
     return nullptr;

--- a/src/corehost/cli/test/mockhostpolicy/mockhostpolicy.cpp
+++ b/src/corehost/cli/test/mockhostpolicy/mockhostpolicy.cpp
@@ -7,6 +7,7 @@
 #include "trace.h"
 #include "error_codes.h"
 #include "host_interface.h"
+#include <hostpolicy.h>
 
 std::vector<char> tostr(const pal::char_t* value)
 {
@@ -29,7 +30,7 @@ void print_strarr(const char* prefix, const strarr_t& arr)
     }
 }
 
-SHARED_API int __cdecl corehost_load(host_interface_t* init)
+SHARED_API int HOSTPOLICY_CALLTYPE corehost_load(host_interface_t* init)
 {
     trace::setup();
 
@@ -86,20 +87,19 @@ SHARED_API int __cdecl corehost_load(host_interface_t* init)
     return StatusCode::Success;
 }
 
-SHARED_API int __cdecl corehost_main(const int argc, const pal::char_t* argv[])
+SHARED_API int HOSTPOLICY_CALLTYPE corehost_main(const int argc, const pal::char_t* argv[])
 {
     trace::verbose(_X("--- Invoked hostpolicy mock - corehost_main"));
     return StatusCode::Success;
 }
 
-SHARED_API int __cdecl corehost_unload()
+SHARED_API int HOSTPOLICY_CALLTYPE corehost_unload()
 {
     trace::verbose(_X("--- Invoked hostpolicy mock - corehost_unload"));
     return StatusCode::Success;
 }
 
-using corehost_error_writer_fn = void(*)(const pal::char_t* message);
-SHARED_API corehost_error_writer_fn __cdecl corehost_set_error_writer(corehost_error_writer_fn error_writer)
+SHARED_API corehost_error_writer_fn HOSTPOLICY_CALLTYPE corehost_set_error_writer(corehost_error_writer_fn error_writer)
 {
     trace::verbose(_X("--- Invoked hostpolicy mock - corehost_set_error_writer"));
     return nullptr;

--- a/src/corehost/cli/test/nativehost/host_context_test.cpp
+++ b/src/corehost/cli/test/nativehost/host_context_test.cpp
@@ -17,8 +17,8 @@ namespace
     const pal::char_t *config_log_prefix = _X("[CONFIG] ");
     const pal::char_t *secondary_log_prefix = _X("[SECONDARY] ");
 
-    const hostfxr_delegate_type first_delegate_type = hostfxr_delegate_type::com_activation;
-    const hostfxr_delegate_type secondary_delegate_type = hostfxr_delegate_type::load_in_memory_assembly;
+    const hostfxr_delegate_type first_delegate_type = hostfxr_delegate_type::hdt_com_activation;
+    const hostfxr_delegate_type secondary_delegate_type = hostfxr_delegate_type::hdt_load_in_memory_assembly;
 
     class hostfxr_exports
     {
@@ -258,7 +258,7 @@ namespace
             const pal::char_t *method_name = argv[i + 2];
 
             LoadAssemblyAndGetFunctionPointer delegate = nullptr;
-            rc = hostfxr.get_delegate(handle, hostfxr_delegate_type::load_assembly_and_get_function_pointer, (void **)&delegate);
+            rc = hostfxr.get_delegate(handle, hostfxr_delegate_type::hdt_load_assembly_and_get_function_pointer, (void **)&delegate);
             if (rc != StatusCode::Success)
             {
                 test_output << log_prefix << _X("hostfxr_get_runtime_delegate failed: ") << std::hex << std::showbase << rc << std::endl;

--- a/src/corehost/cli/test/nativehost/host_context_test.cpp
+++ b/src/corehost/cli/test/nativehost/host_context_test.cpp
@@ -7,6 +7,7 @@
 #include <error_codes.h>
 #include <future>
 #include <hostfxr.h>
+#include <coreclr_delegates.h>
 #include <corehost_context_contract.h>
 #include "host_context_test.h"
 #include <utils.h>
@@ -257,7 +258,7 @@ namespace
             const pal::char_t *type_name = argv[i + 1];
             const pal::char_t *method_name = argv[i + 2];
 
-            LoadAssemblyAndGetFunctionPointer delegate = nullptr;
+            load_assembly_and_get_function_pointer_fn delegate = nullptr;
             rc = hostfxr.get_delegate(handle, hostfxr_delegate_type::hdt_load_assembly_and_get_function_pointer, (void **)&delegate);
             if (rc != StatusCode::Success)
             {
@@ -267,14 +268,14 @@ namespace
             {
                 test_output << log_prefix << _X("hostfxr_get_runtime_delegate succeeded: ") << std::hex << std::showbase << rc << std::endl;
 
-                test_output << log_prefix << _X("calling LoadAssemblyAndGetFunctionPointer(\"")
+                test_output << log_prefix << _X("calling load_assembly_and_get_function_pointer(\"")
                     << assembly_path << _X("\", \"")
                     << type_name << _X("\", \"")
                     << method_name << _X("\", \"")
                     << _X("nullptr, nullptr, &componentEntryPointDelegate)")
                     << std::endl;
 
-                ComponentEntryPointDelegate componentEntryPointDelegate = nullptr;
+                component_entry_point_fn componentEntryPointDelegate = nullptr;
                 rc = delegate(assembly_path,
                               type_name,
                               method_name,
@@ -284,11 +285,11 @@ namespace
 
                 if (rc != StatusCode::Success)
                 {
-                    test_output << log_prefix << _X("LoadAssemblyAndGetFunctionPointer failed: ") << std::hex << std::showbase << rc << std::endl;
+                    test_output << log_prefix << _X("load_assembly_and_get_function_pointer failed: ") << std::hex << std::showbase << rc << std::endl;
                 }
                 else
                 {
-                    test_output << log_prefix << _X("LoadAssemblyAndGetFunctionPointer succeeded: ") << std::hex << std::showbase << rc << std::endl;
+                    test_output << log_prefix << _X("load_assembly_and_get_function_pointer succeeded: ") << std::hex << std::showbase << rc << std::endl;
 
                     int result = componentEntryPointDelegate((void*)(static_cast<size_t>(0xdeadbeef)), 42);
 

--- a/src/corehost/cli/winrthost/winrthost.cpp
+++ b/src/corehost/cli/winrthost/winrthost.cpp
@@ -34,7 +34,7 @@ namespace
     int get_winrt_activation_delegate(pal::string_t* app_path, winrt_activation_fn *delegate)
     {
         return load_fxr_and_get_delegate(
-            hostfxr_delegate_type::winrt_activation,
+            hostfxr_delegate_type::hdt_winrt_activation,
             [app_path](const pal::string_t& host_path, pal::string_t* config_path_out)
             {
                 // Change the extension to get the 'app' and config
@@ -66,7 +66,7 @@ WINRT_API HRESULT STDMETHODCALLTYPE DllGetActivationFactory(_In_ HSTRING activat
         trace::setup();
         reset_redirected_error_writer();
         error_writer_scope_t writer_scope(redirected_error_writer);
-        
+
         int ec = get_winrt_activation_delegate(&app_path, &activator);
         if (ec != StatusCode::Success)
         {


### PR DESCRIPTION
Make hostfxr.h compilable in C. We're not actually deploying this right now, but at least it is one place we can point to for signatures for some hosting scenarios (and it could be copied/downloaded and used if desired).