### PR TITLE
Small improvements to Unix PAL

### DIFF
--- a/src/corehost/common/pal.unix.cpp
+++ b/src/corehost/common/pal.unix.cpp
@@ -811,11 +811,12 @@ static void readdir(const pal::string_t& path, const pal::string_t& pattern, boo
                 continue;
             }
 
-            pal::string_t filepath(entry->d_name);
-            if (filepath != _X(".") && filepath != _X(".."))
+            if (!strcmp(entry->d_name, ".") || !strcmp(entry->d_name, ".."))
             {
-                files.push_back(filepath);
+                continue;
             }
+
+            files.emplace_back(entry->d_name);
         }
 
         closedir(dir);

--- a/src/corehost/common/pal.unix.cpp
+++ b/src/corehost/common/pal.unix.cpp
@@ -785,14 +785,9 @@ static void readdir(const pal::string_t& path, const pal::string_t& pattern, boo
             case DT_LNK:
             case DT_UNKNOWN:
                 {
-                    std::string fullFilename;
-
-                    fullFilename.append(path);
-                    fullFilename.push_back(DIR_SEPARATOR);
-                    fullFilename.append(entry->d_name);
-
                     struct stat sb;
-                    if (stat(fullFilename.c_str(), &sb) == -1)
+
+                    if (fstatat(dirfd(dir), entry->d_name, &sb, 0) == -1)
                     {
                         continue;
                     }

--- a/src/corehost/common/pal.unix.cpp
+++ b/src/corehost/common/pal.unix.cpp
@@ -743,12 +743,7 @@ bool pal::realpath(pal::string_t* path, bool skip_error_logging)
 
 bool pal::file_exists(const pal::string_t& path)
 {
-    if (path.empty())
-    {
-        return false;
-    }
-    struct stat buffer;
-    return (::stat(path.c_str(), &buffer) == 0);
+    return (::access(path.c_str(), F_OK) == 0);
 }
 
 static void readdir(const pal::string_t& path, const pal::string_t& pattern, bool onlydirectories, std::vector<pal::string_t>* list)


### PR DESCRIPTION
This PR makes some small changes to the Unix version of the PAL:

- Uses `fstatat(2)` instead of building a temporary `std::string` while reading directories
- Uses `access(2)` to determine the existence of a file/directory (no need to validate/fill in a `struct stat`)
- Construct the `pal::string_t` entry in `pal::readdir()` in place using `emplace_back()`