### PR TITLE
Fixes for RuntimeList.xml: naming, missing files, Resources type

### DIFF
--- a/src/pkg/packaging-tools/packaging-tools.props
+++ b/src/pkg/packaging-tools/packaging-tools.props
@@ -8,13 +8,18 @@
   <PropertyGroup Condition="$(MSBuildProjectName.EndsWith('.Ref'))">
     <FrameworkPackType>targeting</FrameworkPackType>
 
-    <!-- Include the platform manifest in the data dir. -->
+    <!-- Include manifests in the data dir. -->
     <PlatformManifestTargetPath>data/PlatformManifest.txt</PlatformManifestTargetPath>
+    <FrameworkListTargetPath>data/</FrameworkListTargetPath>
   </PropertyGroup>
 
   <PropertyGroup Condition="$(MSBuildProjectName.EndsWith('.Runtime'))">
     <FrameworkPackType>runtime</FrameworkPackType>
     <BuildRidSpecificPacks>true</BuildRidSpecificPacks>
+
+    <!-- Include a list of runtime files in the data dir. -->
+    <FrameworkListFilename>RuntimeList.xml</FrameworkListFilename>
+    <FrameworkListTargetPath>data/</FrameworkListTargetPath>
   </PropertyGroup>
 
   <PropertyGroup Condition="$(MSBuildProjectName.EndsWith('.Host'))">
@@ -52,9 +57,6 @@
 
     <!-- Location to lay out pack contents, and where to grab bits to create installers. -->
     <PackLayoutDir>$(InstallerSourceIntermediateOutputDir)layout/$(FrameworkPackType)/</PackLayoutDir>
-
-    <!-- Include a list of framework files in the data dir. -->
-    <FrameworkListTargetPath>data/</FrameworkListTargetPath>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/pkg/projects/Microsoft.NETCore.DotNetAppHost/runtime.FreeBSD.Microsoft.NETCore.DotNetAppHost.props
+++ b/src/pkg/projects/Microsoft.NETCore.DotNetAppHost/runtime.FreeBSD.Microsoft.NETCore.DotNetAppHost.props
@@ -7,6 +7,7 @@
 
     <File Include="@(ArchitectureSpecificNativeFile)">
       <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
+      <IsNative>true</IsNative>
     </File>
     <File Include="$(VersionTxtFile)" />
   </ItemGroup>

--- a/src/pkg/projects/Microsoft.NETCore.DotNetAppHost/runtime.Linux.Microsoft.NETCore.DotNetAppHost.props
+++ b/src/pkg/projects/Microsoft.NETCore.DotNetAppHost/runtime.Linux.Microsoft.NETCore.DotNetAppHost.props
@@ -7,6 +7,7 @@
 
     <File Include="@(ArchitectureSpecificNativeFile)">
       <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
+      <IsNative>true</IsNative>
     </File>
     <File Include="$(VersionTxtFile)" />
   </ItemGroup>

--- a/src/pkg/projects/Microsoft.NETCore.DotNetAppHost/runtime.OSX.Microsoft.NETCore.DotNetAppHost.props
+++ b/src/pkg/projects/Microsoft.NETCore.DotNetAppHost/runtime.OSX.Microsoft.NETCore.DotNetAppHost.props
@@ -7,6 +7,7 @@
 
     <File Include="@(ArchitectureSpecificNativeFile)">
       <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
+      <IsNative>true</IsNative>
     </File>
     <File Include="$(VersionTxtFile)" />
   </ItemGroup>

--- a/src/pkg/projects/Microsoft.NETCore.DotNetAppHost/runtime.Windows_NT.Microsoft.NETCore.DotNetAppHost.props
+++ b/src/pkg/projects/Microsoft.NETCore.DotNetAppHost/runtime.Windows_NT.Microsoft.NETCore.DotNetAppHost.props
@@ -11,6 +11,7 @@
 
     <File Include="@(ArchitectureSpecificNativeFile)">
       <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
+      <IsNative>true</IsNative>
     </File>
     <File Include="$(VersionTxtFile)" />
   </ItemGroup>

--- a/src/pkg/projects/Microsoft.NETCore.DotNetHost/runtime.FreeBSD.Microsoft.NETCore.DotNetHost.props
+++ b/src/pkg/projects/Microsoft.NETCore.DotNetHost/runtime.FreeBSD.Microsoft.NETCore.DotNetHost.props
@@ -5,6 +5,7 @@
 
     <File Include="@(ArchitectureSpecificNativeFile)">
       <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
+      <IsNative>true</IsNative>
     </File>
     <File Include="$(VersionTxtFile)" />
   </ItemGroup>

--- a/src/pkg/projects/Microsoft.NETCore.DotNetHost/runtime.Linux.Microsoft.NETCore.DotNetHost.props
+++ b/src/pkg/projects/Microsoft.NETCore.DotNetHost/runtime.Linux.Microsoft.NETCore.DotNetHost.props
@@ -5,6 +5,7 @@
 
     <File Include="@(ArchitectureSpecificNativeFile)">
       <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
+      <IsNative>true</IsNative>
     </File>
     <File Include="$(VersionTxtFile)" />
   </ItemGroup>

--- a/src/pkg/projects/Microsoft.NETCore.DotNetHost/runtime.OSX.Microsoft.NETCore.DotNetHost.props
+++ b/src/pkg/projects/Microsoft.NETCore.DotNetHost/runtime.OSX.Microsoft.NETCore.DotNetHost.props
@@ -5,6 +5,7 @@
 
     <File Include="@(ArchitectureSpecificNativeFile)">
       <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
+      <IsNative>true</IsNative>
     </File>
     <File Include="$(VersionTxtFile)" />
   </ItemGroup>

--- a/src/pkg/projects/Microsoft.NETCore.DotNetHost/runtime.Windows_NT.Microsoft.NETCore.DotNetHost.props
+++ b/src/pkg/projects/Microsoft.NETCore.DotNetHost/runtime.Windows_NT.Microsoft.NETCore.DotNetHost.props
@@ -5,6 +5,7 @@
 
     <File Include="@(ArchitectureSpecificNativeFile)">
       <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
+      <IsNative>true</IsNative>
     </File>
     <File Include="$(VersionTxtFile)" />
   </ItemGroup>

--- a/src/pkg/projects/Microsoft.NETCore.DotNetHostPolicy/runtime.FreeBSD.Microsoft.NETCore.DotNetHostPolicy.props
+++ b/src/pkg/projects/Microsoft.NETCore.DotNetHostPolicy/runtime.FreeBSD.Microsoft.NETCore.DotNetHostPolicy.props
@@ -5,6 +5,7 @@
 
     <File Include="@(ArchitectureSpecificNativeFile)">
       <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
+      <IsNative>true</IsNative>
     </File>
     <File Include="$(VersionTxtFile)" />
   </ItemGroup>

--- a/src/pkg/projects/Microsoft.NETCore.DotNetHostPolicy/runtime.Linux.Microsoft.NETCore.DotNetHostPolicy.props
+++ b/src/pkg/projects/Microsoft.NETCore.DotNetHostPolicy/runtime.Linux.Microsoft.NETCore.DotNetHostPolicy.props
@@ -5,6 +5,7 @@
 
     <File Include="@(ArchitectureSpecificNativeFile)">
       <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
+      <IsNative>true</IsNative>
     </File>
     <File Include="$(VersionTxtFile)" />
   </ItemGroup>

--- a/src/pkg/projects/Microsoft.NETCore.DotNetHostPolicy/runtime.OSX.Microsoft.NETCore.DotNetHostPolicy.props
+++ b/src/pkg/projects/Microsoft.NETCore.DotNetHostPolicy/runtime.OSX.Microsoft.NETCore.DotNetHostPolicy.props
@@ -5,6 +5,7 @@
 
     <File Include="@(ArchitectureSpecificNativeFile)">
       <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
+      <IsNative>true</IsNative>
     </File>
     <File Include="$(VersionTxtFile)" />
   </ItemGroup>

--- a/src/pkg/projects/Microsoft.NETCore.DotNetHostPolicy/runtime.Windows_NT.Microsoft.NETCore.DotNetHostPolicy.props
+++ b/src/pkg/projects/Microsoft.NETCore.DotNetHostPolicy/runtime.Windows_NT.Microsoft.NETCore.DotNetHostPolicy.props
@@ -5,6 +5,7 @@
 
     <File Include="@(ArchitectureSpecificNativeFile)">
       <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
+      <IsNative>true</IsNative>
     </File>
     <File Include="$(VersionTxtFile)" />
   </ItemGroup>

--- a/src/pkg/projects/Microsoft.NETCore.DotNetHostResolver/runtime.FreeBSD.Microsoft.NETCore.DotNetHostResolver.props
+++ b/src/pkg/projects/Microsoft.NETCore.DotNetHostResolver/runtime.FreeBSD.Microsoft.NETCore.DotNetHostResolver.props
@@ -5,6 +5,7 @@
 
     <File Include="@(ArchitectureSpecificNativeFile)">
       <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
+      <IsNative>true</IsNative>
     </File>
     <File Include="$(VersionTxtFile)" />
   </ItemGroup>

--- a/src/pkg/projects/Microsoft.NETCore.DotNetHostResolver/runtime.Linux.Microsoft.NETCore.DotNetHostResolver.props
+++ b/src/pkg/projects/Microsoft.NETCore.DotNetHostResolver/runtime.Linux.Microsoft.NETCore.DotNetHostResolver.props
@@ -5,6 +5,7 @@
 
     <File Include="@(ArchitectureSpecificNativeFile)">
       <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
+      <IsNative>true</IsNative>
     </File>
     <File Include="$(VersionTxtFile)" />
   </ItemGroup>

--- a/src/pkg/projects/Microsoft.NETCore.DotNetHostResolver/runtime.OSX.Microsoft.NETCore.DotNetHostResolver.props
+++ b/src/pkg/projects/Microsoft.NETCore.DotNetHostResolver/runtime.OSX.Microsoft.NETCore.DotNetHostResolver.props
@@ -5,6 +5,7 @@
 
     <File Include="@(ArchitectureSpecificNativeFile)">
       <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
+      <IsNative>true</IsNative>
     </File>
     <File Include="$(VersionTxtFile)" />
   </ItemGroup>

--- a/src/pkg/projects/Microsoft.NETCore.DotNetHostResolver/runtime.Windows_NT.Microsoft.NETCore.DotNetHostResolver.props
+++ b/src/pkg/projects/Microsoft.NETCore.DotNetHostResolver/runtime.Windows_NT.Microsoft.NETCore.DotNetHostResolver.props
@@ -5,6 +5,7 @@
 
     <File Include="@(ArchitectureSpecificNativeFile)">
       <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
+      <IsNative>true</IsNative>
     </File>
     <File Include="$(VersionTxtFile)" />
   </ItemGroup>

--- a/src/pkg/projects/dir.targets
+++ b/src/pkg/projects/dir.targets
@@ -245,7 +245,8 @@
               '$(PackageTargetRuntime)' == '$(PackageRID)'
             )">
     <PropertyGroup>
-      <FrameworkListFile>$(IntermediateOutputPath)FrameworkList.xml</FrameworkListFile>
+      <FrameworkListFilename Condition="'$(FrameworkListFilename)' == ''">FrameworkList.xml</FrameworkListFilename>
+      <FrameworkListFile>$(IntermediateOutputPath)$(FrameworkListFilename)</FrameworkListFile>
     </PropertyGroup>
 
     <ItemGroup>


### PR DESCRIPTION
In runtime packs, change FrameworkList.xml to RuntimeList.xml.

Remove Framework/Runtime list from AppHost pack.

Add IsNative=true to host files to fix missing entries. These items are duplicated: for now, make an expedient fix in the list generation code.

Add Resources type, with annotated Culture.

---

Running a mock official build now to compare across all platforms, I only tested locally on win-x64. This is what I got: https://gist.github.com/dagood/362350180250b244c618dd572599a679.

Resolves https://github.com/dotnet/core-setup/issues/6786, resolves https://github.com/dotnet/core-setup/issues/6768, resolves https://github.com/dotnet/core-setup/issues/6764.