### PR TITLE
Revise breadcrumb_writer_t ownership

### DIFF
--- a/src/corehost/cli/hostpolicy/breadcrumbs.h
+++ b/src/corehost/cli/hostpolicy/breadcrumbs.h
@@ -10,21 +10,18 @@
 class breadcrumb_writer_t
 {
 public:
-    breadcrumb_writer_t(bool enabled, const std::unordered_set<pal::string_t> &files);
-    ~breadcrumb_writer_t();
-
-    void begin_write();
+    breadcrumb_writer_t(std::unordered_set<pal::string_t> &files);
+    static std::shared_ptr<breadcrumb_writer_t> begin_write(std::unordered_set<pal::string_t> &files);
+    void end_write();
 
 private:
     void write_callback();
-    bool end_write();
     static void write_worker_callback(breadcrumb_writer_t* p_this);
 
+    std::shared_ptr<breadcrumb_writer_t> m_threads_instance;
     pal::string_t m_breadcrumb_store;
     std::thread m_thread;
-    const std::unordered_set<pal::string_t> &m_files;
-    bool m_enabled;
-    volatile bool m_status;
+    std::unordered_set<pal::string_t> m_files;
 };
 
 #endif // __BREADCRUMBS_H__

--- a/src/corehost/cli/hostpolicy/hostpolicy_context.h
+++ b/src/corehost/cli/hostpolicy/hostpolicy_context.h
@@ -22,7 +22,7 @@ public:
     pal::string_t host_path;
 
     bool breadcrumbs_enabled;
-    std::unordered_set<pal::string_t> breadcrumbs;
+    mutable std::unordered_set<pal::string_t> breadcrumbs;
 
     coreclr_property_bag_t coreclr_properties;
 

--- a/src/test/HostActivationTests/NativeHostApis.cs
+++ b/src/test/HostActivationTests/NativeHostApis.cs
@@ -107,7 +107,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
                 .Execute()
                 .Should().Pass()
                 .And.HaveStdOutContaining("Hello World")
-                .And.HaveStdErrContaining("Waiting for breadcrumb thread to exit...");
+                .And.HaveStdErrContaining("Done waiting for breadcrumb thread to exit...");
         }
 
         [Fact]
@@ -125,10 +125,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
                 .Execute(fExpectedToFail: true)
                 .Should().Fail()
                 .And.HaveStdErrContaining("Unhandled exception. System.Exception: Goodbye World")
-                // The breadcrumb thread does not wait since destructors are not called when an exception is thrown.
-                // However, destructors will be called when the caller (such as a custom host) is compiled with SEH Exceptions (/EHa) and has a try\catch.
-                // Todo: add a native host test app so we can verify this behavior.
-                .And.NotHaveStdErrContaining("Waiting for breadcrumb thread to exit...");
+                .And.NotHaveStdErrContaining("Done waiting for breadcrumb thread to exit...");
         }
 
         private class SdkResolutionFixture


### PR DESCRIPTION
Make breadcrumb_writer_t own m_files
Manage breadcrumb_writer_t with a shared pointer
Prevent premature destruction by adding a shared pointer for the background thread

Fixes #4646 on master