### PR TITLE
Wait for mock execute assembly to be called before initializing for config in tests

### DIFF
--- a/src/corehost/cli/test/nativehost/host_context_test.cpp
+++ b/src/corehost/cli/test/nativehost/host_context_test.cpp
@@ -478,6 +478,8 @@ bool host_context_test::mixed(
     };
     std::thread app_start = std::thread(run_app);
 
+    wait_for_signal_mock_execute_assembly();
+
     bool success = config_test(hostfxr, check_properties, config_path, argc, argv, secondary_delegate_type, secondary_log_prefix, test_output);
     block_mock.unblock();
     app_start.join();


### PR DESCRIPTION
Band-aid for #6728 without having #6711.

Basically makes it so that we wait until the thread running the app is sitting in mock execute assembly (and not tracing anymore) before initializing for a config. 