### PR TITLE
Publish test results to AzDO

### DIFF
--- a/eng/jobs/bash-build.yml
+++ b/eng/jobs/bash-build.yml
@@ -170,6 +170,15 @@ jobs:
       continueOnError: true
       condition: succeededOrFailed()
 
+    - task: PublishTestResults@2
+      displayName: Publish Test Results
+      inputs:
+        testResultsFormat: VSTest
+        testResultsFiles: 'bin/tests/**/*.trx'
+        mergeTestResults: true
+        testRunTitle: ${{ parameters.displayName }}
+      condition: always()
+
     - task: CopyFiles@2
       displayName: Copy logs to stage
       inputs:

--- a/eng/jobs/osx-build.yml
+++ b/eng/jobs/osx-build.yml
@@ -41,6 +41,14 @@ jobs:
       displayName: Publish 
       condition: and(succeeded(), eq(variables._BuildConfig, 'Release'))
 
+  - task: PublishTestResults@2
+    displayName: Publish Test Results
+    inputs:
+      testResultsFormat: VSTest
+      testResultsFiles: 'bin/tests/**/*.trx'
+      mergeTestResults: true
+      testRunTitle: ${{ parameters.displayName }}
+    condition: always()
   - task: CopyFiles@2
     displayName: Copy Files to $(Build.StagingDirectory)\BuildLogs
     inputs:

--- a/eng/jobs/windows-build.yml
+++ b/eng/jobs/windows-build.yml
@@ -205,7 +205,15 @@ jobs:
           /bl:$(Build.SourcesDirectory)\publish.binlog'
         displayName: Publish build assets
         condition: and(succeeded(), eq(variables._BuildConfig, 'Release'))
-    
+
+    - task: PublishTestResults@2
+      displayName: Publish Test Results
+      inputs:
+        testResultsFormat: VSTest
+        testResultsFiles: 'bin/tests/**/*.trx'
+        mergeTestResults: true
+        testRunTitle: ${{ parameters.displayName }}
+      condition: always()
     - task: CopyFiles@2
       displayName: Copy Files to $(Build.StagingDirectory)\BuildLogs
       inputs:


### PR DESCRIPTION
This should help see test errors way easier and may give us a better view over time for flakiness. Been planning to do something like this, but I saw the exact task to use with some suggested args when I was looking through Arcade SDK switchover docs and threw this together.

/cc @vitek-karas @elinor-fung 