### PR TITLE
Bundler: Check for duplicate file entries.

### DIFF
--- a/src/managed/Microsoft.NET.HostModel/Bundle/Bundler.cs
+++ b/src/managed/Microsoft.NET.HostModel/Bundle/Bundler.cs
@@ -156,7 +156,12 @@ namespace Microsoft.NET.HostModel.Bundle
             }
             catch (InvalidOperationException)
             {
-                throw new ArgumentException("Input must uniquely specify the host binary");
+                throw new ArgumentException("Invalid input specification: Must specify the host binary");
+            }
+
+            if(fileSpecs.GroupBy(file => file.BundleRelativePath).Where(g => g.Count() > 1).Any())
+            {
+                throw new ArgumentException("Invalid input specification: Found multiple entries with the same BundleRelativePath");
             }
 
             string bundlePath = Path.Combine(OutputDir, HostName);

--- a/src/managed/Microsoft.NET.HostModel/Bundle/Bundler.cs
+++ b/src/managed/Microsoft.NET.HostModel/Bundle/Bundler.cs
@@ -187,8 +187,7 @@ namespace Microsoft.NET.HostModel.Bundle
                     {
                         FileType type = InferType(fileSpec.BundleRelativePath, file);
                         long startOffset = AddToBundle(bundle, file, type);
-                        FileEntry entry = new FileEntry(type, fileSpec.BundleRelativePath, startOffset, file.Length);
-                        BundleManifest.Files.Add(entry);
+                        FileEntry entry = BundleManifest.AddEntry(type, fileSpec.BundleRelativePath, startOffset, file.Length);
                         trace.Log($"Embed: {entry}");
                     }
                 }

--- a/src/managed/Microsoft.NET.HostModel/Bundle/Manifest.cs
+++ b/src/managed/Microsoft.NET.HostModel/Bundle/Manifest.cs
@@ -71,6 +71,22 @@ namespace Microsoft.NET.HostModel.Bundle
             BundleID = bundleID;
         }
 
+        public FileEntry AddEntry(FileEntry entry)
+        {
+            if(Files.Any(file => file.RelativePath.Equals(entry.RelativePath)))
+            {
+                throw new BundleException("Found multiple entries with the same bundle-relative-path");
+            }
+
+            Files.Add(entry);
+            return entry;
+        }
+
+        public FileEntry AddEntry(FileType type, string relativePath, long offset, long size)
+        {
+            return AddEntry(new FileEntry(type, relativePath, offset, size));
+        }
+
         public long Write(BinaryWriter writer)
         {
             long startOffset = writer.BaseStream.Position;

--- a/src/managed/Microsoft.NET.HostModel/Bundle/Manifest.cs
+++ b/src/managed/Microsoft.NET.HostModel/Bundle/Manifest.cs
@@ -71,20 +71,11 @@ namespace Microsoft.NET.HostModel.Bundle
             BundleID = bundleID;
         }
 
-        public FileEntry AddEntry(FileEntry entry)
-        {
-            if(Files.Any(file => file.RelativePath.Equals(entry.RelativePath)))
-            {
-                throw new BundleException("Found multiple entries with the same bundle-relative-path");
-            }
-
-            Files.Add(entry);
-            return entry;
-        }
-
         public FileEntry AddEntry(FileType type, string relativePath, long offset, long size)
         {
-            return AddEntry(new FileEntry(type, relativePath, offset, size));
+            FileEntry entry = new FileEntry(type, relativePath, offset, size);
+            Files.Add(entry);
+            return entry;
         }
 
         public long Write(BinaryWriter writer)
@@ -120,7 +111,7 @@ namespace Microsoft.NET.HostModel.Bundle
             string signature = reader.ReadString();
             if (!signature.Equals(Signature))
             {
-                throw new BundleException("Invalid Bundle");
+                throw new BundleException("Extraction failed: Invalid Bundle");
             }
 
             // The manifest header offset resides just behind the signature.
@@ -144,6 +135,11 @@ namespace Microsoft.NET.HostModel.Bundle
             for (long i = 0; i < fileCount; i++)
             {
                 manifest.Files.Add(FileEntry.Read(reader));
+            }
+
+            if (manifest.Files.GroupBy(file => file.RelativePath).Where(g => g.Count() > 1).Any())
+            {
+                throw new BundleException("Extraction failed: Found multiple entries with the same bundle-relative-path");
             }
 
             return manifest;

--- a/src/test/BundleTests/Helpers/BundleHelper.cs
+++ b/src/test/BundleTests/Helpers/BundleHelper.cs
@@ -10,9 +10,25 @@ namespace BundleTests.Helpers
     public static class BundleHelper
     {
         public const string DotnetBundleExtractBaseEnvVariable = "DOTNET_BUNDLE_EXTRACT_BASE_DIR";
+
+        public static string GetHostPath(TestProjectFixture fixture)
+        {
+            return Path.Combine(GetPublishPath(fixture), GetHostName(fixture));
+        }
+
+        public static string GetAppPath(TestProjectFixture fixture)
+        {
+            return Path.Combine(GetPublishPath(fixture), GetAppName(fixture));
+        }
+
         public static string GetHostName(TestProjectFixture fixture)
         {
             return Path.GetFileName(fixture.TestProject.AppExe);
+        }
+
+        public static string GetAppName(TestProjectFixture fixture)
+        {
+            return Path.GetFileName(fixture.TestProject.AppDll);
         }
 
         public static string GetPublishPath(TestProjectFixture fixture)

--- a/src/test/BundleTests/Microsoft.NET.HostModel.Bundle.Tests/BundlerConsistencyTests.cs
+++ b/src/test/BundleTests/Microsoft.NET.HostModel.Bundle.Tests/BundlerConsistencyTests.cs
@@ -77,7 +77,7 @@ namespace Microsoft.NET.HostModel.Tests
             fileSpecs.Add(new FileSpec(BundleHelper.GetAppPath(fixture), "app.repeat"));
 
             Bundler bundler = new Bundler(hostName, bundleDir.FullName);
-            Assert.Throws<BundleException>(() => bundler.GenerateBundle(fileSpecs));
+            Assert.Throws<ArgumentException>(() => bundler.GenerateBundle(fileSpecs));
         }
 
         [InlineData(true)]

--- a/src/test/BundleTests/Microsoft.NET.HostModel.Bundle.Tests/BundlerConsistencyTests.cs
+++ b/src/test/BundleTests/Microsoft.NET.HostModel.Bundle.Tests/BundlerConsistencyTests.cs
@@ -50,7 +50,6 @@ namespace Microsoft.NET.HostModel.Tests
 
             var hostName = BundleHelper.GetHostName(fixture);
             var appName = Path.GetFileNameWithoutExtension(hostName);
-            string publishPath = BundleHelper.GetPublishPath(fixture);
             var bundleDir = BundleHelper.GetBundleDir(fixture);
 
             // Generate a file specification without the apphost
@@ -61,6 +60,24 @@ namespace Microsoft.NET.HostModel.Tests
             Bundler bundler = new Bundler(hostName, bundleDir.FullName);
 
             Assert.Throws<ArgumentException>(() => bundler.GenerateBundle(fileSpecs));
+        }
+
+        [Fact]
+        public void TestWithDuplicateEntriesFails()
+        {
+            var fixture = sharedTestState.TestFixture.Copy();
+
+            var hostName = BundleHelper.GetHostName(fixture);
+            var bundleDir = BundleHelper.GetBundleDir(fixture);
+
+            // Generate a file specification with duplicate entries
+            var fileSpecs = new List<FileSpec>();
+            fileSpecs.Add(new FileSpec(BundleHelper.GetHostPath(fixture), BundleHelper.GetHostName(fixture)));
+            fileSpecs.Add(new FileSpec(BundleHelper.GetAppPath(fixture), "app.repeat"));
+            fileSpecs.Add(new FileSpec(BundleHelper.GetAppPath(fixture), "app.repeat"));
+
+            Bundler bundler = new Bundler(hostName, bundleDir.FullName);
+            Assert.Throws<BundleException>(() => bundler.GenerateBundle(fileSpecs));
         }
 
         [InlineData(true)]


### PR DESCRIPTION
If the input to the bundler contains multiple entries
with the same relative path, we currently generate a bundle
with a larger size with some unusable files.

Therefore, check this condition when generating bundles, and
throw an error.

The extractor also checks this condition when extracting
malformed bundles.
