### PR TITLE
Add roll forward LatestPatch to WindowsDesktop

### DIFF
--- a/src/pkg/packaging-tools/sharedFramework/sharedFramework.csproj
+++ b/src/pkg/packaging-tools/sharedFramework/sharedFramework.csproj
@@ -93,7 +93,8 @@
     "tfm": "$(TargetFramework)",
     "framework": {
       "name": "Microsoft.NETCore.App",
-      "version": "$(SharedFrameworkNugetVersion)"
+      "version": "$(SharedFrameworkNugetVersion)",
+      "rollForward": "LatestPatch"
     }
   }
 }


### PR DESCRIPTION
The Microsoft.WindowsDesktop.App shared framework depends on Microsoft.NETCore.App, but currently it doesn't specify roll forward policy. This means it defaults to Minor. That is not desirable as minor versions are not tested against each other.
Since the WindowsDesktop and NETCore.App always ship together, it's better to specify `rollForward=LatestPatch` to limit the dependency to only patch differences.

Fixes #6552 