### PR TITLE
Fix Alpine rootfs build

### DIFF
--- a/cross/build-rootfs.sh
+++ b/cross/build-rootfs.sh
@@ -180,6 +180,7 @@ if [[ "$__LinuxCodeName" == "alpine" ]]; then
       -X http://dl-cdn.alpinelinux.org/alpine/v$__AlpineVersion/main \
       -X http://dl-cdn.alpinelinux.org/alpine/v$__AlpineVersion/community \
       -X http://dl-cdn.alpinelinux.org/alpine/edge/testing \
+      -X http://dl-cdn.alpinelinux.org/alpine/edge/main \
       -U --allow-untrusted --root $__RootfsDir --arch $__AlpineArch --initdb \
       add $__AlpinePackages
     rm -r $__ApkToolsDir


### PR DESCRIPTION
Alpine has moved to a new version of LLDB (8) and its dependency LLVM
libraries are now in the edge/main branch. This adds edge/main branch to
the apk add command commandline so that the dependencies can be found.

This is a copy of the same change made in dotnet/arcade. We should eventually
move core-setup to get the eng folder from arcade, but for now, we need
a quick solution.

Close #6877