### PR TITLE
Component dependency resolution aware of frameworks

### DIFF
--- a/src/corehost/cli/fx_definition.h
+++ b/src/corehost/cli/fx_definition.h
@@ -43,13 +43,24 @@ private:
 };
 
 typedef std::vector<std::unique_ptr<fx_definition_t>> fx_definition_vector_t;
+typedef std::vector<const fx_definition_t*> fx_definition_const_vector_t;
 
 static const fx_definition_t& get_root_framework(const fx_definition_vector_t& fx_definitions)
 {
     return *fx_definitions[fx_definitions.size() - 1];
 }
 
+static const fx_definition_t& get_root_framework(const fx_definition_const_vector_t& fx_definitions)
+{
+    return *fx_definitions[fx_definitions.size() - 1];
+}
+
 static const fx_definition_t& get_app(const fx_definition_vector_t& fx_definitions)
+{
+    return *fx_definitions[0];
+}
+
+static const fx_definition_t& get_app(const fx_definition_const_vector_t& fx_definitions)
 {
     return *fx_definitions[0];
 }

--- a/src/corehost/cli/hostpolicy/deps_resolver.cpp
+++ b/src/corehost/cli/hostpolicy/deps_resolver.cpp
@@ -747,9 +747,9 @@ void deps_resolver_t::get_app_fx_definition_range(fx_definition_const_vector_t::
  */
 bool deps_resolver_t::resolve_probe_dirs(
         deps_entry_t::asset_types asset_type,
-        size_t max_fx_level_to_include,
         pal::string_t* output,
-        std::unordered_set<pal::string_t>* breadcrumb)
+        std::unordered_set<pal::string_t>* breadcrumb,
+        size_t max_fx_level_to_include)
 {
     bool is_resources = asset_type == deps_entry_t::asset_types::resources;
     assert(is_resources || asset_type == deps_entry_t::asset_types::native);
@@ -881,29 +881,29 @@ bool deps_resolver_t::resolve_probe_dirs(
 //     probe_paths       - Pointer to struct containing fields that will contain
 //                         resolved path ordering.
 //     breadcrumb        - set of breadcrumb paths - or null if no breadcrumbs should be collected.
-//     max_fx_level_to_include   - the maximum framework level for which to include the assets.
-//                                 If this is set to 0, only assets from the app will be returned.
 //     ignore_missing_assemblies - if set to true, resolving TPA assemblies will not fail if an assembly can't be found on disk
 //                                 instead such entry will simply be ignored.
+//     max_fx_level_to_include   - the maximum framework level for which to include the assets.
+//                                 If this is set to 0, only assets from the app will be returned.
 //
 //
 bool deps_resolver_t::resolve_probe_paths(
     probe_paths_t* probe_paths,
     std::unordered_set<pal::string_t>* breadcrumb,
-    size_t max_fx_level_to_include,
-    bool ignore_missing_assemblies)
+    bool ignore_missing_assemblies,
+    size_t max_fx_level_to_include)
 {
     if (!resolve_tpa_list(&probe_paths->tpa, breadcrumb, ignore_missing_assemblies, max_fx_level_to_include))
     {
         return false;
     }
 
-    if (!resolve_probe_dirs(deps_entry_t::asset_types::native, max_fx_level_to_include, &probe_paths->native, breadcrumb))
+    if (!resolve_probe_dirs(deps_entry_t::asset_types::native, &probe_paths->native, breadcrumb, max_fx_level_to_include))
     {
         return false;
     }
 
-    if (!resolve_probe_dirs(deps_entry_t::asset_types::resources, max_fx_level_to_include, &probe_paths->resources, breadcrumb))
+    if (!resolve_probe_dirs(deps_entry_t::asset_types::resources, &probe_paths->resources, breadcrumb, max_fx_level_to_include))
     {
         return false;
     }

--- a/src/corehost/cli/hostpolicy/deps_resolver.cpp
+++ b/src/corehost/cli/hostpolicy/deps_resolver.cpp
@@ -115,7 +115,7 @@ void deps_resolver_t::add_tpa_asset(
 void deps_resolver_t::get_dir_assemblies(
     const pal::string_t& dir,
     const pal::string_t& dir_name,
-    int fx_level,
+    size_t fx_level,
     name_to_resolved_asset_map_t* items)
 {
     version_t empty;
@@ -414,7 +414,7 @@ bool deps_resolver_t::resolve_tpa_list(
         pal::string_t* output,
         std::unordered_set<pal::string_t>* breadcrumb,
         bool ignore_missing_assemblies,
-        int max_fx_level_to_include)
+        size_t max_fx_level_to_include)
 {
     const std::vector<deps_entry_t> empty(0);
     name_to_resolved_asset_map_t items;
@@ -747,7 +747,7 @@ void deps_resolver_t::get_app_fx_definition_range(fx_definition_const_vector_t::
  */
 bool deps_resolver_t::resolve_probe_dirs(
         deps_entry_t::asset_types asset_type,
-        int max_fx_level_to_include,
+        size_t max_fx_level_to_include,
         pal::string_t* output,
         std::unordered_set<pal::string_t>* breadcrumb)
 {
@@ -890,7 +890,7 @@ bool deps_resolver_t::resolve_probe_dirs(
 bool deps_resolver_t::resolve_probe_paths(
     probe_paths_t* probe_paths,
     std::unordered_set<pal::string_t>* breadcrumb,
-    int max_fx_level_to_include,
+    size_t max_fx_level_to_include,
     bool ignore_missing_assemblies)
 {
     if (!resolve_tpa_list(&probe_paths->tpa, breadcrumb, ignore_missing_assemblies, max_fx_level_to_include))

--- a/src/corehost/cli/hostpolicy/deps_resolver.h
+++ b/src/corehost/cli/hostpolicy/deps_resolver.h
@@ -34,7 +34,7 @@ struct deps_resolved_asset_t
 
     deps_asset_t asset;
     pal::string_t resolved_path;
-    int fx_level;
+    size_t fx_level;
 };
 
 typedef std::unordered_map<pal::string_t, deps_resolved_asset_t> name_to_resolved_asset_map_t;
@@ -161,7 +161,7 @@ public:
     bool resolve_probe_paths(
         probe_paths_t* probe_paths,
         std::unordered_set<pal::string_t>* breadcrumb,
-        int max_fx_level_to_include,
+        size_t max_fx_level_to_include,
         bool ignore_missing_assemblies);
 
     void init_known_entry_path(
@@ -225,12 +225,12 @@ private:
         pal::string_t* output,
         std::unordered_set<pal::string_t>* breadcrumb,
         bool ignore_missing_assemblies,
-        int max_fx_level_to_include);
+        size_t max_fx_level_to_include);
 
     // Resolve order for culture and native DLL lookup.
     bool resolve_probe_dirs(
         deps_entry_t::asset_types asset_type,
-        int max_fx_level_to_include,
+        size_t max_fx_level_to_include,
         pal::string_t* output,
         std::unordered_set<pal::string_t>* breadcrumb);
 
@@ -238,7 +238,7 @@ private:
     void get_dir_assemblies(
         const pal::string_t& dir,
         const pal::string_t& dir_name,
-        int fx_level,
+        size_t fx_level,
         name_to_resolved_asset_map_t* items);
 
     // Probe entry in probe configurations and deps dir.

--- a/src/corehost/cli/hostpolicy/deps_resolver.h
+++ b/src/corehost/cli/hostpolicy/deps_resolver.h
@@ -161,8 +161,8 @@ public:
     bool resolve_probe_paths(
         probe_paths_t* probe_paths,
         std::unordered_set<pal::string_t>* breadcrumb,
-        size_t max_fx_level_to_include,
-        bool ignore_missing_assemblies);
+        bool ignore_missing_assemblies,
+        size_t max_fx_level_to_include);
 
     void init_known_entry_path(
         const deps_entry_t& entry,
@@ -230,9 +230,9 @@ private:
     // Resolve order for culture and native DLL lookup.
     bool resolve_probe_dirs(
         deps_entry_t::asset_types asset_type,
-        size_t max_fx_level_to_include,
         pal::string_t* output,
-        std::unordered_set<pal::string_t>* breadcrumb);
+        std::unordered_set<pal::string_t>* breadcrumb,
+        size_t max_fx_level_to_include);
 
     // Populate assemblies from the directory.
     void get_dir_assemblies(

--- a/src/corehost/cli/hostpolicy/hostpolicy.cpp
+++ b/src/corehost/cli/hostpolicy/hostpolicy.cpp
@@ -864,7 +864,7 @@ SHARED_API int HOSTPOLICY_CALLTYPE corehost_resolve_component_dependencies(
     // doesn't guarantee that they will actually execute.
 
     probe_paths_t probe_paths;
-    if (!resolver.resolve_probe_paths(&probe_paths, nullptr, /* max_fx_level_to_include */ 0, /* ignore_missing_assemblies */ true))
+    if (!resolver.resolve_probe_paths(&probe_paths, nullptr, /* ignore_missing_assemblies */ true, /* max_fx_level_to_include */ 0))
     {
         return StatusCode::ResolverResolveFailure;
     }

--- a/src/corehost/cli/hostpolicy/hostpolicy_context.cpp
+++ b/src/corehost/cli/hostpolicy/hostpolicy_context.cpp
@@ -53,8 +53,8 @@ int hostpolicy_context_t::initialize(hostpolicy_init_t &hostpolicy_init, const a
         if (!resolver.resolve_probe_paths(
             &probe_paths, 
             &breadcrumbs, 
-            /* max_fx_level_to_include */ std::numeric_limits<size_t>::max(),
-            /* ignore_missing_assemblies */ false))
+            /* ignore_missing_assemblies */ false,
+            /* max_fx_level_to_include */ std::numeric_limits<size_t>::max()))
         {
             return StatusCode::ResolverResolveFailure;
         }
@@ -64,8 +64,8 @@ int hostpolicy_context_t::initialize(hostpolicy_init_t &hostpolicy_init, const a
         if (!resolver.resolve_probe_paths(
             &probe_paths, 
             /* breadcrumbs */ nullptr,
-            /* max_fx_level_to_include */ std::numeric_limits<size_t>::max(),
-            /* ignore_missing_assemblies */ false))
+            /* ignore_missing_assemblies */ false,
+            /* max_fx_level_to_include */ std::numeric_limits<size_t>::max()))
         {
             return StatusCode::ResolverResolveFailure;
         }

--- a/src/corehost/cli/hostpolicy/hostpolicy_context.cpp
+++ b/src/corehost/cli/hostpolicy/hostpolicy_context.cpp
@@ -53,7 +53,7 @@ int hostpolicy_context_t::initialize(hostpolicy_init_t &hostpolicy_init, const a
         if (!resolver.resolve_probe_paths(
             &probe_paths, 
             &breadcrumbs, 
-            /* max_fx_level_to_include */ INT_MAX,
+            /* max_fx_level_to_include */ std::numeric_limits<size_t>::max(),
             /* ignore_missing_assemblies */ false))
         {
             return StatusCode::ResolverResolveFailure;
@@ -64,7 +64,7 @@ int hostpolicy_context_t::initialize(hostpolicy_init_t &hostpolicy_init, const a
         if (!resolver.resolve_probe_paths(
             &probe_paths, 
             /* breadcrumbs */ nullptr,
-            /* max_fx_level_to_include */ INT_MAX,
+            /* max_fx_level_to_include */ std::numeric_limits<size_t>::max(),
             /* ignore_missing_assemblies */ false))
         {
             return StatusCode::ResolverResolveFailure;

--- a/src/corehost/cli/hostpolicy/hostpolicy_context.cpp
+++ b/src/corehost/cli/hostpolicy/hostpolicy_context.cpp
@@ -109,6 +109,7 @@ int hostpolicy_context_t::initialize(hostpolicy_init_t &hostpolicy_init, const a
     }
 
     const fx_definition_const_vector_t &fx_definitions = resolver.get_fx_definitions();
+    hostpolicy_init.fx_processed_definitions = fx_definitions;
 
     pal::string_t fx_deps_str;
     if (resolver.is_framework_dependent())

--- a/src/corehost/cli/hostpolicy/hostpolicy_init.h
+++ b/src/corehost/cli/hostpolicy/hostpolicy_init.h
@@ -17,6 +17,7 @@ struct hostpolicy_init_t
     pal::string_t additional_deps_serialized;
     std::vector<pal::string_t> probe_paths;
     fx_definition_vector_t fx_definitions;
+    fx_definition_const_vector_t fx_processed_definitions;
     pal::string_t tfm;
     host_mode_t host_mode;
     bool patch_roll_forward;

--- a/src/test/HostActivationTests/DependencyResolution/ComponentDependencyResolutionBase.cs
+++ b/src/test/HostActivationTests/DependencyResolution/ComponentDependencyResolutionBase.cs
@@ -53,9 +53,9 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.DependencyResolution
             {
                 string[] args =
                 {
-                corehost_resolve_component_dependencies,
-                componentPath
-            };
+                    corehost_resolve_component_dependencies,
+                    componentPath
+                };
 
                 Command command = HostApiInvokerAppFixture.BuiltDotnet.Exec(HostApiInvokerAppFixture.TestProject.AppDll, args)
                     .EnableTracingAndCaptureOutputs();
@@ -74,10 +74,11 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.DependencyResolution
             {
                 string[] args =
                 {
-                corehost_resolve_component_dependencies_multithreaded,
-                componentOnePath,
-                componentTwoPath
-            };
+                    corehost_resolve_component_dependencies_multithreaded,
+                    componentOnePath,
+                    componentTwoPath
+                };
+
                 return HostApiInvokerAppFixture.BuiltDotnet.Exec(HostApiInvokerAppFixture.TestProject.AppDll, args)
                     .EnableTracingAndCaptureOutputs()
                     .Execute();

--- a/src/test/HostActivationTests/DependencyResolution/ComponentDependencyResolutionBase.cs
+++ b/src/test/HostActivationTests/DependencyResolution/ComponentDependencyResolutionBase.cs
@@ -1,0 +1,94 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.DotNet.Cli.Build.Framework;
+using System;
+using System.IO;
+using System.Runtime.InteropServices;
+
+namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.DependencyResolution
+{
+    public abstract class ComponentDependencyResolutionBase : DependencyResolutionBase
+    {
+        public abstract class ComponentSharedTestStateBase : SharedTestStateBase
+        {
+            private const string corehost_resolve_component_dependencies = "corehost_resolve_component_dependencies";
+            private const string corehost_resolve_component_dependencies_multithreaded = "corehost_resolve_component_dependencies_multithreaded";
+
+            public TestProjectFixture HostApiInvokerAppFixture { get; }
+
+            public ComponentSharedTestStateBase()
+            {
+                HostApiInvokerAppFixture = CreateHostApiInvokerApp();
+            }
+
+            private TestProjectFixture CreateHostApiInvokerApp()
+            {
+                TestProjectFixture hostApiInvokerAppFixture = new TestProjectFixture("HostApiInvokerApp", RepoDirectories)
+                    .EnsureRestored(RepoDirectories.CorehostPackages)
+                    .BuildProject();
+
+                if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                {
+                    // On non-Windows, we can't just P/Invoke to already loaded hostpolicy, so copy it next to the app dll.
+                    var hostpolicy = Path.Combine(
+                        hostApiInvokerAppFixture.BuiltDotnet.GreatestVersionSharedFxPath,
+                        RuntimeInformationExtensions.GetSharedLibraryFileNameForCurrentPlatform("hostpolicy"));
+
+                    File.Copy(
+                        hostpolicy,
+                        Path.GetDirectoryName(hostApiInvokerAppFixture.TestProject.AppDll));
+                }
+
+                return hostApiInvokerAppFixture;
+            }
+
+            public CommandResult RunComponentResolutionTest(TestApp component, Action<Command> commandCustomizer = null)
+            {
+                return RunComponentResolutionTest(component.AppDll, commandCustomizer);
+            }
+
+            public CommandResult RunComponentResolutionTest(string componentPath, Action<Command> commandCustomizer = null)
+            {
+                string[] args =
+                {
+                corehost_resolve_component_dependencies,
+                componentPath
+            };
+
+                Command command = HostApiInvokerAppFixture.BuiltDotnet.Exec(HostApiInvokerAppFixture.TestProject.AppDll, args)
+                    .EnableTracingAndCaptureOutputs();
+                commandCustomizer?.Invoke(command);
+
+                return command.Execute()
+                    .StdErrAfter("corehost_resolve_component_dependencies = {");
+            }
+
+            public CommandResult RunComponentResolutionMultiThreadedTest(TestApp componentOne, TestApp componentTwo)
+            {
+                return RunComponentResolutionMultiThreadedTest(componentOne.AppDll, componentTwo.AppDll);
+            }
+
+            public CommandResult RunComponentResolutionMultiThreadedTest(string componentOnePath, string componentTwoPath)
+            {
+                string[] args =
+                {
+                corehost_resolve_component_dependencies_multithreaded,
+                componentOnePath,
+                componentTwoPath
+            };
+                return HostApiInvokerAppFixture.BuiltDotnet.Exec(HostApiInvokerAppFixture.TestProject.AppDll, args)
+                    .EnableTracingAndCaptureOutputs()
+                    .Execute();
+            }
+
+            public override void Dispose()
+            {
+                base.Dispose();
+
+                HostApiInvokerAppFixture.Dispose();
+            }
+        }
+    }
+}

--- a/src/test/HostActivationTests/DependencyResolution/DependencyResolutionBase.cs
+++ b/src/test/HostActivationTests/DependencyResolution/DependencyResolutionBase.cs
@@ -12,7 +12,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.DependencyResolution
 
         public abstract class SharedTestStateBase : TestArtifact
         {
-            private readonly string _builtDotnet;
+            protected string BuiltDotnetPath { get; }
 
             private static string GetBaseDir(string name)
             {
@@ -23,12 +23,12 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.DependencyResolution
             public SharedTestStateBase()
                 : base(GetBaseDir("dependencyResolution"), "dependencyResolution")
             {
-                _builtDotnet = Path.Combine(TestArtifactsPath, "sharedFrameworkPublish");
+                BuiltDotnetPath = Path.Combine(TestArtifactsPath, "sharedFrameworkPublish");
             }
 
             public DotNetBuilder DotNet(string name)
             {
-                return new DotNetBuilder(Location, _builtDotnet, name);
+                return new DotNetBuilder(Location, BuiltDotnetPath, name);
             }
 
             public TestApp CreateFrameworkReferenceApp(string fxName, string fxVersion)

--- a/src/test/HostActivationTests/DependencyResolution/PerAssemblyVersionResolution.cs
+++ b/src/test/HostActivationTests/DependencyResolution/PerAssemblyVersionResolution.cs
@@ -1,0 +1,142 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.DotNet.Cli.Build;
+using System;
+using System.IO;
+using Xunit;
+
+namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.DependencyResolution
+{
+    public class PerAssemblyVersionResolution :
+        ComponentDependencyResolutionBase,
+        IClassFixture<PerAssemblyVersionResolution.SharedTestState>
+    {
+        private readonly SharedTestState sharedTestState;
+
+        public PerAssemblyVersionResolution(SharedTestState fixture)
+        {
+            sharedTestState = fixture;
+        }
+
+        private const string TestDependencyResolverFx = "Test.DependencyResolver.Fx";
+        private const string TestVersionsPackage = "Test.Versions.Package";
+        private const string TestAssemblyWithNoVersions = "Test.Assembly.NoVersions";
+        private const string TestAssemblyWithAssemblyVersion = "Test.Assembly.AssemblyVersion";
+        private const string TestAssemblyWithFileVersion = "Test.Assembly.FileVersion";
+        private const string TestAssemblyWithBothVersions = "Test.Assembly.BothVersions";
+
+        [Theory]
+        [InlineData(TestAssemblyWithBothVersions, null, null, false)]
+        [InlineData(TestAssemblyWithBothVersions, "1.0.0.0", "1.0.0.0", false)]
+        [InlineData(TestAssemblyWithBothVersions, "3.0.0.0", "3.0.0.0", true)]
+        public void AppWithSameAssemblyAsFramework(string testAssemblyName, string appAsmVersion, string appFileVersion, bool appWins)
+        {
+            var app = sharedTestState.CreateTestFrameworkReferenceApp(b => b
+                .WithPackage(TestVersionsPackage, "1.0.0", lib => lib
+                    .WithAssemblyGroup(null, g => g
+                        .WithAsset(testAssemblyName + ".dll", rf => rf
+                            .WithVersion(appAsmVersion, appFileVersion)))));
+
+            string expectedTestAssemblyPath =
+                Path.Combine(appWins ? app.Location : sharedTestState.AppTestSharedFramework.Location, testAssemblyName + ".dll");
+
+            sharedTestState.DotNetWithNetCoreApp.Exec(app.AppDll)
+                .EnableTracingAndCaptureOutputs()
+                .Execute()
+                .Should().Pass()
+                .And.HaveResolvedAssembly(expectedTestAssemblyPath);
+        }
+
+        [Theory]
+        [InlineData(TestAssemblyWithBothVersions, null, null, false)]
+        [InlineData(TestAssemblyWithBothVersions, "1.0.0.0", "1.0.0.0", false)]
+        [InlineData(TestAssemblyWithBothVersions, "3.0.0.0", "3.0.0.0", true)]
+        public void ComponentWithSameAssemblyAsFramework(string testAssemblyName, string appAsmVersion, string appFileVersion, bool appWins)
+        {
+            var component = sharedTestState.CreateComponentWithNoDependencies(b => b
+                .WithPackage(TestVersionsPackage, "1.0.0", lib => lib
+                    .WithAssemblyGroup(null, g => g
+                        .WithAsset(testAssemblyName + ".dll", rf => rf
+                            .WithVersion(appAsmVersion, appFileVersion)))));
+
+            string expectedTestAssemblyPath =
+                Path.Combine(appWins ? component.Location : sharedTestState.ComponentTestSharedFramework.Location, testAssemblyName + ".dll");
+
+            sharedTestState.RunComponentResolutionTest(component)
+                .Should().Pass()
+                .And.HaveStdOutContaining("corehost_resolve_component_dependencies:Success")
+                .And.HaveStdOutContaining($"corehost_resolve_component_dependencies assemblies:[" +
+                                          $"{component.AppDll}{Path.PathSeparator}" +
+                                          $"{expectedTestAssemblyPath}{Path.PathSeparator}]");
+        }
+
+        public class SharedTestState : ComponentSharedTestStateBase
+        {
+            public DotNetCli DotNetWithNetCoreApp { get; }
+
+            public TestApp AppTestSharedFramework { get; }
+            public TestApp ComponentTestSharedFramework { get; }
+
+            public SharedTestState()
+            {
+                // The simplest way to setup an assembly in framework we have full control over is to create a custom shared framework
+                // We can't really mock Microsoft.NETCore.App since we need it to run the HostApiInvoker on.
+                string sharedFrameworkPath = Path.Combine(
+                    HostApiInvokerAppFixture.BuiltDotnet.BinPath,
+                    "shared",
+                    TestDependencyResolverFx,
+                    "1.0.0");
+                FileUtils.EnsureDirectoryExists(sharedFrameworkPath);
+
+                ComponentTestSharedFramework = new TestApp(sharedFrameworkPath, TestDependencyResolverFx);
+                NetCoreAppBuilder builder = NetCoreAppBuilder.PortableForNETCoreApp(ComponentTestSharedFramework);
+                PrepareTestFramework(builder);
+                builder.Build(ComponentTestSharedFramework);
+
+                // Modify the host API app to reference this test framework - since the component resolution is invoked by this app
+                // Note: no need for backup, the shared test state instance creates a new instance of the app every time.
+                RuntimeConfig.FromFile(HostApiInvokerAppFixture.TestProject.BuiltApp.RuntimeConfigJson)
+                    .WithFramework(TestDependencyResolverFx, "1.0.0")
+                    .Save();
+
+                DotNetWithNetCoreApp = DotNet("WithNetCoreApp")
+                    .AddMicrosoftNETCoreAppFrameworkMockCoreClr(RepoDirectories.MicrosoftNETCoreAppVersion)
+                    .AddFramework(TestDependencyResolverFx, "1.0.0", PrepareTestFramework)
+                    .Build();
+                AppTestSharedFramework = new TestApp(Path.Combine(DotNetWithNetCoreApp.BinPath, "shared", TestDependencyResolverFx, "1.0.0"));
+            }
+
+            private void PrepareTestFramework(NetCoreAppBuilder builder)
+            {
+                builder
+                    .WithRuntimeConfig(runtimeConfig => runtimeConfig
+                        .WithFramework(MicrosoftNETCoreApp, RepoDirectories.MicrosoftNETCoreAppVersion))
+                    .WithPackage(TestVersionsPackage, "1.0.0", b => b
+                        .WithAssemblyGroup(null, g => g
+                            .WithAsset(TestAssemblyWithNoVersions + ".dll")
+                            .WithAsset(TestAssemblyWithAssemblyVersion + ".dll", rf => rf.WithVersion("2.1.1.1", null))
+                            .WithAsset(TestAssemblyWithFileVersion + ".dll", rf => rf.WithVersion(null, "3.2.2.2"))
+                            .WithAsset(TestAssemblyWithBothVersions + ".dll", rf => rf.WithVersion("2.1.1.1", "3.2.2.2"))));
+            }
+
+            public TestApp CreateTestFrameworkReferenceApp(Action<NetCoreAppBuilder> customizer)
+            {
+                TestApp testApp = CreateFrameworkReferenceApp(TestDependencyResolverFx, "1.0.0");
+                NetCoreAppBuilder builder = NetCoreAppBuilder.PortableForNETCoreApp(testApp);
+                builder.WithProject(p => p
+                    .WithAssemblyGroup(null, g => g.WithMainAssembly()));
+                customizer(builder);
+                return builder.Build(testApp);
+            }
+
+            public override void Dispose()
+            {
+                base.Dispose();
+
+                ComponentTestSharedFramework.Dispose();
+            }
+        }
+    }
+}

--- a/src/test/HostActivationTests/DependencyResolution/PerAssemblyVersionResolution.cs
+++ b/src/test/HostActivationTests/DependencyResolution/PerAssemblyVersionResolution.cs
@@ -22,6 +22,11 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.DependencyResolution
 
         private const string TestDependencyResolverFx = "Test.DependencyResolver.Fx";
         private const string TestVersionsPackage = "Test.Versions.Package";
+
+        // The test framework above has 4 assemblies in it each with different set of assembly and file versions.
+        // The version values are always (if present)
+        // - assembly version: 2.1.1.1
+        // - file version:     3.2.2.2
         private const string TestAssemblyWithNoVersions = "Test.Assembly.NoVersions";
         private const string TestAssemblyWithAssemblyVersion = "Test.Assembly.AssemblyVersion";
         private const string TestAssemblyWithFileVersion = "Test.Assembly.FileVersion";
@@ -30,7 +35,29 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.DependencyResolution
         [Theory]
         [InlineData(TestAssemblyWithBothVersions, null, null, false)]
         [InlineData(TestAssemblyWithBothVersions, "1.0.0.0", "1.0.0.0", false)]
-        [InlineData(TestAssemblyWithBothVersions, "3.0.0.0", "3.0.0.0", true)]
+        [InlineData(TestAssemblyWithBothVersions, "3.0.0.0", "4.0.0.0", true)]
+        [InlineData(TestAssemblyWithBothVersions, "2.1.1.1", "1.0.0.0", false)]
+        [InlineData(TestAssemblyWithBothVersions, "2.1.1.1", "3.3.0.0", true)]
+        [InlineData(TestAssemblyWithBothVersions, "2.1.1.1", "3.2.2.2", false)] // Lower level framework always wins on equality (this is intentional)
+        [InlineData(TestAssemblyWithBothVersions, null, "4.0.0.0", false)] // The one with version wins
+        [InlineData(TestAssemblyWithBothVersions, null, "2.0.0.0", false)] // The one with version wins
+        [InlineData(TestAssemblyWithBothVersions, "3.0.0.0", null, true)]
+        [InlineData(TestAssemblyWithBothVersions, "2.1.1.1", null, false)]
+        [InlineData(TestAssemblyWithNoVersions, null, null, false)] // No versions are treated as equal (so lower one wins)
+        [InlineData(TestAssemblyWithNoVersions, "1.0.0.0", null, true)]
+        [InlineData(TestAssemblyWithNoVersions, "1.0.0.0", "1.0.0.0", true)]
+        [InlineData(TestAssemblyWithNoVersions, null, "1.0.0.0", true)]
+        [InlineData(TestAssemblyWithAssemblyVersion, null, null, false)]
+        [InlineData(TestAssemblyWithAssemblyVersion, "1.0.0.0", null, false)]
+        [InlineData(TestAssemblyWithAssemblyVersion, null, "1.0.0.0", false)]
+        [InlineData(TestAssemblyWithAssemblyVersion, "3.0.0.0", "1.0.0.0", true)]
+        [InlineData(TestAssemblyWithAssemblyVersion, "2.1.1.1", null, false)]
+        [InlineData(TestAssemblyWithAssemblyVersion, "2.1.1.1", "1.0.0.0", true)]
+        [InlineData(TestAssemblyWithFileVersion, null, null, false)]
+        [InlineData(TestAssemblyWithFileVersion, "1.0.0.0", null, true)]
+        [InlineData(TestAssemblyWithFileVersion, null, "1.0.0.0", false)]
+        [InlineData(TestAssemblyWithFileVersion, null, "4.0.0.0", true)]
+        [InlineData(TestAssemblyWithFileVersion, null, "3.2.2.2", false)]
         public void AppWithSameAssemblyAsFramework(string testAssemblyName, string appAsmVersion, string appFileVersion, bool appWins)
         {
             var app = sharedTestState.CreateTestFrameworkReferenceApp(b => b
@@ -52,7 +79,29 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.DependencyResolution
         [Theory]
         [InlineData(TestAssemblyWithBothVersions, null, null, false)]
         [InlineData(TestAssemblyWithBothVersions, "1.0.0.0", "1.0.0.0", false)]
-        [InlineData(TestAssemblyWithBothVersions, "3.0.0.0", "3.0.0.0", true)]
+        [InlineData(TestAssemblyWithBothVersions, "3.0.0.0", "4.0.0.0", true)]
+        [InlineData(TestAssemblyWithBothVersions, "2.1.1.1", "1.0.0.0", false)]
+        [InlineData(TestAssemblyWithBothVersions, "2.1.1.1", "3.3.0.0", true)]
+        [InlineData(TestAssemblyWithBothVersions, "2.1.1.1", "3.2.2.2", false)] // Lower level framework always wins on equality (this is intentional)
+        [InlineData(TestAssemblyWithBothVersions, null, "4.0.0.0", false)] // The one with version wins
+        [InlineData(TestAssemblyWithBothVersions, null, "2.0.0.0", false)] // The one with version wins
+        [InlineData(TestAssemblyWithBothVersions, "3.0.0.0", null, true)]
+        [InlineData(TestAssemblyWithBothVersions, "2.1.1.1", null, false)]
+        [InlineData(TestAssemblyWithNoVersions, null, null, false)] // No versions are treated as equal (so lower one wins)
+        [InlineData(TestAssemblyWithNoVersions, "1.0.0.0", null, true)]
+        [InlineData(TestAssemblyWithNoVersions, "1.0.0.0", "1.0.0.0", true)]
+        [InlineData(TestAssemblyWithNoVersions, null, "1.0.0.0", true)]
+        [InlineData(TestAssemblyWithAssemblyVersion, null, null, false)]
+        [InlineData(TestAssemblyWithAssemblyVersion, "1.0.0.0", null, false)]
+        [InlineData(TestAssemblyWithAssemblyVersion, null, "1.0.0.0", false)]
+        [InlineData(TestAssemblyWithAssemblyVersion, "3.0.0.0", "1.0.0.0", true)]
+        [InlineData(TestAssemblyWithAssemblyVersion, "2.1.1.1", null, false)]
+        [InlineData(TestAssemblyWithAssemblyVersion, "2.1.1.1", "1.0.0.0", true)]
+        [InlineData(TestAssemblyWithFileVersion, null, null, false)]
+        [InlineData(TestAssemblyWithFileVersion, "1.0.0.0", null, true)]
+        [InlineData(TestAssemblyWithFileVersion, null, "1.0.0.0", false)]
+        [InlineData(TestAssemblyWithFileVersion, null, "4.0.0.0", true)]
+        [InlineData(TestAssemblyWithFileVersion, null, "3.2.2.2", false)]
         public void ComponentWithSameAssemblyAsFramework(string testAssemblyName, string appAsmVersion, string appFileVersion, bool appWins)
         {
             var component = sharedTestState.CreateComponentWithNoDependencies(b => b

--- a/src/test/HostActivationTests/DependencyResolution/PortableAppRidAssetResolution.cs
+++ b/src/test/HostActivationTests/DependencyResolution/PortableAppRidAssetResolution.cs
@@ -37,7 +37,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.DependencyResolution
                     .Execute()
                     .Should().Pass()
                     .And.HaveResolvedAssembly(includedPath, app)
-                    .And.NotHaveResolvedAssembly(excludedPath, app);
+                    .And.HaveResolvedAssembly(excludedPath, app);
             }
         }
 

--- a/src/test/HostActivationTests/DependencyResolution/PortableAppRidAssetResolution.cs
+++ b/src/test/HostActivationTests/DependencyResolution/PortableAppRidAssetResolution.cs
@@ -37,7 +37,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.DependencyResolution
                     .Execute()
                     .Should().Pass()
                     .And.HaveResolvedAssembly(includedPath, app)
-                    .And.HaveResolvedAssembly(excludedPath, app);
+                    .And.NotHaveResolvedAssembly(excludedPath, app);
             }
         }
 


### PR DESCRIPTION
Makes component dependency resolution (that is `AssemblyDependencyResolver`) aware of frameworks.
From a functionality perspective this means that components will correctly override assemblies in the frameworks. So if the component contains an assembly A which is also in framework, A will be resolved either from the component or the framework based on version match.
* If the component assembly version is higher the one from the component will be used
* If the one in framework is higher or equal version, it will be used.

This matches the behavior when resolving assemblies in an app during startup.

Note that this doesn't mean that `AssemblyDependencyResolver` will resolve framework assemblies all up. Right now it is intentionally restricted to only resolve assemblies which are references by the component itself. That said this change will make it relatively easy to enable framework assembly resolution as well if we decide to do so.

Changes made:
* Store the list of frameworks on the `hostpolicy_init` object. The stored list is `const` since we need to be able to access it from multiple threads at the same time. The list is only populated once the frameworks are processed during the first context init. After this, the frameworks should not change at all.
* Regarding memory management of frameworks nothing has changed, the `hostpolicy_init` already stored the frameworks, but as a non-const vector, the change is to simply add a const version of the vector - this makes it "Easy" to prove that accesses to this are thread safe.
* Add a new constructor for `deps_resolver` which creates it from already processed frameworks (those from the new const list). In this case there's no need for `.deps.json` parsing and other processing, so the new constructor simply initializes the resolver.
* Change the component dependency resolution entrypoint to construct a list containing the component and all the frameworks (except the app) and pass that list to the resolver (so that it has all the frameworks).
* Modify resolver to be able to limit resolved assemblies to a specific level - currently it's used as either "resolve everything" (when running app), or "resolve just the app" (during component resolution - the component act's an app).
* Some very minor cleanup. Note that there are lot of opportunities to improve the codebase in the dependency resolver, this change doesn't attempt to make any of those.

Test changes:
* Refactor existing component dependency resolution tests to make it easier to reuse.
* Implement new tests which validate the assembly resolution between the app/component and the frameworks, specifically with regard to version resolution. The tests are written for both component and app scenarios (the behaviors should be the same).