### PR TITLE
Fix infinite loop in traversing thunk chunks when checking if thunks are installed.

### DIFF
--- a/src/corehost/cli/ijwhost/bootstrap_thunk_chunk.cpp
+++ b/src/corehost/cli/ijwhost/bootstrap_thunk_chunk.cpp
@@ -8,7 +8,7 @@
 //=================================================================================
 // Ctor
 bootstrap_thunk_chunk::bootstrap_thunk_chunk(size_t numThunks, pal::dll_t dll)
-    : m_dll(dll), m_numThunks(numThunks), m_next(NULL)
+    : m_dll(dll), m_numThunks(numThunks), m_next(nullptr)
 {
 #ifdef _DEBUG
     memset(m_thunks, 0, m_numThunks * sizeof(bootstrap_thunk));

--- a/src/corehost/cli/ijwhost/ijwthunk.cpp
+++ b/src/corehost/cli/ijwhost/ijwthunk.cpp
@@ -183,6 +183,7 @@ bool are_thunks_installed_for_module(pal::dll_t instance)
         {
             return true;
         }
+        currentChunk = currentChunk->GetNext();
     }
 
     return false;


### PR DESCRIPTION
We weren't actually traversing the linked list of `bootstrap_thunk_chunk`s in `are_thunks_installed_for_module`, so if there were multiple IJW assemblies loaded into memory, we'd get an infinite loop when trying to load the second one.

This fixes the infinite loop.