### PR TITLE
Add the error_codes.h to all CMAKE projects

### DIFF
--- a/src/corehost/cli/common.cmake
+++ b/src/corehost/cli/common.cmake
@@ -31,7 +31,8 @@ list(APPEND SOURCES
 list(APPEND HEADERS
     ${CMAKE_CURRENT_LIST_DIR}/../common/trace.h
     ${CMAKE_CURRENT_LIST_DIR}/../common/utils.h
-    ${CMAKE_CURRENT_LIST_DIR}/../common/pal.h)
+    ${CMAKE_CURRENT_LIST_DIR}/../common/pal.h
+    ${CMAKE_CURRENT_LIST_DIR}/../error_codes.h)
 
 if(WIN32)
     list(APPEND SOURCES 


### PR DESCRIPTION
It's true that one or two test projects don't use error codes, but this is simpler then adding to everything else one by one.

This solves the thing where I start VS on core-setup "Find in files" error code - and nothing comes up... even though it's definitely there.