### PR TITLE
Change RID fallback to happen per asset type

### DIFF
--- a/src/corehost/cli/deps_format.cpp
+++ b/src/corehost/cli/deps_format.cpp
@@ -173,41 +173,51 @@ bool deps_json_t::perform_rid_fallback(rid_specific_assets_t* portable_assets, c
     
     for (auto& package : portable_assets->libs)
     {
-        pal::string_t matched_rid = package.second.rid_assets.count(host_rid) ? host_rid : _X("");
-        if (matched_rid.empty())
+        for (size_t asset_type_index = 0; asset_type_index < deps_entry_t::asset_types::count; asset_type_index++)
         {
-            if (rid_fallback_graph.count(host_rid) == 0)
+            auto& rid_assets = package.second[asset_type_index].rid_assets;
+            pal::string_t matched_rid = rid_assets.count(host_rid) ? host_rid : _X("");
+            if (matched_rid.empty())
             {
-                trace::warning(_X("The targeted framework does not support the runtime '%s'. Some native libraries from [%s] may fail to load on this platform."), host_rid.c_str(), package.first.c_str());
-            }
-            else
-            {
-                const auto& fallback_rids = rid_fallback_graph.find(host_rid)->second;
-                auto iter = std::find_if(fallback_rids.begin(), fallback_rids.end(), [&package](const pal::string_t& rid) {
-                    return package.second.rid_assets.count(rid);
-                });
-                if (iter != fallback_rids.end())
+                if (rid_fallback_graph.count(host_rid) == 0)
                 {
-                    matched_rid = *iter;
+                    trace::warning(_X("The targeted framework does not support the runtime '%s'. Some native libraries from [%s] may fail to load on this platform."), host_rid.c_str(), package.first.c_str());
+                }
+                else
+                {
+                    const auto& fallback_rids = rid_fallback_graph.find(host_rid)->second;
+                    auto iter = std::find_if(fallback_rids.begin(), fallback_rids.end(), [&rid_assets](const pal::string_t& rid) {
+                        return rid_assets.count(rid);
+                        });
+                    if (iter != fallback_rids.end())
+                    {
+                        matched_rid = *iter;
+                    }
                 }
             }
-        }
 
-        if (matched_rid.empty())
-        {
-            package.second.rid_assets.clear();
-        }
-
-        for (auto iter = package.second.rid_assets.begin(); iter != package.second.rid_assets.end(); /* */)
-        {
-            if (iter->first != matched_rid)
+            if (matched_rid.empty())
             {
-                trace::verbose(_X("Chose %s, so removing rid (%s) specific assets for package %s"), matched_rid.c_str(), iter->first.c_str(), package.first.c_str());
-                iter = package.second.rid_assets.erase(iter);
+                rid_assets.clear();
             }
-            else
+
+            for (auto iter = rid_assets.begin(); iter != rid_assets.end(); /* */)
             {
-                ++iter;
+                if (iter->first != matched_rid)
+                {
+                    trace::verbose(
+                        _X("Chose %s, so removing rid (%s) specific assets for package %s and asset type %s"),
+                        matched_rid.c_str(),
+                        iter->first.c_str(),
+                        package.first.c_str(),
+                        deps_entry_t::s_known_asset_types[asset_type_index]);
+
+                    iter = rid_assets.erase(iter);
+                }
+                else
+                {
+                    ++iter;
+                }
             }
         }
     }
@@ -231,9 +241,9 @@ bool deps_json_t::process_runtime_targets(const json_value& json, const pal::str
         for (const auto& file : files)
         {
             const auto& type = file.second.at(_X("assetType")).as_string();
-            for (size_t i = 0; i < deps_entry_t::s_known_asset_types.size(); ++i)
+            for (size_t asset_type_index = 0; asset_type_index < deps_entry_t::s_known_asset_types.size(); ++asset_type_index)
             {
-                if (pal::strcasecmp(type.c_str(), deps_entry_t::s_known_asset_types[i]) == 0)
+                if (pal::strcasecmp(type.c_str(), deps_entry_t::s_known_asset_types[asset_type_index]) == 0)
                 {
                     const auto& rid = file.second.at(_X("rid")).as_string();
 
@@ -255,14 +265,14 @@ bool deps_json_t::process_runtime_targets(const json_value& json, const pal::str
                     deps_asset_t asset(get_filename_without_ext(file.first), file.first, assembly_version, file_version);
 
                     trace::info(_X("Adding runtimeTargets %s asset %s rid=%s assemblyVersion=%s fileVersion=%s from %s"),
-                        deps_entry_t::s_known_asset_types[i],
+                        deps_entry_t::s_known_asset_types[asset_type_index],
                         asset.relative_path.c_str(),
                         rid.c_str(),
                         asset.assembly_version.as_str().c_str(),
                         asset.file_version.as_str().c_str(),
                         package.first.c_str());
 
-                    assets.libs[package.first].rid_assets[rid][i].push_back(asset);
+                    assets.libs[package.first][asset_type_index].rid_assets[rid].push_back(asset);
                 }
             }
         }
@@ -338,26 +348,26 @@ bool deps_json_t::load_framework_dependent(const pal::string_t& deps_path, const
     };
 
     const vec_asset_t empty;
-    auto get_relpaths = [&](const pal::string_t& package, int type_index, bool* rid_specific) -> const vec_asset_t& {
+    auto get_relpaths = [&](const pal::string_t& package, int asset_type_index, bool* rid_specific) -> const vec_asset_t& {
 
         *rid_specific = false;
 
         // Is there any rid specific assets for this type ("native" or "runtime" or "resources")
-        if (m_rid_assets.libs.count(package) && !m_rid_assets.libs[package].rid_assets.empty())
+        if (m_rid_assets.libs.count(package) && !m_rid_assets.libs[package][asset_type_index].rid_assets.empty())
         {
-            const auto& assets_by_type = m_rid_assets.libs[package].rid_assets.begin()->second[type_index];
-            if (!assets_by_type.empty())
+            const auto& assets_for_type = m_rid_assets.libs[package][asset_type_index].rid_assets.begin()->second;
+            if (!assets_for_type.empty())
             {
                 *rid_specific = true;
-                return assets_by_type;
+                return assets_for_type;
             }
 
-            trace::verbose(_X("There were no rid specific %s asset for %s"), deps_entry_t::s_known_asset_types[type_index], package.c_str());
+            trace::verbose(_X("There were no rid specific %s asset for %s"), deps_entry_t::s_known_asset_types[asset_type_index], package.c_str());
         }
 
         if (m_assets.libs.count(package))
         {
-            return m_assets.libs[package][type_index];
+            return m_assets.libs[package][asset_type_index];
         }
 
         return empty;
@@ -426,9 +436,12 @@ bool deps_json_t::has_package(const pal::string_t& name, const pal::string_t& ve
     auto iter = m_rid_assets.libs.find(pv);
     if (iter != m_rid_assets.libs.end())
     {
-        if (!iter->second.rid_assets.empty())
+        for (size_t asset_type_index = 0; asset_type_index < deps_entry_t::asset_types::count; asset_type_index++)
         {
-            return true;
+            if (!iter->second[asset_type_index].rid_assets.empty())
+            {
+                return true;
+            }
         }
     }
     

--- a/src/corehost/cli/deps_format.cpp
+++ b/src/corehost/cli/deps_format.cpp
@@ -179,7 +179,7 @@ bool deps_json_t::perform_rid_fallback(rid_specific_assets_t* portable_assets, c
             pal::string_t matched_rid = rid_assets.count(host_rid) ? host_rid : _X("");
             if (matched_rid.empty())
             {
-                auto& rid_fallback_iter = rid_fallback_graph.find(host_rid);
+                auto rid_fallback_iter = rid_fallback_graph.find(host_rid);
                 if (rid_fallback_iter == rid_fallback_graph.end())
                 {
                     trace::warning(_X("The targeted framework does not support the runtime '%s'. Some native libraries from [%s] may fail to load on this platform."), host_rid.c_str(), package.first.c_str());

--- a/src/corehost/cli/deps_format.cpp
+++ b/src/corehost/cli/deps_format.cpp
@@ -179,13 +179,14 @@ bool deps_json_t::perform_rid_fallback(rid_specific_assets_t* portable_assets, c
             pal::string_t matched_rid = rid_assets.count(host_rid) ? host_rid : _X("");
             if (matched_rid.empty())
             {
-                if (rid_fallback_graph.count(host_rid) == 0)
+                auto& rid_fallback_iter = rid_fallback_graph.find(host_rid);
+                if (rid_fallback_iter == rid_fallback_graph.end())
                 {
                     trace::warning(_X("The targeted framework does not support the runtime '%s'. Some native libraries from [%s] may fail to load on this platform."), host_rid.c_str(), package.first.c_str());
                 }
                 else
                 {
-                    const auto& fallback_rids = rid_fallback_graph.find(host_rid)->second;
+                    const auto& fallback_rids = rid_fallback_iter->second;
                     auto iter = std::find_if(fallback_rids.begin(), fallback_rids.end(), [&rid_assets](const pal::string_t& rid) {
                         return rid_assets.count(rid);
                         });

--- a/src/corehost/cli/deps_format.h
+++ b/src/corehost/cli/deps_format.h
@@ -20,8 +20,9 @@ class deps_json_t
     typedef std::vector<deps_asset_t> vec_asset_t;
     typedef std::array<vec_asset_t, deps_entry_t::asset_types::count> assets_t;
     struct deps_assets_t { std::unordered_map<pal::string_t, assets_t> libs; };
-    struct rid_assets_t { std::unordered_map<pal::string_t, assets_t> rid_assets; };
-    struct rid_specific_assets_t { std::unordered_map<pal::string_t, rid_assets_t> libs; };
+    struct rid_assets_t { std::unordered_map<pal::string_t, vec_asset_t> rid_assets; };
+    typedef std::array<rid_assets_t, deps_entry_t::asset_types::count> rid_assets_per_type_t;
+    struct rid_specific_assets_t { std::unordered_map<pal::string_t, rid_assets_per_type_t> libs; };
 
     typedef std::unordered_map<pal::string_t, std::vector<pal::string_t>> str_to_vector_map_t;
 

--- a/src/test/HostActivationTests/DependencyResolution/PortableAppRidAssetResolution.cs
+++ b/src/test/HostActivationTests/DependencyResolution/PortableAppRidAssetResolution.cs
@@ -136,6 +136,45 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.DependencyResolution
             }
         }
 
+        [Theory]
+        // For "win" RIDs the DependencyLib which is RID-agnostic will not be included, 
+        // since there are other assembly (runtime) assets with more specific RID match.
+        [InlineData("win10-x64", "win/ManagedWin.dll;win/AnotherWin.dll", "native/win10-x64;native/win10-x64-2")]
+        [InlineData("win10-x86", "win/ManagedWin.dll;win/AnotherWin.dll", "native/win-x86")]
+        // For "linux" on the other hand the DependencyLib will be resolved because there are
+        // no RID-specific assembly assets available.
+        [InlineData("linux", "", "native/linux")]
+        public void MostSpecificRidAssemblySelectedPerTypeMultipleAssets(string rid, string expectedAssemblyPath, string expectedNativePath)
+        {
+            using (TestApp app = NetCoreAppBuilder.PortableForNETCoreApp(SharedState.FrameworkReferenceApp)
+                .WithProject(p => p
+                    .WithAssemblyGroup(null, g => g.WithMainAssembly()))
+                .WithPackage("ridSpecificLib", "1.0.0", p => p
+                    .WithAssemblyGroup(null, g => g.WithAsset("DependencyLib.dll"))
+                    .WithAssemblyGroup("win", g => g.WithAsset("win/ManagedWin.dll"))
+                    .WithAssemblyGroup("win", g => g.WithAsset("win/AnotherWin.dll"))
+                    .WithNativeLibraryGroup("win10-x64", g => g.WithAsset("native/win10-x64/n1.dll"))
+                    .WithNativeLibraryGroup("win10-x64", g => g.WithAsset("native/win10-x64/n2.dll"))
+                    .WithNativeLibraryGroup("win10-x64", g => g.WithAsset("native/win10-x64-2/n3.dll"))
+                    .WithNativeLibraryGroup("win-x86", g => g.WithAsset("native/win-x86/n1.dll"))
+                    .WithNativeLibraryGroup("win-x86", g => g.WithAsset("native/win-x86/n2.dll"))
+                    .WithNativeLibraryGroup("linux", g => g.WithAsset("native/linux/n.so")))
+                .WithPackage("ridAgnosticLib", "2.0.0", p => p
+                    .WithAssemblyGroup(null, g => g.WithAsset("PortableLib.dll").WithAsset("PortableLib2.dll")))
+                .Build())
+            {
+                SharedState.DotNetWithNetCoreApp.Exec(app.AppDll)
+                    .EnableTracingAndCaptureOutputs()
+                    .RuntimeId(rid)
+                    .Execute()
+                    .Should().Pass()
+                    // These are from a separate package which has no RID specific assets, so the RID-agnostic assets are always included
+                    .And.HaveResolvedAssembly("PortableLib.dll;PortableLib2.dll", app)
+                    .And.HaveResolvedAssembly(expectedAssemblyPath, app)
+                    .And.HaveResolvedNativeLibraryPath(expectedNativePath, app);
+            }
+        }
+
         public class SharedTestState : SharedTestStateBase
         {
             public TestApp FrameworkReferenceApp { get; }


### PR DESCRIPTION
Previously the `hostpolicy` would find the best RID match across all assets in a given package. Once it found one, it removed all assets not matching the found RID.

This means that if there's a managed assembly for RID `win` and native library for RID `win-x86`, only the native library would be resolved, the managed assembly would never be used (since it doesn't match exactly the more specific `win-x86` RID).

This is not what NuGet does, NuGet performs the RID fallback per asset type, so native libraries are processed separately from managed assemblies.

This change modifies `hostpolicy` to match the NuGet behavior. Had to change the data structures which stored package->rid->asset-type. Now it's package->asset-type->rid.

Added tests for this case.

Fixes #5728 