### PR TITLE
Store the full metadata token in the bootstrap thunk on x86.

### DIFF
--- a/src/corehost/cli/ijwhost/i386/bootstrap_thunk.cpp
+++ b/src/corehost/cli/ijwhost/i386/bootstrap_thunk.cpp
@@ -38,12 +38,7 @@ pal::dll_t bootstrap_thunk::get_dll_handle()
 // Returns the token of this thunk
 std::uint32_t bootstrap_thunk::get_token()
 {
-    std::uint32_t ulTok = 0;
-    BYTE *pbTok = (BYTE *)&ulTok;
-
-    memcpy(pbTok, &m_tok[0], sizeof(m_tok));
-
-    return ulTok;
+    return m_token;
 }
 
 //=================================================================================
@@ -62,9 +57,7 @@ void bootstrap_thunk::initialize(std::uintptr_t pThunkInitFcn,
                                           std::uintptr_t *pSlot)
 {
     
-    // First fill in the token portion of the struct.
-    BYTE *pbTok = (BYTE *)(&token);
-    memcpy(&m_tok[0], pbTok, sizeof(m_tok));
+    m_token = token;
 
     // Now set up the thunk code
     std::uintptr_t pFrom;

--- a/src/corehost/cli/ijwhost/i386/bootstrap_thunk.h
+++ b/src/corehost/cli/ijwhost/i386/bootstrap_thunk.h
@@ -19,7 +19,7 @@ extern "C" void STDMETHODCALLTYPE start_runtime_thunk_stub();
 class bootstrap_thunk
 {
 private:
-    BYTE            m_tok[3];
+    std::uint32_t m_token;
 
     struct {
         BYTE            m_call;         //0xe8


### PR DESCRIPTION
We were trying to save space by not storing the full metadata token on x86. In the .NET Framework version of the host, there was some bit-fiddling to store the information from the top byte of the token in the bottom bit, which was accidentally removed when first writing ijwhost. This PR changes it to just store the full token and not do any of the shenanigans that we were doing beforehand.
