### PR TITLE
Change GUI apphost tests to not rely on window searches

### DIFF
--- a/src/corehost/corehost.cpp
+++ b/src/corehost/corehost.cpp
@@ -317,8 +317,7 @@ int main(const int argc, const pal::char_t* argv[])
 
     int exit_code = exe_start(argc, argv);
 
-    // Flush traces before exit - just to be sure, and also if we're showing a popup below the error should show up in traces
-    // by the time the popup is displayed.
+    // Flush traces before exit - just to be sure
     trace::flush();
 
 #if defined(_WIN32) && defined(FEATURE_APPHOST)
@@ -331,6 +330,11 @@ int main(const int argc, const pal::char_t* argv[])
         {
             executable_name = get_filename(executable_name);
         }
+
+        trace::verbose(_X("Creating a GUI message box with title: '%s' and message: '%s;."), executable_name.c_str(), g_buffered_errors.c_str());
+
+        // Flush here so that when the dialog is up, the traces are up to date (specifically when they are redirected to a file).
+        trace::flush();
 
         ::MessageBoxW(NULL, g_buffered_errors.c_str(), executable_name.c_str(), MB_OK);
     }

--- a/src/test/HostActivationTests/CommandExtensions.cs
+++ b/src/test/HostActivationTests/CommandExtensions.cs
@@ -3,6 +3,8 @@
 // See the LICENSE file in the project root for more information.
 
 using Microsoft.DotNet.Cli.Build.Framework;
+using System;
+using System.IO;
 
 namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
 {
@@ -11,6 +13,19 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
         public static Command EnableHostTracing(this Command command)
         {
             return command.EnvironmentVariable(Constants.HostTracing.TraceLevelEnvironmentVariable, "1");
+        }
+
+        public static Command EnableHostTracingToFile(this Command command, out string filePath)
+        {
+            filePath = Path.Combine(TestArtifact.TestArtifactsPath, "trace" + Guid.NewGuid().ToString() + ".log");
+            if (File.Exists(filePath))
+            {
+                File.Delete(filePath);
+            }
+
+            return command
+                .EnableHostTracing()
+                .EnvironmentVariable(Constants.HostTracing.TraceFileEnvironmentVariable, filePath);
         }
 
         public static Command EnableTracingAndCaptureOutputs(this Command command)

--- a/src/test/TestUtils/Assertions/CommandResultAssertions.cs
+++ b/src/test/TestUtils/Assertions/CommandResultAssertions.cs
@@ -126,15 +126,17 @@ namespace Microsoft.DotNet.CoreSetup.Test
 
         public AndConstraint<CommandResultAssertions> FileContains(string path, string pattern)
         {
-            Execute.Assertion.ForCondition(System.IO.File.ReadAllText(path).Contains(pattern))
-                .FailWith("The command did not write the expected result '{0}' to the file: {1}{2}", pattern, path, GetDiagnosticsInfo());
+            string fileContent = System.IO.File.ReadAllText(path);
+            Execute.Assertion.ForCondition(fileContent.Contains(pattern))
+                .FailWith("The command did not write the expected result '{0}' to the file: {1}{2}\nfile content: {3}", pattern, path, GetDiagnosticsInfo(), fileContent);
             return new AndConstraint<CommandResultAssertions>(this);
         }
 
         public AndConstraint<CommandResultAssertions> NotFileContains(string path, string pattern)
         {
-            Execute.Assertion.ForCondition(!System.IO.File.ReadAllText(path).Contains(pattern))
-                .FailWith("The command did not write the expected result '{1}' to the file: {1}{2}", pattern, path, GetDiagnosticsInfo());
+            string fileContent = System.IO.File.ReadAllText(path);
+            Execute.Assertion.ForCondition(!fileContent.Contains(pattern))
+                .FailWith("The command did not write the expected result '{1}' to the file: {1}{2}\nfile content: {3}", pattern, path, GetDiagnosticsInfo(), fileContent);
             return new AndConstraint<CommandResultAssertions>(this);
         }
 

--- a/src/test/TestUtils/FileUtils.cs
+++ b/src/test/TestUtils/FileUtils.cs
@@ -146,5 +146,16 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
             EnsureFileDirectoryExists(filePath);
             File.WriteAllText(filePath, string.Empty);
         }
+
+        public static void DeleteFileIfPossible(string filePath)
+        {
+            try
+            {
+                File.Delete(filePath);
+            }
+            catch (System.IO.IOException)
+            {
+            }
+        }
     }
 }


### PR DESCRIPTION
* Disable failures when no window popup is detected. I kept the window popup detection code active as a "Fast" way to detect the process is done (it would timeout otherwise)
* Add new trace to note that we are trying to popup a window
* Add some test helpers to remove code duplication and better logging
* Validate product behavior based on traces

- Please add a description for changes you are making.
- If there is an issue related to this PR, please add a reference to it.
- If this PR should not run tests please add say skip_ci_please in this description replacing the underscores with spaces.