### PR TITLE
Do not throw during startup if not running a bundled executable

### DIFF
--- a/src/corehost/cli/apphost/bundle/bundle_runner.h
+++ b/src/corehost/cli/apphost/bundle/bundle_runner.h
@@ -30,14 +30,19 @@ namespace bundle
 
         StatusCode extract();
 
+        static StatusCode try_read(void* buf, size_t size, FILE* stream);
+        static StatusCode try_write(const void* buf, size_t size, FILE* stream);
+
         static void read(void* buf, size_t size, FILE* stream);
         static void write(const void* buf, size_t size, FILE* stream);
+
         static size_t get_path_length(int8_t first_byte, FILE* stream);
         static void read_string(pal::string_t& str, size_t size, FILE* stream);
 
     private:
         void reopen_host_for_reading();
         static void seek(FILE* stream, long offset, int origin);
+        static StatusCode try_seek(FILE* stream, long offset, int origin);
 
         bool process_manifest_footer(int64_t& header_offset);
         void process_manifest_header(int64_t header_offset);

--- a/src/corehost/cli/apphost/bundle/manifest.cpp
+++ b/src/corehost/cli/apphost/bundle/manifest.cpp
@@ -50,13 +50,9 @@ bool manifest_footer_t::is_valid()
         strcmp(m_signature, m_expected_signature) == 0;
 }
 
-manifest_footer_t* manifest_footer_t::read(FILE* stream)
+StatusCode manifest_footer_t::try_read(FILE* stream, manifest_footer_t *footer)
 {
-    manifest_footer_t* footer = new manifest_footer_t();
-
-    bundle_runner_t::read(footer, num_bytes_read(), stream);
-
-    return footer;
+    return bundle_runner_t::try_read(footer, num_bytes_read(), stream);
 }
 
 manifest_t* manifest_t::read(FILE* stream, int32_t num_files)

--- a/src/corehost/cli/apphost/bundle/manifest.h
+++ b/src/corehost/cli/apphost/bundle/manifest.h
@@ -8,6 +8,7 @@
 #include <cstdint>
 #include <list>
 #include "file_entry.h"
+#include "error_codes.h"
 
 namespace bundle
 {
@@ -64,7 +65,7 @@ namespace bundle
         }
 
         bool is_valid();
-        static manifest_footer_t* read(FILE* stream);
+        static StatusCode try_read(FILE* stream, struct manifest_footer_t* footer);
         int64_t manifest_header_offset() { return m_header_offset; }
         static size_t num_bytes_read()
         {


### PR DESCRIPTION
This fixes #6883.  This requires some further love and dedication, but will do for now so we can stabilize 3.0 further.

Also plugs a memory leak while reading the footer by allocating the space for the footer in the stack rather than from the heap.
