### PR TITLE
Allow ijwhost to work without requiring a runtimeconfig.json for dll being loaded

### DIFF
--- a/src/corehost/cli/fxr/corehost_init.cpp
+++ b/src/corehost/cli/fxr/corehost_init.cpp
@@ -16,12 +16,14 @@ void make_cstr_arr(const std::vector<pal::string_t>& arr, std::vector<const pal:
 corehost_init_t::corehost_init_t(
     const pal::string_t& host_command,
     const host_startup_info_t& host_info,
+    const pal::string_t &runtime_config_file,
     const pal::string_t& deps_file,
     const pal::string_t& additional_deps_serialized,
     const std::vector<pal::string_t>& probe_paths,
     const host_mode_t mode,
     const fx_definition_vector_t& fx_definitions)
     : m_tfm(get_app(fx_definitions).get_runtime_config().get_tfm())
+    , m_runtime_config_file(runtime_config_file)
     , m_deps_file(deps_file)
     , m_additional_deps_serialized(additional_deps_serialized)
     , m_is_framework_dependent(get_app(fx_definitions).get_runtime_config().get_is_framework_dependent())
@@ -93,6 +95,7 @@ const host_interface_t& corehost_init_t::get_host_init_data()
         hi.fx_ver = _X("");
     }
 
+    hi.runtime_config_file = m_runtime_config_file.c_str();
     hi.deps_file = m_deps_file.c_str();
     hi.additional_deps_serialized = m_additional_deps_serialized.c_str();
     hi.is_framework_dependent = m_is_framework_dependent;

--- a/src/corehost/cli/fxr/corehost_init.h
+++ b/src/corehost/cli/fxr/corehost_init.h
@@ -17,6 +17,7 @@ private:
     std::vector<const pal::char_t*> m_clr_keys_cstr;
     std::vector<const pal::char_t*> m_clr_values_cstr;
     const pal::string_t m_tfm;
+    const pal::string_t m_runtime_config_file;
     const pal::string_t m_deps_file;
     const pal::string_t m_additional_deps_serialized;
     bool m_is_framework_dependent;
@@ -40,6 +41,7 @@ public:
     corehost_init_t(
         const pal::string_t& host_command,
         const host_startup_info_t& host_info,
+        const pal::string_t &runtime_config_file,
         const pal::string_t& deps_file,
         const pal::string_t& additional_deps_serialized,
         const std::vector<pal::string_t>& probe_paths,

--- a/src/corehost/cli/fxr/fx_muxer.h
+++ b/src/corehost/cli/fxr/fx_muxer.h
@@ -29,7 +29,7 @@ public:
         hostfxr_handle *host_context_handle);
     static int initialize_for_runtime_config(
         const host_startup_info_t& host_info,
-        const pal::char_t * runtime_config_path,
+        const pal::char_t * runtime_config_file,
         hostfxr_handle *host_context_handle);
     static int run_app(host_context_t *context);
     static int get_runtime_delegate(

--- a/src/corehost/cli/host_interface.h
+++ b/src/corehost/cli/host_interface.h
@@ -58,6 +58,7 @@ struct host_interface_t
     const pal::char_t* host_info_host_path;
     const pal::char_t* host_info_dotnet_root;
     const pal::char_t* host_info_app_path;
+    const pal::char_t* runtime_config_file;
     // !! WARNING / WARNING / WARNING / WARNING / WARNING / WARNING / WARNING / WARNING / WARNING
     // !! 1. Only append to this structure to maintain compat.
     // !! 2. Any nested structs should not use compiler specific padding (pack with _HOST_INTERFACE_PACK)
@@ -91,7 +92,8 @@ static_assert(offsetof(host_interface_t, host_command) == 26 * sizeof(size_t), "
 static_assert(offsetof(host_interface_t, host_info_host_path) == 27 * sizeof(size_t), "Struct offset breaks backwards compatibility");
 static_assert(offsetof(host_interface_t, host_info_dotnet_root) == 28 * sizeof(size_t), "Struct offset breaks backwards compatibility");
 static_assert(offsetof(host_interface_t, host_info_app_path) == 29 * sizeof(size_t), "Struct offset breaks backwards compatibility");
-static_assert(sizeof(host_interface_t) == 30 * sizeof(size_t), "Did you add static asserts for the newly added fields?");
+static_assert(offsetof(host_interface_t, runtime_config_file) == 30 * sizeof(size_t), "Struct offset breaks backwards compatibility");
+static_assert(sizeof(host_interface_t) == 31 * sizeof(size_t), "Did you add static asserts for the newly added fields?");
 
 #define HOST_INTERFACE_LAYOUT_VERSION_HI 0x16041101 // YYMMDD:nn always increases when layout breaks compat.
 #define HOST_INTERFACE_LAYOUT_VERSION_LO sizeof(host_interface_t)

--- a/src/corehost/cli/hostpolicy/coreclr.cpp
+++ b/src/corehost/cli/hostpolicy/coreclr.cpp
@@ -204,7 +204,8 @@ namespace
         _X("JIT_PATH"),
         _X("STARTUP_HOOKS"),
         _X("APP_PATHS"),
-        _X("APP_NI_PATHS")
+        _X("APP_NI_PATHS"),
+        _X("APP_CONTEXT_RUNTIME_CONFIG_FILE"),
     };
 
     static_assert((sizeof(PropertyNameMapping) / sizeof(*PropertyNameMapping)) == static_cast<size_t>(common_property::Last), "Invalid property count");

--- a/src/corehost/cli/hostpolicy/coreclr.h
+++ b/src/corehost/cli/hostpolicy/coreclr.h
@@ -68,7 +68,7 @@ enum class common_property
     StartUpHooks,
     AppPaths,
     AppNIPaths,
-
+    AppContextRuntimeConfigFile,
     // Sentinel value - new values should be defined above
     Last
 };

--- a/src/corehost/cli/hostpolicy/hostpolicy_context.cpp
+++ b/src/corehost/cli/hostpolicy/hostpolicy_context.cpp
@@ -142,6 +142,7 @@ int hostpolicy_context_t::initialize(hostpolicy_init_t &hostpolicy_init, const a
     coreclr_properties.add(common_property::PlatformResourceRoots, probe_paths.resources.c_str());
     coreclr_properties.add(common_property::AppDomainCompatSwitch, _X("UseLatestBehaviorWhenTFMNotSpecified"));
     coreclr_properties.add(common_property::AppContextBaseDirectory, app_base.c_str());
+    coreclr_properties.add(common_property::AppContextRuntimeConfigFile, hostpolicy_init.runtime_config_file.c_str());
     coreclr_properties.add(common_property::AppContextDepsFiles, app_context_deps_str.c_str());
     coreclr_properties.add(common_property::FxDepsFile, fx_deps_str.c_str());
     coreclr_properties.add(common_property::ProbingDirectories, resolver.get_lookup_probe_directories().c_str());

--- a/src/corehost/cli/hostpolicy/hostpolicy_init.cpp
+++ b/src/corehost/cli/hostpolicy/hostpolicy_init.cpp
@@ -35,6 +35,7 @@ bool hostpolicy_init_t::init(host_interface_t* input, hostpolicy_init_t* init)
         make_palstr_arr(input->config_keys.len, input->config_keys.arr, &init->cfg_keys);
         make_palstr_arr(input->config_values.len, input->config_values.arr, &init->cfg_values);
 
+        init->runtime_config_file = input->runtime_config_file;
         init->deps_file = input->deps_file;
         init->is_framework_dependent = input->is_framework_dependent;
 

--- a/src/corehost/cli/hostpolicy/hostpolicy_init.h
+++ b/src/corehost/cli/hostpolicy/hostpolicy_init.h
@@ -13,6 +13,7 @@ struct hostpolicy_init_t
 {
     std::vector<pal::string_t> cfg_keys;
     std::vector<pal::string_t> cfg_values;
+    pal::string_t runtime_config_file;
     pal::string_t deps_file;
     pal::string_t additional_deps_serialized;
     std::vector<pal::string_t> probe_paths;

--- a/src/corehost/cli/ijwhost/ijwhost.cpp
+++ b/src/corehost/cli/ijwhost/ijwhost.cpp
@@ -30,12 +30,13 @@ pal::hresult_t get_load_in_memory_assembly_delegate(pal::dll_t handle, load_in_m
             pal::string_t mod_path;
             if (!pal::get_module_path(handle, &mod_path))
             {
-                trace::error(_X("Failed to resolve full path of the current mixed-mode module [%s]"), host_path.c_str());
+                trace::error(_X("Failed to resolve full path of the current mixed-mode module [%s]"), mod_path.c_str());
                 return StatusCode::LibHostCurExeFindFailure;
             }
 
             pal::string_t config_path_local { strip_file_ext(mod_path) };
             config_path_local.append(_X(".runtimeconfig.json"));
+
             *config_path_out = std::move(config_path_local);
 
             return StatusCode::Success;


### PR DESCRIPTION
This PR will allow ijwhost to work without requiring a runtimeconfig.json for dll being loaded.

This is made possible by adding the runtime_config_file to the properties of hostpolicy_init and reusing this in ijwhost if the calculated config file does not exist.
Due to this we can just reuse an existing loaded runtime.
I also thought that adding the runtimeconfig.json file to the properties makes sense as the deps file is also already added.

The use case for this are, at least but not limited to, tools like https://github.com/snoopwpf/snoopwpf which inject themselves into foreign processes.
Please note that the current version of snoop uses c++/cli and is not compatible with .net core 3.0 and that this PR tries to pave to way to get away from c++/cli in that project as it's way easier to have pure managed code (plus some tool to produce the modified assemblies exporting functions) than managing c++/cli projects.
You can see how it works with "pure" managed code, but currently only working with the full .net framework instead of core, in https://github.com/batzen/snoopwpf/tree/NETCore3.

This PR is related to #6100 (which got moved to https://github.com/dotnet/coreclr/issues/24318).

Notes:
For this to fully work out of the box the DLLMain/ExeMain of the library being loaded has to point to ijwhost.dll instead of mscoree.dll.
I did this by using a modified version of dnlib as i need those changes there anyway to create a fully managed dll with exported function.
You can find the PR at https://github.com/0xd4d/dnlib/pull/281.

I also prepared a demo project creating such dlls at https://github.com/batzen/NativeToManagedTest. 
To test this out you have to:
- clone the NativeToManagedTest repository
- build it (via dotnet build)
- checkout this PR
- build it 
- copy hostfxr.dll and ijwhost.dll to the "NativeToManagedTest\bin\Debug\x64\netcoreapp3.0" directory 
- copy hostpolicy.dll (make a backup of the original one before this step) to the dotnet shared framework directory being referenced in the NativeToManagedTest projects
- run WPFTestApp.exe
- click the button labeled "Call managed native"
- two message boxes should be shown saying "Hi from method ..."

Questions:
- I had a hard time figuring out how to use my self compiled hostpolicy.dll instead of the one from the shared framework. Do you have any hints on how to achieve this easily? Placing hostfxr.dll beside my .exe was enough for that one to be picked up.
- How and where should i write tests for this? The only tests for ijwhost i could find are in coreclr and not in core-setup.

Also adding @jeffschwMSFT @vitek-karas @AaronRobinsonMSFT as requested.