### PR TITLE
Consolidate MSBuild versions for source-build

### DIFF
--- a/dependencies.props
+++ b/dependencies.props
@@ -32,7 +32,7 @@
   <!-- infrastructure and test only dependencies -->
   <PropertyGroup>
     <NugetProjectModelPackageVersion>4.3.0-preview2-4095</NugetProjectModelPackageVersion>
-    <MicrosoftBuildPackageVersion>15.7.0-preview-000143</MicrosoftBuildPackageVersion>
+    <MicrosoftBuildPackageVersion>15.7.179</MicrosoftBuildPackageVersion>
     <MicrosoftBuildFrameworkPackageVersion>$(MicrosoftBuildPackageVersion)</MicrosoftBuildFrameworkPackageVersion>
     <MicrosoftBuildTasksCorePackageVersion>$(MicrosoftBuildPackageVersion)</MicrosoftBuildTasksCorePackageVersion>
     <MicrosoftBuildUtilitiesCorePackageVersion>$(MicrosoftBuildPackageVersion)</MicrosoftBuildUtilitiesCorePackageVersion>


### PR DESCRIPTION
Consolidate versions of MSBuild* versions to 15.7.179 to allow source-build reference packages to only build one version.