### PR TITLE
Add apphost.exe and comhost.dll to signing list

### DIFF
--- a/signing/sign.proj
+++ b/signing/sign.proj
@@ -37,6 +37,12 @@
       <FilesToSign Include="$(OutDir)corehost/**/dotnet.exe">
         <Authenticode>$(CertificateId)</Authenticode>
       </FilesToSign>
+      <FilesToSign Include="$(OutDir)corehost/**/apphost.exe">
+        <Authenticode>$(CertificateId)</Authenticode>
+      </FilesToSign>
+      <FilesToSign Include="$(OutDir)corehost/**/comhost.dll">
+        <Authenticode>$(CertificateId)</Authenticode>
+      </FilesToSign>
       <FilesToSign Include="$(OutDir)corehost/**/ijwhost.dll">
         <Authenticode>$(CertificateId)</Authenticode>
       </FilesToSign>


### PR DESCRIPTION
For https://github.com/dotnet/core-setup/issues/6839, failure to insert into VS:

> https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=2773348&_a=summary
> 
> These files failed signing:
> 
> ```
> SRC\REDIST\COMMON\NETCOREAPPHOSTPACK_3.0\X64\DOTNET-APPHOST-PACK-3.0.0-PREVIEW7-27809-09-WIN-X64.MSIDIR\CAB1.CAB.CABDIR\FIL2193BEF427239477D6C998B8B8E70D28.EXE
> SRC\REDIST\COMMON\NETCOREAPPHOSTPACK_3.0\X64\DOTNET-APPHOST-PACK-3.0.0-PREVIEW7-27809-09-WIN-X64.MSIDIR\CAB1.CAB.CABDIR\FIL84262D2CA8B5E692CEF2A459B3849D1B.DLL
> SRC\REDIST\COMMON\NETCOREAPPHOSTPACK_3.0\X86\DOTNET-APPHOST-PACK-3.0.0-PREVIEW7-27809-09-WIN-X86.MSIDIR\CAB1.CAB.CABDIR\FIL776E3A99A3B251BD4E1B77C394915450.DLL
> SRC\REDIST\COMMON\NETCOREAPPHOSTPACK_3.0\X86\DOTNET-APPHOST-PACK-3.0.0-PREVIEW7-27809-09-WIN-X86.MSIDIR\CAB1.CAB.CABDIR\FIL99BB0C9F86161C4A790C53F59523618A.EXE
> ```
> 
> (Note that those are files within the MSIs, not the MSIs themselves.)

I peeked at the MSI with Orca and `apphost.exe` and `comhost.dll` correspond.

@vitek-karas, @elinor-fung, @AaronRobinsonMSFT, @swaroop-sridhar, are these missing signing (and it's ok to add it), or is this intended for some reason due to how they're used?