### PR TITLE
Fix a bug in propagation of roll to highest version with LatestPatch

### DIFF
--- a/src/corehost/cli/fxr/fx_resolver.cpp
+++ b/src/corehost/cli/fxr/fx_resolver.cpp
@@ -27,7 +27,7 @@ namespace
         {
             // Roll to highest version should have no effect on patch compatibility range as that has special rules
             // For release versions we will always roll to latest (that is done in automatic_roll_to_latest_patch)
-            // For pre-release we will only rool to closest available.
+            // For pre-release we will only roll to closest available.
             bool roll_to_highest_version =
                 fx_ref.get_version_compatibility_range() != version_compatibility_range_t::patch
                 && fx_ref.get_roll_to_highest_version();

--- a/src/corehost/cli/fxr/fx_resolver.cpp
+++ b/src/corehost/cli/fxr/fx_resolver.cpp
@@ -25,10 +25,17 @@ namespace
 
         if (fx_ref.get_version_compatibility_range() >= version_compatibility_range_t::patch)
         {
+            // Roll to highest version should have no effect on patch compatibility range as that has special rules
+            // For release versions we will always roll to latest (that is done in automatic_roll_to_latest_patch)
+            // For pre-release we will only rool to closest available.
+            bool roll_to_highest_version =
+                fx_ref.get_version_compatibility_range() != version_compatibility_range_t::patch
+                && fx_ref.get_roll_to_highest_version();
+
             trace::verbose(
                 _X("'Roll forward' enabled with version_compatibility_range [%s]. Looking for the %s %s greater than or equal version to [%s]"),
                 version_compatibility_range_to_string(fx_ref.get_version_compatibility_range()).c_str(),
-                fx_ref.get_roll_to_highest_version() ? _X("highest") : _X("lowest"),
+                roll_to_highest_version ? _X("highest") : _X("lowest"),
                 release_only ? _X("release") : _X("release/pre-release"),
                 fx_ref.get_fx_version().c_str());
 
@@ -44,7 +51,7 @@ namespace
 
                     best_match_version = (best_match_version == fx_ver_t())
                         ? ver
-                        : (fx_ref.get_roll_to_highest_version() ? std::max(best_match_version, ver) : std::min(best_match_version, ver));
+                        : (roll_to_highest_version ? std::max(best_match_version, ver) : std::min(best_match_version, ver));
                 }
             }
 

--- a/src/test/HostActivationTests/FrameworkResolution/RollForwardMultipleFrameworks.cs
+++ b/src/test/HostActivationTests/FrameworkResolution/RollForwardMultipleFrameworks.cs
@@ -40,6 +40,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.FrameworkResolution
                     .AddMicrosoftNETCoreAppFrameworkMockHostPolicy("6.0.0")
                     .AddMicrosoftNETCoreAppFrameworkMockHostPolicy("6.1.0")
                     .AddMicrosoftNETCoreAppFrameworkMockHostPolicy("6.1.1-preview.2")
+                    .AddMicrosoftNETCoreAppFrameworkMockHostPolicy("6.1.1-preview.3")
                     .AddMicrosoftNETCoreAppFrameworkMockHostPolicy("6.2.1")
                     .AddFramework(MiddleWare, "2.1.2", runtimeConfig =>
                         runtimeConfig.WithFramework(MicrosoftNETCoreApp, "5.1.3"))
@@ -269,13 +270,13 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.FrameworkResolution
         // Also validates the effect of DOTNET_ROLL_FORWARD_TO_PRERELEASE on the result.
         [Theory] // fxRefVersion       rollForward                               rollForwadToPreRelease resolvedFramework
         [InlineData("6.0.0",           null,                                     false,                 "6.1.0")]
-        [InlineData("6.0.0",           null,                                     true,                  "6.1.1-preview.2")]
+        [InlineData("6.0.0",           null,                                     true,                  "6.1.1-preview.3")]
         [InlineData("6.0.0",           Constants.RollForwardSetting.LatestPatch, false,                 ResolvedFramework.FailedToReconcile)]
         [InlineData("6.0.0",           Constants.RollForwardSetting.Minor,       false,                 "6.1.0")]
-        [InlineData("6.0.0",           Constants.RollForwardSetting.Minor,       true,                  "6.1.1-preview.2")]
+        [InlineData("6.0.0",           Constants.RollForwardSetting.Minor,       true,                  "6.1.1-preview.3")]
         [InlineData("6.0.1-preview.0", Constants.RollForwardSetting.LatestPatch, false,                 ResolvedFramework.FailedToReconcile)]
         [InlineData("6.1.0",           null,                                     false,                 "6.1.0")]
-        [InlineData("6.1.0",           null,                                     true,                  "6.1.1-preview.2")]
+        [InlineData("6.1.0",           null,                                     true,                  "6.1.1-preview.3")]
         [InlineData("6.1.1-preview.0", null,                                     false,                 "6.2.1")]
         [InlineData("6.1.1-preview.0", null,                                     true,                  "6.1.1-preview.2")]
         [InlineData("6.1.1-preview.0", Constants.RollForwardSetting.Disable,     false,                 ResolvedFramework.NotFound)]
@@ -691,31 +692,47 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.FrameworkResolution
         // Verify that the "roll to highest version" flag is propagated into inner framework reference.
         // The app references MiddleWare framework with the specified appRollForward setting
         // then the MiddleWare framework references Microsoft.NETCore.App with the specified fxRefVersion and fxRollForward.
-        [Theory] // appRollForward                            fxRefVersion fxRollForward                             resolvedFramework
+        [Theory] // appRollForward                            fxRefVersion       fxRollForward                             resolvedFramework
         // LatestPatch does not imply roll_to_highest
-        [InlineData(Constants.RollForwardSetting.LatestPatch, "5.1.1",     Constants.RollForwardSetting.Disable,     "5.1.1")]
-        [InlineData(Constants.RollForwardSetting.LatestPatch, "5.1.0",     Constants.RollForwardSetting.LatestPatch, "5.1.3")]
-        [InlineData(Constants.RollForwardSetting.LatestPatch, "5.1.0",     null,                                     "5.1.3")]
-        [InlineData(Constants.RollForwardSetting.LatestPatch, "5.1.0",     Constants.RollForwardSetting.Minor,       "5.1.3")]
-        [InlineData(Constants.RollForwardSetting.LatestPatch, "5.1.0",     Constants.RollForwardSetting.Major,       "5.1.3")]
-        [InlineData(Constants.RollForwardSetting.LatestPatch, "5.1.0",     Constants.RollForwardSetting.LatestMajor, "6.2.1")]
+        [InlineData(Constants.RollForwardSetting.LatestPatch, "5.1.1",           Constants.RollForwardSetting.Disable,     "5.1.1")]
+        [InlineData(Constants.RollForwardSetting.LatestPatch, "5.1.0",           Constants.RollForwardSetting.LatestPatch, "5.1.3")]
+        [InlineData(Constants.RollForwardSetting.LatestPatch, "5.1.0",           null,                                     "5.1.3")]
+        [InlineData(Constants.RollForwardSetting.LatestPatch, "5.1.0",           Constants.RollForwardSetting.Minor,       "5.1.3")]
+        [InlineData(Constants.RollForwardSetting.LatestPatch, "5.1.0",           Constants.RollForwardSetting.Major,       "5.1.3")]
+        [InlineData(Constants.RollForwardSetting.LatestPatch, "5.1.0",           Constants.RollForwardSetting.LatestMajor, "6.2.1")]
+        [InlineData(Constants.RollForwardSetting.LatestPatch, "6.1.1-preview.1", Constants.RollForwardSetting.LatestPatch, "6.1.1-preview.2")]
+        [InlineData(Constants.RollForwardSetting.LatestPatch, "6.1.1-preview.2", Constants.RollForwardSetting.LatestPatch, "6.1.1-preview.2")]
         // Minor/Major do not imply roll_to_highest
-        [InlineData(Constants.RollForwardSetting.Minor,       "5.1.0",     Constants.RollForwardSetting.Minor,       "5.1.3")]
-        [InlineData(Constants.RollForwardSetting.Major,       "5.1.0",     Constants.RollForwardSetting.Minor,       "5.1.3")]
+        [InlineData(Constants.RollForwardSetting.Minor,       "5.1.0",           Constants.RollForwardSetting.Minor,       "5.1.3")]
+        [InlineData(Constants.RollForwardSetting.Major,       "5.1.0",           Constants.RollForwardSetting.Minor,       "5.1.3")]
+        [InlineData(Constants.RollForwardSetting.Minor,       "6.1.1-preview.2", Constants.RollForwardSetting.Minor,       "6.1.1-preview.2")]
+        [InlineData(Constants.RollForwardSetting.Minor,       "6.1.1-preview.2", Constants.RollForwardSetting.LatestPatch, "6.1.1-preview.2")]
+        [InlineData(Constants.RollForwardSetting.Minor,       "6.1.1-preview.1", Constants.RollForwardSetting.LatestPatch, "6.1.1-preview.2")]
+        [InlineData(Constants.RollForwardSetting.Major,       "6.1.1-preview.2", Constants.RollForwardSetting.Major,       "6.1.1-preview.2")]
+        [InlineData(Constants.RollForwardSetting.Major,       "6.1.1-preview.2", Constants.RollForwardSetting.LatestPatch, "6.1.1-preview.2")]
+        [InlineData(Constants.RollForwardSetting.Major,       "6.1.1-preview.1", Constants.RollForwardSetting.LatestPatch, "6.1.1-preview.2")]
         // LatestMinor does imply roll_to_highest
-        [InlineData(Constants.RollForwardSetting.LatestMinor, "5.1.1",     Constants.RollForwardSetting.Disable,     "5.1.1")]
-        [InlineData(Constants.RollForwardSetting.LatestMinor, "5.1.0",     Constants.RollForwardSetting.LatestPatch, "5.1.3")]
-        [InlineData(Constants.RollForwardSetting.LatestMinor, "5.1.0",     null,                                     "5.6.0")]
-        [InlineData(Constants.RollForwardSetting.LatestMinor, "5.1.0",     Constants.RollForwardSetting.Minor,       "5.6.0")]
-        [InlineData(Constants.RollForwardSetting.LatestMinor, "5.1.0",     Constants.RollForwardSetting.Major,       "6.2.1")]
-        [InlineData(Constants.RollForwardSetting.LatestMinor, "5.1.0",     Constants.RollForwardSetting.LatestMajor, "6.2.1")]
+        [InlineData(Constants.RollForwardSetting.LatestMinor, "5.1.1",           Constants.RollForwardSetting.Disable,     "5.1.1")]
+        [InlineData(Constants.RollForwardSetting.LatestMinor, "5.1.0",           Constants.RollForwardSetting.LatestPatch, "5.1.3")]
+        [InlineData(Constants.RollForwardSetting.LatestMinor, "5.1.0",           null,                                     "5.6.0")]
+        [InlineData(Constants.RollForwardSetting.LatestMinor, "5.1.0",           Constants.RollForwardSetting.Minor,       "5.6.0")]
+        [InlineData(Constants.RollForwardSetting.LatestMinor, "5.1.0",           Constants.RollForwardSetting.Major,       "6.2.1")]
+        [InlineData(Constants.RollForwardSetting.LatestMinor, "5.1.0",           Constants.RollForwardSetting.LatestMajor, "6.2.1")]
+        // In this case the "roll to highest" should not impact the pre-release search since it should not have any influence on LatestPatch behavior
+        // which for pre-release versions is to pick the closest match - in this case the exact match exists, so it should pick that one.
+        [InlineData(Constants.RollForwardSetting.LatestMinor, "6.1.1-preview.2", Constants.RollForwardSetting.LatestPatch, "6.1.1-preview.2")]
+        [InlineData(Constants.RollForwardSetting.LatestMinor, "6.1.1-preview.1", Constants.RollForwardSetting.LatestPatch, "6.1.1-preview.2")]
         // LatestMajor does imply roll_to_highest
-        [InlineData(Constants.RollForwardSetting.LatestMajor, "5.1.1",     Constants.RollForwardSetting.Disable,     "5.1.1")]
-        [InlineData(Constants.RollForwardSetting.LatestMajor, "5.1.0",     Constants.RollForwardSetting.LatestPatch, "5.1.3")]
-        [InlineData(Constants.RollForwardSetting.LatestMajor, "5.1.0",     null,                                     "5.6.0")]
-        [InlineData(Constants.RollForwardSetting.LatestMajor, "5.1.0",     Constants.RollForwardSetting.Minor,       "5.6.0")]
-        [InlineData(Constants.RollForwardSetting.LatestMajor, "5.1.0",     Constants.RollForwardSetting.Major,       "6.2.1")]
-        [InlineData(Constants.RollForwardSetting.LatestMajor, "5.1.0",     Constants.RollForwardSetting.LatestMajor, "6.2.1")]
+        [InlineData(Constants.RollForwardSetting.LatestMajor, "5.1.1",           Constants.RollForwardSetting.Disable,     "5.1.1")]
+        [InlineData(Constants.RollForwardSetting.LatestMajor, "5.1.0",           Constants.RollForwardSetting.LatestPatch, "5.1.3")]
+        [InlineData(Constants.RollForwardSetting.LatestMajor, "5.1.0",           null,                                     "5.6.0")]
+        [InlineData(Constants.RollForwardSetting.LatestMajor, "5.1.0",           Constants.RollForwardSetting.Minor,       "5.6.0")]
+        [InlineData(Constants.RollForwardSetting.LatestMajor, "5.1.0",           Constants.RollForwardSetting.Major,       "6.2.1")]
+        [InlineData(Constants.RollForwardSetting.LatestMajor, "5.1.0",           Constants.RollForwardSetting.LatestMajor, "6.2.1")]
+        // In this case the "roll to highest" should not impact the pre-release search since it should not have any influence on LatestPatch behavior
+        // which for pre-release versions is to pick the closest match - in this case the exact match exists, so it should pick that one.
+        [InlineData(Constants.RollForwardSetting.LatestMajor, "6.1.1-preview.2", Constants.RollForwardSetting.LatestPatch, "6.1.1-preview.2")]
+        [InlineData(Constants.RollForwardSetting.LatestMajor, "6.1.1-preview.1", Constants.RollForwardSetting.LatestPatch, "6.1.1-preview.2")]
         public void PropagateRollToHighestVersion(string appRollForward, string fxRefVersion, string fxRollForward, string resolvedFramework)
         {
             RunTest(


### PR DESCRIPTION
LatestPatch setting should ignore "roll to highest version" semantics as it has its own rules:
* For release versions it will always roll to latest patch (regardless of roll_to_highest_version)
* For pre-release versions ti will roll to closest available (again regardless of roll_to_highest_version)

The bug was that the roll_to_highest_version was applied even for patch version compatibility range. For release versions this does not cause any trouble as it would always roll to latest patch anyway. But for pre-release this meant we would pick the latest available pre-release which is not desirable.