### PR TITLE
Lazily evaluate tracer arguments

### DIFF
--- a/src/corehost/cli/apphost/bundle/bundle_runner.cpp
+++ b/src/corehost/cli/apphost/bundle/bundle_runner.cpp
@@ -13,8 +13,8 @@ void bundle_runner_t::seek(FILE* stream, long offset, int origin)
 {
     if (fseek(stream, offset, origin) != 0)
     {
-        trace::error(_X("Failure processing application bundle; possible file corruption."));
-        trace::error(_X("I/O seek failure within the bundle."));
+        TRACE_ERROR(_X("Failure processing application bundle; possible file corruption."));
+        TRACE_ERROR(_X("I/O seek failure within the bundle."));
         throw StatusCode::BundleExtractionIOError;
     }
 }
@@ -23,8 +23,8 @@ void bundle_runner_t::write(const void* buf, size_t size, FILE *stream)
 {
     if (fwrite(buf, 1, size, stream) != size)
     {
-        trace::error(_X("Failure extracting contents of the application bundle."));
-        trace::error(_X("I/O failure when writing extracted files."));
+        TRACE_ERROR(_X("Failure extracting contents of the application bundle."));
+        TRACE_ERROR(_X("I/O failure when writing extracted files."));
         throw StatusCode::BundleExtractionIOError;
     }
 }
@@ -33,8 +33,8 @@ void bundle_runner_t::read(void* buf, size_t size, FILE* stream)
 {
     if (fread(buf, 1, size, stream) != size)
     {
-        trace::error(_X("Failure processing application bundle; possible file corruption."));
-        trace::error(_X("I/O failure reading contents of the bundle."));
+        TRACE_ERROR(_X("Failure processing application bundle; possible file corruption."));
+        TRACE_ERROR(_X("I/O failure reading contents of the bundle."));
         throw StatusCode::BundleExtractionIOError;
     }
 }
@@ -58,8 +58,8 @@ size_t bundle_runner_t::get_path_length(int8_t first_byte, FILE* stream)
         if (second_byte & 0x80)
         {
             // There can be no more than two bytes in path_length
-            trace::error(_X("Failure processing application bundle; possible file corruption."));
-            trace::error(_X("Path length encoding read beyond two bytes"));
+            TRACE_ERROR(_X("Failure processing application bundle; possible file corruption."));
+            TRACE_ERROR(_X("Path length encoding read beyond two bytes"));
 
             throw StatusCode::BundleExtractionFailure;
         }
@@ -69,8 +69,8 @@ size_t bundle_runner_t::get_path_length(int8_t first_byte, FILE* stream)
 
     if (length <= 0 || length > PATH_MAX)
     {
-        trace::error(_X("Failure processing application bundle; possible file corruption."));
-        trace::error(_X("Path length is zero or too long"));
+        TRACE_ERROR(_X("Failure processing application bundle; possible file corruption."));
+        TRACE_ERROR(_X("Path length is zero or too long"));
         throw StatusCode::BundleExtractionFailure;
     }
 
@@ -117,8 +117,8 @@ static void create_directory_tree(const pal::string_t &path)
             return;
         }
 
-        trace::error(_X("Failure processing application bundle."));
-        trace::error(_X("Failed to create directory [%s] for extracting bundled files"), path.c_str());
+        TRACE_ERROR(_X("Failure processing application bundle."));
+        TRACE_ERROR(_X("Failed to create directory [%s] for extracting bundled files"), path.c_str());
         throw StatusCode::BundleExtractionIOError;
     }
 }
@@ -145,13 +145,13 @@ static void remove_directory_tree(const pal::string_t& path)
     {
         if (!pal::remove(file.c_str()))
         {
-            trace::warning(_X("Failed to remove temporary file [%s]."), file.c_str());
+            TRACE_WARNING(_X("Failed to remove temporary file [%s]."), file.c_str());
         }
     }
 
     if (!pal::rmdir(path.c_str()))
     {
-        trace::warning(_X("Failed to remove temporary directory [%s]."), path.c_str());
+        TRACE_WARNING(_X("Failed to remove temporary directory [%s]."), path.c_str());
     }
 }
 
@@ -160,8 +160,8 @@ void bundle_runner_t::reopen_host_for_reading()
     m_bundle_stream = pal::file_open(m_bundle_path, _X("rb"));
     if (m_bundle_stream == nullptr)
     {
-        trace::error(_X("Failure processing application bundle."));
-        trace::error(_X("Couldn't open host binary for reading contents"));
+        TRACE_ERROR(_X("Failure processing application bundle."));
+        TRACE_ERROR(_X("Couldn't open host binary for reading contents"));
         throw StatusCode::BundleExtractionIOError;
     }
 }
@@ -177,7 +177,7 @@ bool bundle_runner_t::process_manifest_footer(int64_t &header_offset)
 
     if (!footer->is_valid())
     {
-        trace::info(_X("This executable is not recognized as a .net core bundle."));
+        TRACE_INFO(_X("This executable is not recognized as a .net core bundle."));
         return false;
     }
 
@@ -206,8 +206,8 @@ void bundle_runner_t::determine_extraction_dir()
     {
         if (!pal::get_temp_directory(m_extraction_dir))
         {
-            trace::error(_X("Failure processing application bundle."));
-            trace::error(_X("Failed to determine location for extracting embedded files"));
+            TRACE_ERROR(_X("Failure processing application bundle."));
+            TRACE_ERROR(_X("Failed to determine location for extracting embedded files"));
             throw StatusCode::BundleExtractionFailure;
         }
 
@@ -218,7 +218,7 @@ void bundle_runner_t::determine_extraction_dir()
     append_path(&m_extraction_dir, host_name.c_str());
     append_path(&m_extraction_dir, m_bundle_id.c_str());
 
-    trace::info(_X("Files embedded within the bundled will be extracted to [%s] directory"), m_extraction_dir.c_str());
+    TRACE_INFO(_X("Files embedded within the bundled will be extracted to [%s] directory"), m_extraction_dir.c_str());
 }
 
 // Compute the worker extraction location for this process, before the 
@@ -234,7 +234,7 @@ void bundle_runner_t::create_working_extraction_dir()
 
     create_directory_tree(m_working_extraction_dir);
 
-    trace::info(_X("Temporary directory used to extract bundled files is [%s]"), m_working_extraction_dir.c_str());
+    TRACE_INFO(_X("Temporary directory used to extract bundled files is [%s]"), m_working_extraction_dir.c_str());
 }
 
 // Create a file to be extracted out on disk, including any intermediate sub-directories.
@@ -254,8 +254,8 @@ FILE* bundle_runner_t::create_extraction_file(const pal::string_t& relative_path
 
     if (file == nullptr)
     {
-        trace::error(_X("Failure processing application bundle."));
-        trace::error(_X("Failed to open file [%s] for writing"), file_path.c_str());
+        TRACE_ERROR(_X("Failure processing application bundle."));
+        TRACE_ERROR(_X("Failed to open file [%s] for writing"), file_path.c_str());
         throw StatusCode::BundleExtractionIOError;
     }
 
@@ -358,14 +358,14 @@ StatusCode bundle_runner_t::extract()
             {
                 // Another process successfully extracted the dependencies
 
-                trace::info(_X("Extraction completed by another process, aborting current extracion."));
+                TRACE_INFO(_X("Extraction completed by another process, aborting current extracion."));
 
                 remove_directory_tree(m_working_extraction_dir);
                 return StatusCode::Success;
             }
 
-            trace::error(_X("Failure processing application bundle."));
-            trace::error(_X("Failed to commit extracted to files to directory [%s]"), m_extraction_dir.c_str());
+            TRACE_ERROR(_X("Failure processing application bundle."));
+            TRACE_ERROR(_X("Failed to commit extracted to files to directory [%s]"), m_extraction_dir.c_str());
             throw StatusCode::BundleExtractionFailure;
         }
 

--- a/src/corehost/cli/apphost/bundle/file_entry.cpp
+++ b/src/corehost/cli/apphost/bundle/file_entry.cpp
@@ -24,8 +24,8 @@ file_entry_t* file_entry_t::read(FILE* stream)
     bundle_runner_t::read(&entry->m_data, sizeof(entry->m_data), stream);
     if (!entry->is_valid())
     {
-        trace::error(_X("Failure processing application bundle; possible file corruption."));
-        trace::error(_X("Invalid FileEntry detected."));
+        TRACE_ERROR(_X("Failure processing application bundle; possible file corruption."));
+        TRACE_ERROR(_X("Invalid FileEntry detected."));
         throw StatusCode::BundleExtractionFailure;
     }
 

--- a/src/corehost/cli/apphost/bundle/manifest.cpp
+++ b/src/corehost/cli/apphost/bundle/manifest.cpp
@@ -25,8 +25,8 @@ manifest_header_t* manifest_header_t::read(FILE* stream)
     bundle_runner_t::read(&header->m_data, sizeof(header->m_data), stream);
     if (!header->is_valid())
     {
-        trace::error(_X("Failure processing application bundle."));
-        trace::error(_X("Manifest header version compatibility check failed"));
+        TRACE_ERROR(_X("Failure processing application bundle."));
+        TRACE_ERROR(_X("Manifest header version compatibility check failed"));
 
         throw StatusCode::BundleExtractionFailure;
     }

--- a/src/corehost/cli/comhost/clsidmap.cpp
+++ b/src/corehost/cli/comhost/clsidmap.cpp
@@ -55,7 +55,7 @@ namespace
         }
         catch (const json::json_exception&)
         {
-            trace::error(_X("Embedded .clsidmap format is invalid"));
+            TRACE_ERROR(_X("Embedded .clsidmap format is invalid"));
             throw HResultException{ StatusCode::InvalidConfigFile };
         }
 
@@ -71,7 +71,7 @@ namespace
             if (FAILED(hr))
             {
                 assert(false && "Invalid CLSID");
-                trace::error(_X("Invalid CLSID format in .clsidmap"));
+                TRACE_ERROR(_X("Invalid CLSID format in .clsidmap"));
                 continue;
             }
 
@@ -182,7 +182,7 @@ namespace
 
         if (!is_binary_unsigned(this_module))
         {
-            trace::verbose(_X("Binary is signed, disabling loose .clsidmap file discovery"));
+            TRACE_VERBOSE(_X("Binary is signed, disabling loose .clsidmap file discovery"));
             return {};
         }
 
@@ -223,11 +223,11 @@ clsid_map comhost::get_clsid_map()
     clsid_map mapping = get_json_map_from_resource(found_resource);
     if (!found_resource && mapping.empty())
     {
-        trace::verbose(_X("JSON map resource stream not found"));
+        TRACE_VERBOSE(_X("JSON map resource stream not found"));
 
         mapping = get_json_map_from_file();
         if (mapping.empty())
-            trace::verbose(_X("JSON map .clsidmap file not found"));
+            TRACE_VERBOSE(_X("JSON map .clsidmap file not found"));
     }
 
     // Make a copy to retain

--- a/src/corehost/cli/comhost/comhost.cpp
+++ b/src/corehost/cli/comhost/comhost.cpp
@@ -324,7 +324,7 @@ COM_API HRESULT STDMETHODCALLTYPE DllRegisterServer(void)
     clsid_map map;
     RETURN_HRESULT_IF_EXCEPT(map = comhost::get_clsid_map());
 
-    trace::info(_X("Registering %d CLSIDs"), (int)map.size());
+    TRACE_INFO(_X("Registering %d CLSIDs"), (int)map.size());
 
     HRESULT hr;
     pal::string_t app_path;
@@ -368,7 +368,7 @@ COM_API HRESULT STDMETHODCALLTYPE DllUnregisterServer(void)
     clsid_map map;
     RETURN_HRESULT_IF_EXCEPT(map = comhost::get_clsid_map());
 
-    trace::info(_X("Unregistering %d CLSIDs"), (int)map.size());
+    TRACE_INFO(_X("Unregistering %d CLSIDs"), (int)map.size());
 
     HRESULT hr;
     pal::string_t app_path;

--- a/src/corehost/cli/deps_entry.cpp
+++ b/src/corehost/cli/deps_entry.cpp
@@ -40,12 +40,12 @@ bool deps_entry_t::to_path(const pal::string_t& base, bool look_in_base, pal::st
     const pal::char_t* query_type = look_in_base ? _X("Local") : _X("Relative");
     if (!exists)
     {
-        trace::verbose(_X("    %s path query did not exist %s"), query_type, candidate.c_str());
+        TRACE_VERBOSE(_X("    %s path query did not exist %s"), query_type, candidate.c_str());
         candidate.clear();
     }
     else
     {
-        trace::verbose(_X("    %s path query exists %s"), query_type, candidate.c_str());
+        TRACE_VERBOSE(_X("    %s path query exists %s"), query_type, candidate.c_str());
     }
     return exists;
 }
@@ -84,7 +84,7 @@ bool deps_entry_t::to_dir_path(const pal::string_t& base, pal::string_t* str) co
         
         pal::string_t base_ietf_dir = base;
         append_path(&base_ietf_dir, ietf.c_str());
-        trace::verbose(_X("Detected a resource asset, will query dir/ietf-tag/resource base: %s asset: %s"), base_ietf_dir.c_str(), asset.name.c_str());
+        TRACE_VERBOSE(_X("Detected a resource asset, will query dir/ietf-tag/resource base: %s asset: %s"), base_ietf_dir.c_str(), asset.name.c_str());
         return to_path(base_ietf_dir, true, str);
     }
     return to_path(base, true, str);

--- a/src/corehost/cli/deps_format.cpp
+++ b/src/corehost/cli/deps_format.cpp
@@ -121,7 +121,7 @@ void deps_json_t::reconcile_libraries_with_targets(
                         [deps_entry_t::asset_types::runtime].size() - 1;
                 }
 
-                TRACE_INFO(_X("Parsed %s deps entry %d for asset name: %s from %s: %s, library version: %s, relpath: %s, assemblyVersion %s, fileVersion %s"),
+                TRACE_INFO(_X("Parsed %s deps entry %zu for asset name: %s from %s: %s, library version: %s, relpath: %s, assemblyVersion %s, fileVersion %s"),
                     deps_entry_t::s_known_asset_types[i],
                     m_deps_entries[i].size() - 1,
                     entry.asset.name.c_str(),

--- a/src/corehost/cli/deps_format.cpp
+++ b/src/corehost/cli/deps_format.cpp
@@ -67,11 +67,11 @@ void deps_json_t::reconcile_libraries_with_targets(
     const auto& libraries = json.at(_X("libraries")).as_object();
     for (const auto& library : libraries)
     {
-        trace::info(_X("Reconciling library %s"), library.first.c_str());
+        TRACE_INFO(_X("Reconciling library %s"), library.first.c_str());
 
         if (!library_exists_fn(library.first))
         {
-            trace::info(_X("Library %s does not exist"), library.first.c_str());
+            TRACE_INFO(_X("Library %s does not exist"), library.first.c_str());
             continue;
         }
 
@@ -121,7 +121,7 @@ void deps_json_t::reconcile_libraries_with_targets(
                         [deps_entry_t::asset_types::runtime].size() - 1;
                 }
 
-                trace::info(_X("Parsed %s deps entry %d for asset name: %s from %s: %s, library version: %s, relpath: %s, assemblyVersion %s, fileVersion %s"),
+                TRACE_INFO(_X("Parsed %s deps entry %d for asset name: %s from %s: %s, library version: %s, relpath: %s, assemblyVersion %s, fileVersion %s"),
                     deps_entry_t::s_known_asset_types[i],
                     m_deps_entries[i].size() - 1,
                     entry.asset.name.c_str(),
@@ -150,7 +150,7 @@ pal::string_t deps_json_t::get_current_rid(const rid_fallback_graph_t& rid_fallb
         }
     }
     
-    trace::info(_X("HostRID is %s"), currentRid.empty()? _X("not available"): currentRid.c_str());
+    TRACE_INFO(_X("HostRID is %s"), currentRid.empty()? _X("not available"): currentRid.c_str());
 
     // If the current RID is not present in the RID fallback graph, then the platform
     // is unknown to us. At this point, we will fallback to using the base RIDs and attempt
@@ -161,7 +161,7 @@ pal::string_t deps_json_t::get_current_rid(const rid_fallback_graph_t& rid_fallb
     {
         currentRid = pal::get_current_os_fallback_rid() + pal::string_t(_X("-")) + get_arch();
 
-        trace::info(_X("Falling back to base HostRID: %s"), currentRid.c_str());
+        TRACE_INFO(_X("Falling back to base HostRID: %s"), currentRid.c_str());
     }
 
     return currentRid;
@@ -182,7 +182,7 @@ bool deps_json_t::perform_rid_fallback(rid_specific_assets_t* portable_assets, c
                 auto rid_fallback_iter = rid_fallback_graph.find(host_rid);
                 if (rid_fallback_iter == rid_fallback_graph.end())
                 {
-                    trace::warning(_X("The targeted framework does not support the runtime '%s'. Some native libraries from [%s] may fail to load on this platform."), host_rid.c_str(), package.first.c_str());
+                    TRACE_WARNING(_X("The targeted framework does not support the runtime '%s'. Some native libraries from [%s] may fail to load on this platform."), host_rid.c_str(), package.first.c_str());
                 }
                 else
                 {
@@ -206,7 +206,7 @@ bool deps_json_t::perform_rid_fallback(rid_specific_assets_t* portable_assets, c
             {
                 if (iter->first != matched_rid)
                 {
-                    trace::verbose(
+                    TRACE_VERBOSE(
                         _X("Chose %s, so removing rid (%s) specific assets for package %s and asset type %s"),
                         matched_rid.c_str(),
                         iter->first.c_str(),
@@ -265,7 +265,7 @@ bool deps_json_t::process_runtime_targets(const json_value& json, const pal::str
 
                     deps_asset_t asset(get_filename_without_ext(file.first), file.first, assembly_version, file_version);
 
-                    trace::info(_X("Adding runtimeTargets %s asset %s rid=%s assemblyVersion=%s fileVersion=%s from %s"),
+                    TRACE_INFO(_X("Adding runtimeTargets %s asset %s rid=%s assemblyVersion=%s fileVersion=%s from %s"),
                         deps_entry_t::s_known_asset_types[asset_type_index],
                         asset.relative_path.c_str(),
                         rid.c_str(),
@@ -317,7 +317,7 @@ bool deps_json_t::process_targets(const json_value& json, const pal::string_t& t
 
                     deps_asset_t asset(get_filename_without_ext(file.first), file.first, assembly_version, file_version);
 
-                    trace::info(_X("Adding %s asset %s assemblyVersion=%s fileVersion=%s from %s"),
+                    TRACE_INFO(_X("Adding %s asset %s assemblyVersion=%s fileVersion=%s from %s"),
                         deps_entry_t::s_known_asset_types[i],
                         asset.relative_path.c_str(),
                         asset.assembly_version.as_str().c_str(),
@@ -363,7 +363,7 @@ bool deps_json_t::load_framework_dependent(const pal::string_t& deps_path, const
                 return assets_for_type;
             }
 
-            trace::verbose(_X("There were no rid specific %s asset for %s"), deps_entry_t::s_known_asset_types[asset_type_index], package.c_str());
+            TRACE_VERBOSE(_X("There were no rid specific %s asset for %s"), deps_entry_t::s_known_asset_types[asset_type_index], package.c_str());
         }
 
         if (m_assets.libs.count(package))
@@ -413,17 +413,17 @@ bool deps_json_t::load_self_contained(const pal::string_t& deps_path, const json
 
     if (trace::is_enabled())
     {
-        trace::verbose(_X("The rid fallback graph is: {"));
+        TRACE_VERBOSE(_X("The rid fallback graph is: {"));
         for (const auto& rid : m_rid_fallback_graph)
         {
-            trace::verbose(_X("%s => ["), rid.first.c_str());
+            TRACE_VERBOSE(_X("%s => ["), rid.first.c_str());
             for (const auto& fallback : rid.second)
             {
-                trace::verbose(_X("%s, "), fallback.c_str());
+                TRACE_VERBOSE(_X("%s, "), fallback.c_str());
             }
-            trace::verbose(_X("]"));
+            TRACE_VERBOSE(_X("]"));
         }
-        trace::verbose(_X("}"));
+        TRACE_VERBOSE(_X("}"));
     }
     return true;
 }
@@ -461,7 +461,7 @@ bool deps_json_t::load(bool is_framework_dependent, const pal::string_t& deps_pa
     // If file doesn't exist, then assume parsed.
     if (!m_file_exists)
     {
-        trace::verbose(_X("Could not locate the dependencies manifest file [%s]. Some libraries may fail to resolve."), deps_path.c_str());
+        TRACE_VERBOSE(_X("Could not locate the dependencies manifest file [%s]. Some libraries may fail to resolve."), deps_path.c_str());
         return true;
     }
 
@@ -469,13 +469,13 @@ bool deps_json_t::load(bool is_framework_dependent, const pal::string_t& deps_pa
     pal::ifstream_t file(deps_path);
     if (!file.good())
     {
-        trace::error(_X("Could not open dependencies manifest file [%s]"), deps_path.c_str());
+        TRACE_ERROR(_X("Could not open dependencies manifest file [%s]"), deps_path.c_str());
         return false;
     }
 
     if (skip_utf8_bom(&file))
     {
-        trace::verbose(_X("UTF-8 BOM skipped while reading [%s]"), deps_path.c_str());
+        TRACE_VERBOSE(_X("UTF-8 BOM skipped while reading [%s]"), deps_path.c_str());
     }
 
     try
@@ -488,7 +488,7 @@ bool deps_json_t::load(bool is_framework_dependent, const pal::string_t& deps_pa
             runtime_target.as_string():
             runtime_target.at(_X("name")).as_string();
 
-        trace::verbose(_X("Loading deps file... %s as framework dependent=[%d]"), deps_path.c_str(), is_framework_dependent);
+        TRACE_VERBOSE(_X("Loading deps file... %s as framework dependent=[%d]"), deps_path.c_str(), is_framework_dependent);
 
         return (is_framework_dependent) ? load_framework_dependent(deps_path, json, name, rid_fallback_graph) : load_self_contained(deps_path, json, name);
     }
@@ -496,7 +496,7 @@ bool deps_json_t::load(bool is_framework_dependent, const pal::string_t& deps_pa
     {
         pal::string_t jes;
         (void) pal::utf8_palstring(je.what(), &jes);
-        trace::error(_X("A JSON parsing exception occurred in [%s]: %s"), deps_path.c_str(), jes.c_str());
+        TRACE_ERROR(_X("A JSON parsing exception occurred in [%s]: %s"), deps_path.c_str(), jes.c_str());
         return false;
     }
 }

--- a/src/corehost/cli/fxr/command_line.cpp
+++ b/src/corehost/cli/fxr/command_line.cpp
@@ -101,7 +101,7 @@ namespace
                 return false;
             }
 
-            trace::verbose(_X("Parsed known arg %s = %s"), arg.c_str(), argv[arg_i + 1]);
+            TRACE_VERBOSE(_X("Parsed known arg %s = %s"), arg.c_str(), argv[arg_i + 1]);
             (*opts)[*iter].push_back(argv[arg_i + 1]);
 
             // Increment for both the option and its value.
@@ -130,11 +130,11 @@ namespace
         int num_parsed = 0;
         if (!parse_known_args(argc - argoff, &argv[argoff], known_opts, &opts, &num_parsed))
         {
-            trace::error(_X("Failed to parse supported options or their values:"));
+            TRACE_ERROR(_X("Failed to parse supported options or their values:"));
             for (const auto& opt : known_opts)
             {
                 const host_option &arg = get_host_option(opt);
-                trace::error(_X("  %-37s  %s"), (arg.option + _X(" ") + arg.argument).c_str(), arg.description.c_str());
+                TRACE_ERROR(_X("  %-37s  %s"), (arg.option + _X(" ") + arg.argument).c_str(), arg.description.c_str());
             }
             return StatusCode::InvalidArgFailure;
         }
@@ -148,7 +148,7 @@ namespace
         }
         else
         {
-            trace::verbose(_X("Using the provided arguments to determine the application to execute."));
+            TRACE_VERBOSE(_X("Using the provided arguments to determine the application to execute."));
             if (*new_argoff >= argc)
             {
                 command_line::print_muxer_usage(!is_sdk_dir_present(host_info.dotnet_root));
@@ -160,7 +160,7 @@ namespace
             bool is_app_managed = ends_with(app_candidate, _X(".dll"), false) || ends_with(app_candidate, _X(".exe"), false);
             if (!is_app_managed)
             {
-                trace::verbose(_X("Application '%s' is not a managed executable."), app_candidate.c_str());
+                TRACE_VERBOSE(_X("Application '%s' is not a managed executable."), app_candidate.c_str());
                 if (!exec_mode)
                 {
                     // Route to CLI.
@@ -171,7 +171,7 @@ namespace
             doesAppExist = pal::realpath(&app_candidate);
             if (!doesAppExist)
             {
-                trace::verbose(_X("Application '%s' does not exist."), app_candidate.c_str());
+                TRACE_VERBOSE(_X("Application '%s' does not exist."), app_candidate.c_str());
                 if (!exec_mode)
                 {
                     // Route to CLI.
@@ -182,7 +182,7 @@ namespace
             if (!is_app_managed && doesAppExist)
             {
                 assert(exec_mode == true);
-                trace::error(_X("dotnet exec needs a managed .dll or .exe extension. The application specified was '%s'"), app_candidate.c_str());
+                TRACE_ERROR(_X("dotnet exec needs a managed .dll or .exe extension. The application specified was '%s'"), app_candidate.c_str());
                 return StatusCode::InvalidArgFailure;
             }
         }
@@ -190,7 +190,7 @@ namespace
         // App is managed executable.
         if (!doesAppExist)
         {
-            trace::error(_X("The application to execute does not exist: '%s'"), app_candidate.c_str());
+            TRACE_ERROR(_X("The application to execute does not exist: '%s'"), app_candidate.c_str());
             return StatusCode::InvalidArgFailure;
         }
 
@@ -231,20 +231,20 @@ int command_line::parse_args_for_mode(
     if (mode == host_mode_t::split_fx)
     {
         // Invoked as corehost
-        trace::verbose(_X("--- Executing in split/FX mode..."));
+        TRACE_VERBOSE(_X("--- Executing in split/FX mode..."));
         result = parse_args(host_info, argoff, argc, argv, false, mode, new_argoff, app_candidate, opts);
     }
     else if (mode == host_mode_t::apphost)
     {
         // Invoked from the application base.
-        trace::verbose(_X("--- Executing in a native executable mode..."));
+        TRACE_VERBOSE(_X("--- Executing in a native executable mode..."));
         result = parse_args(host_info, argoff, argc, argv, false, mode, new_argoff, app_candidate, opts);
     }
     else
     {
         // Invoked as the dotnet.exe muxer.
         assert(mode == host_mode_t::muxer);
-        trace::verbose(_X("--- Executing in muxer mode..."));
+        TRACE_VERBOSE(_X("--- Executing in muxer mode..."));
 
         if (argc <= argoff)
         {

--- a/src/corehost/cli/fxr/framework_info.cpp
+++ b/src/corehost/cli/fxr/framework_info.cpp
@@ -57,7 +57,7 @@ bool compare_by_name_and_version(const framework_info &a, const framework_info &
 
                 if (pal::directory_exists(fx_dir))
                 {
-                    trace::verbose(_X("Gathering FX locations in [%s]"), fx_dir.c_str());
+                    TRACE_VERBOSE(_X("Gathering FX locations in [%s]"), fx_dir.c_str());
 
                     std::vector<pal::string_t> versions;
                     pal::readdir_onlydirectories(fx_dir, &versions);
@@ -67,7 +67,7 @@ bool compare_by_name_and_version(const framework_info &a, const framework_info &
                         fx_ver_t parsed;
                         if (fx_ver_t::parse(ver, &parsed, false))
                         {
-                            trace::verbose(_X("Found FX version [%s]"), ver.c_str());
+                            TRACE_VERBOSE(_X("Found FX version [%s]"), ver.c_str());
 
                             framework_info info(fx_name, fx_dir, parsed);
                             framework_infos->push_back(info);

--- a/src/corehost/cli/fxr/fx_muxer.cpp
+++ b/src/corehost/cli/fxr/fx_muxer.cpp
@@ -79,7 +79,7 @@ int load_hostpolicy(
     int rc = hostpolicy_resolver::load(lib_dir, h_host, hostpolicy_contract);
     if (rc != StatusCode::Success)
     {
-        trace::error(_X("An error occurred while loading required library %s from [%s]"), LIBHOSTPOLICY_NAME, lib_dir.c_str());
+        TRACE_ERROR(_X("An error occurred while loading required library %s from [%s]"), LIBHOSTPOLICY_NAME, lib_dir.c_str());
         return rc;
     }
 
@@ -103,7 +103,7 @@ static int execute_app(
 
         if (g_active_host_context != nullptr)
         {
-            trace::error(_X("Hosting components are already initialized. Re-initialization to execute an app is not allowed."));
+            TRACE_ERROR(_X("Hosting components are already initialized. Re-initialization to execute an app is not allowed."));
             return StatusCode::HostInvalidState;
         }
 
@@ -197,7 +197,7 @@ void get_runtime_config_paths_from_arg(const pal::string_t& arg, pal::string_t* 
     append_path(&json_path, json_name.c_str());
     append_path(&dev_json_path, dev_json_name.c_str());
 
-    trace::verbose(_X("Runtime config is cfg=%s dev=%s"), json_path.c_str(), dev_json_path.c_str());
+    TRACE_VERBOSE(_X("Runtime config is cfg=%s dev=%s"), json_path.c_str(), dev_json_path.c_str());
 
     dev_cfg->assign(dev_json_path);
     cfg->assign(json_path);
@@ -245,12 +245,12 @@ void append_probe_realpath(const pal::string_t& path, std::vector<pal::string_t>
             }
             else
             {
-                trace::verbose(_X("Ignoring host interpreted additional probing path %s as it does not exist."), probe_path.c_str());
+                TRACE_VERBOSE(_X("Ignoring host interpreted additional probing path %s as it does not exist."), probe_path.c_str());
             }
         }
         else
         {
-            trace::verbose(_X("Ignoring additional probing path %s as it does not exist."), probe_path.c_str());
+            TRACE_VERBOSE(_X("Ignoring additional probing path %s as it does not exist."), probe_path.c_str());
         }
     }
 }
@@ -265,7 +265,7 @@ namespace
     {
         if (!runtime_config.empty() && !pal::realpath(&runtime_config))
         {
-            trace::error(_X("The specified runtimeconfig.json [%s] does not exist"), runtime_config.c_str());
+            TRACE_ERROR(_X("The specified runtimeconfig.json [%s] does not exist"), runtime_config.c_str());
             return StatusCode::InvalidConfigFile;
         }
 
@@ -273,19 +273,19 @@ namespace
 
         if (runtime_config.empty())
         {
-            trace::verbose(_X("App runtimeconfig.json from [%s]"), app_candidate.c_str());
+            TRACE_VERBOSE(_X("App runtimeconfig.json from [%s]"), app_candidate.c_str());
             get_runtime_config_paths_from_app(app_candidate, &config_file, &dev_config_file);
         }
         else
         {
-            trace::verbose(_X("Specified runtimeconfig.json from [%s]"), runtime_config.c_str());
+            TRACE_VERBOSE(_X("Specified runtimeconfig.json from [%s]"), runtime_config.c_str());
             get_runtime_config_paths_from_arg(runtime_config, &config_file, &dev_config_file);
         }
 
         app.parse_runtime_config(config_file, dev_config_file, override_settings);
         if (!app.get_runtime_config().is_valid())
         {
-            trace::error(_X("Invalid runtimeconfig.json [%s] [%s]"), app.get_runtime_config().get_path().c_str(), app.get_runtime_config().get_dev_path().c_str());
+            TRACE_ERROR(_X("Invalid runtimeconfig.json [%s] [%s]"), app.get_runtime_config().get_path().c_str(), app.get_runtime_config().get_dev_path().c_str());
             return StatusCode::InvalidConfigFile;
         }
 
@@ -303,7 +303,7 @@ namespace
             append_path(&deps_in_dotnet_root, deps_filename.c_str());
             bool deps_exists = pal::file_exists(deps_in_dotnet_root);
 
-            trace::info(_X("Detecting mode... CoreCLR present in dotnet root [%s] and checking if [%s] file present=[%d]"),
+            TRACE_INFO(_X("Detecting mode... CoreCLR present in dotnet root [%s] and checking if [%s] file present=[%d]"),
                 host_info.dotnet_root.c_str(), deps_filename.c_str(), deps_exists);
 
             // Name of runtimeconfig file; since no path is included here the check is in the current working directory
@@ -361,7 +361,7 @@ namespace
         pal::string_t deps_file = command_line::get_option_value(opts, known_options::deps_file, _X(""));
         if (!deps_file.empty() && !pal::realpath(&deps_file))
         {
-            trace::error(_X("The specified deps.json [%s] does not exist"), deps_file.c_str());
+            TRACE_ERROR(_X("The specified deps.json [%s] does not exist"), deps_file.c_str());
             return StatusCode::InvalidArgFailure;
         }
 
@@ -386,7 +386,7 @@ namespace
             auto val = roll_forward_option_from_string(roll_forward);
             if (val == roll_forward_option::__Last)
             {
-                trace::error(_X("Invalid value for command line argument '%s'"), command_line::get_option_name(known_options::roll_forward).c_str());
+                TRACE_ERROR(_X("Invalid value for command line argument '%s'"), command_line::get_option_name(known_options::roll_forward).c_str());
                 return StatusCode::InvalidArgFailure;
             }
 
@@ -398,7 +398,7 @@ namespace
         {
             if (override_settings.has_roll_forward)
             {
-                trace::error(_X("It's invalid to use both '%s' and '%s' command line options."),
+                TRACE_ERROR(_X("It's invalid to use both '%s' and '%s' command line options."),
                     command_line::get_option_name(known_options::roll_forward).c_str(),
                     command_line::get_option_name(known_options::roll_forward_on_no_candidate_fx).c_str());
                 return StatusCode::InvalidArgFailure;
@@ -459,7 +459,7 @@ namespace
         std::vector<pal::string_t> spec_probe_paths = opts.count(opts_probe_path) ? opts.find(opts_probe_path)->second : std::vector<pal::string_t>();
         std::vector<pal::string_t> probe_realpaths = get_probe_realpaths(fx_definitions, spec_probe_paths);
 
-        trace::verbose(_X("Executing as a %s app as per config file [%s]"),
+        TRACE_VERBOSE(_X("Executing as a %s app as per config file [%s]"),
             (is_framework_dependent ? _X("framework-dependent") : _X("self-contained")), app_config.get_path().c_str());
 
         if (!hostpolicy_resolver::try_get_dir(mode, host_info.dotnet_root, fx_definitions, app_candidate, deps_file, probe_realpaths, &hostpolicy_dir))
@@ -577,7 +577,7 @@ namespace
         const runtime_config_t app_config = app->get_runtime_config();
         if (!app_config.get_is_framework_dependent())
         {
-            trace::error(_X("Initialization for self-contained components is not supported"));
+            TRACE_ERROR(_X("Initialization for self-contained components is not supported"));
             return StatusCode::InvalidConfigFile;
         }
 
@@ -587,7 +587,7 @@ namespace
 
         const std::vector<pal::string_t> probe_realpaths = get_probe_realpaths(fx_definitions, std::vector<pal::string_t>() /* specified_probing_paths */);
 
-        trace::verbose(_X("Libhost loading occurring for a framework-dependent component per config file [%s]"), app_config.get_path().c_str());
+        TRACE_VERBOSE(_X("Libhost loading occurring for a framework-dependent component per config file [%s]"), app_config.get_path().c_str());
 
         const pal::string_t deps_file;
         if (!hostpolicy_resolver::try_get_dir(mode, host_info.dotnet_root, fx_definitions, host_info.app_path, deps_file, probe_realpaths, &hostpolicy_dir))
@@ -618,7 +618,7 @@ namespace
         const runtime_config_t app_config = app.get_runtime_config();
         if (!app_config.get_is_framework_dependent())
         {
-            trace::error(_X("Initialization for self-contained components is not supported"));
+            TRACE_ERROR(_X("Initialization for self-contained components is not supported"));
             return StatusCode::InvalidConfigFile;
         }
 
@@ -641,7 +641,7 @@ namespace
         int rc = hostpolicy_resolver::load(hostpolicy_dir, &hostpolicy_dll, hostpolicy_contract);
         if (rc != StatusCode::Success)
         {
-            trace::error(_X("An error occurred while loading required library %s from [%s]"), LIBHOSTPOLICY_NAME, hostpolicy_dir.c_str());
+            TRACE_ERROR(_X("An error occurred while loading required library %s from [%s]"), LIBHOSTPOLICY_NAME, hostpolicy_dir.c_str());
         }
         else
         {
@@ -670,7 +670,7 @@ int fx_muxer_t::initialize_for_app(
 
         if (g_active_host_context != nullptr)
         {
-            trace::error(_X("Hosting components are already initialized. Re-initialization for an app is not allowed."));
+            TRACE_ERROR(_X("Hosting components are already initialized. Re-initialization for an app is not allowed."));
             return StatusCode::HostInvalidState;
         }
 
@@ -698,7 +698,7 @@ int fx_muxer_t::initialize_for_app(
     rc = initialize_context(hostpolicy_dir, *init, intialization_options_t::none, context);
     if (rc != StatusCode::Success)
     {
-        trace::error(_X("Failed to initialize context for app: %s. Error code: 0x%x"), host_info.app_path.c_str(), rc);
+        TRACE_ERROR(_X("Failed to initialize context for app: %s. Error code: 0x%x"), host_info.app_path.c_str(), rc);
         return rc;
     }
 
@@ -706,7 +706,7 @@ int fx_muxer_t::initialize_for_app(
     for (int i = 0; i < argc; ++i)
         context->argv.push_back(argv[i]);
 
-    trace::info(_X("Initialized context for app: %s"), host_info.app_path.c_str());
+    TRACE_INFO(_X("Initialized context for app: %s"), host_info.app_path.c_str());
     *host_context_handle = context.release();
     return rc;
 }
@@ -768,13 +768,13 @@ int fx_muxer_t::initialize_for_runtime_config(
 
     if (!STATUS_CODE_SUCCEEDED(rc))
     {
-        trace::error(_X("Failed to initialize context for config: %s. Error code: 0x%x"), runtime_config_path, rc);
+        TRACE_ERROR(_X("Failed to initialize context for config: %s. Error code: 0x%x"), runtime_config_path, rc);
         return rc;
     }
 
     context->is_app = false;
 
-    trace::info(_X("Initialized %s for config: %s"), already_initialized ? _X("secondary context") : _X("context"), runtime_config_path);
+    TRACE_INFO(_X("Initialized %s for config: %s"), already_initialized ? _X("secondary context") : _X("context"), runtime_config_path);
     *host_context_handle = context.release();
     return rc;
 }
@@ -864,7 +864,7 @@ const host_context_t* fx_muxer_t::get_active_host_context()
     const hostpolicy_contract_t &hostpolicy_contract = g_active_host_context->hostpolicy_contract;
     if (hostpolicy_contract.initialize == nullptr)
     {
-        trace::warning(_X("Getting the contract for the initialized hostpolicy is only supprted for .NET Core 3.0 or a higher version."));
+        TRACE_WARNING(_X("Getting the contract for the initialized hostpolicy is only supprted for .NET Core 3.0 or a higher version."));
         return nullptr;
     }
 
@@ -874,7 +874,7 @@ const host_context_t* fx_muxer_t::get_active_host_context()
         int rc = hostpolicy_contract.initialize(nullptr, intialization_options_t::get_contract, &hostpolicy_context_contract);
         if (rc != StatusCode::Success)
         {
-            trace::error(_X("Failed to get contract for existing initialized hostpolicy: 0x%x"), rc);
+            TRACE_ERROR(_X("Failed to get contract for existing initialized hostpolicy: 0x%x"), rc);
             return nullptr;
         }
     }
@@ -932,7 +932,7 @@ int fx_muxer_t::handle_exec_host_command(
         new_argc = vec_argv.size();
     }
 
-    trace::info(_X("Using dotnet root path [%s]"), host_info.dotnet_root.c_str());
+    TRACE_INFO(_X("Using dotnet root path [%s]"), host_info.dotnet_root.c_str());
 
     // Transform dotnet [exec] [--additionalprobingpath path] [--depsfile file] [dll] [args] -> dotnet [dll] [args]
     return read_config_and_execute(
@@ -994,7 +994,7 @@ int fx_muxer_t::handle_cli(
 
     if (!pal::file_exists(sdk_dotnet))
     {
-        trace::error(_X("Found dotnet SDK, but did not find dotnet.dll at [%s]"), sdk_dotnet.c_str());
+        TRACE_ERROR(_X("Found dotnet SDK, but did not find dotnet.dll at [%s]"), sdk_dotnet.c_str());
         return StatusCode::LibHostSdkFindFailure;
     }
 
@@ -1006,7 +1006,7 @@ int fx_muxer_t::handle_cli(
     new_argv.push_back(sdk_dotnet.c_str());
     new_argv.insert(new_argv.end(), argv + 1, argv + argc);
 
-    trace::verbose(_X("Using dotnet SDK dll=[%s]"), sdk_dotnet.c_str());
+    TRACE_VERBOSE(_X("Using dotnet SDK dll=[%s]"), sdk_dotnet.c_str());
 
     int new_argoff;
     pal::string_t app_candidate;

--- a/src/corehost/cli/fxr/fx_resolver.cpp
+++ b/src/corehost/cli/fxr/fx_resolver.cpp
@@ -32,7 +32,7 @@ namespace
                 fx_ref.get_version_compatibility_range() != version_compatibility_range_t::patch
                 && fx_ref.get_roll_to_highest_version();
 
-            trace::verbose(
+            TRACE_VERBOSE(
                 _X("'Roll forward' enabled with version_compatibility_range [%s]. Looking for the %s %s greater than or equal version to [%s]"),
                 version_compatibility_range_to_string(fx_ref.get_version_compatibility_range()).c_str(),
                 roll_to_highest_version ? _X("highest") : _X("lowest"),
@@ -57,11 +57,11 @@ namespace
 
             if (best_match_version == fx_ver_t())
             {
-                trace::verbose(_X("No match greater than or equal to [%s] found."), fx_ref.get_fx_version().c_str());
+                TRACE_VERBOSE(_X("No match greater than or equal to [%s] found."), fx_ref.get_fx_version().c_str());
             }
             else
             {
-                trace::verbose(_X("Found version [%s]"), best_match_version.as_str().c_str());
+                TRACE_VERBOSE(_X("Found version [%s]"), best_match_version.as_str().c_str());
             }
         }
 
@@ -90,14 +90,14 @@ namespace
                 apply_patch_from_version = fx_ref.get_fx_version_number();
             }
 
-            trace::verbose(
+            TRACE_VERBOSE(
                 _X("Applying patch roll forward from [%s] on %s"),
                 apply_patch_from_version.as_str().c_str(),
                 release_only ? _X("release only") : _X("release/pre-release"));
 
             for (const auto& ver : version_list)
             {
-                trace::verbose(_X("Inspecting version... [%s]"), ver.as_str().c_str());
+                TRACE_VERBOSE(_X("Inspecting version... [%s]"), ver.as_str().c_str());
 
                 if ((!release_only || !ver.is_prerelease()) &&
                     (fx_ref.get_apply_patches() || ver.get_patch() == apply_patch_from_version.get_patch()) &&
@@ -135,7 +135,7 @@ namespace
         const std::vector<fx_ver_t>& version_list,
         const fx_reference_t& fx_ref)
     {
-        trace::verbose(
+        TRACE_VERBOSE(
             _X("Attempting FX roll forward starting from version='[%s]', apply_patches=%d, version_compatibility_range=%s, roll_to_highest_version=%d, prefer_release=%d"),
             fx_ref.get_fx_version().c_str(),
             fx_ref.get_apply_patches(),
@@ -169,11 +169,11 @@ namespace
             // This is not strictly necessary, we just need to return version which doesn't exist.
             // But it's cleaner to return the desider reference then invalid -1.-1.-1 version.
             best_match = fx_ref.get_fx_version_number();
-            trace::verbose(_X("Framework reference didn't resolve to any available version."));
+            TRACE_VERBOSE(_X("Framework reference didn't resolve to any available version."));
         }
         else
         {
-            trace::verbose(_X("Framework reference resolved to version '%s'."), best_match.as_str().c_str());
+            TRACE_VERBOSE(_X("Framework reference resolved to version '%s'."), best_match.as_str().c_str());
         }
 
         return best_match;
@@ -193,7 +193,7 @@ namespace
         assert(_debug_ver == fx_ref.get_fx_version_number());
 #endif // defined(DEBUG)
 
-        trace::verbose(_X("--- Resolving FX directory, name '%s' version '%s'"),
+        TRACE_VERBOSE(_X("--- Resolving FX directory, name '%s' version '%s'"),
             fx_ref.get_fx_name().c_str(), fx_ref.get_fx_version().c_str());
 
         std::vector<pal::string_t> hive_dir;
@@ -206,7 +206,7 @@ namespace
         for (pal::string_t dir : hive_dir)
         {
             auto fx_dir = dir;
-            trace::verbose(_X("Searching FX directory in [%s]"), fx_dir.c_str());
+            TRACE_VERBOSE(_X("Searching FX directory in [%s]"), fx_dir.c_str());
 
             append_path(&fx_dir, _X("shared"));
             append_path(&fx_dir, fx_ref.get_fx_name().c_str());
@@ -220,7 +220,7 @@ namespace
             if ((fx_ref.get_version_compatibility_range() == version_compatibility_range_t::exact) ||
                 ((fx_ref.get_version_compatibility_range() == version_compatibility_range_t::patch) && (!fx_ref.get_apply_patches() && !fx_ref.get_fx_version_number().is_prerelease())))
             {
-                trace::verbose(
+                TRACE_VERBOSE(
                     _X("Did not roll forward because apply_patches=%d, version_compatibility_range=%s chose [%s]"),
                     fx_ref.get_apply_patches(),
                     version_compatibility_range_to_string(fx_ref.get_version_compatibility_range()).c_str(),
@@ -267,7 +267,7 @@ namespace
 
                     if (resolved_ver != selected_ver)
                     {
-                        trace::verbose(_X("Changing Selected FX version from [%s] to [%s]"), selected_fx_dir.c_str(), fx_dir.c_str());
+                        TRACE_VERBOSE(_X("Changing Selected FX version from [%s] to [%s]"), selected_fx_dir.c_str(), fx_dir.c_str());
                         selected_ver = resolved_ver;
                         selected_fx_dir = fx_dir;
                         selected_fx_version = resolved_ver_str;
@@ -278,11 +278,11 @@ namespace
 
         if (selected_fx_dir.empty())
         {
-            trace::error(_X("It was not possible to find any compatible framework version"));
+            TRACE_ERROR(_X("It was not possible to find any compatible framework version"));
             return nullptr;
         }
 
-        trace::verbose(_X("Chose FX version [%s]"), selected_fx_dir.c_str());
+        TRACE_VERBOSE(_X("Chose FX version [%s]"), selected_fx_dir.c_str());
 
         return new fx_definition_t(fx_ref.get_fx_name(), selected_fx_dir, oldest_requested_version, selected_fx_version);
     }
@@ -459,7 +459,7 @@ StatusCode fx_resolver_t::read_framework(
             runtime_config_t new_config = fx->get_runtime_config();
             if (!new_config.is_valid())
             {
-                trace::error(_X("Invalid framework config.json [%s]"), new_config.get_path().c_str());
+                TRACE_ERROR(_X("Invalid framework config.json [%s]"), new_config.get_path().c_str());
                 return StatusCode::InvalidConfigFile;
             }
 

--- a/src/corehost/cli/fxr/fx_resolver.messages.cpp
+++ b/src/corehost/cli/fxr/fx_resolver.messages.cpp
@@ -13,7 +13,7 @@ void fx_resolver_t::display_incompatible_framework_error(
     const pal::string_t& higher,
     const fx_reference_t& lower)
 {
-    trace::error(_X("The specified framework '%s', version '%s', apply_patches=%d, version_compatibility_range=%s cannot roll-forward to the previously referenced version '%s'."),
+    TRACE_ERROR(_X("The specified framework '%s', version '%s', apply_patches=%d, version_compatibility_range=%s cannot roll-forward to the previously referenced version '%s'."),
         lower.get_fx_name().c_str(),
         lower.get_fx_version().c_str(),
         lower.get_apply_patches(),
@@ -27,7 +27,7 @@ void fx_resolver_t::display_compatible_framework_trace(
 {
     if (trace::is_enabled())
     {
-        trace::verbose(_X("--- The specified framework '%s', version '%s', apply_patches=%d, version_compatibility_range=%s is compatible with the previously referenced version '%s'."),
+        TRACE_VERBOSE(_X("--- The specified framework '%s', version '%s', apply_patches=%d, version_compatibility_range=%s is compatible with the previously referenced version '%s'."),
             lower.get_fx_name().c_str(),
             lower.get_fx_version().c_str(),
             lower.get_apply_patches(),
@@ -42,7 +42,7 @@ void fx_resolver_t::display_retry_framework_trace(
 {
     if (trace::is_enabled())
     {
-        trace::verbose(_X("--- Restarting all framework resolution because the previously resolved framework '%s', version '%s' must be re-resolved with the new version '%s', apply_patches=%d, version_compatibility_range=%s, roll_to_highest_version=%d ."),
+        TRACE_VERBOSE(_X("--- Restarting all framework resolution because the previously resolved framework '%s', version '%s' must be re-resolved with the new version '%s', apply_patches=%d, version_compatibility_range=%s, roll_to_highest_version=%d ."),
             fx_existing.get_fx_name().c_str(),
             fx_existing.get_fx_version().c_str(),
             fx_new.get_fx_version().c_str(),
@@ -58,7 +58,7 @@ void fx_resolver_t::display_summary_of_frameworks(
 {
     if (trace::is_enabled())
     {
-        trace::verbose(_X("--- Summary of all frameworks:"));
+        TRACE_VERBOSE(_X("--- Summary of all frameworks:"));
 
         bool is_app = true;
         for (const auto& fx : fx_definitions)
@@ -72,7 +72,7 @@ void fx_resolver_t::display_summary_of_frameworks(
                 auto newest_ref = newest_references.find(fx->get_name());
                 assert(newest_ref != newest_references.end());
 
-                trace::verbose(_X("     framework:'%s', lowest requested version='%s', found version='%s', effective reference version='%s' apply_patches=%d, version_compatibility_range=%s, roll_to_highest_version=%d, folder=%s"),
+                TRACE_VERBOSE(_X("     framework:'%s', lowest requested version='%s', found version='%s', effective reference version='%s' apply_patches=%d, version_compatibility_range=%s, roll_to_highest_version=%d, folder=%s"),
                     fx->get_name().c_str(),
                     fx->get_requested_version().c_str(),
                     fx->get_found_version().c_str(),
@@ -113,38 +113,38 @@ void fx_resolver_t::display_missing_framework_error(
     // Display the error message about missing FX.
     if (fx_version.length())
     {
-        trace::error(_X("The specified framework '%s', version '%s' was not found."), fx_name.c_str(), fx_version.c_str());
+        TRACE_ERROR(_X("The specified framework '%s', version '%s' was not found."), fx_name.c_str(), fx_version.c_str());
     }
     else
     {
-        trace::error(_X("The specified framework '%s' was not found."), fx_name.c_str());
+        TRACE_ERROR(_X("The specified framework '%s' was not found."), fx_name.c_str());
     }
 
     if (framework_infos.size())
     {
-        trace::error(_X("  - The following frameworks were found:"));
+        TRACE_ERROR(_X("  - The following frameworks were found:"));
         for (const framework_info& info : framework_infos)
         {
-            trace::error(_X("      %s at [%s]"), info.version.as_str().c_str(), info.path.c_str());
+            TRACE_ERROR(_X("      %s at [%s]"), info.version.as_str().c_str(), info.path.c_str());
         }
     }
     else
     {
-        trace::error(_X("  - No frameworks were found."));
+        TRACE_ERROR(_X("  - No frameworks were found."));
     }
 
-    trace::error(_X(""));
-    trace::error(_X("You can resolve the problem by installing the specified framework and/or SDK."));
-    trace::error(_X(""));
-    trace::error(_X("The .NET Core frameworks can be found at:"));
-    trace::error(_X("  - %s"), DOTNET_CORE_DOWNLOAD_URL);
+    TRACE_ERROR(_X(""));
+    TRACE_ERROR(_X("You can resolve the problem by installing the specified framework and/or SDK."));
+    TRACE_ERROR(_X(""));
+    TRACE_ERROR(_X("The .NET Core frameworks can be found at:"));
+    TRACE_ERROR(_X("  - %s"), DOTNET_CORE_DOWNLOAD_URL);
 }
 
 void fx_resolver_t::display_incompatible_loaded_framework_error(
     const pal::string_t& loaded_version,
     const fx_reference_t& fx_ref)
 {
-    trace::error(_X("The specified framework '%s', version '%s', apply_patches=%d, version_compatibility_range=%s is incompatible with the previously loaded version '%s'."),
+    TRACE_ERROR(_X("The specified framework '%s', version '%s', apply_patches=%d, version_compatibility_range=%s is incompatible with the previously loaded version '%s'."),
         fx_ref.get_fx_name().c_str(),
         fx_ref.get_fx_version().c_str(),
         fx_ref.get_apply_patches(),
@@ -154,5 +154,5 @@ void fx_resolver_t::display_incompatible_loaded_framework_error(
 
 void fx_resolver_t::display_missing_loaded_framework_error(const pal::string_t& fx_name)
 {
-    trace::error(_X("The specified framework '%s' is not present in the previously loaded runtime."), fx_name.c_str());
+    TRACE_ERROR(_X("The specified framework '%s' is not present in the previously loaded runtime."), fx_name.c_str());
 }

--- a/src/corehost/cli/fxr/host_context.cpp
+++ b/src/corehost/cli/fxr/host_context.cpp
@@ -20,7 +20,7 @@ namespace
     {
         if (hostpolicy_contract.initialize == nullptr)
         {
-            trace::error(_X("This component must target .NET Core 3.0 or a higher version."));
+            TRACE_ERROR(_X("This component must target .NET Core 3.0 or a higher version."));
             return StatusCode::HostApiUnsupportedVersion;
         }
 
@@ -108,15 +108,15 @@ host_context_t* host_context_t::from_handle(const hostfxr_handle handle, bool al
         if (allow_invalid_type || context->type != host_context_type::invalid)
             return context;
 
-        trace::error(_X("Host context is in an invalid state"));
+        TRACE_ERROR(_X("Host context is in an invalid state"));
     }
     else if (marker == closed_host_context_marker)
     {
-        trace::error(_X("Host context has already been closed"));
+        TRACE_ERROR(_X("Host context has already been closed"));
     }
     else
     {
-        trace::error(_X("Invalid host context handle marker: 0x%x"), marker);
+        TRACE_ERROR(_X("Invalid host context handle marker: 0x%x"), marker);
     }
 
     return nullptr;

--- a/src/corehost/cli/fxr/hostfxr.cpp
+++ b/src/corehost/cli/fxr/hostfxr.cpp
@@ -20,7 +20,7 @@ namespace
     void trace_hostfxr_entry_point(const pal::char_t *entry_point)
     {
         trace::setup();
-        trace::info(_X("--- Invoked %s [commit hash: %s]"), entry_point, _STRINGIFY(REPO_COMMIT_HASH));
+        TRACE_INFO(_X("--- Invoked %s [commit hash: %s]"), entry_point, _STRINGIFY(REPO_COMMIT_HASH));
     }
 }
 
@@ -96,7 +96,7 @@ SHARED_API int32_t HOSTFXR_CALLTYPE hostfxr_resolve_sdk(
 
     if (buffer_size < 0 || (buffer_size > 0 && buffer == nullptr))
     {
-        trace::error(_X("hostfxr_resolve_sdk received an invalid argument."));
+        TRACE_ERROR(_X("hostfxr_resolve_sdk received an invalid argument."));
         return -1;
     }
 
@@ -127,7 +127,7 @@ SHARED_API int32_t HOSTFXR_CALLTYPE hostfxr_resolve_sdk(
     }
     else
     {
-        trace::info(_X("hostfxr_resolve_sdk received a buffer that is too small to hold the located SDK path."));
+        TRACE_INFO(_X("hostfxr_resolve_sdk received a buffer that is too small to hold the located SDK path."));
     }
 
     return cli_sdk.size() + 1;
@@ -354,7 +354,7 @@ SHARED_API int32_t HOSTFXR_CALLTYPE hostfxr_get_native_search_directories(const 
 
     if (buffer_size < 0 || (buffer_size > 0 && buffer == nullptr) || required_buffer_size == nullptr)
     {
-        trace::error(_X("hostfxr_get_native_search_directories received an invalid argument."));
+        TRACE_ERROR(_X("hostfxr_get_native_search_directories received an invalid argument."));
         return InvalidArgFailure;
     }
 
@@ -410,7 +410,7 @@ namespace
         {
             if (!pal::get_own_executable_path(&startup_info.host_path) || !pal::realpath(&startup_info.host_path))
             {
-                trace::error(_X("Failed to resolve full path of the current host [%s]"), startup_info.host_path.c_str());
+                TRACE_ERROR(_X("Failed to resolve full path of the current host [%s]"), startup_info.host_path.c_str());
                 return StatusCode::CoreHostCurHostFindFailure;
             }
         }
@@ -424,7 +424,7 @@ namespace
             startup_info.dotnet_root = get_dotnet_root_from_fxr_path(mod_path);
             if (!pal::realpath(&startup_info.dotnet_root))
             {
-                trace::error(_X("Failed to resolve full path of dotnet root [%s]"), startup_info.dotnet_root.c_str());
+                TRACE_ERROR(_X("Failed to resolve full path of dotnet root [%s]"), startup_info.dotnet_root.c_str());
                 return StatusCode::CoreHostCurHostFindFailure;
             }
         }
@@ -676,7 +676,7 @@ SHARED_API int32_t HOSTFXR_CALLTYPE hostfxr_get_runtime_property_value(
         const host_context_t *context_maybe = fx_muxer_t::get_active_host_context();
         if (context_maybe == nullptr)
         {
-            trace::error(_X("Hosting components context has not been initialized. Cannot get runtime properties."));
+            TRACE_ERROR(_X("Hosting components context has not been initialized. Cannot get runtime properties."));
             return StatusCode::HostInvalidState;
         }
 
@@ -741,7 +741,7 @@ SHARED_API int32_t HOSTFXR_CALLTYPE hostfxr_set_runtime_property_value(
 
     if (context->type != host_context_type::initialized)
     {
-        trace::error(_X("Setting properties is not allowed once runtime has been loaded."));
+        TRACE_ERROR(_X("Setting properties is not allowed once runtime has been loaded."));
         return StatusCode::InvalidArgFailure;
     }
 
@@ -793,7 +793,7 @@ SHARED_API int32_t HOSTFXR_CALLTYPE hostfxr_get_runtime_properties(
         const host_context_t *context_maybe = fx_muxer_t::get_active_host_context();
         if (context_maybe == nullptr)
         {
-            trace::error(_X("Hosting components context has not been initialized. Cannot get runtime properties."));
+            TRACE_ERROR(_X("Hosting components context has not been initialized. Cannot get runtime properties."));
             return StatusCode::HostInvalidState;
         }
 

--- a/src/corehost/cli/fxr/hostpolicy_resolver.cpp
+++ b/src/corehost/cli/fxr/hostpolicy_resolver.cpp
@@ -150,7 +150,7 @@ namespace
         }
 
         // Print detailed message about the file not found in the probe paths.
-        TRACE_ERROR(_X("Could not find required library %s in %d probing paths:"),
+        TRACE_ERROR(_X("Could not find required library %s in %zu probing paths:"),
             LIBHOSTPOLICY_NAME, probe_realpaths.size());
         for (const auto& path : probe_realpaths)
         {

--- a/src/corehost/cli/fxr/hostpolicy_resolver.cpp
+++ b/src/corehost/cli/fxr/hostpolicy_resolver.cpp
@@ -24,25 +24,25 @@ namespace
     */
     pal::string_t resolve_hostpolicy_version_from_deps(const pal::string_t& deps_json)
     {
-        trace::verbose(_X("--- Resolving %s version from deps json [%s]"), LIBHOSTPOLICY_NAME, deps_json.c_str());
+        TRACE_VERBOSE(_X("--- Resolving %s version from deps json [%s]"), LIBHOSTPOLICY_NAME, deps_json.c_str());
 
         pal::string_t retval;
         if (!pal::file_exists(deps_json))
         {
-            trace::verbose(_X("Dependency manifest [%s] does not exist"), deps_json.c_str());
+            TRACE_VERBOSE(_X("Dependency manifest [%s] does not exist"), deps_json.c_str());
             return retval;
         }
 
         pal::ifstream_t file(deps_json);
         if (!file.good())
         {
-            trace::verbose(_X("Dependency manifest [%s] could not be opened"), deps_json.c_str());
+            TRACE_VERBOSE(_X("Dependency manifest [%s] could not be opened"), deps_json.c_str());
             return retval;
         }
 
         if (skip_utf8_bom(&file))
         {
-            trace::verbose(_X("UTF-8 BOM skipped while reading [%s]"), deps_json.c_str());
+            TRACE_VERBOSE(_X("UTF-8 BOM skipped while reading [%s]"), deps_json.c_str());
         }
 
         try
@@ -68,9 +68,9 @@ namespace
         {
             pal::string_t jes;
             (void)pal::utf8_palstring(je.what(), &jes);
-            trace::error(_X("A JSON parsing exception occurred in [%s]: %s"), deps_json.c_str(), jes.c_str());
+            TRACE_ERROR(_X("A JSON parsing exception occurred in [%s]: %s"), deps_json.c_str(), jes.c_str());
         }
-        trace::verbose(_X("Resolved version %s from dependency manifest file [%s]"), retval.c_str(), deps_json.c_str());
+        TRACE_VERBOSE(_X("Resolved version %s from dependency manifest file [%s]"), retval.c_str(), deps_json.c_str());
         return retval;
     }
 
@@ -100,14 +100,14 @@ namespace
                                                             // Check if "path" contains the required library.
         if (!library_exists_in_dir(path, LIBHOSTPOLICY_NAME, nullptr))
         {
-            trace::verbose(_X("Did not find %s in directory %s"), LIBHOSTPOLICY_NAME, path.c_str());
+            TRACE_VERBOSE(_X("Did not find %s in directory %s"), LIBHOSTPOLICY_NAME, path.c_str());
             return false;
         }
 
         // "path" contains the directory containing hostpolicy library.
         *candidate = path;
 
-        trace::verbose(_X("Found %s in directory %s"), LIBHOSTPOLICY_NAME, path.c_str());
+        TRACE_VERBOSE(_X("Found %s in directory %s"), LIBHOSTPOLICY_NAME, path.c_str());
         return true;
     }
 
@@ -142,7 +142,7 @@ namespace
         // Check if the package relative directory containing hostpolicy exists.
         for (const auto& probe_path : probe_realpaths)
         {
-            trace::verbose(_X("Considering %s to probe for %s"), probe_path.c_str(), LIBHOSTPOLICY_NAME);
+            TRACE_VERBOSE(_X("Considering %s to probe for %s"), probe_path.c_str(), LIBHOSTPOLICY_NAME);
             if (to_hostpolicy_package_dir(probe_path, version, candidate))
             {
                 return true;
@@ -150,11 +150,11 @@ namespace
         }
 
         // Print detailed message about the file not found in the probe paths.
-        trace::error(_X("Could not find required library %s in %d probing paths:"),
+        TRACE_ERROR(_X("Could not find required library %s in %d probing paths:"),
             LIBHOSTPOLICY_NAME, probe_realpaths.size());
         for (const auto& path : probe_realpaths)
         {
-            trace::error(_X("  %s"), path.c_str());
+            TRACE_ERROR(_X("  %s"), path.c_str());
         }
         return false;
     }
@@ -206,7 +206,7 @@ int hostpolicy_resolver::load(
         // We expect to leak hostpolicy - just as we do not unload coreclr, we do not unload hostpolicy
         if (!pal::load_library(&host_path, &g_hostpolicy))
         {
-            trace::info(_X("Load library of %s failed"), host_path.c_str());
+            TRACE_INFO(_X("Load library of %s failed"), host_path.c_str());
             return StatusCode::CoreHostLibLoadFailure;
         }
 
@@ -229,7 +229,7 @@ int hostpolicy_resolver::load(
     else
     {
         if (!pal::are_paths_equal_with_normalized_casing(g_hostpolicy_dir, lib_dir))
-            trace::warning(_X("The library %s was already loaded from [%s]. Reusing the existing library for the request to load from [%s]"), LIBHOSTPOLICY_NAME, g_hostpolicy_dir.c_str(), lib_dir.c_str());
+            TRACE_WARNING(_X("The library %s was already loaded from [%s]. Reusing the existing library for the request to load from [%s]"), LIBHOSTPOLICY_NAME, g_hostpolicy_dir.c_str(), lib_dir.c_str());
     }
 
     // Return global values
@@ -260,7 +260,7 @@ bool hostpolicy_resolver::try_get_dir(
     pal::string_t version = resolve_hostpolicy_version_from_deps(resolved_deps);
     if (trace::is_enabled() && version.empty() && pal::file_exists(resolved_deps))
     {
-        trace::warning(_X("Dependency manifest %s does not contain an entry for %s"),
+        TRACE_WARNING(_X("Dependency manifest %s does not contain an entry for %s"),
             resolved_deps.c_str(), _STRINGIFY(HOST_POLICY_PKG_NAME));
     }
 
@@ -299,14 +299,14 @@ bool hostpolicy_resolver::try_get_dir(
     }
 
     // Check if hostpolicy exists in "expected" directory.
-    trace::verbose(_X("The expected %s directory is [%s]"), LIBHOSTPOLICY_NAME, expected.c_str());
+    TRACE_VERBOSE(_X("The expected %s directory is [%s]"), LIBHOSTPOLICY_NAME, expected.c_str());
     if (library_exists_in_dir(expected, LIBHOSTPOLICY_NAME, nullptr))
     {
         impl_dir->assign(expected);
         return true;
     }
 
-    trace::verbose(_X("The %s was not found in [%s]"), LIBHOSTPOLICY_NAME, expected.c_str());
+    TRACE_VERBOSE(_X("The %s was not found in [%s]"), LIBHOSTPOLICY_NAME, expected.c_str());
 
     // Start probing for hostpolicy in the specified probe paths.
     pal::string_t candidate;
@@ -317,18 +317,18 @@ bool hostpolicy_resolver::try_get_dir(
     }
 
     // If it still couldn't be found, somebody upstack messed up. Flag an error for the "expected" location.
-    trace::error(_X("A fatal error was encountered. The library '%s' required to execute the application was not found in '%s'."),
+    TRACE_ERROR(_X("A fatal error was encountered. The library '%s' required to execute the application was not found in '%s'."),
         LIBHOSTPOLICY_NAME, expected.c_str());
     if (mode == host_mode_t::muxer && !is_framework_dependent)
     {
         if (!pal::file_exists(get_app(fx_definitions).get_runtime_config().get_path()))
         {
-            trace::error(_X("Failed to run as a self-contained app. If this should be a framework-dependent app, add the %s file specifying the appropriate framework."),
+            TRACE_ERROR(_X("Failed to run as a self-contained app. If this should be a framework-dependent app, add the %s file specifying the appropriate framework."),
                 get_app(fx_definitions).get_runtime_config().get_path().c_str());
         }
         else if (get_app(fx_definitions).get_name().empty())
         {
-            trace::error(_X("Failed to run as a self-contained app. If this should be a framework-dependent app, specify the appropriate framework in %s."),
+            TRACE_ERROR(_X("Failed to run as a self-contained app. If this should be a framework-dependent app, specify the appropriate framework in %s."),
                 get_app(fx_definitions).get_runtime_config().get_path().c_str());
         }
     }

--- a/src/corehost/cli/fxr/sdk_info.cpp
+++ b/src/corehost/cli/fxr/sdk_info.cpp
@@ -53,7 +53,7 @@ void sdk_info::get_all_sdk_infos(
     for (pal::string_t dir : hive_dir)
     {
         auto base_dir = dir;
-        trace::verbose(_X("Gathering SDK locations in [%s]"), base_dir.c_str());
+        TRACE_VERBOSE(_X("Gathering SDK locations in [%s]"), base_dir.c_str());
 
         append_path(&base_dir, _X("sdk"));
 
@@ -67,7 +67,7 @@ void sdk_info::get_all_sdk_infos(
                 fx_ver_t parsed;
                 if (fx_ver_t::parse(ver, &parsed, false))
                 {
-                    trace::verbose(_X("Found SDK version [%s]"), ver.c_str());
+                    TRACE_VERBOSE(_X("Found SDK version [%s]"), ver.c_str());
 
                     auto full_dir = base_dir;
                     append_path(&full_dir, ver.c_str());

--- a/src/corehost/cli/fxr/sdk_resolver.cpp
+++ b/src/corehost/cli/fxr/sdk_resolver.cpp
@@ -15,25 +15,25 @@ typedef web::json::object json_object;
 
 pal::string_t resolve_cli_version(const pal::string_t& global_json)
 {
-    trace::verbose(_X("--- Resolving CLI version from global json [%s]"), global_json.c_str());
+    TRACE_VERBOSE(_X("--- Resolving CLI version from global json [%s]"), global_json.c_str());
 
     pal::string_t retval;
     if (!pal::file_exists(global_json))
     {
-        trace::verbose(_X("[%s] does not exist"), global_json.c_str());
+        TRACE_VERBOSE(_X("[%s] does not exist"), global_json.c_str());
         return retval;
     }
 
     pal::ifstream_t file(global_json);
     if (!file.good())
     {
-        trace::verbose(_X("[%s] could not be opened"), global_json.c_str());
+        TRACE_VERBOSE(_X("[%s] could not be opened"), global_json.c_str());
         return retval;
     }
 
     if (skip_utf8_bom(&file))
     {
-        trace::verbose(_X("UTF-8 BOM skipped while reading [%s]"), global_json.c_str());
+        TRACE_VERBOSE(_X("UTF-8 BOM skipped while reading [%s]"), global_json.c_str());
     }
 
     try
@@ -43,7 +43,7 @@ pal::string_t resolve_cli_version(const pal::string_t& global_json)
         const auto sdk_iter = json.find(_X("sdk"));
         if (sdk_iter == json.end() || sdk_iter->second.is_null())
         {
-            trace::verbose(_X("CLI '/sdk/version' field not present/null in [%s]"), global_json.c_str());
+            TRACE_VERBOSE(_X("CLI '/sdk/version' field not present/null in [%s]"), global_json.c_str());
             return retval;
         }
 
@@ -51,7 +51,7 @@ pal::string_t resolve_cli_version(const pal::string_t& global_json)
         const auto ver_iter = sdk_obj.find(_X("version"));
         if (ver_iter == sdk_obj.end() || ver_iter->second.is_null())
         {
-            trace::verbose(_X("CLI 'sdk/version' field not present/null in [%s]"), global_json.c_str());
+            TRACE_VERBOSE(_X("CLI 'sdk/version' field not present/null in [%s]"), global_json.c_str());
             return retval;
         }
         retval = ver_iter->second.as_string();
@@ -60,9 +60,9 @@ pal::string_t resolve_cli_version(const pal::string_t& global_json)
     {
         pal::string_t jes;
         (void)pal::utf8_palstring(je.what(), &jes);
-        trace::error(_X("A JSON parsing exception occurred in [%s]: %s"), global_json.c_str(), jes.c_str());
+        TRACE_ERROR(_X("A JSON parsing exception occurred in [%s]: %s"), global_json.c_str(), jes.c_str());
     }
-    trace::verbose(_X("CLI version is [%s] in global json file [%s]"), retval.c_str(), global_json.c_str());
+    TRACE_VERBOSE(_X("CLI version is [%s] in global json file [%s]"), retval.c_str(), global_json.c_str());
     return retval;
 }
 
@@ -75,7 +75,7 @@ pal::string_t resolve_sdk_version(pal::string_t sdk_path, bool disallow_prerelea
     {
         if (!fx_ver_t::parse(global_cli_version, &specified, false))
         {
-            trace::error(_X("The specified SDK version '%s' could not be parsed"), global_cli_version.c_str());
+            TRACE_ERROR(_X("The specified SDK version '%s' could not be parsed"), global_cli_version.c_str());
             return pal::string_t();
         }
 
@@ -86,7 +86,7 @@ pal::string_t resolve_sdk_version(pal::string_t sdk_path, bool disallow_prerelea
         }
     }
 
-    trace::verbose(_X("--- Resolving SDK version from SDK dir [%s]"), sdk_path.c_str());
+    TRACE_VERBOSE(_X("--- Resolving SDK version from SDK dir [%s]"), sdk_path.c_str());
 
     pal::string_t retval;
     std::vector<pal::string_t> versions;
@@ -95,7 +95,7 @@ pal::string_t resolve_sdk_version(pal::string_t sdk_path, bool disallow_prerelea
     fx_ver_t max_ver;
     for (const auto& version : versions)
     {
-        trace::verbose(_X("Considering version... [%s]"), version.c_str());
+        TRACE_VERBOSE(_X("Considering version... [%s]"), version.c_str());
 
         fx_ver_t ver;
         if (fx_ver_t::parse(version, &ver, disallow_prerelease))
@@ -117,10 +117,10 @@ pal::string_t resolve_sdk_version(pal::string_t sdk_path, bool disallow_prerelea
         pal::string_t max_ver_str = max_ver.as_str();
         append_path(&sdk_path, max_ver_str.c_str());
 
-        trace::verbose(_X("Checking if resolved SDK dir [%s] exists"), sdk_path.c_str());
+        TRACE_VERBOSE(_X("Checking if resolved SDK dir [%s] exists"), sdk_path.c_str());
         if (pal::directory_exists(sdk_path))
         {
-            trace::verbose(_X("Resolved SDK dir is [%s]"), sdk_path.c_str());
+            TRACE_VERBOSE(_X("Resolved SDK dir is [%s]"), sdk_path.c_str());
             retval = max_ver_str;
         }
     }
@@ -130,11 +130,11 @@ pal::string_t resolve_sdk_version(pal::string_t sdk_path, bool disallow_prerelea
 
 bool sdk_resolver_t::resolve_sdk_dotnet_path(const pal::string_t& dotnet_root, pal::string_t* cli_sdk)
 {
-    trace::verbose(_X("--- Resolving dotnet from working dir"));
+    TRACE_VERBOSE(_X("--- Resolving dotnet from working dir"));
     pal::string_t cwd;
     if (!pal::getcwd(&cwd))
     {
-        trace::verbose(_X("Failed to obtain current working dir"));
+        TRACE_VERBOSE(_X("Failed to obtain current working dir"));
         assert(cwd.empty());
     }
 
@@ -176,17 +176,17 @@ bool sdk_resolver_t::resolve_sdk_dotnet_path(
             pal::string_t file = cur_dir;
             append_path(&file, _X("global.json"));
 
-            trace::verbose(_X("Probing path [%s] for global.json"), file.c_str());
+            TRACE_VERBOSE(_X("Probing path [%s] for global.json"), file.c_str());
             if (pal::file_exists(file))
             {
                 global = file;
-                trace::verbose(_X("Found global.json [%s]"), global.c_str());
+                TRACE_VERBOSE(_X("Found global.json [%s]"), global.c_str());
                 break;
             }
             parent_dir = get_directory(cur_dir);
             if (parent_dir.empty() || parent_dir.size() == cur_dir.size())
             {
-                trace::verbose(_X("Terminating global.json search at [%s]"), parent_dir.c_str());
+                TRACE_VERBOSE(_X("Terminating global.json search at [%s]"), parent_dir.c_str());
                 break;
             }
         }
@@ -206,7 +206,7 @@ bool sdk_resolver_t::resolve_sdk_dotnet_path(
 
     for (pal::string_t dir : hive_dir)
     {
-        trace::verbose(_X("Searching SDK directory in [%s]"), dir.c_str());
+        TRACE_VERBOSE(_X("Searching SDK directory in [%s]"), dir.c_str());
         pal::string_t current_sdk_path = dir;
         append_path(&current_sdk_path, _X("sdk"));
 
@@ -230,7 +230,7 @@ bool sdk_resolver_t::resolve_sdk_dotnet_path(
 
             if (pal::directory_exists(probing_sdk_path))
             {
-                trace::verbose(_X("CLI directory [%s] from global.json exists"), probing_sdk_path.c_str());
+                TRACE_VERBOSE(_X("CLI directory [%s] from global.json exists"), probing_sdk_path.c_str());
                 cli_version = global_cli_version;
                 sdk_path = current_sdk_path;
                 //  Use the first matching version
@@ -251,20 +251,20 @@ bool sdk_resolver_t::resolve_sdk_dotnet_path(
     {
         append_path(&sdk_path, cli_version.c_str());
         cli_sdk->assign(sdk_path);
-        trace::verbose(_X("Found CLI SDK in: %s"), cli_sdk->c_str());
+        TRACE_VERBOSE(_X("Found CLI SDK in: %s"), cli_sdk->c_str());
         return true;
     }
 
     if (!global_cli_version.empty())
     {
-        trace::error(_X("A compatible installed dotnet SDK for global.json version: [%s] from [%s] was not found"), global_cli_version.c_str(), global.c_str());
-        trace::error(_X("Please install the [%s] SDK or update [%s] with an installed dotnet SDK:"), global_cli_version.c_str(), global.c_str());
+        TRACE_ERROR(_X("A compatible installed dotnet SDK for global.json version: [%s] from [%s] was not found"), global_cli_version.c_str(), global.c_str());
+        TRACE_ERROR(_X("Please install the [%s] SDK or update [%s] with an installed dotnet SDK:"), global_cli_version.c_str(), global.c_str());
     }
     if (global_cli_version.empty() || !sdk_info::print_all_sdks(dotnet_root, _X("  ")))
     {
-        trace::error(_X("  It was not possible to find any installed dotnet SDKs"));
-        trace::error(_X("  Did you mean to run dotnet SDK commands? Please install dotnet SDK from:"));
-        trace::error(_X("      %s"), DOTNET_CORE_DOWNLOAD_URL);
+        TRACE_ERROR(_X("  It was not possible to find any installed dotnet SDKs"));
+        TRACE_ERROR(_X("  Did you mean to run dotnet SDK commands? Please install dotnet SDK from:"));
+        TRACE_ERROR(_X("      %s"), DOTNET_CORE_DOWNLOAD_URL);
     }
     return false;
 }

--- a/src/corehost/cli/fxr_resolver.cpp
+++ b/src/corehost/cli/fxr_resolver.cpp
@@ -12,7 +12,7 @@ namespace
 {
     bool get_latest_fxr(pal::string_t fxr_root, pal::string_t* out_fxr_path)
     {
-        trace::info(_X("Reading fx resolver directory=[%s]"), fxr_root.c_str());
+        TRACE_INFO(_X("Reading fx resolver directory=[%s]"), fxr_root.c_str());
 
         std::vector<pal::string_t> list;
         pal::readdir_onlydirectories(fxr_root, &list);
@@ -20,7 +20,7 @@ namespace
         fx_ver_t max_ver;
         for (const auto& dir : list)
         {
-            trace::info(_X("Considering fxr version=[%s]..."), dir.c_str());
+            TRACE_INFO(_X("Considering fxr version=[%s]..."), dir.c_str());
 
             pal::string_t ver = get_filename(dir);
 
@@ -33,21 +33,21 @@ namespace
 
         if (max_ver == fx_ver_t())
         {
-            trace::error(_X("A fatal error occurred, the folder [%s] does not contain any version-numbered child folders"), fxr_root.c_str());
+            TRACE_ERROR(_X("A fatal error occurred, the folder [%s] does not contain any version-numbered child folders"), fxr_root.c_str());
             return false;
         }
 
         pal::string_t max_ver_str = max_ver.as_str();
         append_path(&fxr_root, max_ver_str.c_str());
-        trace::info(_X("Detected latest fxr version=[%s]..."), fxr_root.c_str());
+        TRACE_INFO(_X("Detected latest fxr version=[%s]..."), fxr_root.c_str());
 
         if (library_exists_in_dir(fxr_root, LIBFXR_NAME, out_fxr_path))
         {
-            trace::info(_X("Resolved fxr [%s]..."), out_fxr_path->c_str());
+            TRACE_INFO(_X("Resolved fxr [%s]..."), out_fxr_path->c_str());
             return true;
         }
 
-        trace::error(_X("A fatal error occurred, the required library %s could not be found in [%s]"), LIBFXR_NAME, fxr_root.c_str());
+        TRACE_ERROR(_X("A fatal error occurred, the required library %s could not be found in [%s]"), LIBFXR_NAME, fxr_root.c_str());
 
         return false;
     }
@@ -62,7 +62,7 @@ bool fxr_resolver::try_get_path(const pal::string_t& root_path, pal::string_t* o
     // If a hostfxr exists in root_path, then assume self-contained.
     if (root_path.length() > 0 && library_exists_in_dir(root_path, LIBFXR_NAME, out_fxr_path))
     {
-        trace::info(_X("Resolved fxr [%s]..."), out_fxr_path->c_str());
+        TRACE_INFO(_X("Resolved fxr [%s]..."), out_fxr_path->c_str());
         out_dotnet_root->assign(root_path);
         return true;
     }
@@ -72,18 +72,18 @@ bool fxr_resolver::try_get_path(const pal::string_t& root_path, pal::string_t* o
     pal::string_t dotnet_root_env_var_name = get_dotnet_root_env_var_name();
     if (get_file_path_from_env(dotnet_root_env_var_name.c_str(), out_dotnet_root))
     {
-        trace::info(_X("Using environment variable %s=[%s] as runtime location."), dotnet_root_env_var_name.c_str(), out_dotnet_root->c_str());
+        TRACE_INFO(_X("Using environment variable %s=[%s] as runtime location."), dotnet_root_env_var_name.c_str(), out_dotnet_root->c_str());
     }
     else
     {
         if (pal::get_dotnet_self_registered_dir(&default_install_location) || pal::get_default_installation_dir(&default_install_location))
         {
-            trace::info(_X("Using global installation location [%s] as runtime location."), default_install_location.c_str());
+            TRACE_INFO(_X("Using global installation location [%s] as runtime location."), default_install_location.c_str());
             out_dotnet_root->assign(default_install_location);
         }
         else
         {
-            trace::error(_X("A fatal error occurred, the default install location cannot be obtained."));
+            TRACE_ERROR(_X("A fatal error occurred, the default install location cannot be obtained."));
             return false;
         }
     }
@@ -110,7 +110,7 @@ bool fxr_resolver::try_get_path(const pal::string_t& root_path, pal::string_t* o
                 pal::string_t(_X(" or register the runtime location in [") + self_registered_config_location + _X("]"));
         }
 
-        trace::error(_X("A fatal error occurred. The required library %s could not be found.\n"
+        TRACE_ERROR(_X("A fatal error occurred. The required library %s could not be found.\n"
             "If this is a self-contained application, that library should exist in [%s].\n"
             "If this is a framework-dependent application, install the runtime in the global location [%s] or use the %s environment variable to specify the runtime location%s."),
             LIBFXR_NAME,
@@ -132,7 +132,7 @@ bool fxr_resolver::try_get_path(const pal::string_t& root_path, pal::string_t* o
     append_path(&fxr_dir, _X("fxr"));
     if (!pal::directory_exists(fxr_dir))
     {
-        trace::error(_X("A fatal error occurred. The folder [%s] does not exist"), fxr_dir.c_str());
+        TRACE_ERROR(_X("A fatal error occurred. The folder [%s] does not exist"), fxr_dir.c_str());
         return false;
     }
 #endif // !FEATURE_APPHOST && !FEATURE_LIBHOST
@@ -148,6 +148,6 @@ bool fxr_resolver::try_get_existing_fxr(pal::dll_t *out_fxr, pal::string_t *out_
     if (!pal::get_loaded_library(LIBFXR_NAME, "hostfxr_main", out_fxr, out_fxr_path))
         return false;
 
-    trace::verbose(_X("Found previously loaded library %s [%s]."), LIBFXR_NAME, out_fxr_path->c_str());
+    TRACE_VERBOSE(_X("Found previously loaded library %s [%s]."), LIBFXR_NAME, out_fxr_path->c_str());
     return true;
 }

--- a/src/corehost/cli/fxr_resolver.h
+++ b/src/corehost/cli/fxr_resolver.h
@@ -25,7 +25,7 @@ int load_fxr_and_get_delegate(hostfxr_delegate_type type, THostPathToConfigCallb
     pal::string_t host_path;
     if (!pal::get_own_module_path(&host_path) || !pal::realpath(&host_path))
     {
-        trace::error(_X("Failed to resolve full path of the current host module [%s]"), host_path.c_str());
+        TRACE_ERROR(_X("Failed to resolve full path of the current host module [%s]"), host_path.c_str());
         return StatusCode::CoreHostCurHostFindFailure;
     }
 
@@ -34,7 +34,7 @@ int load_fxr_and_get_delegate(hostfxr_delegate_type type, THostPathToConfigCallb
     if (fxr_resolver::try_get_existing_fxr(&fxr, &fxr_path))
     {
         dotnet_root = get_dotnet_root_from_fxr_path(fxr_path);
-        trace::verbose(_X("The library %s was already loaded. Reusing the previously loaded library [%s]."), LIBFXR_NAME, fxr_path.c_str());
+        TRACE_VERBOSE(_X("The library %s was already loaded. Reusing the previously loaded library [%s]."), LIBFXR_NAME, fxr_path.c_str());
     }
     else
     {
@@ -47,9 +47,9 @@ int load_fxr_and_get_delegate(hostfxr_delegate_type type, THostPathToConfigCallb
         // Load library
         if (!pal::load_library(&fxr_path, &fxr))
         {
-            trace::error(_X("The library %s was found, but loading it from %s failed"), LIBFXR_NAME, fxr_path.c_str());
-            trace::error(_X("  - Installing .NET Core prerequisites might help resolve this problem."));
-            trace::error(_X("     %s"), DOTNET_CORE_INSTALL_PREREQUISITES_URL);
+            TRACE_ERROR(_X("The library %s was found, but loading it from %s failed"), LIBFXR_NAME, fxr_path.c_str());
+            TRACE_ERROR(_X("  - Installing .NET Core prerequisites might help resolve this problem."));
+            TRACE_ERROR(_X("     %s"), DOTNET_CORE_INSTALL_PREREQUISITES_URL);
             return StatusCode::CoreHostLibLoadFailure;
         }
     }
@@ -87,7 +87,7 @@ int load_fxr_and_get_delegate(hostfxr_delegate_type type, THostPathToConfigCallb
     if (rcClose != StatusCode::Success)
     {
         assert(false && "Failed to close host context");
-        trace::verbose(_X("Failed to close host context: 0x%x"), rcClose);
+        TRACE_VERBOSE(_X("Failed to close host context: 0x%x"), rcClose);
     }
 
     return rc;

--- a/src/corehost/cli/host_startup_info.cpp
+++ b/src/corehost/cli/host_startup_info.cpp
@@ -46,9 +46,9 @@ int host_startup_info_t::parse(
     append_path(&app_path, app_name.c_str());
     app_path.append(_X(".dll"));
 
-    trace::info(_X("Host path: [%s]"), host_path.c_str());
-    trace::info(_X("Dotnet path: [%s]"), dotnet_root.c_str());
-    trace::info(_X("App path: [%s]"), app_path.c_str());
+    TRACE_INFO(_X("Host path: [%s]"), host_path.c_str());
+    TRACE_INFO(_X("Dotnet path: [%s]"), dotnet_root.c_str());
+    TRACE_INFO(_X("App path: [%s]"), app_path.c_str());
     return 0;
 }
 
@@ -78,10 +78,10 @@ const pal::string_t host_startup_info_t::get_app_name() const
         host_path->assign(argv[0]);
         if (!host_path->empty())
         {
-            trace::info(_X("Attempting to use argv[0] as path [%s]"), host_path->c_str());
+            TRACE_INFO(_X("Attempting to use argv[0] as path [%s]"), host_path->c_str());
             if (!get_path_from_argv(host_path))
             {
-                trace::warning(_X("Failed to resolve argv[0] as path [%s]. Using location of current executable instead."), host_path->c_str());
+                TRACE_WARNING(_X("Failed to resolve argv[0] as path [%s]. Using location of current executable instead."), host_path->c_str());
                 host_path->clear();
             }
         }
@@ -90,7 +90,7 @@ const pal::string_t host_startup_info_t::get_app_name() const
     // If argv[0] did not work, get the executable name
     if (host_path->empty() && (!pal::get_own_executable_path(host_path) || !pal::realpath(host_path)))
     {
-        trace::error(_X("Failed to resolve full path of the current executable [%s]"), host_path->c_str());
+        TRACE_ERROR(_X("Failed to resolve full path of the current executable [%s]"), host_path->c_str());
         return StatusCode::LibHostCurExeFindFailure;
     }
 

--- a/src/corehost/cli/hostpolicy/args.cpp
+++ b/src/corehost/cli/hostpolicy/args.cpp
@@ -118,7 +118,7 @@ bool init_arguments(
     args.managed_application = managed_application_path;
     if (!args.managed_application.empty() && !pal::realpath(&args.managed_application))
     {
-        trace::error(_X("Failed to locate managed application [%s]"), args.managed_application.c_str());
+        TRACE_ERROR(_X("Failed to locate managed application [%s]"), args.managed_application.c_str());
         return false;
     }
     args.app_root = get_directory(args.managed_application);

--- a/src/corehost/cli/hostpolicy/args.h
+++ b/src/corehost/cli/hostpolicy/args.h
@@ -24,7 +24,7 @@ struct probe_config_t
 
     void print() const
     {
-        trace::verbose(_X("probe_config_t: probe=[%s] deps-dir-probe=[%d]"),
+        TRACE_VERBOSE(_X("probe_config_t: probe=[%s] deps-dir-probe=[%d]"),
             probe_dir.c_str(), probe_publish_dir);
     }
 
@@ -111,20 +111,20 @@ struct arguments_t
     {
         if (trace::is_enabled())
         {
-            trace::verbose(_X("-- arguments_t: host_path='%s' app_root='%s' deps='%s' core_svc='%s' mgd_app='%s'"),
+            TRACE_VERBOSE(_X("-- arguments_t: host_path='%s' app_root='%s' deps='%s' core_svc='%s' mgd_app='%s'"),
                 host_path.c_str(), app_root.c_str(), deps_path.c_str(), core_servicing.c_str(), managed_application.c_str());
             for (const auto& probe : probe_paths)
             {
-                trace::verbose(_X("-- arguments_t: probe dir: '%s'"), probe.c_str());
+                TRACE_VERBOSE(_X("-- arguments_t: probe dir: '%s'"), probe.c_str());
             }
             for (const auto& shared : env_shared_store)
             {
-                trace::verbose(_X("-- arguments_t: env shared store: '%s'"), shared.c_str());
+                TRACE_VERBOSE(_X("-- arguments_t: env shared store: '%s'"), shared.c_str());
             }
-            trace::verbose(_X("-- arguments_t: dotnet shared store: '%s'"), dotnet_shared_store.c_str());
+            TRACE_VERBOSE(_X("-- arguments_t: dotnet shared store: '%s'"), dotnet_shared_store.c_str());
             for (const auto& global_shared : global_shared_stores)
             {
-                trace::verbose(_X("-- arguments_t: global shared store: '%s'"), global_shared.c_str());
+                TRACE_VERBOSE(_X("-- arguments_t: global shared store: '%s'"), global_shared.c_str());
             }
         }
     }

--- a/src/corehost/cli/hostpolicy/breadcrumbs.cpp
+++ b/src/corehost/cli/hostpolicy/breadcrumbs.cpp
@@ -23,12 +23,12 @@ breadcrumb_writer_t::breadcrumb_writer_t(std::unordered_set<pal::string_t> &file
 // thread to write breadcrumbs.
 std::shared_ptr<breadcrumb_writer_t> breadcrumb_writer_t::begin_write(std::unordered_set<pal::string_t> &files)
 {
-    trace::verbose(_X("--- Begin breadcrumb write"));
+    TRACE_VERBOSE(_X("--- Begin breadcrumb write"));
 
     auto instance = std::make_shared<breadcrumb_writer_t>(files);
     if (instance->m_breadcrumb_store.empty())
     {
-        trace::verbose(_X("Breadcrumb store was not obtained... skipping write."));
+        TRACE_VERBOSE(_X("Breadcrumb store was not obtained... skipping write."));
         return nullptr;
     }
 
@@ -36,7 +36,7 @@ std::shared_ptr<breadcrumb_writer_t> breadcrumb_writer_t::begin_write(std::unord
     instance->m_threads_instance = instance;
 
     instance->m_thread = std::thread(write_worker_callback, instance.get());
-    trace::verbose(_X("Breadcrumbs will be written using a background thread"));
+    TRACE_VERBOSE(_X("Breadcrumbs will be written using a background thread"));
 
     return instance;
 }
@@ -59,7 +59,7 @@ void breadcrumb_writer_t::write_callback()
             }
         }
     }
-    trace::verbose(_X("--- End breadcrumb write %d"), successful);
+    TRACE_VERBOSE(_X("--- End breadcrumb write %d"), successful);
 
     // Clear reference to this object for the thread.
     m_threads_instance.reset();
@@ -73,12 +73,12 @@ void breadcrumb_writer_t::write_worker_callback(breadcrumb_writer_t* p_this)
     assert(p_this->m_threads_instance.get() == p_this);
     try
     {
-        trace::verbose(_X("Breadcrumb thread write callback..."));
+        TRACE_VERBOSE(_X("Breadcrumb thread write callback..."));
         p_this->write_callback();
     }
     catch (...)
     {
-        trace::warning(_X("An unexpected exception was thrown while leaving breadcrumbs"));
+        TRACE_WARNING(_X("An unexpected exception was thrown while leaving breadcrumbs"));
     }
 }
 
@@ -87,10 +87,10 @@ void breadcrumb_writer_t::end_write()
 {
     if (m_thread.joinable())
     {
-        trace::verbose(_X("Waiting for breadcrumb thread to exit..."));
+        TRACE_VERBOSE(_X("Waiting for breadcrumb thread to exit..."));
 
         // Block on the thread to exit.
         m_thread.join();
     }
-    trace::verbose(_X("Done waiting for breadcrumb thread to exit..."));
+    TRACE_VERBOSE(_X("Done waiting for breadcrumb thread to exit..."));
 }

--- a/src/corehost/cli/hostpolicy/coreclr.cpp
+++ b/src/corehost/cli/hostpolicy/coreclr.cpp
@@ -85,7 +85,7 @@ pal::hresult_t coreclr_t::create(
 {
     if (!coreclr_bind(libcoreclr_path))
     {
-        trace::error(_X("Failed to bind to CoreCLR at '%s'"), libcoreclr_path.c_str());
+        TRACE_ERROR(_X("Failed to bind to CoreCLR at '%s'"), libcoreclr_path.c_str());
         return StatusCode::CoreClrBindFailure;
     }
 
@@ -246,7 +246,7 @@ bool coreclr_property_bag_t::add(const pal::char_t *key, const pal::char_t *valu
     }
     else
     {
-        trace::verbose(_X("Overwriting property %s. New value: '%s'. Old value: '%s'."), key, value, (*iter).second.c_str());
+        TRACE_VERBOSE(_X("Overwriting property %s. New value: '%s'. Old value: '%s'."), key, value, (*iter).second.c_str());
         _properties[key] = value;
         return false;
     }
@@ -280,14 +280,14 @@ void coreclr_property_bag_t::remove(const pal::char_t *key)
     if (iter == _properties.cend())
         return;
 
-    trace::verbose(_X("Removing property %s. Old value: '%s'."), key, (*iter).second.c_str());
+    TRACE_VERBOSE(_X("Removing property %s. Old value: '%s'."), key, (*iter).second.c_str());
     _properties.erase(iter);
 }
 
 void coreclr_property_bag_t::log_properties() const
 {
     for (auto &kv : _properties)
-        trace::verbose(_X("Property %s = %s"), kv.first.c_str(), kv.second.c_str());
+        TRACE_VERBOSE(_X("Property %s = %s"), kv.first.c_str(), kv.second.c_str());
 }
 
 int coreclr_property_bag_t::count() const

--- a/src/corehost/cli/hostpolicy/deps_resolver.cpp
+++ b/src/corehost/cli/hostpolicy/deps_resolver.cpp
@@ -53,7 +53,7 @@ void add_unique_path(
         return;
     }
 
-    trace::verbose(_X("Adding to %s path: %s"), deps_entry_t::s_known_asset_types[asset_type], real.c_str());
+    TRACE_VERBOSE(_X("Adding to %s path: %s"), deps_entry_t::s_known_asset_types[asset_type], real.c_str());
 
     if (starts_with(real, svc_dir, false))
     {
@@ -99,7 +99,7 @@ void deps_resolver_t::add_tpa_asset(
     name_to_resolved_asset_map_t::iterator existing = items->find(resolved_asset.asset.name);
     if (existing == items->end())
     {
-        trace::verbose(_X("Adding tpa entry: %s, AssemblyVersion: %s, FileVersion: %s"),
+        TRACE_VERBOSE(_X("Adding tpa entry: %s, AssemblyVersion: %s, FileVersion: %s"),
             resolved_asset.resolved_path.c_str(),
             resolved_asset.asset.assembly_version.as_str().c_str(),
             resolved_asset.asset.file_version.as_str().c_str());
@@ -118,7 +118,7 @@ void deps_resolver_t::get_dir_assemblies(
     name_to_resolved_asset_map_t* items)
 {
     version_t empty;
-    trace::verbose(_X("Adding files from %s dir %s"), dir_name.c_str(), dir.c_str());
+    TRACE_VERBOSE(_X("Adding files from %s dir %s"), dir_name.c_str(), dir.c_str());
 
     // Managed extensions in priority order, pick DLL over EXE and NI over IL.
     const pal::string_t managed_ext[] = { _X(".ni.dll"), _X(".dll"), _X(".ni.exe"), _X(".exe") };
@@ -149,7 +149,7 @@ void deps_resolver_t::get_dir_assemblies(
             // Already added entry for this asset, by priority order skip this ext
             if (items->count(file_name))
             {
-                trace::verbose(_X("Skipping %s because the %s already exists in %s assemblies"),
+                TRACE_VERBOSE(_X("Skipping %s because the %s already exists in %s assemblies"),
                     file.c_str(),
                     items->find(file_name)->second.asset.relative_path.c_str(),
                     dir_name.c_str());
@@ -165,7 +165,7 @@ void deps_resolver_t::get_dir_assemblies(
             }
             file_path.append(file);
 
-            trace::verbose(_X("Adding %s to %s assembly set from %s"),
+            TRACE_VERBOSE(_X("Adding %s to %s assembly set from %s"),
                 file_name.c_str(),
                 dir_name.c_str(),
                 file_path.c_str());
@@ -262,7 +262,7 @@ void deps_resolver_t::setup_probe_config(
 
     if (trace::is_enabled())
     {
-        trace::verbose(_X("-- Listing probe configurations..."));
+        TRACE_VERBOSE(_X("-- Listing probe configurations..."));
         for (const auto& pc : m_probes)
         {
             pc.print();
@@ -288,17 +288,17 @@ bool deps_resolver_t::probe_deps_entry(const deps_entry_t& entry, const pal::str
 
     for (const auto& config : m_probes)
     {
-        trace::verbose(_X("  Considering entry [%s/%s/%s], probe dir [%s], probe fx level:%d, entry fx level:%d"),
+        TRACE_VERBOSE(_X("  Considering entry [%s/%s/%s], probe dir [%s], probe fx level:%d, entry fx level:%d"),
             entry.library_name.c_str(), entry.library_version.c_str(), entry.asset.relative_path.c_str(), config.probe_dir.c_str(), config.fx_level, fx_level);
 
         if (config.only_serviceable_assets && !entry.is_serviceable)
         {
-            trace::verbose(_X("    Skipping... not serviceable asset"));
+            TRACE_VERBOSE(_X("    Skipping... not serviceable asset"));
             continue;
         }
         if (config.only_runtime_assets && entry.asset_type != deps_entry_t::asset_types::runtime)
         {
-            trace::verbose(_X("    Skipping... not runtime asset"));
+            TRACE_VERBOSE(_X("    Skipping... not runtime asset"));
             continue;
         }
         pal::string_t probe_dir = config.probe_dir;
@@ -318,12 +318,12 @@ bool deps_resolver_t::probe_deps_entry(const deps_entry_t& entry, const pal::str
                 // No need to check further for the exact asset relative sub path.
                 if (config.probe_deps_json->has_package(entry.library_name, entry.library_version) && entry.to_dir_path(probe_dir, candidate))
                 {
-                    trace::verbose(_X("    Probed deps json and matched '%s'"), candidate->c_str());
+                    TRACE_VERBOSE(_X("    Probed deps json and matched '%s'"), candidate->c_str());
                     return true;
                 }
             }
 
-            trace::verbose(_X("    Skipping... not found in deps json."));
+            TRACE_VERBOSE(_X("    Skipping... not found in deps json."));
         }
         else if (config.is_app())
         {
@@ -336,7 +336,7 @@ bool deps_resolver_t::probe_deps_entry(const deps_entry_t& entry, const pal::str
                 {
                     if (entry.to_rel_path(deps_dir, candidate))
                     {
-                        trace::verbose(_X("    Probed deps dir and matched '%s'"), candidate->c_str());
+                        TRACE_VERBOSE(_X("    Probed deps dir and matched '%s'"), candidate->c_str());
                         return true;
                     }
                 }
@@ -345,21 +345,21 @@ bool deps_resolver_t::probe_deps_entry(const deps_entry_t& entry, const pal::str
                     // Non-rid assets, lookup in the published dir.
                     if (entry.to_dir_path(deps_dir, candidate))
                     {
-                        trace::verbose(_X("    Probed deps dir and matched '%s'"), candidate->c_str());
+                        TRACE_VERBOSE(_X("    Probed deps dir and matched '%s'"), candidate->c_str());
                         return true;
                     }
                 }
             }
 
-            trace::verbose(_X("    Skipping... not found in deps dir '%s'"), deps_dir.c_str());
+            TRACE_VERBOSE(_X("    Skipping... not found in deps dir '%s'"), deps_dir.c_str());
         }
         else if (entry.to_full_path(probe_dir, candidate))
         {
-            trace::verbose(_X("    Probed package dir and matched '%s'"), candidate->c_str());
+            TRACE_VERBOSE(_X("    Probed package dir and matched '%s'"), candidate->c_str());
             return true;
         }
 
-        trace::verbose(_X("    Skipping... not found in probe dir '%s'"), probe_dir.c_str());
+        TRACE_VERBOSE(_X("    Skipping... not found in probe dir '%s'"), probe_dir.c_str());
         // continue to try next probe config
     }
     return false;
@@ -374,32 +374,32 @@ bool report_missing_assembly_in_manifest(const deps_entry_t& entry, bool continu
         // Treat missing resource assemblies as informational.
         continueResolving = true;
 
-        trace::info(MissingAssemblyMessage.c_str(), _X("Info"),
+        TRACE_INFO(MissingAssemblyMessage.c_str(), _X("Info"),
             entry.deps_file.c_str(), entry.library_name.c_str(), entry.library_version.c_str(), entry.asset.relative_path.c_str());
 
         if (showManifestListMessage)
         {
-            trace::info(ManifestListMessage.c_str(), entry.runtime_store_manifest_list.c_str());
+            TRACE_INFO(ManifestListMessage.c_str(), entry.runtime_store_manifest_list.c_str());
         }
     }
     else if (continueResolving)
     {
-        trace::warning(MissingAssemblyMessage.c_str(), _X("Warning"),
+        TRACE_WARNING(MissingAssemblyMessage.c_str(), _X("Warning"),
             entry.deps_file.c_str(), entry.library_name.c_str(), entry.library_version.c_str(), entry.asset.relative_path.c_str());
 
         if (showManifestListMessage)
         {
-            trace::warning(ManifestListMessage.c_str(), entry.runtime_store_manifest_list.c_str());
+            TRACE_WARNING(ManifestListMessage.c_str(), entry.runtime_store_manifest_list.c_str());
         }
     }
     else
     {
-        trace::error(MissingAssemblyMessage.c_str(), _X("Error"),
+        TRACE_ERROR(MissingAssemblyMessage.c_str(), _X("Error"),
             entry.deps_file.c_str(), entry.library_name.c_str(), entry.library_version.c_str(), entry.asset.relative_path.c_str());
 
         if (showManifestListMessage)
         {
-            trace::error(ManifestListMessage.c_str(), entry.runtime_store_manifest_list.c_str());
+            TRACE_ERROR(ManifestListMessage.c_str(), entry.runtime_store_manifest_list.c_str());
         }
     }
 
@@ -431,7 +431,7 @@ bool deps_resolver_t::resolve_tpa_list(
             return true;
         }
 
-        trace::info(_X("Processing TPA for deps entry [%s, %s, %s]"), entry.library_name.c_str(), entry.library_version.c_str(), entry.asset.relative_path.c_str());
+        TRACE_INFO(_X("Processing TPA for deps entry [%s, %s, %s]"), entry.library_name.c_str(), entry.library_version.c_str(), entry.asset.relative_path.c_str());
 
         pal::string_t resolved_path;
 
@@ -452,7 +452,7 @@ bool deps_resolver_t::resolve_tpa_list(
             // Verify the extension is the same as the previous verified entry
             if (get_deps_filename(entry.asset.relative_path) != get_filename(existing->second.resolved_path))
             {
-                trace::error(
+                TRACE_ERROR(
                     DuplicateAssemblyWithDifferentExtensionMessage.c_str(),
                     entry.deps_file.c_str(),
                     entry.library_name.c_str(),
@@ -474,7 +474,7 @@ bool deps_resolver_t::resolve_tpa_list(
                     // If the path is the same, then no need to replace
                     if (resolved_path != existing_entry->resolved_path)
                     {
-                        trace::verbose(_X("Replacing deps entry [%s, AssemblyVersion:%s, FileVersion:%s] with [%s, AssemblyVersion:%s, FileVersion:%s]"),
+                        TRACE_VERBOSE(_X("Replacing deps entry [%s, AssemblyVersion:%s, FileVersion:%s] with [%s, AssemblyVersion:%s, FileVersion:%s]"),
                             existing_entry->resolved_path.c_str(), existing_entry->asset.assembly_version.as_str().c_str(), existing_entry->asset.file_version.as_str().c_str(),
                             resolved_path.c_str(), entry.asset.assembly_version.as_str().c_str(), entry.asset.file_version.as_str().c_str());
 
@@ -635,14 +635,14 @@ void deps_resolver_t::resolve_additional_deps(const arguments_t& args, const dep
         {
             if (pal::file_exists(additional_deps_path))
             {
-                trace::verbose(_X("Using specified additional deps.json: '%s'"), 
+                TRACE_VERBOSE(_X("Using specified additional deps.json: '%s'"), 
                     additional_deps_path.c_str());
 
                 m_additional_deps_files.push_back(additional_deps_path);
             }
             else
             {
-                trace::warning(_X("Warning: Specified additional deps.json does not exist: '%s'"), 
+                TRACE_WARNING(_X("Warning: Specified additional deps.json does not exist: '%s'"), 
                     additional_deps_path.c_str());
             }
         }
@@ -658,7 +658,7 @@ void deps_resolver_t::resolve_additional_deps(const arguments_t& args, const dep
                 pal::string_t additional_deps_path_fx = additional_deps_path;
                 append_path(&additional_deps_path_fx, _X("shared"));
                 append_path(&additional_deps_path_fx, m_fx_definitions[i]->get_name().c_str());
-                trace::verbose(_X("Searching for most compatible deps directory in [%s]"), additional_deps_path_fx.c_str());
+                TRACE_VERBOSE(_X("Searching for most compatible deps directory in [%s]"), additional_deps_path_fx.c_str());
                 std::vector<pal::string_t> deps_dirs;
                 pal::readdir_onlydirectories(additional_deps_path_fx, &deps_dirs);
 
@@ -679,11 +679,11 @@ void deps_resolver_t::resolve_additional_deps(const arguments_t& args, const dep
 
                 if (most_compatible_deps_folder_version == fx_ver_t())
                 {
-                    trace::verbose(_X("No additional deps directory less than or equal to [%s] found with same major and minor version."), framework_found_version.as_str().c_str());
+                    TRACE_VERBOSE(_X("No additional deps directory less than or equal to [%s] found with same major and minor version."), framework_found_version.as_str().c_str());
                 }
                 else
                 {
-                    trace::verbose(_X("Found additional deps directory [%s]"), most_compatible_deps_folder_version.as_str().c_str());
+                    TRACE_VERBOSE(_X("Found additional deps directory [%s]"), most_compatible_deps_folder_version.as_str().c_str());
 
                     append_path(&additional_deps_path_fx, most_compatible_deps_folder_version.as_str().c_str());
 
@@ -696,7 +696,7 @@ void deps_resolver_t::resolve_additional_deps(const arguments_t& args, const dep
                         append_path(&json_full_path, json_file.c_str());
                         m_additional_deps_files.push_back(json_full_path);
 
-                        trace::verbose(_X("Using specified additional deps.json: '%s'"),
+                        TRACE_VERBOSE(_X("Using specified additional deps.json: '%s'"),
                             json_full_path.c_str());
                     }
                 }
@@ -786,7 +786,7 @@ bool deps_resolver_t::resolve_probe_dirs(
             return true;
         }
 
-        trace::verbose(_X("Processing native/culture for deps entry [%s, %s, %s]"), 
+        TRACE_VERBOSE(_X("Processing native/culture for deps entry [%s, %s, %s]"), 
             entry.library_name.c_str(), entry.library_version.c_str(), entry.asset.relative_path.c_str());
 
         if (probe_deps_entry(entry, deps_dir, fx_level, &candidate))

--- a/src/corehost/cli/hostpolicy/deps_resolver.h
+++ b/src/corehost/cli/hostpolicy/deps_resolver.h
@@ -67,13 +67,13 @@ public:
             if (i == 0)
             {
                 m_fx_definitions[i]->set_deps_file(args.deps_path);
-                trace::verbose(_X("Using %s deps file"), m_fx_definitions[i]->get_deps_file().c_str());
+                TRACE_VERBOSE(_X("Using %s deps file"), m_fx_definitions[i]->get_deps_file().c_str());
             }
             else
             {
                 pal::string_t fx_deps_file = get_fx_deps(m_fx_definitions[i]->get_dir(), m_fx_definitions[i]->get_name());
                 m_fx_definitions[i]->set_deps_file(fx_deps_file);
-                trace::verbose(_X("Using Fx %s deps file"), fx_deps_file.c_str());
+                TRACE_VERBOSE(_X("Using Fx %s deps file"), fx_deps_file.c_str());
             }
 
             if (i == root_framework)

--- a/src/corehost/cli/hostpolicy/hostpolicy.cpp
+++ b/src/corehost/cli/hostpolicy/hostpolicy.cpp
@@ -410,7 +410,7 @@ SHARED_API int HOSTPOLICY_CALLTYPE corehost_main_with_output_buffer(const int ar
         {
             rc = StatusCode::HostApiBufferTooSmall;
             *required_buffer_size = len + 1;
-            TRACE_INFO(_X("get-native-search-directories failed with buffer too small"), output_string.c_str());
+            TRACE_INFO(_X("get-native-search-directories failed with buffer too small: %s"), output_string.c_str());
         }
         else
         {

--- a/src/corehost/cli/hostpolicy/hostpolicy.cpp
+++ b/src/corehost/cli/hostpolicy/hostpolicy.cpp
@@ -52,13 +52,13 @@ namespace
             std::lock_guard<std::mutex> context_lock { g_context_lock };
             if (g_context == nullptr)
             {
-                trace::error(_X("Hostpolicy has not been initialized"));
+                TRACE_ERROR(_X("Hostpolicy has not been initialized"));
                 return StatusCode::HostInvalidState;
             }
 
             if (g_context->coreclr != nullptr)
             {
-                trace::error(_X("CoreClr has already been loaded"));
+                TRACE_ERROR(_X("CoreClr has already been loaded"));
                 return StatusCode::HostInvalidState;
             }
 
@@ -71,7 +71,7 @@ namespace
             const char *app_domain_friendly_name = g_context->host_mode == host_mode_t::libhost ? "clr_libhost" : "clrhost";
 
             // Create a CoreCLR instance
-            trace::verbose(_X("CoreCLR path = '%s', CoreCLR dir = '%s'"), g_context->clr_path.c_str(), g_context->clr_dir.c_str());
+            TRACE_VERBOSE(_X("CoreCLR path = '%s', CoreCLR dir = '%s'"), g_context->clr_path.c_str(), g_context->clr_dir.c_str());
             auto hr = coreclr_t::create(
                 g_context->clr_dir,
                 host_path.data(),
@@ -81,7 +81,7 @@ namespace
 
             if (!SUCCEEDED(hr))
             {
-                trace::error(_X("Failed to create CoreCLR, HRESULT: 0x%X"), hr);
+                TRACE_ERROR(_X("Failed to create CoreCLR, HRESULT: 0x%X"), hr);
                 rc = StatusCode::CoreClrInitFailure;
             }
             else
@@ -108,7 +108,7 @@ namespace
             const hostpolicy_context_t *existing_context = g_context.get();
             if (existing_context != nullptr)
             {
-                trace::info(_X("Host context has already been initialized"));
+                TRACE_INFO(_X("Host context has already been initialized"));
                 assert(existing_context->coreclr != nullptr);
                 return StatusCode::Success_HostAlreadyInitialized;
             }
@@ -145,13 +145,13 @@ namespace
         const hostpolicy_context_t *existing_context = g_context.get();
         if (existing_context == nullptr)
         {
-            trace::error(_X("Hostpolicy context has not been created"));
+            TRACE_ERROR(_X("Hostpolicy context has not been created"));
             return nullptr;
         }
 
         if (require_runtime && existing_context->coreclr == nullptr)
         {
-            trace::error(_X("Runtime has not been loaded and initialized"));
+            TRACE_ERROR(_X("Runtime has not been loaded and initialized"));
             return nullptr;
         }
 
@@ -179,7 +179,7 @@ int run_host_command(
         const pal::char_t *value;
         if (!context.coreclr_properties.try_get(common_property::NativeDllSearchDirectories, &value))
         {
-            trace::error(_X("get-native-search-directories failed to find NATIVE_DLL_SEARCH_DIRECTORIES property"));
+            TRACE_ERROR(_X("get-native-search-directories failed to find NATIVE_DLL_SEARCH_DIRECTORIES property"));
             return StatusCode::HostApiFailed;
         }
 
@@ -217,7 +217,7 @@ int run_app_for_context(
             arg_str.append(cur);
             arg_str.append(_X(","));
         }
-        trace::info(_X("Launch host: %s, app: %s, argc: %d, args: %s"), context.host_path.c_str(),
+        TRACE_INFO(_X("Launch host: %s, app: %s, argc: %d, args: %s"), context.host_path.c_str(),
             context.application.c_str(), argc, arg_str.c_str());
     }
 
@@ -245,17 +245,17 @@ int run_app_for_context(
 
     if (!SUCCEEDED(hr))
     {
-        trace::error(_X("Failed to execute managed app, HRESULT: 0x%X"), hr);
+        TRACE_ERROR(_X("Failed to execute managed app, HRESULT: 0x%X"), hr);
         return StatusCode::CoreClrExeFailure;
     }
 
-    trace::info(_X("Execute managed assembly exit code: 0x%X"), exit_code);
+    TRACE_INFO(_X("Execute managed assembly exit code: 0x%X"), exit_code);
 
     // Shut down the CoreCLR
     hr = context.coreclr->shutdown(reinterpret_cast<int*>(&exit_code));
     if (!SUCCEEDED(hr))
     {
-        trace::warning(_X("Failed to shut down CoreCLR, HRESULT: 0x%X"), hr);
+        TRACE_WARNING(_X("Failed to shut down CoreCLR, HRESULT: 0x%X"), hr);
     }
 
     if (writer)
@@ -277,7 +277,7 @@ int run_app(const int argc, const pal::char_t *argv[])
 
 void trace_hostpolicy_entrypoint_invocation(const pal::string_t& entryPointName)
 {
-    trace::info(_X("--- Invoked hostpolicy [commit hash: %s] [%s,%s,%s][%s] %s = {"),
+    TRACE_INFO(_X("--- Invoked hostpolicy [commit hash: %s] [%s,%s,%s][%s] %s = {"),
         _STRINGIFY(REPO_COMMIT_HASH),
         _STRINGIFY(HOST_POLICY_PKG_NAME),
         _STRINGIFY(HOST_POLICY_PKG_VER),
@@ -333,14 +333,14 @@ int corehost_init(
 
         for (int i = 0; i < argc; ++i)
         {
-            trace::info(_X("%s"), argv[i]);
+            TRACE_INFO(_X("%s"), argv[i]);
         }
-        trace::info(_X("}"));
+        TRACE_INFO(_X("}"));
 
-        trace::info(_X("Deps file: %s"), hostpolicy_init.deps_file.c_str());
+        TRACE_INFO(_X("Deps file: %s"), hostpolicy_init.deps_file.c_str());
         for (const auto& probe : hostpolicy_init.probe_paths)
         {
-            trace::info(_X("Additional probe dir: %s"), probe.c_str());
+            TRACE_INFO(_X("Additional probe dir: %s"), probe.c_str());
         }
     }
 
@@ -410,19 +410,19 @@ SHARED_API int HOSTPOLICY_CALLTYPE corehost_main_with_output_buffer(const int ar
         {
             rc = StatusCode::HostApiBufferTooSmall;
             *required_buffer_size = len + 1;
-            trace::info(_X("get-native-search-directories failed with buffer too small"), output_string.c_str());
+            TRACE_INFO(_X("get-native-search-directories failed with buffer too small"), output_string.c_str());
         }
         else
         {
             output_string.copy(buffer, len);
             buffer[len] = '\0';
             *required_buffer_size = 0;
-            trace::info(_X("get-native-search-directories success: %s"), output_string.c_str());
+            TRACE_INFO(_X("get-native-search-directories success: %s"), output_string.c_str());
         }
     }
     else
     {
-        trace::error(_X("Unknown command: %s"), g_init.host_command.c_str());
+        TRACE_ERROR(_X("Unknown command: %s"), g_init.host_command.c_str());
         rc = StatusCode::LibHostUnknownCommand;
     }
 
@@ -515,7 +515,7 @@ namespace
         std::lock_guard<std::mutex> lock{ g_context_lock };
         if (g_context == nullptr || g_context->coreclr != nullptr)
         {
-            trace::error(_X("Setting properties is only allowed before runtime has been loaded and initialized"));
+            TRACE_ERROR(_X("Setting properties is only allowed before runtime has been loaded and initialized"));
             return HostInvalidState;
         }
 
@@ -576,19 +576,19 @@ namespace
             {
                 if (pal::strcmp(existingValue, value) != 0)
                 {
-                    trace::warning(_X("The property [%s] has a different value [%s] from that in the previously loaded runtime [%s]"), key, value, existingValue);
+                    TRACE_WARNING(_X("The property [%s] has a different value [%s] from that in the previously loaded runtime [%s]"), key, value, existingValue);
                     hasDifferentProperties = true;
                 }
             }
             else
             {
-                trace::warning(_X("The property [%s] is not present in the previously loaded runtime."), key);
+                TRACE_WARNING(_X("The property [%s] is not present in the previously loaded runtime."), key);
                 hasDifferentProperties = true;
             }
         }
 
         if (len > 0 && !hasDifferentProperties)
-            trace::info(_X("All specified properties match those in the previously loaded runtime"));
+            TRACE_INFO(_X("All specified properties match those in the previously loaded runtime"));
 
         return !hasDifferentProperties;
     }
@@ -634,7 +634,7 @@ SHARED_API int HOSTPOLICY_CALLTYPE corehost_initialize(const corehost_initialize
     bool get_contract = (options & intialization_options_t::get_contract) != 0;
     if (wait_for_initialized && get_contract)
     {
-        trace::error(_X("Specifying both initialization options for wait_for_initialized and get_contract is not allowed"));
+        TRACE_ERROR(_X("Specifying both initialization options for wait_for_initialized and get_contract is not allowed"));
         return StatusCode::InvalidArgFailure;
     }
 
@@ -642,7 +642,7 @@ SHARED_API int HOSTPOLICY_CALLTYPE corehost_initialize(const corehost_initialize
     {
         if (init_request != nullptr)
         {
-            trace::error(_X("Initialization request is expected to be null when getting the already initialized contract"));
+            TRACE_ERROR(_X("Initialization request is expected to be null when getting the already initialized contract"));
             return StatusCode::InvalidArgFailure;
         }
     }
@@ -654,17 +654,17 @@ SHARED_API int HOSTPOLICY_CALLTYPE corehost_initialize(const corehost_initialize
 
         if (wait_for_initialized)
         {
-            trace::verbose(_X("Initialization option to wait for initialize request is set"));
+            TRACE_VERBOSE(_X("Initialization option to wait for initialize request is set"));
             if (init_request == nullptr)
             {
-                trace::error(_X("Initialization request is expected to be non-null when waiting for initialize request option is set"));
+                TRACE_ERROR(_X("Initialization request is expected to be non-null when waiting for initialize request option is set"));
                 return StatusCode::InvalidArgFailure;
             }
 
             // If we are not already initializing or done initializing, wait until another context initialization has started
             if (!already_initialized && !already_initializing)
             {
-                trace::info(_X("Waiting for another request to initialize hostpolicy"));
+                TRACE_INFO(_X("Waiting for another request to initialize hostpolicy"));
                 g_context_initializing_cv.wait(lock, [&] { return g_context_initializing.load(); });
             }
         }
@@ -672,13 +672,13 @@ SHARED_API int HOSTPOLICY_CALLTYPE corehost_initialize(const corehost_initialize
         {
             if (init_request != nullptr && !already_initialized && !already_initializing)
             {
-                trace::error(_X("Initialization request is expected to be null for the first initialization request"));
+                TRACE_ERROR(_X("Initialization request is expected to be null for the first initialization request"));
                 return StatusCode::InvalidArgFailure;
             }
 
             if (init_request == nullptr && (already_initializing || already_initialized))
             {
-                trace::error(_X("Initialization request is expected to be non-null for requests other than the first one"));
+                TRACE_ERROR(_X("Initialization request is expected to be non-null for requests other than the first one"));
                 return StatusCode::InvalidArgFailure;
             }
         }
@@ -700,7 +700,7 @@ SHARED_API int HOSTPOLICY_CALLTYPE corehost_initialize(const corehost_initialize
         const hostpolicy_context_t *existing_context = g_context.get();
         if (existing_context == nullptr || existing_context->coreclr == nullptr)
         {
-            trace::info(_X("Option to wait for initialize request was set, but that request did not result in initialization"));
+            TRACE_INFO(_X("Option to wait for initialize request was set, but that request did not result in initialization"));
             return StatusCode::HostInvalidState;
         }
 
@@ -711,7 +711,7 @@ SHARED_API int HOSTPOLICY_CALLTYPE corehost_initialize(const corehost_initialize
         const hostpolicy_context_t *context = get_hostpolicy_context(/*require_runtime*/ true);
         if (context == nullptr)
         {
-            trace::error(_X("Option to get the contract for the initialized hostpolicy was set, but hostpolicy has not been initialized"));
+            TRACE_ERROR(_X("Option to get the contract for the initialized hostpolicy was set, but hostpolicy has not been initialized"));
             return StatusCode::HostInvalidState;
         }
 
@@ -779,12 +779,12 @@ SHARED_API int HOSTPOLICY_CALLTYPE corehost_resolve_component_dependencies(
     {
         trace_hostpolicy_entrypoint_invocation(_X("corehost_resolve_component_dependencies"));
 
-        trace::info(_X("  Component main assembly path: %s"), component_main_assembly_path);
-        trace::info(_X("}"));
+        TRACE_INFO(_X("  Component main assembly path: %s"), component_main_assembly_path);
+        TRACE_INFO(_X("}"));
 
         for (const auto& probe : g_init.probe_paths)
         {
-            trace::info(_X("Additional probe dir: %s"), probe.c_str());
+            TRACE_INFO(_X("Additional probe dir: %s"), probe.c_str());
         }
     }
 
@@ -798,7 +798,7 @@ SHARED_API int HOSTPOLICY_CALLTYPE corehost_resolve_component_dependencies(
     // have already called corehost_main_init.
     if (!g_init.host_info.is_valid(g_init.host_mode))
     {
-        trace::error(_X("Hostpolicy must be initialized and corehost_main must have been called before calling corehost_resolve_component_dependencies."));
+        TRACE_ERROR(_X("Hostpolicy must be initialized and corehost_main must have been called before calling corehost_resolve_component_dependencies."));
         return StatusCode::CoreHostLibLoadFailure;
     }
 
@@ -835,7 +835,7 @@ SHARED_API int HOSTPOLICY_CALLTYPE corehost_resolve_component_dependencies(
     {
         // This should really never happen, but fail gracefully if it does anyway.
         assert(false);
-        trace::error(_X("Failed to initialize empty runtime config for the component."));
+        TRACE_ERROR(_X("Failed to initialize empty runtime config for the component."));
         return StatusCode::InvalidConfigFile;
     }
 
@@ -858,7 +858,7 @@ SHARED_API int HOSTPOLICY_CALLTYPE corehost_resolve_component_dependencies(
     pal::string_t resolver_errors;
     if (!resolver.valid(&resolver_errors))
     {
-        trace::error(_X("Error initializing the dependency resolver: %s"), resolver_errors.c_str());
+        TRACE_ERROR(_X("Error initializing the dependency resolver: %s"), resolver_errors.c_str());
         return StatusCode::ResolverInitFailure;
     }
 
@@ -873,11 +873,11 @@ SHARED_API int HOSTPOLICY_CALLTYPE corehost_resolve_component_dependencies(
 
     if (trace::is_enabled())
     {
-        trace::info(_X("corehost_resolve_component_dependencies results: {"));
-        trace::info(_X("  assembly_paths: '%s'"), probe_paths.tpa.data());
-        trace::info(_X("  native_search_paths: '%s'"), probe_paths.native.data());
-        trace::info(_X("  resource_search_paths: '%s'"), probe_paths.resources.data());
-        trace::info(_X("}"));
+        TRACE_INFO(_X("corehost_resolve_component_dependencies results: {"));
+        TRACE_INFO(_X("  assembly_paths: '%s'"), probe_paths.tpa.data());
+        TRACE_INFO(_X("  native_search_paths: '%s'"), probe_paths.native.data());
+        TRACE_INFO(_X("  resource_search_paths: '%s'"), probe_paths.resources.data());
+        TRACE_INFO(_X("}"));
     }
 
     result(

--- a/src/corehost/cli/hostpolicy/hostpolicy_context.cpp
+++ b/src/corehost/cli/hostpolicy/hostpolicy_context.cpp
@@ -12,8 +12,8 @@ namespace
 {
     void log_duplicate_property_error(const pal::char_t *property_key)
     {
-        trace::error(_X("Duplicate runtime property found: %s"), property_key);
-        trace::error(_X("It is invalid to specify values for properties populated by the hosting layer in the the application's .runtimeconfig.json"));
+        TRACE_ERROR(_X("Duplicate runtime property found: %s"), property_key);
+        TRACE_ERROR(_X("It is invalid to specify values for properties populated by the hosting layer in the the application's .runtimeconfig.json"));
     }
 }
 
@@ -35,7 +35,7 @@ int hostpolicy_context_t::initialize(hostpolicy_init_t &hostpolicy_init, const a
     pal::string_t resolver_errors;
     if (!resolver.valid(&resolver_errors))
     {
-        trace::error(_X("Error initializing the dependency resolver: %s"), resolver_errors.c_str());
+        TRACE_ERROR(_X("Error initializing the dependency resolver: %s"), resolver_errors.c_str());
         return StatusCode::ResolverInitFailure;
     }
 
@@ -67,7 +67,7 @@ int hostpolicy_context_t::initialize(hostpolicy_init_t &hostpolicy_init, const a
     clr_path = probe_paths.coreclr;
     if (clr_path.empty() || !pal::realpath(&clr_path))
     {
-        trace::error(_X("Could not resolve CoreCLR path. For more details, enable tracing by setting COREHOST_TRACE environment variable to 1"));
+        TRACE_ERROR(_X("Could not resolve CoreCLR path. For more details, enable tracing by setting COREHOST_TRACE environment variable to 1"));
         return StatusCode::CoreClrResolveFailure;
     }
 
@@ -89,16 +89,16 @@ int hostpolicy_context_t::initialize(hostpolicy_init_t &hostpolicy_init, const a
     pal::string_t clrjit_path = probe_paths.clrjit;
     if (clrjit_path.empty())
     {
-        trace::warning(_X("Could not resolve CLRJit path"));
+        TRACE_WARNING(_X("Could not resolve CLRJit path"));
     }
     else if (pal::realpath(&clrjit_path))
     {
-        trace::verbose(_X("The resolved JIT path is '%s'"), clrjit_path.c_str());
+        TRACE_VERBOSE(_X("The resolved JIT path is '%s'"), clrjit_path.c_str());
     }
     else
     {
         clrjit_path.clear();
-        trace::warning(_X("Could not resolve symlink to CLRJit path '%s'"), probe_paths.clrjit.c_str());
+        TRACE_WARNING(_X("Could not resolve symlink to CLRJit path '%s'"), probe_paths.clrjit.c_str());
     }
 
     const fx_definition_vector_t &fx_definitions = resolver.get_fx_definitions();

--- a/src/corehost/cli/hostpolicy/hostpolicy_init.cpp
+++ b/src/corehost/cli/hostpolicy/hostpolicy_init.cpp
@@ -19,11 +19,11 @@ bool hostpolicy_init_t::init(host_interface_t* input, hostpolicy_init_t* init)
     // Check if there are any breaking changes.
     if (input->version_hi != HOST_INTERFACE_LAYOUT_VERSION_HI)
     {
-        trace::error(_X("The version of the data layout used to initialize %s is [0x%04x]; expected version [0x%04x]"), LIBHOSTPOLICY_NAME, input->version_hi, HOST_INTERFACE_LAYOUT_VERSION_HI);
+        TRACE_ERROR(_X("The version of the data layout used to initialize %s is [0x%04x]; expected version [0x%04x]"), LIBHOSTPOLICY_NAME, input->version_hi, HOST_INTERFACE_LAYOUT_VERSION_HI);
         return false;
     }
 
-    trace::verbose(_X("Reading from host interface version: [0x%04x:%d] to initialize policy version: [0x%04x:%d]"), input->version_hi, input->version_lo, HOST_INTERFACE_LAYOUT_VERSION_HI, HOST_INTERFACE_LAYOUT_VERSION_LO);
+    TRACE_VERBOSE(_X("Reading from host interface version: [0x%04x:%d] to initialize policy version: [0x%04x:%d]"), input->version_hi, input->version_lo, HOST_INTERFACE_LAYOUT_VERSION_HI, HOST_INTERFACE_LAYOUT_VERSION_LO);
 
     //This check is to ensure is an old hostfxr can still load new hostpolicy.
     //We should not read garbage due to potentially shorter struct size
@@ -46,7 +46,7 @@ bool hostpolicy_init_t::init(host_interface_t* input, hostpolicy_init_t* init)
     }
     else
     {
-        trace::error(_X("The size of the data layout used to initialize %s is %d; expected at least %d"), LIBHOSTPOLICY_NAME, input->version_lo, 
+        TRACE_ERROR(_X("The size of the data layout used to initialize %s is %d; expected at least %d"), LIBHOSTPOLICY_NAME, input->version_lo, 
             offsetof(host_interface_t, host_mode) + sizeof(input->host_mode));
     }
 

--- a/src/corehost/cli/hostpolicy/hostpolicy_init.cpp
+++ b/src/corehost/cli/hostpolicy/hostpolicy_init.cpp
@@ -19,11 +19,11 @@ bool hostpolicy_init_t::init(host_interface_t* input, hostpolicy_init_t* init)
     // Check if there are any breaking changes.
     if (input->version_hi != HOST_INTERFACE_LAYOUT_VERSION_HI)
     {
-        TRACE_ERROR(_X("The version of the data layout used to initialize %s is [0x%04x]; expected version [0x%04x]"), LIBHOSTPOLICY_NAME, input->version_hi, HOST_INTERFACE_LAYOUT_VERSION_HI);
+        TRACE_ERROR(_X("The version of the data layout used to initialize %s is [0x%04zx]; expected version [0x%04x]"), LIBHOSTPOLICY_NAME, input->version_hi, HOST_INTERFACE_LAYOUT_VERSION_HI);
         return false;
     }
 
-    TRACE_VERBOSE(_X("Reading from host interface version: [0x%04x:%d] to initialize policy version: [0x%04x:%d]"), input->version_hi, input->version_lo, HOST_INTERFACE_LAYOUT_VERSION_HI, HOST_INTERFACE_LAYOUT_VERSION_LO);
+    TRACE_VERBOSE(_X("Reading from host interface version: [0x%04zx:%zu] to initialize policy version: [0x%04x:%zu]"), input->version_hi, input->version_lo, HOST_INTERFACE_LAYOUT_VERSION_HI, HOST_INTERFACE_LAYOUT_VERSION_LO);
 
     //This check is to ensure is an old hostfxr can still load new hostpolicy.
     //We should not read garbage due to potentially shorter struct size
@@ -46,7 +46,7 @@ bool hostpolicy_init_t::init(host_interface_t* input, hostpolicy_init_t* init)
     }
     else
     {
-        TRACE_ERROR(_X("The size of the data layout used to initialize %s is %d; expected at least %d"), LIBHOSTPOLICY_NAME, input->version_lo, 
+        TRACE_ERROR(_X("The size of the data layout used to initialize %s is %zu; expected at least %zu"), LIBHOSTPOLICY_NAME, input->version_lo,
             offsetof(host_interface_t, host_mode) + sizeof(input->host_mode));
     }
 

--- a/src/corehost/cli/ijwhost/ijwhost.cpp
+++ b/src/corehost/cli/ijwhost/ijwhost.cpp
@@ -30,7 +30,7 @@ pal::hresult_t get_load_in_memory_assembly_delegate(pal::dll_t handle, load_in_m
             pal::string_t mod_path;
             if (!pal::get_module_path(handle, &mod_path))
             {
-                trace::error(_X("Failed to resolve full path of the current mixed-mode module [%s]"), host_path.c_str());
+                TRACE_ERROR(_X("Failed to resolve full path of the current mixed-mode module [%s]"), host_path.c_str());
                 return StatusCode::LibHostCurExeFindFailure;
             }
 

--- a/src/corehost/cli/ijwhost/ijwthunk.cpp
+++ b/src/corehost/cli/ijwhost/ijwthunk.cpp
@@ -83,7 +83,7 @@ bool patch_vtable_entries(PEDecoder& pe)
             DWORD oldProtect;
             if(!VirtualProtect(pointers, (sizeof(BYTE*) * pFixupTable[i].Count), PAGE_READWRITE, &oldProtect))
             {
-                trace::error(_X("Failed to change the vtfixup table from RO to R/W failed.\n"));
+                TRACE_ERROR(_X("Failed to change the vtfixup table from RO to R/W failed.\n"));
                 return false;
             }
 #endif
@@ -103,7 +103,7 @@ bool patch_vtable_entries(PEDecoder& pe)
             DWORD _;
             if(!VirtualProtect(pointers, (sizeof(BYTE*) * pFixupTable[i].Count), oldProtect, &_))
             {
-                trace::warning(_X("Failed to change the vtfixup table from R/W back to RO failed.\n"));
+                TRACE_WARNING(_X("Failed to change the vtfixup table from R/W back to RO failed.\n"));
             }
 #endif
         }
@@ -129,7 +129,7 @@ extern "C" std::uintptr_t __stdcall start_runtime_and_get_target_address(std::ui
         // As we were taken here via an entry point with arbitrary signature,
         // there's no way of returning the error code so we just throw it.
 
-        trace::error(_X("Failed to start the .NET Core runtime. Error code %d"), status);
+        TRACE_ERROR(_X("Failed to start the .NET Core runtime. Error code %d"), status);
 
 #pragma warning (push)
 #pragma warning (disable: 4297)

--- a/src/corehost/cli/roll_forward_option.cpp
+++ b/src/corehost/cli/roll_forward_option.cpp
@@ -48,7 +48,7 @@ roll_forward_option roll_forward_option_from_string(const pal::string_t& value)
         }
     }
 
-    trace::error(_X("Unrecognized roll forward setting value '%s'."), value.c_str());
+    TRACE_ERROR(_X("Unrecognized roll forward setting value '%s'."), value.c_str());
     return roll_forward_option::__Last;
 }
 

--- a/src/corehost/cli/runtime_config.cpp
+++ b/src/corehost/cli/runtime_config.cpp
@@ -66,7 +66,7 @@ void runtime_config_t::parse(const pal::string_t& path, const pal::string_t& dev
     // Parse the file
     m_valid = ensure_parsed();
 
-    trace::verbose(_X("Runtime config [%s] is valid=[%d]"), path.c_str(), m_valid);
+    TRACE_VERBOSE(_X("Runtime config [%s] is valid=[%d]"), path.c_str(), m_valid);
 }
 
 bool runtime_config_t::parse_opts(const json_value& opts)
@@ -116,7 +116,7 @@ bool runtime_config_t::parse_opts(const json_value& opts)
         auto val = roll_forward_option_from_string(roll_forward->second.as_string());
         if (val == roll_forward_option::__Last)
         {
-            trace::error(_X("Invalid value for property 'rollForward'."));
+            TRACE_ERROR(_X("Invalid value for property 'rollForward'."));
             return false;
         }
         m_default_settings.set_roll_forward(val);
@@ -231,7 +231,7 @@ bool runtime_config_t::parse_framework(const json_object& fx_obj, fx_reference_t
         auto val = roll_forward_option_from_string(roll_forward->second.as_string());
         if (val == roll_forward_option::__Last)
         {
-            trace::error(_X("Invalid value for property 'rollForward'."));
+            TRACE_ERROR(_X("Invalid value for property 'rollForward'."));
             return false;
         }
         fx_out.set_roll_forward(val);
@@ -269,7 +269,7 @@ bool runtime_config_t::parse_framework(const json_object& fx_obj, fx_reference_t
         auto val = roll_forward_option_from_string(env_roll_forward);
         if (val == roll_forward_option::__Last)
         {
-            trace::error(_X("Invalid value for environment variable 'DOTNET_ROLL_FORWARD'."));
+            TRACE_ERROR(_X("Invalid value for environment variable 'DOTNET_ROLL_FORWARD'."));
             return false;
         }
 
@@ -284,7 +284,7 @@ bool runtime_config_t::parse_framework(const json_object& fx_obj, fx_reference_t
 
 bool runtime_config_t::ensure_dev_config_parsed()
 {
-    trace::verbose(_X("Attempting to read dev runtime config: %s"), m_dev_path.c_str());
+    TRACE_VERBOSE(_X("Attempting to read dev runtime config: %s"), m_dev_path.c_str());
 
     pal::string_t retval;
     if (!pal::file_exists(m_dev_path))
@@ -296,13 +296,13 @@ bool runtime_config_t::ensure_dev_config_parsed()
     pal::ifstream_t file(m_dev_path);
     if (!file.good())
     {
-        trace::verbose(_X("File stream not good %s"), m_dev_path.c_str());
+        TRACE_VERBOSE(_X("File stream not good %s"), m_dev_path.c_str());
         return false;
     }
 
     if (skip_utf8_bom(&file))
     {
-        trace::verbose(_X("UTF-8 BOM skipped while reading [%s]"), m_dev_path.c_str());
+        TRACE_VERBOSE(_X("UTF-8 BOM skipped while reading [%s]"), m_dev_path.c_str());
     }
     
     try
@@ -319,7 +319,7 @@ bool runtime_config_t::ensure_dev_config_parsed()
     {
         pal::string_t jes;
         (void) pal::utf8_palstring(je.what(), &jes);
-        trace::error(_X("A JSON parsing exception occurred in [%s]: %s"), m_dev_path.c_str(), jes.c_str());
+        TRACE_ERROR(_X("A JSON parsing exception occurred in [%s]: %s"), m_dev_path.c_str(), jes.c_str());
         return false;
     }
 
@@ -343,7 +343,7 @@ bool runtime_config_t::read_framework_array(web::json::array frameworks_json)
 
         if (fx_out.get_fx_name().length() == 0)
         {
-            trace::verbose(_X("No framework name specified."));
+            TRACE_VERBOSE(_X("No framework name specified."));
             rc = false;
             break;
         }
@@ -354,7 +354,7 @@ bool runtime_config_t::read_framework_array(web::json::array frameworks_json)
                 [&](const fx_reference_t& item) { return fx_out.get_fx_name() == item.get_fx_name(); })
             != m_frameworks.end())
         {
-            trace::verbose(_X("Framework %s already specified."), fx_out.get_fx_name().c_str());
+            TRACE_VERBOSE(_X("Framework %s already specified."), fx_out.get_fx_name().c_str());
             rc = false;
             break;
         }
@@ -367,10 +367,10 @@ bool runtime_config_t::read_framework_array(web::json::array frameworks_json)
 
 bool runtime_config_t::ensure_parsed()
 {
-    trace::verbose(_X("Attempting to read runtime config: %s"), m_path.c_str());
+    TRACE_VERBOSE(_X("Attempting to read runtime config: %s"), m_path.c_str());
     if (!ensure_dev_config_parsed())
     {
-        trace::verbose(_X("Did not successfully parse the runtimeconfig.dev.json"));
+        TRACE_VERBOSE(_X("Did not successfully parse the runtimeconfig.dev.json"));
     }
 
     pal::string_t retval;
@@ -383,13 +383,13 @@ bool runtime_config_t::ensure_parsed()
     pal::ifstream_t file(m_path);
     if (!file.good())
     {
-        trace::verbose(_X("File stream not good %s"), m_path.c_str());
+        TRACE_VERBOSE(_X("File stream not good %s"), m_path.c_str());
         return false;
     }
 
     if (skip_utf8_bom(&file))
     {
-        trace::verbose(_X("UTF-8 BOM skipped while reading [%s]"), m_path.c_str());
+        TRACE_VERBOSE(_X("UTF-8 BOM skipped while reading [%s]"), m_path.c_str());
     }
 
     bool rc = true;
@@ -407,7 +407,7 @@ bool runtime_config_t::ensure_parsed()
     {
         pal::string_t jes;
         (void) pal::utf8_palstring(je.what(), &jes);
-        trace::error(_X("A JSON parsing exception occurred in [%s]: %s"), m_path.c_str(), jes.c_str());
+        TRACE_ERROR(_X("A JSON parsing exception occurred in [%s]: %s"), m_path.c_str(), jes.c_str());
         return false;
     }
 
@@ -457,7 +457,7 @@ bool runtime_config_t::mark_specified_setting(specified_setting setting)
     // If there's any flag set but the one we're trying to set, it's invalid
     if (m_specified_settings & ~setting)
     {
-        trace::error(_X("It's invalid to use both `rollForward` and one of `rollForwardOnNoCandidateFx` or `applyPatches` in the same runtime config."));
+        TRACE_ERROR(_X("It's invalid to use both `rollForward` and one of `rollForwardOnNoCandidateFx` or `applyPatches` in the same runtime config."));
         return false;
     }
 

--- a/src/corehost/cli/test/mockhostpolicy/mockhostpolicy.cpp
+++ b/src/corehost/cli/test/mockhostpolicy/mockhostpolicy.cpp
@@ -34,7 +34,7 @@ SHARED_API int HOSTPOLICY_CALLTYPE corehost_load(host_interface_t* init)
 {
     trace::setup();
 
-    trace::verbose(_X("--- Invoked hostpolicy mock - corehost_load"));
+    TRACE_VERBOSE(_X("--- Invoked hostpolicy mock - corehost_load"));
 
     std::cout << "--- Invoked hostpolicy mock - corehost_load" << std::endl;
     std::cout << "mock version: " << init->version_hi << " " << init->version_lo << std::endl;
@@ -89,19 +89,19 @@ SHARED_API int HOSTPOLICY_CALLTYPE corehost_load(host_interface_t* init)
 
 SHARED_API int HOSTPOLICY_CALLTYPE corehost_main(const int argc, const pal::char_t* argv[])
 {
-    trace::verbose(_X("--- Invoked hostpolicy mock - corehost_main"));
+    TRACE_VERBOSE(_X("--- Invoked hostpolicy mock - corehost_main"));
     return StatusCode::Success;
 }
 
 SHARED_API int HOSTPOLICY_CALLTYPE corehost_unload()
 {
-    trace::verbose(_X("--- Invoked hostpolicy mock - corehost_unload"));
+    TRACE_VERBOSE(_X("--- Invoked hostpolicy mock - corehost_unload"));
     return StatusCode::Success;
 }
 
 SHARED_API corehost_error_writer_fn HOSTPOLICY_CALLTYPE corehost_set_error_writer(corehost_error_writer_fn error_writer)
 {
-    trace::verbose(_X("--- Invoked hostpolicy mock - corehost_set_error_writer"));
+    TRACE_VERBOSE(_X("--- Invoked hostpolicy mock - corehost_set_error_writer"));
     return nullptr;
 }
 

--- a/src/corehost/cli/test/nativehost/host_context_test.cpp
+++ b/src/corehost/cli/test/nativehost/host_context_test.cpp
@@ -501,7 +501,7 @@ bool host_context_test::non_context_mixed(
     pal::string_t host_path;
     if (!pal::get_own_executable_path(&host_path) || !pal::realpath(&host_path))
     {
-        trace::error(_X("Failed to resolve full path of the current executable [%s]"), host_path.c_str());
+        TRACE_ERROR(_X("Failed to resolve full path of the current executable [%s]"), host_path.c_str());
         return false;
     }
 

--- a/src/corehost/common/pal.h
+++ b/src/corehost/common/pal.h
@@ -108,6 +108,7 @@ namespace pal
     #define COLD_FUNCTION
     #define NO_INLINE
     #define PURE_FUNCTION
+    #define PRINTF_FUNCTION(FormatArg, FirstToCheck)
 
     typedef wchar_t char_t;
     typedef std::wstring string_t;
@@ -188,6 +189,7 @@ namespace pal
     #define COLD_FUNCTION __attribute__((cold))
     #define NO_INLINE __attribute__((noinline))
     #define PURE_FUNCTION __attribute__((pure))
+    #define PRINTF_FUNCTION(FormatArg, FirstToCheck)  __attribute__((format(printf, FormatArg, FirstToCheck)))
 
     typedef char char_t;
     typedef std::string string_t;

--- a/src/corehost/common/pal.h
+++ b/src/corehost/common/pal.h
@@ -105,6 +105,10 @@ namespace pal
 
     #define STDMETHODCALLTYPE __stdcall
 
+    #define COLD_FUNCTION
+    #define NO_INLINE
+    #define PURE_FUNCTION
+
     typedef wchar_t char_t;
     typedef std::wstring string_t;
     typedef std::wstringstream stringstream_t;
@@ -180,6 +184,10 @@ namespace pal
         #include <sys/param.h>
     #endif
     #define STDMETHODCALLTYPE __stdcall
+
+    #define COLD_FUNCTION __attribute__((cold))
+    #define NO_INLINE __attribute__((noinline))
+    #define PURE_FUNCTION __attribute__((pure))
 
     typedef char char_t;
     typedef std::string string_t;

--- a/src/corehost/common/pal.unix.cpp
+++ b/src/corehost/common/pal.unix.cpp
@@ -50,7 +50,7 @@ bool pal::touch_file(const pal::string_t& path)
     int fd = open(path.c_str(), (O_CREAT | O_EXCL), (S_IRUSR | S_IRGRP | S_IROTH));
     if (fd == -1)
     {
-        trace::warning(_X("open(%s) failed in %s"), path.c_str(), _STRINGIFY(__FUNCTION__));
+        TRACE_WARNING(_X("open(%s) failed in %s"), path.c_str(), _STRINGIFY(__FUNCTION__));
         return false;
     }
     (void) close(fd);
@@ -165,7 +165,7 @@ bool pal::load_library(const string_t* path, dll_t* dll)
     *dll = dlopen(path->c_str(), RTLD_LAZY);
     if (*dll == nullptr)
     {
-        trace::error(_X("Failed to load %s, error: %s"), path, dlerror());
+        TRACE_ERROR(_X("Failed to load %s, error: %s"), path, dlerror());
         return false;
     }
     return true;
@@ -176,7 +176,7 @@ pal::proc_t pal::get_symbol(dll_t library, const char* name)
     auto result = dlsym(library, name);
     if (result == nullptr)
     {
-        trace::info(_X("Probed for and did not find library symbol %s, error: %s"), name, dlerror());
+        TRACE_INFO(_X("Probed for and did not find library symbol %s, error: %s"), name, dlerror());
     }
 
     return result;
@@ -186,7 +186,7 @@ void pal::unload_library(dll_t library)
 {
     if (dlclose(library) != 0)
     {
-        trace::warning(_X("Failed to unload library, error: %s"), dlerror());
+        TRACE_WARNING(_X("Failed to unload library, error: %s"), dlerror());
     }
 }
 
@@ -207,25 +207,25 @@ bool pal::get_default_breadcrumb_store(string_t* recv)
     if (pal::getenv(_X("CORE_BREADCRUMBS"), &ext) && pal::realpath(&ext))
     {
         // We should have the path in ext.
-        trace::info(_X("Realpath CORE_BREADCRUMBS [%s]"), ext.c_str());
+        TRACE_INFO(_X("Realpath CORE_BREADCRUMBS [%s]"), ext.c_str());
     }
 
     if (!pal::directory_exists(ext))
     {
-        trace::info(_X("Directory core breadcrumbs [%s] was not specified or found"), ext.c_str());
+        TRACE_INFO(_X("Directory core breadcrumbs [%s] was not specified or found"), ext.c_str());
         ext.clear();
         append_path(&ext, _X("opt"));
         append_path(&ext, _X("corebreadcrumbs"));
         if (!pal::directory_exists(ext))
         {
-            trace::info(_X("Fallback directory core breadcrumbs at [%s] was not found"), ext.c_str());
+            TRACE_INFO(_X("Fallback directory core breadcrumbs at [%s] was not found"), ext.c_str());
             return false;
         }
     }
 
     if (access(ext.c_str(), (R_OK | W_OK)) != 0)
     {
-        trace::info(_X("Breadcrumb store [%s] is not ACL-ed with rw-"), ext.c_str());
+        TRACE_INFO(_X("Breadcrumb store [%s] is not ACL-ed with rw-"), ext.c_str());
     }
 
     recv->assign(ext);
@@ -239,29 +239,29 @@ bool pal::get_default_servicing_directory(string_t* recv)
     if (pal::getenv(_X("CORE_SERVICING"), &ext) && pal::realpath(&ext))
     {
         // We should have the path in ext.
-        trace::info(_X("Realpath CORE_SERVICING [%s]"), ext.c_str());
+        TRACE_INFO(_X("Realpath CORE_SERVICING [%s]"), ext.c_str());
     }
 
     if (!pal::directory_exists(ext))
     {
-        trace::info(_X("Directory core servicing at [%s] was not specified or found"), ext.c_str());
+        TRACE_INFO(_X("Directory core servicing at [%s] was not specified or found"), ext.c_str());
         ext.clear();
         append_path(&ext, _X("opt"));
         append_path(&ext, _X("coreservicing"));
         if (!pal::directory_exists(ext))
         {
-            trace::info(_X("Fallback directory core servicing at [%s] was not found"), ext.c_str());
+            TRACE_INFO(_X("Fallback directory core servicing at [%s] was not found"), ext.c_str());
             return false;
         }
     }
 
     if (access(ext.c_str(), R_OK) != 0)
     {
-        trace::info(_X("Directory core servicing at [%s] was not ACL-ed properly"), ext.c_str());
+        TRACE_INFO(_X("Directory core servicing at [%s] was not ACL-ed properly"), ext.c_str());
     }
 
     recv->assign(ext);
-    trace::info(_X("Using core servicing at [%s]"), ext.c_str());
+    TRACE_INFO(_X("Using core servicing at [%s]"), ext.c_str());
     return true;
 }
 
@@ -333,11 +333,11 @@ bool pal::get_dotnet_self_registered_dir(pal::string_t* recv)
     }
     //  ***************************
 
-    trace::verbose(_X("Looking for install_location file in '%s'."), install_location_file_path.c_str());
+    TRACE_VERBOSE(_X("Looking for install_location file in '%s'."), install_location_file_path.c_str());
     FILE* install_location_file = pal::file_open(install_location_file_path, "r");
     if (install_location_file == nullptr)
     {
-        trace::verbose(_X("The install_location file failed to open."));
+        TRACE_VERBOSE(_X("The install_location file failed to open."));
         return false;
     }
 
@@ -355,13 +355,13 @@ bool pal::get_dotnet_self_registered_dir(pal::string_t* recv)
             install_location[len - 1] = '\0';
         }
 
-        trace::verbose(_X("Using install location '%s'."), install_location);
+        TRACE_VERBOSE(_X("Using install location '%s'."), install_location);
         *recv = install_location;
         result = true;
     }
     else
     {
-        trace::verbose(_X("The install_location file first line could not be read."));
+        TRACE_VERBOSE(_X("The install_location file first line could not be read."));
     }
 
     fclose(install_location_file);

--- a/src/corehost/common/pal.unix.cpp
+++ b/src/corehost/common/pal.unix.cpp
@@ -165,7 +165,7 @@ bool pal::load_library(const string_t* path, dll_t* dll)
     *dll = dlopen(path->c_str(), RTLD_LAZY);
     if (*dll == nullptr)
     {
-        TRACE_ERROR(_X("Failed to load %s, error: %s"), path, dlerror());
+        TRACE_ERROR(_X("Failed to load %s, error: %s"), path->c_str(), dlerror());
         return false;
     }
     return true;

--- a/src/corehost/common/pal.windows.cpp
+++ b/src/corehost/common/pal.windows.cpp
@@ -69,7 +69,7 @@ bool pal::touch_file(const pal::string_t& path)
     HANDLE hnd = ::CreateFileW(path.c_str(), 0, 0, NULL, CREATE_NEW, FILE_ATTRIBUTE_NORMAL, NULL);
     if (hnd == INVALID_HANDLE_VALUE)
     {
-        trace::verbose(_X("Failed to leave breadcrumb, HRESULT: 0x%X"), HRESULT_FROM_WIN32(GetLastError()));
+        TRACE_VERBOSE(_X("Failed to leave breadcrumb, HRESULT: 0x%X"), HRESULT_FROM_WIN32(GetLastError()));
         return false;
     }
     ::CloseHandle(hnd);
@@ -100,7 +100,7 @@ bool pal::getcwd(pal::string_t* recv)
         }
     }
     assert(result == 0);
-    trace::error(_X("Failed to obtain working directory, HRESULT: 0x%X"), HRESULT_FROM_WIN32(GetLastError()));
+    TRACE_ERROR(_X("Failed to obtain working directory, HRESULT: 0x%X"), HRESULT_FROM_WIN32(GetLastError()));
     return false;
 }
 
@@ -130,7 +130,7 @@ bool pal::load_library(const string_t* in_path, dll_t* dll)
     {
         if (!pal::realpath(&path))
         {
-            trace::error(_X("Failed to load the dll from [%s], HRESULT: 0x%X"), path.c_str(), HRESULT_FROM_WIN32(GetLastError()));
+            TRACE_ERROR(_X("Failed to load the dll from [%s], HRESULT: 0x%X"), path.c_str(), HRESULT_FROM_WIN32(GetLastError()));
             return false;
         }
     }
@@ -141,7 +141,7 @@ bool pal::load_library(const string_t* in_path, dll_t* dll)
     *dll = ::LoadLibraryExW(path.c_str(), NULL, LOAD_LIBRARY_SEARCH_DLL_LOAD_DIR | LOAD_LIBRARY_SEARCH_DEFAULT_DIRS);
     if (*dll == nullptr)
     {
-        trace::error(_X("Failed to load the dll from [%s], HRESULT: 0x%X"), path.c_str(), HRESULT_FROM_WIN32(GetLastError()));
+        TRACE_ERROR(_X("Failed to load the dll from [%s], HRESULT: 0x%X"), path.c_str(), HRESULT_FROM_WIN32(GetLastError()));
         return false;
     }
 
@@ -149,7 +149,7 @@ bool pal::load_library(const string_t* in_path, dll_t* dll)
     HMODULE dummy_module;
     if (!::GetModuleHandleExW(GET_MODULE_HANDLE_EX_FLAG_PIN, path.c_str(), &dummy_module))
     {
-        trace::error(_X("Failed to pin library [%s] in [%s]"), path.c_str(), _STRINGIFY(__FUNCTION__));
+        TRACE_ERROR(_X("Failed to pin library [%s] in [%s]"), path.c_str(), _STRINGIFY(__FUNCTION__));
         return false;
     }
 
@@ -157,7 +157,7 @@ bool pal::load_library(const string_t* in_path, dll_t* dll)
     {
         string_t buf;
         GetModuleFileNameWrapper(*dll, &buf);
-        trace::info(_X("Loaded library from %s"), buf.c_str());
+        TRACE_INFO(_X("Loaded library from %s"), buf.c_str());
     }
 
     return true;
@@ -168,7 +168,7 @@ pal::proc_t pal::get_symbol(dll_t library, const char* name)
     auto result = ::GetProcAddress(library, name);
     if (result == nullptr)
     {
-        trace::info(_X("Probed for and did not resolve library symbol %S"), name);
+        TRACE_INFO(_X("Probed for and did not resolve library symbol %S"), name);
     }
 
     return result;
@@ -199,7 +199,7 @@ bool pal::get_default_breadcrumb_store(string_t* recv)
     if (!get_file_path_from_env(_X("ProgramData"), &prog_dat))
     {
         // We should have the path in prog_dat.
-        trace::verbose(_X("Failed to read default breadcrumb store [%s]"), prog_dat.c_str());
+        TRACE_VERBOSE(_X("Failed to read default breadcrumb store [%s]"), prog_dat.c_str());
         return false;
     }
     recv->assign(prog_dat);
@@ -319,7 +319,7 @@ bool pal::get_dotnet_self_registered_dir(pal::string_t* recv)
     LSTATUS result = ::RegOpenKeyExW(hkeyHive, sub_key.c_str(), 0, KEY_READ | KEY_WOW64_32KEY, &hkey);
     if (result != ERROR_SUCCESS)
     {
-        trace::verbose(_X("Can't open the SDK installed location registry key, result: 0x%X"), result);
+        TRACE_VERBOSE(_X("Can't open the SDK installed location registry key, result: 0x%X"), result);
         return false;
     }
 
@@ -328,7 +328,7 @@ bool pal::get_dotnet_self_registered_dir(pal::string_t* recv)
     result = ::RegGetValueW(hkey, nullptr, value, RRF_RT_REG_SZ, nullptr, nullptr, &size);
     if (result != ERROR_SUCCESS || size == 0)
     {
-        trace::verbose(_X("Can't get the size of the SDK location registry value or it's empty, result: 0x%X"), result);
+        TRACE_VERBOSE(_X("Can't get the size of the SDK location registry value or it's empty, result: 0x%X"), result);
         ::RegCloseKey(hkey);
         return false;
     }
@@ -338,7 +338,7 @@ bool pal::get_dotnet_self_registered_dir(pal::string_t* recv)
     result = ::RegGetValueW(hkey, nullptr, value, RRF_RT_REG_SZ, nullptr, &buffer[0], &size);
     if (result != ERROR_SUCCESS)
     {
-        trace::verbose(_X("Can't get the value of the SDK location registry value, result: 0x%X"), result);
+        TRACE_VERBOSE(_X("Can't get the value of the SDK location registry value, result: 0x%X"), result);
         ::RegCloseKey(hkey);
         return false;
     }
@@ -455,14 +455,14 @@ bool pal::getenv(const char_t* name, string_t* recv)
         auto err = GetLastError();
         if (err != ERROR_ENVVAR_NOT_FOUND)
         {
-            trace::error(_X("Failed to read environment variable [%s], HRESULT: 0x%X"), name, HRESULT_FROM_WIN32(GetLastError()));
+            TRACE_ERROR(_X("Failed to read environment variable [%s], HRESULT: 0x%X"), name, HRESULT_FROM_WIN32(GetLastError()));
         }
         return false;
     }
     auto buf = new char_t[length];
     if (::GetEnvironmentVariableW(name, buf, length) == 0)
     {
-        trace::error(_X("Failed to read environment variable [%s], HRESULT: 0x%X"), name, HRESULT_FROM_WIN32(GetLastError()));
+        TRACE_ERROR(_X("Failed to read environment variable [%s], HRESULT: 0x%X"), name, HRESULT_FROM_WIN32(GetLastError()));
         return false;
     }
 
@@ -584,7 +584,7 @@ bool pal::realpath(string_t* path, bool skip_error_logging)
     {
         if (!skip_error_logging)
         {
-            trace::error(_X("Error resolving full path [%s]"), path->c_str());
+            TRACE_ERROR(_X("Error resolving full path [%s]"), path->c_str());
         }
         return false;
     }
@@ -605,7 +605,7 @@ bool pal::realpath(string_t* path, bool skip_error_logging)
         {
             if (!skip_error_logging)
             {
-                trace::error(_X("Error resolving full path [%s]"), path->c_str());
+                TRACE_ERROR(_X("Error resolving full path [%s]"), path->c_str());
             }
             return false;
         }

--- a/src/corehost/common/trace.h
+++ b/src/corehost/common/trace.h
@@ -35,10 +35,10 @@ namespace trace
     // Returns the currently set callback for error writing
     error_writer_fn get_error_writer();
 
-    void trace(const pal::char_t* format, ...) COLD_FUNCTION;
-    void trace_error(const pal::char_t* format, ...) COLD_FUNCTION;
+    void trace(const pal::char_t* format, ...) COLD_FUNCTION PRINTF_FUNCTION(1, 2);
+    void trace_error(const pal::char_t* format, ...) COLD_FUNCTION PRINTF_FUNCTION(1, 2);
 
-    void println(const pal::char_t* format, ...);
+    void println(const pal::char_t* format, ...) COLD_FUNCTION PRINTF_FUNCTION(1, 2);
     void println();
     void flush();
 };

--- a/src/corehost/common/utils.cpp
+++ b/src/corehost/common/utils.cpp
@@ -25,7 +25,7 @@ bool coreclr_exists_in_dir(const pal::string_t& candidate)
 {
     pal::string_t test(candidate);
     append_path(&test, LIBCORECLR_NAME);
-    trace::verbose(_X("Checking if CoreCLR path exists=[%s]"), test.c_str());
+    TRACE_VERBOSE(_X("Checking if CoreCLR path exists=[%s]"), test.c_str());
     return pal::file_exists(test);
 }
 
@@ -330,7 +330,7 @@ bool get_file_path_from_env(const pal::char_t* env_key, pal::string_t* recv)
             recv->assign(file_path);
             return true;
         }
-        trace::verbose(_X("Did not find [%s] directory [%s]"), env_key, file_path.c_str());
+        TRACE_VERBOSE(_X("Did not find [%s] directory [%s]"), env_key, file_path.c_str());
     }
 
     return false;
@@ -396,7 +396,7 @@ void get_runtime_config_paths(const pal::string_t& path, const pal::string_t& na
     append_path(&dev_json_path, dev_json_name.c_str());
     dev_cfg->assign(dev_json_path);
 
-    trace::verbose(_X("Runtime config is cfg=%s dev=%s"), json_path.c_str(), dev_json_path.c_str());
+    TRACE_VERBOSE(_X("Runtime config is cfg=%s dev=%s"), json_path.c_str(), dev_json_path.c_str());
 }
 
 pal::string_t get_dotnet_root_from_fxr_path(const pal::string_t &fxr_path)

--- a/src/corehost/corehost.cpp
+++ b/src/corehost/corehost.cpp
@@ -52,7 +52,7 @@ bool is_exe_enabled_for_execution(pal::string_t* app_dll)
     std::string binding(&embed[0]);
     if (!pal::utf8_palstring(binding, app_dll))
     {
-        trace::error(_X("The managed DLL bound to this executable could not be retrieved from the executable image."));
+        TRACE_ERROR(_X("The managed DLL bound to this executable could not be retrieved from the executable image."));
         return false;
     }
 
@@ -65,11 +65,11 @@ bool is_exe_enabled_for_execution(pal::string_t* app_dll)
         binding.compare(0, hi_len, &hi_part[0]) == 0 &&
         binding.compare(hi_len, lo_len, &lo_part[0]) == 0)
     {
-        trace::error(_X("This executable is not bound to a managed DLL to execute. The binding value is: '%s'"), app_dll->c_str());
+        TRACE_ERROR(_X("This executable is not bound to a managed DLL to execute. The binding value is: '%s'"), app_dll->c_str());
         return false;
     }
 
-    trace::info(_X("The managed DLL bound to this executable is: '%s'"), app_dll->c_str());
+    TRACE_INFO(_X("The managed DLL bound to this executable is: '%s'"), app_dll->c_str());
     return true;
 }
 #elif !defined(FEATURE_LIBHOST)
@@ -85,7 +85,7 @@ int exe_start(const int argc, const pal::char_t* argv[])
     pal::string_t host_path;
     if (!pal::get_own_executable_path(&host_path) || !pal::realpath(&host_path))
     {
-        trace::error(_X("Failed to resolve full path of the current executable [%s]"), host_path.c_str());
+        TRACE_ERROR(_X("Failed to resolve full path of the current executable [%s]"), host_path.c_str());
         return StatusCode::CoreHostCurHostFindFailure;
     }
 
@@ -97,7 +97,7 @@ int exe_start(const int argc, const pal::char_t* argv[])
     pal::string_t embedded_app_name;
     if (!is_exe_enabled_for_execution(&embedded_app_name))
     {
-        trace::error(_X("A fatal error was encountered. This executable was not bound to load a managed DLL."));
+        TRACE_ERROR(_X("A fatal error was encountered. This executable was not bound to load a managed DLL."));
         return StatusCode::AppHostExeNotBoundFailure;
     }
 
@@ -127,14 +127,14 @@ int exe_start(const int argc, const pal::char_t* argv[])
 
     case StatusCode::BundleExtractionFailure:
     default:
-        trace::error(_X("A fatal error was encountered. Could not extract contents of the bundle"));
+        TRACE_ERROR(_X("A fatal error was encountered. Could not extract contents of the bundle"));
         return StatusCode::AppHostExeNotBoundFailure;
     }
 
     append_path(&app_path, embedded_app_name.c_str());
     if (!pal::realpath(&app_path))
     {
-        trace::error(_X("The application to execute does not exist: '%s'."), app_path.c_str());
+        TRACE_ERROR(_X("The application to execute does not exist: '%s'."), app_path.c_str());
         return StatusCode::LibHostAppRootFindFailure;
     }
 
@@ -149,7 +149,7 @@ int exe_start(const int argc, const pal::char_t* argv[])
         // dotnet.exe is signed by Microsoft. It is technically possible to rename the file MyApp.exe and include it in the application.
         // Then one can create a shortcut for "MyApp.exe MyApp.dll" which works. The end result is that MyApp looks like it's signed by Microsoft.
         // To prevent this dotnet.exe must not be renamed, otherwise it won't run.
-        trace::error(_X("A fatal error was encountered. Cannot execute %s when renamed to %s."), CURHOST_TYPE, own_name.c_str());
+        TRACE_ERROR(_X("A fatal error was encountered. Cannot execute %s when renamed to %s."), CURHOST_TYPE, own_name.c_str());
         return StatusCode::CoreHostEntryPointFailure;
     }
 
@@ -187,9 +187,9 @@ int exe_start(const int argc, const pal::char_t* argv[])
     pal::dll_t fxr;
     if (!pal::load_library(&fxr_path, &fxr))
     {
-        trace::error(_X("The library %s was found, but loading it from %s failed"), LIBFXR_NAME, fxr_path.c_str());
-        trace::error(_X("  - Installing .NET Core prerequisites might help resolve this problem."));
-        trace::error(_X("     %s"), DOTNET_CORE_INSTALL_PREREQUISITES_URL);
+        TRACE_ERROR(_X("The library %s was found, but loading it from %s failed"), LIBFXR_NAME, fxr_path.c_str());
+        TRACE_ERROR(_X("  - Installing .NET Core prerequisites might help resolve this problem."));
+        TRACE_ERROR(_X("     %s"), DOTNET_CORE_INSTALL_PREREQUISITES_URL);
         return StatusCode::CoreHostLibLoadFailure;
     }
 
@@ -202,10 +202,10 @@ int exe_start(const int argc, const pal::char_t* argv[])
         const pal::char_t* dotnet_root_cstr = dotnet_root.empty() ? nullptr : dotnet_root.c_str();
         const pal::char_t* app_path_cstr = app_path.empty() ? nullptr : app_path.c_str();
 
-        trace::info(_X("Invoking fx resolver [%s] v2"), fxr_path.c_str());
-        trace::info(_X("Host path: [%s]"), host_path.c_str());
-        trace::info(_X("Dotnet path: [%s]"), dotnet_root.c_str());
-        trace::info(_X("App path: [%s]"), app_path.c_str());
+        TRACE_INFO(_X("Invoking fx resolver [%s] v2"), fxr_path.c_str());
+        TRACE_INFO(_X("Host path: [%s]"), host_path.c_str());
+        TRACE_INFO(_X("Dotnet path: [%s]"), dotnet_root.c_str());
+        TRACE_INFO(_X("App path: [%s]"), app_path.c_str());
 
         hostfxr_set_error_writer_fn set_error_writer_fn = reinterpret_cast<hostfxr_set_error_writer_fn>(pal::get_symbol(fxr, "hostfxr_set_error_writer"));
 
@@ -219,12 +219,12 @@ int exe_start(const int argc, const pal::char_t* argv[])
     {
         if (requires_v2_hostfxr_interface)
         {
-            trace::error(_X("The required library %s does not support relative app dll paths."), fxr_path.c_str());
+            TRACE_ERROR(_X("The required library %s does not support relative app dll paths."), fxr_path.c_str());
             rc = StatusCode::CoreHostEntryPointFailure;
         }
         else
         {
-            trace::info(_X("Invoking fx resolver [%s] v1"), fxr_path.c_str());
+            TRACE_INFO(_X("Invoking fx resolver [%s] v1"), fxr_path.c_str());
 
             // Previous corehost trace messages must be printed before calling trace::setup in hostfxr
             trace::flush();
@@ -238,7 +238,7 @@ int exe_start(const int argc, const pal::char_t* argv[])
             }
             else
             {
-                trace::error(_X("The required library %s does not contain the expected entry point."), fxr_path.c_str());
+                TRACE_ERROR(_X("The required library %s does not contain the expected entry point."), fxr_path.c_str());
                 rc = StatusCode::CoreHostEntryPointFailure;
             }
         }
@@ -282,12 +282,12 @@ int main(const int argc, const pal::char_t* argv[])
 
     if (trace::is_enabled())
     {
-        trace::info(_X("--- Invoked %s [version: %s, commit hash: %s] main = {"), CURHOST_TYPE, _STRINGIFY(CUREXE_PKG_VER), _STRINGIFY(REPO_COMMIT_HASH));
+        TRACE_INFO(_X("--- Invoked %s [version: %s, commit hash: %s] main = {"), CURHOST_TYPE, _STRINGIFY(CUREXE_PKG_VER), _STRINGIFY(REPO_COMMIT_HASH));
         for (int i = 0; i < argc; ++i)
         {
-            trace::info(_X("%s"), argv[i]);
+            TRACE_INFO(_X("%s"), argv[i]);
         }
-        trace::info(_X("}"));
+        TRACE_INFO(_X("}"));
     }
 
 #if defined(_WIN32) && defined(FEATURE_APPHOST)
@@ -303,14 +303,14 @@ int main(const int argc, const pal::char_t* argv[])
 
         if (!gui_errors_disabled)
         {
-            trace::verbose(_X("Redirecting errors to custom writer."));
+            TRACE_VERBOSE(_X("Redirecting errors to custom writer."));
             // If this is a GUI application, buffer errors to display them later. Without this any errors are effectively lost
             // unless the caller explicitly redirects stderr. This leads to bad experience of running the GUI app and nothing happening.
             trace::set_error_writer(buffering_trace_writer);
         }
         else
         {
-            trace::verbose(_X("Gui errors disabled, keeping errors in stderr."));
+            TRACE_VERBOSE(_X("Gui errors disabled, keeping errors in stderr."));
         }
     }
 #endif


### PR DESCRIPTION
Individual commit messages will have more detail, but here's the gist:

> Introduce TRACE_ERROR(), TRACE_WARNING(), TRACE_INFO(), and TRACE_VERBOSE() macros, that supersede similarly-named functions in the trace namespace.
> 
> Using these macros will ensure that the arguments are only evaluated in the expected verbosity levels.  Some arguments create temporary objects that are only visible in high verbosity levels, creating useless churn in the allocator.

This has been suggested by @vitek-karas and is my first attempt at this:

> I did some rough profiling of hostpolicy trying to figure out why some tests take so long to run (1 sec per iteration). And one of the things which jumped out was `version_t::as_str()` which is basically only used for tracing. The short version of the story is that we call something like `trace::verbose("..", version.as_str())`. The compiler can't optimize the call to `as_str` away (it may be used at runtime if tracing is on) and it probably doesn't inline it (it's part of varargs). The end result is that we pay the price for all of the arguments to trace calls even if tracing is disabled.
> 
> In case of `as_str` this is exaggerated by the fact that the function will allocate internally (it uses std string formatting to construct the version string from numbers, one by one). We call this function a LOT (cca 700 times to run a simple console app). This internally will end up calling some of the string functions 4 times per call which is almost 3000 calls. All done for effectively nothing.