### PR TITLE
Export unmangled name for get_hostfxr_path on nethost (Windows x86)

### DIFF
--- a/src/corehost/cli/nethost/CMakeLists.txt
+++ b/src/corehost/cli/nethost/CMakeLists.txt
@@ -17,6 +17,11 @@ set(SOURCES
     ../fxr/fx_ver.cpp
 )
 
+if(WIN32)
+    list(APPEND SOURCES
+        Exports.def)
+endif()
+
 include(../lib.cmake)
 
 add_definitions(-DFEATURE_LIBHOST=1)

--- a/src/corehost/cli/nethost/Exports.def
+++ b/src/corehost/cli/nethost/Exports.def
@@ -1,0 +1,2 @@
+EXPORTS
+    get_hostfxr_path

--- a/src/corehost/cli/nethost/nethost.cpp
+++ b/src/corehost/cli/nethost/nethost.cpp
@@ -18,9 +18,6 @@ namespace
     }
 }
 
-#if defined(_WIN32) && defined(_TARGET_X86_)
-    #pragma comment(linker, "/export:get_hostfxr_path=_get_hostfxr_path@12")
-#endif
 NETHOST_API int NETHOST_CALLTYPE get_hostfxr_path(
     char_t * buffer,
     size_t * buffer_size,

--- a/src/corehost/cli/nethost/nethost.cpp
+++ b/src/corehost/cli/nethost/nethost.cpp
@@ -18,6 +18,9 @@ namespace
     }
 }
 
+#if defined(_WIN32) && defined(_TARGET_X86_)
+    #pragma comment(linker, "/export:get_hostfxr_path=_get_hostfxr_path@12")
+#endif
 NETHOST_API int NETHOST_CALLTYPE get_hostfxr_path(
     char_t * buffer,
     size_t * buffer_size,


### PR DESCRIPTION
The export from `declspec(dllexport)` includes decoration for the `__stdcall` calling convention. Explicitly export a non-decorated name for Windows x86.