### PR TITLE
Implement roll-forward policies for .NET Core SDK resolution.

### DIFF
--- a/src/corehost/cli/fxr/fx_muxer.cpp
+++ b/src/corehost/cli/fxr/fx_muxer.cpp
@@ -969,8 +969,8 @@ int fx_muxer_t::handle_cli(
     // Did not exececute the app or run other commands, so try the CLI SDK dotnet.dll
     //
 
-    pal::string_t sdk_dotnet;
-    if (!sdk_resolver_t::resolve_sdk_dotnet_path(host_info.dotnet_root, &sdk_dotnet))
+    auto sdk_dotnet = sdk_resolver::from_nearest_global_file().resolve(host_info.dotnet_root);
+    if (sdk_dotnet.empty())
     {
         assert(argc > 1);
         if (pal::strcasecmp(_X("-h"), argv[1]) == 0 ||
@@ -994,7 +994,7 @@ int fx_muxer_t::handle_cli(
 
     if (!pal::file_exists(sdk_dotnet))
     {
-        trace::error(_X("Found dotnet SDK, but did not find dotnet.dll at [%s]"), sdk_dotnet.c_str());
+        trace::error(_X("Found .NET Core SDK, but did not find dotnet.dll at [%s]"), sdk_dotnet.c_str());
         return StatusCode::LibHostSdkFindFailure;
     }
 
@@ -1006,7 +1006,7 @@ int fx_muxer_t::handle_cli(
     new_argv.push_back(sdk_dotnet.c_str());
     new_argv.insert(new_argv.end(), argv + 1, argv + argc);
 
-    trace::verbose(_X("Using dotnet SDK dll=[%s]"), sdk_dotnet.c_str());
+    trace::verbose(_X("Using .NET Core SDK dll=[%s]"), sdk_dotnet.c_str());
 
     int new_argoff;
     pal::string_t app_candidate;

--- a/src/corehost/cli/fxr/sdk_resolver.cpp
+++ b/src/corehost/cli/fxr/sdk_resolver.cpp
@@ -225,7 +225,7 @@ bool sdk_resolver::parse_global_file(pal::string_t global_file_path)
     {
         pal::string_t msg;
         (void)pal::utf8_palstring(ex.what(), &msg);
-        trace::warning(_X("A JSON parsing exception occurred in [%s]: %s"), global_file_path.c_str(), msg.c_str());
+        trace::error(_X("A JSON parsing exception occurred in [%s]: %s"), global_file_path.c_str(), msg.c_str());
         return false;
     }
 

--- a/src/corehost/cli/fxr/sdk_resolver.cpp
+++ b/src/corehost/cli/fxr/sdk_resolver.cpp
@@ -5,7 +5,6 @@
 #include "sdk_resolver.h"
 
 #include "cpprest/json.h"
-#include "fx_ver.h"
 #include "trace.h"
 #include "utils.h"
 #include "sdk_info.h"
@@ -13,175 +12,233 @@
 typedef web::json::value json_value;
 typedef web::json::object json_object;
 
-pal::string_t resolve_cli_version(const pal::string_t& global_json)
+using namespace std;
+
+sdk_resolver::sdk_resolver(bool allow_prerelease) :
+    sdk_resolver({}, sdk_roll_forward_policy::latest_major, allow_prerelease)
 {
-    trace::verbose(_X("--- Resolving CLI version from global json [%s]"), global_json.c_str());
-
-    pal::string_t retval;
-    if (!pal::file_exists(global_json))
-    {
-        trace::verbose(_X("[%s] does not exist"), global_json.c_str());
-        return retval;
-    }
-
-    pal::ifstream_t file(global_json);
-    if (!file.good())
-    {
-        trace::verbose(_X("[%s] could not be opened"), global_json.c_str());
-        return retval;
-    }
-
-    if (skip_utf8_bom(&file))
-    {
-        trace::verbose(_X("UTF-8 BOM skipped while reading [%s]"), global_json.c_str());
-    }
-
-    try
-    {
-        const auto root = json_value::parse(file);
-        const auto& json = root.as_object();
-        const auto sdk_iter = json.find(_X("sdk"));
-        if (sdk_iter == json.end() || sdk_iter->second.is_null())
-        {
-            trace::verbose(_X("CLI '/sdk/version' field not present/null in [%s]"), global_json.c_str());
-            return retval;
-        }
-
-        const auto& sdk_obj = sdk_iter->second.as_object();
-        const auto ver_iter = sdk_obj.find(_X("version"));
-        if (ver_iter == sdk_obj.end() || ver_iter->second.is_null())
-        {
-            trace::verbose(_X("CLI 'sdk/version' field not present/null in [%s]"), global_json.c_str());
-            return retval;
-        }
-        retval = ver_iter->second.as_string();
-    }
-    catch (const std::exception& je)
-    {
-        pal::string_t jes;
-        (void)pal::utf8_palstring(je.what(), &jes);
-        trace::error(_X("A JSON parsing exception occurred in [%s]: %s"), global_json.c_str(), jes.c_str());
-    }
-    trace::verbose(_X("CLI version is [%s] in global json file [%s]"), retval.c_str(), global_json.c_str());
-    return retval;
 }
 
-pal::string_t resolve_sdk_version(pal::string_t sdk_path, bool disallow_prerelease, pal::string_t global_cli_version)
+sdk_resolver::sdk_resolver(fx_ver_t requested, sdk_roll_forward_policy policy, bool allow_prerelease) :
+    _requested(move(requested)),
+    _policy(policy),
+    _allow_prerelease(allow_prerelease)
 {
-    fx_ver_t specified;
-
-    //   Validate the global cli version if specified
-    if (!global_cli_version.empty())
-    {
-        if (!fx_ver_t::parse(global_cli_version, &specified, false))
-        {
-            trace::error(_X("The specified SDK version '%s' could not be parsed"), global_cli_version.c_str());
-            return pal::string_t();
-        }
-
-        // Always consider prereleases when the version specified in global.json is itself a prerelease
-        if (specified.is_prerelease())
-        {
-            disallow_prerelease = false;
-        }
-    }
-
-    trace::verbose(_X("--- Resolving SDK version from SDK dir [%s]"), sdk_path.c_str());
-
-    pal::string_t retval;
-    std::vector<pal::string_t> versions;
-
-    pal::readdir_onlydirectories(sdk_path, &versions);
-    fx_ver_t max_ver;
-    for (const auto& version : versions)
-    {
-        trace::verbose(_X("Considering version... [%s]"), version.c_str());
-
-        fx_ver_t ver;
-        if (fx_ver_t::parse(version, &ver, disallow_prerelease))
-        {
-            if (global_cli_version.empty() ||
-                // If a global cli version is specified:
-                //   pick the greatest version that differs only in the 'minor-patch'
-                //   and is semantically greater than or equal to the global cli version specified.
-                (ver.get_major() == specified.get_major() && ver.get_minor() == specified.get_minor() &&
-                (ver.get_patch() / 100) == (specified.get_patch() / 100) && ver >= specified))
-            {
-                max_ver = std::max(ver, max_ver);
-            }
-        }
-    }
-
-    if (!max_ver.is_empty())
-    {
-        pal::string_t max_ver_str = max_ver.as_str();
-        append_path(&sdk_path, max_ver_str.c_str());
-
-        trace::verbose(_X("Checking if resolved SDK dir [%s] exists"), sdk_path.c_str());
-        if (pal::directory_exists(sdk_path))
-        {
-            trace::verbose(_X("Resolved SDK dir is [%s]"), sdk_path.c_str());
-            retval = max_ver_str;
-        }
-    }
-
-    return retval;
 }
 
-bool sdk_resolver_t::resolve_sdk_dotnet_path(const pal::string_t& dotnet_root, pal::string_t* cli_sdk)
+pal::string_t const& sdk_resolver::global_file_path() const
 {
-    trace::verbose(_X("--- Resolving dotnet from working dir"));
+    return _global_file_path;
+}
+
+fx_ver_t const& sdk_resolver::requested_version() const
+{
+    return _requested;
+}
+
+sdk_roll_forward_policy sdk_resolver::policy() const
+{
+    return _policy;
+}
+
+bool sdk_resolver::allow_prerelease() const
+{
+    return _allow_prerelease;
+}
+
+pal::string_t sdk_resolver::resolve(const pal::string_t& dotnet_root) const
+{
+    auto requested = _requested.is_empty() ? pal::string_t{} : _requested.as_str();
+
+    trace::verbose(
+        _X("Resolving SDKs with version = '%s', roll-forward = '%s', allow-prerelease = %s"),
+        requested.empty() ? _X("latest") : requested.c_str(),
+        to_policy_name(_policy),
+        _allow_prerelease ? _X("true") : _X("false"));
+
+    pal::string_t resolved_sdk_path;
+    fx_ver_t resolved_version;
+
+    vector<pal::string_t> locations;
+    get_framework_and_sdk_locations(dotnet_root, &locations);
+
+    for (auto&& dir : locations)
+    {
+        append_path(&dir, _X("sdk"));
+
+        if (resolve_sdk_path_and_version(dir, resolved_sdk_path, resolved_version))
+        {
+            break;
+        }
+    }
+
+    if (!resolved_sdk_path.empty())
+    {
+        trace::verbose(_X("SDK path resolved to [%s]"), resolved_sdk_path.c_str());
+        return resolved_sdk_path;
+    }
+
+    if (!requested.empty())
+    {
+        if (!_global_file_path.empty())
+        {
+            trace::error(_X("A compatible installed .NET Core SDK for global.json version [%s] from [%s] was not found"), requested.c_str(), _global_file_path.c_str());
+            trace::error(_X("Install the [%s] .NET Core SDK or update [%s] with an installed .NET Core SDK:"), requested.c_str(), _global_file_path.c_str());
+        }
+        else
+        {
+            trace::error(_X("A compatible installed .NET Core SDK version [%s] was not found"), requested.c_str());
+            trace::error(_X("Install the [%s] .NET Core SDK or create a global.json file with an installed .NET Core SDK:"), requested.c_str());
+        }
+    }
+
+    if (requested.empty() || !sdk_info::print_all_sdks(dotnet_root, _X("  ")))
+    {
+        trace::error(_X("  It was not possible to find any installed .NET Core SDKs"));
+        trace::error(_X("  Did you mean to run .NET Core SDK commands? Install a .NET Core SDK from:"));
+        trace::error(_X("      %s"), DOTNET_CORE_DOWNLOAD_URL);
+    }
+    return {};
+}
+
+sdk_resolver sdk_resolver::from_nearest_global_file(bool allow_prerelease)
+{
     pal::string_t cwd;
     if (!pal::getcwd(&cwd))
     {
         trace::verbose(_X("Failed to obtain current working dir"));
         assert(cwd.empty());
     }
-
-    return resolve_sdk_dotnet_path(dotnet_root, cwd, cli_sdk);
+    else
+    {
+        trace::verbose(_X("--- Resolving .NET Core SDK with working dir [%s]"), cwd.c_str());
+    }
+    return from_nearest_global_file(cwd, allow_prerelease);
 }
 
-bool higher_sdk_version(const pal::string_t& new_version, pal::string_t* version)
+sdk_resolver sdk_resolver::from_nearest_global_file(const pal::string_t& cwd, bool allow_prerelease)
 {
-    bool disallow_prerelease = false;
-    bool retval = false;
-    fx_ver_t ver;
-    fx_ver_t new_ver;
+    sdk_resolver resolver{ allow_prerelease };
 
-    if (fx_ver_t::parse(new_version, &new_ver, disallow_prerelease))
+    if (!resolver.parse_global_file(find_nearest_global_file(cwd)))
     {
-        if (!fx_ver_t::parse(*version, &ver, disallow_prerelease) || (new_ver > ver))
-        {
-            version->assign(new_version);
-            retval = true;
-        }
+        // Fall back to a default SDK resolver
+        resolver = sdk_resolver{ allow_prerelease };
+
+        trace::error(
+            _X("Ignoring SDK settings in global.json: the latest installed .NET Core SDK (%s prereleases) will be used"),
+            resolver.allow_prerelease() ? _X("including") : _X("excluding"));
     }
 
-    return retval;
+    // If the requested version is a prerelease, always allow prerelease versions
+    if (resolver._requested.is_prerelease())
+    {
+        resolver._allow_prerelease = true;
+    }
+
+    return resolver;
 }
 
-bool sdk_resolver_t::resolve_sdk_dotnet_path(
-    const pal::string_t& dotnet_root, 
-    const pal::string_t& cwd, 
-    pal::string_t* cli_sdk,
-    bool disallow_prerelease,
-    pal::string_t* global_json_path)
+sdk_roll_forward_policy sdk_resolver::to_policy(const pal::string_t& name)
 {
-    pal::string_t global;
+    if (name == _X("disable"))
+    {
+        return sdk_roll_forward_policy::disable;
+    }
 
+    if (name == _X("patch"))
+    {
+        return sdk_roll_forward_policy::patch;
+    }
+
+    if (name == _X("feature"))
+    {
+        return sdk_roll_forward_policy::feature;
+    }
+
+    if (name == _X("minor"))
+    {
+        return sdk_roll_forward_policy::minor;
+    }
+
+    if (name == _X("major"))
+    {
+        return sdk_roll_forward_policy::major;
+    }
+
+    if (name == _X("latestPatch"))
+    {
+        return sdk_roll_forward_policy::latest_patch;
+    }
+
+    if (name == _X("latestFeature"))
+    {
+        return sdk_roll_forward_policy::latest_feature;
+    }
+
+    if (name == _X("latestMinor"))
+    {
+        return sdk_roll_forward_policy::latest_minor;
+    }
+
+    if (name == _X("latestMajor"))
+    {
+        return sdk_roll_forward_policy::latest_major;
+    }
+
+    return sdk_roll_forward_policy::unsupported;
+}
+
+const char* sdk_resolver::to_policy_name(sdk_roll_forward_policy policy)
+{
+    switch (policy)
+    {
+        case sdk_roll_forward_policy::unsupported:
+            return "unsupported";
+
+        case sdk_roll_forward_policy::disable:
+            return "disable";
+
+        case sdk_roll_forward_policy::patch:
+            return "patch";
+
+        case sdk_roll_forward_policy::feature:
+            return "feature";
+
+        case sdk_roll_forward_policy::minor:
+            return "minor";
+
+        case sdk_roll_forward_policy::major:
+            return "major";
+
+        case sdk_roll_forward_policy::latest_patch:
+            return "latestPatch";
+
+        case sdk_roll_forward_policy::latest_feature:
+            return "latestFeature";
+
+        case sdk_roll_forward_policy::latest_minor:
+            return "latestMinor";
+
+        case sdk_roll_forward_policy::latest_major:
+            return "latestMajor";
+    }
+}
+
+pal::string_t sdk_resolver::find_nearest_global_file(const pal::string_t& cwd)
+{
     if (!cwd.empty())
     {
         for (pal::string_t parent_dir, cur_dir = cwd; true; cur_dir = parent_dir)
         {
-            pal::string_t file = cur_dir;
+            auto file = cur_dir;
             append_path(&file, _X("global.json"));
 
             trace::verbose(_X("Probing path [%s] for global.json"), file.c_str());
             if (pal::file_exists(file))
             {
-                global = file;
-                trace::verbose(_X("Found global.json [%s]"), global.c_str());
-                break;
+                trace::verbose(_X("Found global.json [%s]"), file.c_str());
+                return file;
             }
             parent_dir = get_directory(cur_dir);
             if (parent_dir.empty() || parent_dir.size() == cur_dir.size())
@@ -192,79 +249,374 @@ bool sdk_resolver_t::resolve_sdk_dotnet_path(
         }
     }
 
-    std::vector<pal::string_t> hive_dir;
-    get_framework_and_sdk_locations(dotnet_root, &hive_dir);
+    return {};
+}
 
-    pal::string_t cli_version;
-    pal::string_t sdk_path;
-    pal::string_t global_cli_version;
-
-    if (!global.empty())
+bool sdk_resolver::parse_global_file(pal::string_t global_file_path)
+{
+    if (global_file_path.empty())
     {
-        global_cli_version = resolve_cli_version(global);
-    }
-
-    for (pal::string_t dir : hive_dir)
-    {
-        trace::verbose(_X("Searching SDK directory in [%s]"), dir.c_str());
-        pal::string_t current_sdk_path = dir;
-        append_path(&current_sdk_path, _X("sdk"));
-
-        if (global_cli_version.empty())
-        {
-            pal::string_t new_cli_version = resolve_sdk_version(current_sdk_path, disallow_prerelease, global_cli_version);
-            if (higher_sdk_version(new_cli_version, &cli_version))
-            {
-                sdk_path = current_sdk_path;
-            }
-        }
-        else
-        {
-            if (global_json_path != nullptr)
-            {
-                global_json_path->assign(global);
-            }
-
-            pal::string_t probing_sdk_path = current_sdk_path;
-            append_path(&probing_sdk_path, global_cli_version.c_str());
-
-            if (pal::directory_exists(probing_sdk_path))
-            {
-                trace::verbose(_X("CLI directory [%s] from global.json exists"), probing_sdk_path.c_str());
-                cli_version = global_cli_version;
-                sdk_path = current_sdk_path;
-                //  Use the first matching version
-                break;
-            }
-            else
-            {
-                pal::string_t new_cli_version = resolve_sdk_version(current_sdk_path, disallow_prerelease, global_cli_version);
-                if (higher_sdk_version(new_cli_version, &cli_version))
-                {
-                    sdk_path = current_sdk_path;
-                }
-            }
-        }
-    }
-
-    if (!cli_version.empty())
-    {
-        append_path(&sdk_path, cli_version.c_str());
-        cli_sdk->assign(sdk_path);
-        trace::verbose(_X("Found CLI SDK in: %s"), cli_sdk->c_str());
+        // Missing global.json is treated as success (use default resolver)
         return true;
     }
 
-    if (!global_cli_version.empty())
+    trace::verbose(_X("--- Resolving SDK information from global.json [%s]"), global_file_path.c_str());
+
+    pal::ifstream_t file{ global_file_path };
+    if (!file.good())
     {
-        trace::error(_X("A compatible installed dotnet SDK for global.json version: [%s] from [%s] was not found"), global_cli_version.c_str(), global.c_str());
-        trace::error(_X("Please install the [%s] SDK or update [%s] with an installed dotnet SDK:"), global_cli_version.c_str(), global.c_str());
+        trace::error(_X("[%s] could not be opened"), global_file_path.c_str());
+        return false;
     }
-    if (global_cli_version.empty() || !sdk_info::print_all_sdks(dotnet_root, _X("  ")))
+
+    if (skip_utf8_bom(&file))
     {
-        trace::error(_X("  It was not possible to find any installed dotnet SDKs"));
-        trace::error(_X("  Did you mean to run dotnet SDK commands? Please install dotnet SDK from:"));
-        trace::error(_X("      %s"), DOTNET_CORE_DOWNLOAD_URL);
+        trace::verbose(_X("UTF-8 BOM skipped while reading [%s]"), global_file_path.c_str());
     }
+
+    json_value doc;
+    try
+    {
+        doc = json_value::parse(file);
+    }
+    catch (const exception& ex)
+    {
+        pal::string_t msg;
+        (void)pal::utf8_palstring(ex.what(), &msg);
+        trace::error(_X("A JSON parsing exception occurred in [%s]: %s"), global_file_path.c_str(), msg.c_str());
+        return false;
+    }
+
+    if (!doc.is_object())
+    {
+        trace::error(_X("Expected a JSON object in [%s]"), global_file_path.c_str());
+        return false;
+    }
+
+    const auto& doc_obj = doc.as_object();
+
+    const auto sdk = doc_obj.find(_X("sdk"));
+    if (sdk == doc_obj.end() || sdk->second.is_null())
+    {
+        // Missing SDK is treated as success (use default resolver)
+        trace::verbose(_X("Value 'sdk' is missing or null in [%s]"), global_file_path.c_str());
+        return true;
+    }
+
+    if (!sdk->second.is_object())
+    {
+        trace::error(_X("Expected a JSON object for the 'sdk' value in [%s]"), global_file_path.c_str());
+        return false;
+    }
+
+    const auto& sdk_obj = sdk->second.as_object();
+
+    const auto version = sdk_obj.find(_X("version"));
+    if (version == sdk_obj.end() || version->second.is_null())
+    {
+        trace::verbose(_X("Value 'sdk/version' is missing or null in [%s]"), global_file_path.c_str());
+    }
+    else
+    {
+        if (!version->second.is_string())
+        {
+            trace::error(_X("Expected a string for the 'sdk/version' value in [%s]"), global_file_path.c_str());
+            return false;
+        }
+
+        if (!fx_ver_t::parse(version->second.as_string(), &_requested, false))
+        {
+            trace::error(
+                _X("Version '%s' is not valid for the 'sdk/version' value in [%s]"),
+                version->second.as_string().c_str(),
+                global_file_path.c_str()
+            );
+            return false;
+        }
+
+        // The default policy when a version is specified is 'patch'
+        _policy = sdk_roll_forward_policy::patch;
+    }
+
+    const auto roll_forward = sdk_obj.find(_X("rollForward"));
+    if (roll_forward == sdk_obj.end() || roll_forward->second.is_null())
+    {
+        trace::verbose(_X("Value 'sdk/rollForward' is missing or null in [%s]"), global_file_path.c_str());
+    }
+    else
+    {
+        if (!roll_forward->second.is_string())
+        {
+            trace::error(_X("Expected a string for the 'sdk/rollForward' value in [%s]"), global_file_path.c_str());
+            return false;
+        }
+
+        _policy = to_policy(roll_forward->second.as_string());
+        if (_policy == sdk_roll_forward_policy::unsupported)
+        {
+            trace::error(
+                _X("The roll-forward policy '%s' is not supported for the 'sdk/rollForward' value in [%s]"),
+                roll_forward->second.as_string().c_str(),
+                global_file_path.c_str()
+            );
+            return false;
+        }
+
+        // All policies other than 'latestMajor' require a version to operate
+        if (_policy != sdk_roll_forward_policy::latest_major && _requested.is_empty())
+        {
+            trace::error(
+                _X("The roll-forward policy '%s' requires a 'sdk/version' value in [%s]"),
+                roll_forward->second.as_string().c_str(),
+                global_file_path.c_str()
+            );
+            return false;
+        }
+    }
+
+    const auto prerelease = sdk_obj.find(_X("allowPrerelease"));
+    if (prerelease == sdk_obj.end() || prerelease->second.is_null())
+    {
+        trace::verbose(_X("Value 'sdk/allowPrerelease' is missing or null in [%s]"), global_file_path.c_str());
+    }
+    else
+    {
+        if (!prerelease->second.is_boolean())
+        {
+            trace::error(_X("Expected a boolean for the 'sdk/allowPrerelease' value in [%s]"), global_file_path.c_str());
+            return false;
+        }
+
+        _allow_prerelease = prerelease->second.as_bool();
+
+        if (!_allow_prerelease && _requested.is_prerelease())
+        {
+            trace::warning(_X("Ignoring the 'sdk/allowPrerelease' value in [%s] because a prerelease version was specified"), global_file_path.c_str());
+            _allow_prerelease = true;
+        }
+    }
+
+    _global_file_path = move(global_file_path);
+    return true;
+}
+
+bool sdk_resolver::matches_policy(const fx_ver_t& version) const
+{
+    // Check for unallowed prerelease versions
+    if (version.is_empty() || (!_allow_prerelease && version.is_prerelease()))
+    {
+        return false;
+    }
+
+    // If no version was requested, then all versions match
+    if (_requested.is_empty())
+    {
+        return true;
+    }
+
+    int requested_patch = _requested.get_patch() % 100;
+    int version_patch = version.get_patch() % 100;
+
+    int requested_feature = _requested.get_patch() / 100;
+    int version_feature = version.get_patch() / 100;
+
+    int requested_minor = _requested.get_minor();
+    int version_minor = version.get_minor();
+
+    int requested_major = _requested.get_major();
+    int version_major = version.get_major();
+
+    // First exclude any versions that don't match the policy requirements
+    switch (_policy)
+    {
+        case sdk_roll_forward_policy::unsupported:
+        case sdk_roll_forward_policy::disable:
+            return false;
+
+        case sdk_roll_forward_policy::patch:
+        case sdk_roll_forward_policy::latest_patch:
+            if (version_major != requested_major ||
+                version_minor != requested_minor ||
+                version_feature != requested_feature ||
+                version_patch < requested_patch)
+            {
+                return false;
+            }
+            break;
+
+        case sdk_roll_forward_policy::feature:
+        case sdk_roll_forward_policy::latest_feature:
+            if (version_major != requested_major ||
+                version_minor != requested_minor ||
+                version_feature < requested_feature ||
+                (version_feature == requested_feature &&
+                 version_patch < requested_patch))
+            {
+                return false;
+            }
+            break;
+
+        case sdk_roll_forward_policy::minor:
+        case sdk_roll_forward_policy::latest_minor:
+            if (version_major != requested_major)
+            {
+                return false;
+            }
+            break;
+
+        case sdk_roll_forward_policy::major:
+        case sdk_roll_forward_policy::latest_major:
+            break;
+    }
+
+    // The version must be at least what was requested
+    return version >= _requested;
+}
+
+bool sdk_resolver::is_better_match(const fx_ver_t& current, const fx_ver_t& previous) const
+{
+    // Assumption: both current and previous (if there is one) match the policy
+
+    // If no previous match, then the current one is better
+    if (previous.is_empty())
+    {
+        return true;
+    }
+
+    // If there wasn't a requested version, then latest is best
+    if (_requested.is_empty())
+    {
+        return current > previous;
+    }
+
+    int current_patch = current.get_patch() % 100;
+    int previous_patch = previous.get_patch() % 100;
+
+    int current_feature = current.get_patch() / 100;
+    int previous_feature = previous.get_patch() / 100;
+
+    int current_minor = current.get_minor();
+    int previous_minor = previous.get_minor();
+
+    int current_major = current.get_major();
+    int previous_major = previous.get_major();
+
+    bool use_latest = is_policy_use_latest();
+
+    if (current_major == previous_major)
+    {
+        if (current_minor == previous_minor)
+        {
+            if (current_feature == previous_feature)
+            {
+                if (current_patch == previous_patch)
+                {
+                    // Accept the later of the versions
+                    // This will handle stable and prerelease comparisons
+                    return current > previous;
+                }
+
+                // Latest always wins for patch level
+                return current_patch > previous_patch;
+            }
+
+            return use_latest ? (current_feature > previous_feature) : (current_feature < previous_feature);
+        }
+
+        return use_latest ? (current_minor > previous_minor) : (current_minor < previous_minor);
+    }
+
+    return use_latest ? (current_major > previous_major) : (current_major < previous_major);
+}
+
+bool sdk_resolver::exact_match_allowed() const
+{
+    return _policy == sdk_roll_forward_policy::disable ||
+           _policy == sdk_roll_forward_policy::patch;
+}
+
+bool sdk_resolver::is_policy_use_latest() const
+{
+    return _policy == sdk_roll_forward_policy::latest_patch ||
+           _policy == sdk_roll_forward_policy::latest_feature ||
+           _policy == sdk_roll_forward_policy::latest_minor ||
+           _policy == sdk_roll_forward_policy::latest_major;
+}
+
+bool sdk_resolver::resolve_sdk_path_and_version(const pal::string_t& dir, pal::string_t& sdk_path, fx_ver_t& resolved_version) const
+{
+    trace::verbose(_X("Searching for SDK versions in [%s]"), dir.c_str());
+
+    // If an exact match is allowed, check for the existence of the version
+    if (exact_match_allowed() && !_requested.is_empty())
+    {
+        auto probe_path = dir;
+        append_path(&probe_path, _requested.as_str().c_str());
+
+        if (pal::directory_exists(probe_path))
+        {
+            trace::verbose(_X("Found requested SDK directory [%s]"), probe_path.c_str());
+            sdk_path = move(probe_path);
+            resolved_version = _requested;
+
+            // The SDK path has been resolved
+            return true;
+        }
+    }
+
+    if (_policy == sdk_roll_forward_policy::disable)
+    {
+        // Not yet fully resolved
+        return false;
+    }
+
+    vector<pal::string_t> versions;
+    pal::readdir_onlydirectories(dir, &versions);
+
+    bool changed = false;
+    pal::string_t resolved_version_str = resolved_version.is_empty() ? pal::string_t{} : resolved_version.as_str();
+    for (auto&& version : versions)
+    {
+        fx_ver_t ver;
+        if (!fx_ver_t::parse(version, &ver, false))
+        {
+            trace::verbose(_X("Ignoring invalid version [%s]"), version.c_str());
+            continue;
+        }
+
+        if (!matches_policy(ver))
+        {
+            trace::verbose(_X("Ignoring version [%s] because it does not match the roll-forward policy"), version.c_str());
+            continue;
+        }
+
+        if (!is_better_match(ver, resolved_version))
+        {
+            trace::verbose(
+                _X("Ignoring version [%s] because it is not a better match than [%s]"),
+                version.c_str(),
+                resolved_version_str.empty() ? _X("none") : resolved_version_str.c_str()
+            );
+            continue;
+        }
+
+        trace::verbose(
+            _X("Version [%s] is a better match than [%s]"),
+            version.c_str(),
+            resolved_version_str.empty() ? _X("none") : resolved_version_str.c_str()
+        );
+
+        changed = true;
+        resolved_version = ver;
+        resolved_version_str = move(version);
+    }
+
+    if (changed)
+    {
+        sdk_path = dir;
+        append_path(&sdk_path, resolved_version_str.c_str());
+    }
+
+    // Not yet fully resolved
     return false;
 }

--- a/src/corehost/cli/fxr/sdk_resolver.cpp
+++ b/src/corehost/cli/fxr/sdk_resolver.cpp
@@ -14,6 +14,24 @@ typedef web::json::object json_object;
 
 using namespace std;
 
+namespace
+{
+    // Note: this array must be in the same order as the `sdk_roll_forward_policy` enumeration
+    const pal::char_t* const RollForwardPolicyNames[] =
+    {
+        _X("unsupported"),
+        _X("disable"),
+        _X("patch"),
+        _X("feature"),
+        _X("minor"),
+        _X("major"),
+        _X("latestPatch"),
+        _X("latestFeature"),
+        _X("latestMinor"),
+        _X("latestMajor"),
+    };
+}
+
 sdk_resolver::sdk_resolver(bool allow_prerelease) :
     sdk_resolver({}, sdk_roll_forward_policy::latest_major, allow_prerelease)
 {
@@ -141,88 +159,30 @@ sdk_resolver sdk_resolver::from_nearest_global_file(const pal::string_t& cwd, bo
 
 sdk_roll_forward_policy sdk_resolver::to_policy(const pal::string_t& name)
 {
-    if (name == _X("disable"))
+    int index = 0;
+    for (auto policy : RollForwardPolicyNames)
     {
-        return sdk_roll_forward_policy::disable;
-    }
+        if (pal::strcasecmp(name.c_str(), policy) == 0)
+        {
+            return static_cast<sdk_roll_forward_policy>(index);
+        }
 
-    if (name == _X("patch"))
-    {
-        return sdk_roll_forward_policy::patch;
-    }
-
-    if (name == _X("feature"))
-    {
-        return sdk_roll_forward_policy::feature;
-    }
-
-    if (name == _X("minor"))
-    {
-        return sdk_roll_forward_policy::minor;
-    }
-
-    if (name == _X("major"))
-    {
-        return sdk_roll_forward_policy::major;
-    }
-
-    if (name == _X("latestPatch"))
-    {
-        return sdk_roll_forward_policy::latest_patch;
-    }
-
-    if (name == _X("latestFeature"))
-    {
-        return sdk_roll_forward_policy::latest_feature;
-    }
-
-    if (name == _X("latestMinor"))
-    {
-        return sdk_roll_forward_policy::latest_minor;
-    }
-
-    if (name == _X("latestMajor"))
-    {
-        return sdk_roll_forward_policy::latest_major;
+        ++index;
     }
 
     return sdk_roll_forward_policy::unsupported;
 }
 
-const char* sdk_resolver::to_policy_name(sdk_roll_forward_policy policy)
+const pal::char_t* sdk_resolver::to_policy_name(sdk_roll_forward_policy policy)
 {
-    switch (policy)
+    auto index = static_cast<int>(policy);
+
+    if (index < 0 || index > (end(RollForwardPolicyNames) - begin(RollForwardPolicyNames)))
     {
-        case sdk_roll_forward_policy::unsupported:
-            return "unsupported";
-
-        case sdk_roll_forward_policy::disable:
-            return "disable";
-
-        case sdk_roll_forward_policy::patch:
-            return "patch";
-
-        case sdk_roll_forward_policy::feature:
-            return "feature";
-
-        case sdk_roll_forward_policy::minor:
-            return "minor";
-
-        case sdk_roll_forward_policy::major:
-            return "major";
-
-        case sdk_roll_forward_policy::latest_patch:
-            return "latestPatch";
-
-        case sdk_roll_forward_policy::latest_feature:
-            return "latestFeature";
-
-        case sdk_roll_forward_policy::latest_minor:
-            return "latestMinor";
-
-        case sdk_roll_forward_policy::latest_major:
-            return "latestMajor";
+        return RollForwardPolicyNames[static_cast<int>(sdk_roll_forward_policy::unsupported)];
     }
+
+    return RollForwardPolicyNames[index];
 }
 
 pal::string_t sdk_resolver::find_nearest_global_file(const pal::string_t& cwd)

--- a/src/corehost/cli/fxr/sdk_resolver.h
+++ b/src/corehost/cli/fxr/sdk_resolver.h
@@ -3,18 +3,64 @@
 // See the LICENSE file in the project root for more information.
 
 #include "pal.h"
+#include "fx_ver.h"
 
-class sdk_resolver_t
+enum class sdk_roll_forward_policy
+{
+    // The specified policy is not supported.
+    unsupported,
+    // Do not roll forward (require an exact match to requested).
+    disable,
+    // Allow a roll-forward to the latest patch level if the requested version is not installed.
+    patch,
+    // Allow a roll-forward to the nearest available feature band with latest patch level.
+    feature,
+    // Allow a roll-forward to the nearest available minor version with latest patch level.
+    minor,
+    // Allow a roll-forward to the nearest available major version with latest patch level.
+    major,
+    // Roll-forward to the latest patch level (major, minor, and feature band must match).
+    latest_patch,
+    // Roll-forward to the latest installed feature band (major and minor must match).
+    latest_feature,
+    // Roll-forward to the latest minor version (major must match).
+    latest_minor,
+    // Roll-forward to the latest major version (latest version installed).
+    latest_major,
+};
+
+class sdk_resolver
 {
 public:
-    static bool resolve_sdk_dotnet_path(
-        const pal::string_t& dotnet_root, 
-        pal::string_t* cli_sdk);
+    explicit sdk_resolver(bool allow_prerelease = true);
+    sdk_resolver(fx_ver_t requested, sdk_roll_forward_policy policy, bool allow_prerelease);
 
-    static bool resolve_sdk_dotnet_path(
-        const pal::string_t& dotnet_root,
+    pal::string_t const& global_file_path() const;
+    fx_ver_t const& requested_version() const;
+    sdk_roll_forward_policy policy() const;
+    bool allow_prerelease() const;
+
+    pal::string_t resolve(const pal::string_t& dotnet_root) const;
+
+    static sdk_resolver from_nearest_global_file(bool allow_prerelease = true);
+
+    static sdk_resolver from_nearest_global_file(
         const pal::string_t& cwd,
-        pal::string_t* cli_sdk,
-        bool disallow_prerelease = false,
-        pal::string_t* global_json_path = nullptr);
+        bool allow_prerelease = true);
+
+private:
+    static sdk_roll_forward_policy to_policy(const pal::string_t& name);
+    static const char* to_policy_name(sdk_roll_forward_policy policy);
+    static pal::string_t find_nearest_global_file(const pal::string_t& cwd);
+    bool parse_global_file(pal::string_t global_file_path);
+    bool matches_policy(const fx_ver_t& version) const;
+    bool is_better_match(const fx_ver_t& current, const fx_ver_t& previous) const;
+    bool exact_match_allowed() const;
+    bool is_policy_use_latest() const;
+    bool resolve_sdk_path_and_version(const pal::string_t& dir, pal::string_t& sdk_path, fx_ver_t& resolved_version) const;
+
+    pal::string_t _global_file_path;
+    fx_ver_t _requested;
+    sdk_roll_forward_policy _policy;
+    bool _allow_prerelease;
 };

--- a/src/corehost/cli/fxr/sdk_resolver.h
+++ b/src/corehost/cli/fxr/sdk_resolver.h
@@ -5,6 +5,7 @@
 #include "pal.h"
 #include "fx_ver.h"
 
+// Note: this must be kept in-sync with `RollForwardPolicyNames`.
 enum class sdk_roll_forward_policy
 {
     // The specified policy is not supported.
@@ -50,7 +51,7 @@ public:
 
 private:
     static sdk_roll_forward_policy to_policy(const pal::string_t& name);
-    static const char* to_policy_name(sdk_roll_forward_policy policy);
+    static const pal::char_t* to_policy_name(sdk_roll_forward_policy policy);
     static pal::string_t find_nearest_global_file(const pal::string_t& cwd);
     bool parse_global_file(pal::string_t global_file_path);
     bool matches_policy(const fx_ver_t& version) const;

--- a/src/corehost/cli/fxr/sdk_resolver.h
+++ b/src/corehost/cli/fxr/sdk_resolver.h
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#pragma once
+
 #include "pal.h"
 #include "fx_ver.h"
 
@@ -34,12 +36,9 @@ class sdk_resolver
 {
 public:
     explicit sdk_resolver(bool allow_prerelease = true);
-    sdk_resolver(fx_ver_t requested, sdk_roll_forward_policy policy, bool allow_prerelease);
+    sdk_resolver(fx_ver_t version, sdk_roll_forward_policy roll_forward, bool allow_prerelease);
 
     pal::string_t const& global_file_path() const;
-    fx_ver_t const& requested_version() const;
-    sdk_roll_forward_policy policy() const;
-    bool allow_prerelease() const;
 
     pal::string_t resolve(const pal::string_t& dotnet_root) const;
 
@@ -54,14 +53,14 @@ private:
     static const pal::char_t* to_policy_name(sdk_roll_forward_policy policy);
     static pal::string_t find_nearest_global_file(const pal::string_t& cwd);
     bool parse_global_file(pal::string_t global_file_path);
-    bool matches_policy(const fx_ver_t& version) const;
+    bool matches_policy(const fx_ver_t& current) const;
     bool is_better_match(const fx_ver_t& current, const fx_ver_t& previous) const;
-    bool exact_match_allowed() const;
+    bool exact_match_preferred() const;
     bool is_policy_use_latest() const;
     bool resolve_sdk_path_and_version(const pal::string_t& dir, pal::string_t& sdk_path, fx_ver_t& resolved_version) const;
 
-    pal::string_t _global_file_path;
-    fx_ver_t _requested;
-    sdk_roll_forward_policy _policy;
-    bool _allow_prerelease;
+    pal::string_t global_file;
+    fx_ver_t version;
+    sdk_roll_forward_policy roll_forward;
+    bool allow_prerelease;
 };

--- a/src/test/HostActivationTests/MultilevelSDKLookup.cs
+++ b/src/test/HostActivationTests/MultilevelSDKLookup.cs
@@ -73,8 +73,8 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
             Directory.CreateDirectory(_regSdkBaseDir);
 
             // Trace messages used to identify from which folder the SDK was picked
-            _exeSelectedMessage = $"Using dotnet SDK dll=[{_exeSdkBaseDir}";
-            _regSelectedMessage = $"Using dotnet SDK dll=[{_regSdkBaseDir}";
+            _exeSelectedMessage = $"Using .NET Core SDK dll=[{_exeSdkBaseDir}";
+            _regSelectedMessage = $"Using .NET Core SDK dll=[{_regSdkBaseDir}";
 
             _testOnlyProductBehaviorMarker = TestOnlyProductBehavior.Enable(DotNet.GreatestVersionHostFxrFilePath);
         }
@@ -117,7 +117,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
                 .CaptureStdErr()
                 .Execute(fExpectedToFail: true)
                 .Should().Fail()
-                .And.HaveStdErrContaining("A compatible installed dotnet SDK for global.json version");
+                .And.HaveStdErrContaining("A compatible installed .NET Core SDK for global.json version");
 
             // Add SDK versions
             AddAvailableSdkVersions(_exeSdkBaseDir, "9999.4.1", "9999.3.4-dummy");
@@ -138,7 +138,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
                 .CaptureStdErr()
                 .Execute(fExpectedToFail: true)
                 .Should().Fail()
-                .And.HaveStdErrContaining("A compatible installed dotnet SDK for global.json version");
+                .And.HaveStdErrContaining("A compatible installed .NET Core SDK for global.json version");
 
             // Add SDK versions
             AddAvailableSdkVersions(_regSdkBaseDir, "9999.3.3");
@@ -159,7 +159,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
                 .CaptureStdErr()
                 .Execute(fExpectedToFail: true)
                 .Should().Fail()
-                .And.HaveStdErrContaining("A compatible installed dotnet SDK for global.json version");
+                .And.HaveStdErrContaining("A compatible installed .NET Core SDK for global.json version");
 
             // Add SDK versions
             AddAvailableSdkVersions(_exeSdkBaseDir, "9999.3.4");
@@ -292,7 +292,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
                 .CaptureStdErr()
                 .Execute(fExpectedToFail: true)
                 .Should().Fail()
-                .And.HaveStdErrContaining("A compatible installed dotnet SDK for global.json version");
+                .And.HaveStdErrContaining("A compatible installed .NET Core SDK for global.json version");
 
             // Add SDK versions
             AddAvailableSdkVersions(_regSdkBaseDir, "9999.3.57", "9999.3.4-dummy");
@@ -313,7 +313,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
                 .CaptureStdErr()
                 .Execute(fExpectedToFail: true)
                 .Should().Fail()
-                .And.HaveStdErrContaining("A compatible installed dotnet SDK for global.json version");
+                .And.HaveStdErrContaining("A compatible installed .NET Core SDK for global.json version");
 
             // Add SDK versions
             AddAvailableSdkVersions(_exeSdkBaseDir, "9999.3.300", "9999.7.304-global-dummy");
@@ -334,7 +334,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
                 .CaptureStdErr()
                 .Execute(fExpectedToFail: true)
                 .Should().Fail()
-                .And.HaveStdErrContaining("A compatible installed dotnet SDK for global.json version");
+                .And.HaveStdErrContaining("A compatible installed .NET Core SDK for global.json version");
 
             // Add SDK versions
             AddAvailableSdkVersions(_regSdkBaseDir, "9999.3.304");

--- a/src/test/HostActivationTests/NativeHostApis.cs
+++ b/src/test/HostActivationTests/NativeHostApis.cs
@@ -189,7 +189,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
             
             var f = new SdkResolutionFixture(sharedTestState);
 
-            // With multi-level lookup (windows onnly): get local and global sdks sorted by ascending version,
+            // With multi-level lookup (windows only): get local and global sdks sorted by ascending version,
             // with global sdk coming before local sdk when versions are equal
             string expectedList = string.Join(';', new[]
             {

--- a/src/test/HostActivationTests/SDKLookup.cs
+++ b/src/test/HostActivationTests/SDKLookup.cs
@@ -611,7 +611,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
             // Write a global.json that doesn't contain an object
             WriteGlobalJson("true");
 
-             DotNet.Exec("help")
+            DotNet.Exec("help")
                 .WorkingDirectory(_currentWorkingDir)
                 .WithUserProfile(_userDir)
                 .Environment(s_DefaultEnvironment)

--- a/src/test/HostActivationTests/SDKLookup.cs
+++ b/src/test/HostActivationTests/SDKLookup.cs
@@ -555,6 +555,37 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
                 .And.HaveStdOutContaining("9999.0.52000000");
         }
 
+        [Theory]
+        [InlineData("diSABle")]
+        [InlineData("PaTCh")]
+        [InlineData("FeaturE")]
+        [InlineData("MINOR")]
+        [InlineData("maJor")]
+        [InlineData("LatestPatch")]
+        [InlineData("Latestfeature")]
+        [InlineData("latestMINOR")]
+        [InlineData("latESTMajor")]
+        public void It_allows_case_insensitive_roll_forward_policy_names(string rollForward)
+        {
+            const string Requested = "9999.0.100";
+
+            AddAvailableSdkVersions(_exeSdkBaseDir, Requested);
+
+            CreateGlobalJson(policy: rollForward, version: Requested);
+
+            DotNet.Exec("help")
+                .WorkingDirectory(_currentWorkingDir)
+                .WithUserProfile(_userDir)
+                .Environment(s_DefaultEnvironment)
+                .EnvironmentVariable("DOTNET_MULTILEVEL_LOOKUP", "0")
+                .CaptureStdOut()
+                .CaptureStdErr()
+                .Execute()
+                .Should()
+                .Pass()
+                .And.HaveStdErrContaining(Path.Combine(_exeSelectedMessage, Requested, _dotnetSdkDllMessageTerminator));
+        }
+
         [Fact]
         public void It_falls_back_to_latest_sdk_for_invalid_global_json()
         {

--- a/src/test/HostActivationTests/SDKLookup.cs
+++ b/src/test/HostActivationTests/SDKLookup.cs
@@ -64,7 +64,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
             Directory.CreateDirectory(_exeSdkBaseDir);
             
             // Trace messages used to identify from which folder the SDK was picked
-            _exeSelectedMessage = $"Using dotnet SDK dll=[{_exeSdkBaseDir}";
+            _exeSelectedMessage = $"Using .NET Core SDK dll=[{_exeSdkBaseDir}";
         }
 
         public void Dispose()
@@ -79,7 +79,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
         public void SdkLookup_Global_Json_Single_Digit_Patch_Rollup()
         {
             // Set specified SDK version = 9999.3.4-global-dummy
-            SetGlobalJsonVersion("SingleDigit-global.json");
+            CopyGlobalJson("SingleDigit-global.json");
 
             // Specified SDK version: 9999.3.4-global-dummy
             // Exe: empty
@@ -93,8 +93,8 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
                 .CaptureStdErr()
                 .Execute(fExpectedToFail: true)
                 .Should().Fail()
-                .And.HaveStdErrContaining("A compatible installed dotnet SDK for global.json version")
-                .And.HaveStdErrContaining("It was not possible to find any installed dotnet SDKs")
+                .And.HaveStdErrContaining("A compatible installed .NET Core SDK for global.json version")
+                .And.HaveStdErrContaining("It was not possible to find any installed .NET Core SDKs")
                 .And.HaveStdErrContaining("aka.ms/dotnet-download")
                 .And.NotHaveStdErrContaining("Checking if resolved SDK dir");
 
@@ -113,8 +113,8 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
                 .CaptureStdErr()
                 .Execute(fExpectedToFail: true)
                 .Should().Fail()
-                .And.HaveStdErrContaining("A compatible installed dotnet SDK for global.json version")
-                .And.NotHaveStdErrContaining("It was not possible to find any installed dotnet SDKs");
+                .And.HaveStdErrContaining("A compatible installed .NET Core SDK for global.json version")
+                .And.NotHaveStdErrContaining("It was not possible to find any installed .NET Core SDKs");
 
             // Add SDK versions
             AddAvailableSdkVersions(_exeSdkBaseDir, "9999.3.3");
@@ -131,8 +131,8 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
                 .CaptureStdErr()
                 .Execute(fExpectedToFail: true)
                 .Should().Fail()
-                .And.HaveStdErrContaining("A compatible installed dotnet SDK for global.json version")
-                .And.NotHaveStdErrContaining("It was not possible to find any installed dotnet SDKs");
+                .And.HaveStdErrContaining("A compatible installed .NET Core SDK for global.json version")
+                .And.NotHaveStdErrContaining("It was not possible to find any installed .NET Core SDKs");
 
             // Add SDK versions
             AddAvailableSdkVersions(_exeSdkBaseDir, "9999.3.4");
@@ -224,7 +224,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
         public void SdkLookup_Global_Json_Two_Part_Patch_Rollup()
         {
             // Set specified SDK version = 9999.3.304-global-dummy
-            SetGlobalJsonVersion("TwoPart-global.json");
+            CopyGlobalJson("TwoPart-global.json");
 
             // Specified SDK version: 9999.3.304-global-dummy
             // Exe: empty
@@ -238,8 +238,8 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
                 .CaptureStdErr()
                 .Execute(fExpectedToFail: true)
                 .Should().Fail()
-                .And.HaveStdErrContaining("A compatible installed dotnet SDK for global.json version")
-                .And.HaveStdErrContaining("It was not possible to find any installed dotnet SDKs");
+                .And.HaveStdErrContaining("A compatible installed .NET Core SDK for global.json version")
+                .And.HaveStdErrContaining("It was not possible to find any installed .NET Core SDKs");
 
             // Add SDK versions
             AddAvailableSdkVersions(_exeSdkBaseDir, "9999.3.57", "9999.3.4-dummy");
@@ -256,8 +256,8 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
                 .CaptureStdErr()
                 .Execute(fExpectedToFail: true)
                 .Should().Fail()
-                .And.HaveStdErrContaining("A compatible installed dotnet SDK for global.json version")
-                .And.NotHaveStdErrContaining("It was not possible to find any installed dotnet SDKs");
+                .And.HaveStdErrContaining("A compatible installed .NET Core SDK for global.json version")
+                .And.NotHaveStdErrContaining("It was not possible to find any installed .NET Core SDKs");
 
             // Add SDK versions
             AddAvailableSdkVersions(_exeSdkBaseDir, "9999.3.300", "9999.7.304-global-dummy");
@@ -274,8 +274,8 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
                 .CaptureStdErr()
                 .Execute(fExpectedToFail: true)
                 .Should().Fail()
-                .And.HaveStdErrContaining("A compatible installed dotnet SDK for global.json version")
-                .And.NotHaveStdErrContaining("It was not possible to find any installed dotnet SDKs");
+                .And.HaveStdErrContaining("A compatible installed .NET Core SDK for global.json version")
+                .And.NotHaveStdErrContaining("It was not possible to find any installed .NET Core SDKs");
 
             // Add SDK versions
             AddAvailableSdkVersions(_exeSdkBaseDir, "9999.3.304");
@@ -385,8 +385,8 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
                 .CaptureStdErr()
                 .Execute(fExpectedToFail: true)
                 .Should().Fail()
-                .And.HaveStdErrContaining("It was not possible to find any installed dotnet SDKs")
-                .And.HaveStdErrContaining("Did you mean to run dotnet SDK commands? Please install dotnet SDK from");
+                .And.HaveStdErrContaining("It was not possible to find any installed .NET Core SDKs")
+                .And.HaveStdErrContaining("Did you mean to run .NET Core SDK commands? Install a .NET Core SDK from");
 
             // Add SDK versions
             AddAvailableSdkVersions(_exeSdkBaseDir, "9999.0.4");
@@ -555,6 +555,706 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
                 .And.HaveStdOutContaining("9999.0.52000000");
         }
 
+        [Fact]
+        public void It_falls_back_to_latest_sdk_for_invalid_global_json()
+        {
+            AddAvailableSdkVersions(_exeSdkBaseDir, "9999.0.100", "9999.0.300-dummy.9", "9999.1.402");
+
+            // Write an invalid global.json file
+            WriteGlobalJson("{ sdk: { \"version\": \"9999.0.100\" } }");
+
+            DotNet.Exec("help")
+                .WorkingDirectory(_currentWorkingDir)
+                .WithUserProfile(_userDir)
+                .Environment(s_DefaultEnvironment)
+                .EnvironmentVariable("DOTNET_MULTILEVEL_LOOKUP", "0")
+                .CaptureStdOut()
+                .CaptureStdErr()
+                .Execute()
+                .Should()
+                .Pass()
+                .And.HaveStdErrContaining("A JSON parsing exception occurred")
+                .And.HaveStdErrContaining("Ignoring SDK settings in global.json: the latest installed .NET Core SDK (including prereleases) will be used")
+                .And.HaveStdErrContaining(Path.Combine(_exeSelectedMessage, "9999.1.402", _dotnetSdkDllMessageTerminator));
+
+            // Write a global.json that doesn't contain an object
+            WriteGlobalJson("true");
+
+             DotNet.Exec("help")
+                .WorkingDirectory(_currentWorkingDir)
+                .WithUserProfile(_userDir)
+                .Environment(s_DefaultEnvironment)
+                .EnvironmentVariable("DOTNET_MULTILEVEL_LOOKUP", "0")
+                .CaptureStdOut()
+                .CaptureStdErr()
+                .Execute()
+                .Should()
+                .Pass()
+                .And.HaveStdErrContaining("Expected a JSON object")
+                .And.HaveStdErrContaining("Ignoring SDK settings in global.json: the latest installed .NET Core SDK (including prereleases) will be used")
+                .And.HaveStdErrContaining(Path.Combine(_exeSelectedMessage, "9999.1.402", _dotnetSdkDllMessageTerminator));
+
+            // Write a global.json that has a non-string version
+            WriteGlobalJson("{ \"sdk\": { \"version\": 1 } }");
+
+            DotNet.Exec("help")
+                .WorkingDirectory(_currentWorkingDir)
+                .WithUserProfile(_userDir)
+                .Environment(s_DefaultEnvironment)
+                .EnvironmentVariable("DOTNET_MULTILEVEL_LOOKUP", "0")
+                .CaptureStdOut()
+                .CaptureStdErr()
+                .Execute()
+                .Should()
+                .Pass()
+                .And.HaveStdErrContaining("Expected a string for the 'sdk/version' value")
+                .And.HaveStdErrContaining("Ignoring SDK settings in global.json: the latest installed .NET Core SDK (including prereleases) will be used")
+                .And.HaveStdErrContaining(Path.Combine(_exeSelectedMessage, "9999.1.402", _dotnetSdkDllMessageTerminator));
+
+            // Write a global.json with an invalid version value
+            CreateGlobalJson(version: "invalid");
+
+            DotNet.Exec("help")
+                .WorkingDirectory(_currentWorkingDir)
+                .WithUserProfile(_userDir)
+                .Environment(s_DefaultEnvironment)
+                .EnvironmentVariable("DOTNET_MULTILEVEL_LOOKUP", "0")
+                .CaptureStdOut()
+                .CaptureStdErr()
+                .Execute()
+                .Should()
+                .Pass()
+                .And.HaveStdErrContaining("Version 'invalid' is not valid for the 'sdk/version' value")
+                .And.HaveStdErrContaining("Ignoring SDK settings in global.json: the latest installed .NET Core SDK (including prereleases) will be used")
+                .And.HaveStdErrContaining(Path.Combine(_exeSelectedMessage, "9999.1.402", _dotnetSdkDllMessageTerminator));
+
+            // Write a global.json that has a non-string policy
+            WriteGlobalJson("{ \"sdk\": { \"rollForward\": true } }");
+
+            DotNet.Exec("help")
+                .WorkingDirectory(_currentWorkingDir)
+                .WithUserProfile(_userDir)
+                .Environment(s_DefaultEnvironment)
+                .EnvironmentVariable("DOTNET_MULTILEVEL_LOOKUP", "0")
+                .CaptureStdOut()
+                .CaptureStdErr()
+                .Execute()
+                .Should()
+                .Pass()
+                .And.HaveStdErrContaining("Expected a string for the 'sdk/rollForward' value")
+                .And.HaveStdErrContaining("Ignoring SDK settings in global.json: the latest installed .NET Core SDK (including prereleases) will be used")
+                .And.HaveStdErrContaining(Path.Combine(_exeSelectedMessage, "9999.1.402", _dotnetSdkDllMessageTerminator));
+
+            // Write a global.json that has a policy but no version
+            CreateGlobalJson(policy: "latestPatch");
+
+            DotNet.Exec("help")
+                .WorkingDirectory(_currentWorkingDir)
+                .WithUserProfile(_userDir)
+                .Environment(s_DefaultEnvironment)
+                .EnvironmentVariable("DOTNET_MULTILEVEL_LOOKUP", "0")
+                .CaptureStdOut()
+                .CaptureStdErr()
+                .Execute()
+                .Should()
+                .Pass()
+                .And.HaveStdErrContaining("The roll-forward policy 'latestPatch' requires a 'sdk/version' value")
+                .And.HaveStdErrContaining("Ignoring SDK settings in global.json: the latest installed .NET Core SDK (including prereleases) will be used")
+                .And.HaveStdErrContaining(Path.Combine(_exeSelectedMessage, "9999.1.402", _dotnetSdkDllMessageTerminator));
+
+            // Write a global.json that has an invalid policy value
+            CreateGlobalJson(policy: "invalid");
+
+            DotNet.Exec("help")
+                .WorkingDirectory(_currentWorkingDir)
+                .WithUserProfile(_userDir)
+                .Environment(s_DefaultEnvironment)
+                .EnvironmentVariable("DOTNET_MULTILEVEL_LOOKUP", "0")
+                .CaptureStdOut()
+                .CaptureStdErr()
+                .Execute()
+                .Should()
+                .Pass()
+                .And.HaveStdErrContaining("The roll-forward policy 'invalid' is not supported for the 'sdk/rollForward' value")
+                .And.HaveStdErrContaining("Ignoring SDK settings in global.json: the latest installed .NET Core SDK (including prereleases) will be used")
+                .And.HaveStdErrContaining(Path.Combine(_exeSelectedMessage, "9999.1.402", _dotnetSdkDllMessageTerminator));
+
+            // Write a global.json that has a non-boolean allow prerelease
+            WriteGlobalJson("{ \"sdk\": { \"allowPrerelease\": \"true\" } }");
+
+            DotNet.Exec("help")
+                .WorkingDirectory(_currentWorkingDir)
+                .WithUserProfile(_userDir)
+                .Environment(s_DefaultEnvironment)
+                .EnvironmentVariable("DOTNET_MULTILEVEL_LOOKUP", "0")
+                .CaptureStdOut()
+                .CaptureStdErr()
+                .Execute()
+                .Should()
+                .Pass()
+                .And.HaveStdErrContaining("Expected a boolean for the 'sdk/allowPrerelease' value")
+                .And.HaveStdErrContaining("Ignoring SDK settings in global.json: the latest installed .NET Core SDK (including prereleases) will be used")
+                .And.HaveStdErrContaining(Path.Combine(_exeSelectedMessage, "9999.1.402", _dotnetSdkDllMessageTerminator));
+
+            // Write a global.json that has a prerelease version and allowPrerelease = false
+            CreateGlobalJson(version: "9999.1.402-preview1", allowPrerelease: false);
+
+            DotNet.Exec("help")
+                .WorkingDirectory(_currentWorkingDir)
+                .WithUserProfile(_userDir)
+                .Environment(s_DefaultEnvironment)
+                .EnvironmentVariable("DOTNET_MULTILEVEL_LOOKUP", "0")
+                .CaptureStdOut()
+                .CaptureStdErr()
+                .Execute()
+                .Should()
+                .Pass()
+                .And.HaveStdErrContaining("Ignoring the 'sdk/allowPrerelease' value")
+                .And.HaveStdErrContaining(Path.Combine(_exeSelectedMessage, "9999.1.402", _dotnetSdkDllMessageTerminator));
+        }
+
+        [Theory]
+        [MemberData(nameof(SdkRollForwardData))]
+        public void It_rolls_forward_as_expected(string policy, string requested, bool allowPrerelease, string expected, string[] installed)
+        {
+            AddAvailableSdkVersions(_exeSdkBaseDir, installed);
+
+            CreateGlobalJson(policy: policy, version: requested, allowPrerelease: allowPrerelease);
+
+            var result = DotNet.Exec("help")
+                .WorkingDirectory(_currentWorkingDir)
+                .WithUserProfile(_userDir)
+                .Environment(s_DefaultEnvironment)
+                .EnvironmentVariable("DOTNET_MULTILEVEL_LOOKUP", "0")
+                .CaptureStdOut()
+                .CaptureStdErr()
+                .Execute();
+
+            var globalJson = Path.Combine(_currentWorkingDir, "global.json");
+
+            if (expected == null)
+            {
+                result
+                    .Should()
+                    .Fail()
+                    .And.HaveStdErrContaining($"A compatible installed .NET Core SDK for global.json version [{requested}] from [{globalJson}] was not found")
+                    .And.HaveStdErrContaining($"Install the [{requested}] .NET Core SDK or update [{globalJson}] with an installed .NET Core SDK:");
+            }
+            else
+            {
+                result
+                    .Should()
+                    .Pass()
+                    .And.HaveStdErrContaining($"SDK path resolved to [{Path.Combine(_exeSdkBaseDir, expected)}]");
+            }
+        }
+
+        [Fact]
+        public void It_uses_latest_stable_sdk_if_allow_prerelease_is_false()
+        {
+            var installed = new string[] {
+                    "9999.1.702",
+                    "9999.2.101",
+                    "9999.2.203",
+                    "9999.2.204-preview1",
+                    "10000.0.100-preview3",
+                    "10000.0.100-preview7",
+                    "10000.0.100",
+                    "10000.1.102",
+                    "10000.1.106",
+                    "10000.0.200-preview5",
+                    "10000.1.100-preview3",
+                    "10001.0.100-preview3",
+                };
+
+            const string ExpectedVersion = "10000.1.106";
+
+            AddAvailableSdkVersions(_exeSdkBaseDir, installed);
+
+            CreateGlobalJson(allowPrerelease: false);
+
+            var result = DotNet.Exec("help")
+                .WorkingDirectory(_currentWorkingDir)
+                .WithUserProfile(_userDir)
+                .Environment(s_DefaultEnvironment)
+                .EnvironmentVariable("DOTNET_MULTILEVEL_LOOKUP", "0")
+                .CaptureStdOut()
+                .CaptureStdErr()
+                .Execute()
+                .Should()
+                .Pass()
+                .And.HaveStdErrContaining($"SDK path resolved to [{Path.Combine(_exeSdkBaseDir, ExpectedVersion)}]");
+        }
+
+        public static IEnumerable<object[]> SdkRollForwardData
+        {
+            get
+            {
+                const string Requested = "9999.1.501";
+
+                var installed = new string[] {
+                    "9999.1.500",
+                };
+
+                // Array of (policy, expected) tuples
+                var policies = new[] {
+                    ((string)null,    (string)null),
+                    ("patch",         (string)null),
+                    ("feature",       (string)null),
+                    ("minor",         (string)null),
+                    ("major",         (string)null),
+                    ("latestPatch",   (string)null),
+                    ("latestFeature", (string)null),
+                    ("latestMinor",   (string)null),
+                    ("latestMajor",   (string)null),
+                    ("disable",       (string)null),
+                    ("invalid",       "9999.1.500"),
+                };
+
+                foreach (var policy in policies)
+                {
+                    yield return new object[] {
+                        policy.Item1, // policy
+                        Requested,    // requested
+                        true,         // allow prerelease
+                        policy.Item2, // expected
+                        installed     // installed
+                    };
+                }
+
+                installed = new string[] {
+                    "9999.1.500",
+                    "9999.2.100-preview1",
+                };
+
+                // Array of (policy, expected) tuples
+                policies = new[] {
+                    ((string)null,    (string)null),
+                    ("patch",         (string)null),
+                    ("feature",       (string)null),
+                    ("minor",         (string)null),
+                    ("major",         (string)null),
+                    ("latestPatch",   (string)null),
+                    ("latestFeature", (string)null),
+                    ("latestMinor",   (string)null),
+                    ("latestMajor",   (string)null),
+                    ("disable",       (string)null),
+                    ("invalid",       "9999.2.100-preview1"),
+                };
+
+                foreach (var policy in policies)
+                {
+                    yield return new object[] {
+                        policy.Item1, // policy
+                        Requested,    // requested
+                        false,        // do not allow prerelease
+                        policy.Item2, // expected
+                        installed     // installed
+                    };
+                }
+
+                installed = new string[] {
+                    "9998.0.300",
+                    "9999.1.500",
+                    "9999.1.501",
+                    "9999.1.503-preview5",
+                    "9999.1.503",
+                    "9999.1.504-preview1",
+                    "9999.1.504-preview2",
+                };
+
+                // Array of (policy, expected) tuples
+                policies = new[] {
+                    ((string)null,    "9999.1.501"),
+                    ("patch",         "9999.1.501"),
+                    ("feature",       "9999.1.504-preview2"),
+                    ("minor",         "9999.1.504-preview2"),
+                    ("major",         "9999.1.504-preview2"),
+                    ("latestPatch",   "9999.1.504-preview2"),
+                    ("latestFeature", "9999.1.504-preview2"),
+                    ("latestMinor",   "9999.1.504-preview2"),
+                    ("latestMajor",   "9999.1.504-preview2"),
+                    ("disable",       "9999.1.501"),
+                    ("invalid",       "9999.1.504-preview2"),
+                };
+
+                foreach (var policy in policies)
+                {
+                    yield return new object[] {
+                        policy.Item1, // policy
+                        Requested,    // requested
+                        true,         // allow prerelease
+                        policy.Item2, // expected
+                        installed     // installed
+                    };
+                }
+
+                installed = new string[] {
+                    "9998.0.300",
+                    "9999.1.500",
+                    "9999.1.501",
+                    "9999.1.503-preview5",
+                    "9999.1.503",
+                    "9999.1.504-preview1",
+                    "9999.1.504-preview2",
+                };
+
+                // Array of (policy, expected) tuples
+                policies = new[] {
+                    ((string)null,    "9999.1.501"),
+                    ("patch",         "9999.1.501"),
+                    ("feature",       "9999.1.503"),
+                    ("minor",         "9999.1.503"),
+                    ("major",         "9999.1.503"),
+                    ("latestPatch",   "9999.1.503"),
+                    ("latestFeature", "9999.1.503"),
+                    ("latestMinor",   "9999.1.503"),
+                    ("latestMajor",   "9999.1.503"),
+                    ("disable",       "9999.1.501"),
+                    ("invalid",       "9999.1.504-preview2"),
+                };
+
+                foreach (var policy in policies)
+                {
+                    yield return new object[] {
+                        policy.Item1, // policy
+                        Requested,    // requested
+                        false,        // don't allow prerelease
+                        policy.Item2, // expected
+                        installed     // installed
+                    };
+                }
+
+                installed = new string[] {
+                    "9998.0.300",
+                    "9999.1.500",
+                    "9999.1.503",
+                    "9999.1.505-preview2",
+                    "9999.1.505",
+                    "9999.1.506-preview1",
+                    "9999.1.601",
+                    "9999.1.608-preview3",
+                    "9999.1.609",
+                    "9999.2.101",
+                    "9999.2.203-preview1",
+                    "9999.2.203",
+                    "10000.0.100",
+                    "10000.1.100-preview1"
+                };
+
+                // Array of (policy, expected) tuples
+                policies = new[] {
+                    (null,            "9999.1.506-preview1"),
+                    ("patch",         "9999.1.506-preview1"),
+                    ("feature",       "9999.1.506-preview1"),
+                    ("minor",         "9999.1.506-preview1"),
+                    ("major",         "9999.1.506-preview1"),
+                    ("latestPatch",   "9999.1.506-preview1"),
+                    ("latestFeature", "9999.1.609"),
+                    ("latestMinor",   "9999.2.203"),
+                    ("latestMajor",   "10000.1.100-preview1"),
+                    ("disable",       (string)null),
+                    ("invalid",       "10000.1.100-preview1"),
+                };
+
+                foreach (var policy in policies)
+                {
+                    yield return new object[] {
+                        policy.Item1, // policy
+                        Requested,    // requested
+                        true,         // allow prerelease
+                        policy.Item2, // expected
+                        installed     // installed
+                    };
+                }
+
+                installed = new string[] {
+                    "9998.0.300",
+                    "9999.1.500",
+                    "9999.1.503",
+                    "9999.1.505-preview2",
+                    "9999.1.505",
+                    "9999.1.506-preview1",
+                    "9999.1.601",
+                    "9999.1.608-preview3",
+                    "9999.1.609",
+                    "9999.2.101",
+                    "9999.2.203-preview1",
+                    "9999.2.203",
+                    "10000.0.100",
+                    "10000.1.100-preview1"
+                };
+
+                // Array of (policy, expected) tuples
+                policies = new[] {
+                    (null,            "9999.1.505"),
+                    ("patch",         "9999.1.505"),
+                    ("feature",       "9999.1.505"),
+                    ("minor",         "9999.1.505"),
+                    ("major",         "9999.1.505"),
+                    ("latestPatch",   "9999.1.505"),
+                    ("latestFeature", "9999.1.609"),
+                    ("latestMinor",   "9999.2.203"),
+                    ("latestMajor",   "10000.0.100"),
+                    ("disable",       (string)null),
+                    ("invalid",       "10000.1.100-preview1"),
+                };
+
+                foreach (var policy in policies)
+                {
+                    yield return new object[] {
+                        policy.Item1, // policy
+                        Requested,    // requested
+                        false,        // don't allow prerelease
+                        policy.Item2, // expected
+                        installed     // installed
+                    };
+                }
+
+                installed = new string[] {
+                    "9998.0.300",
+                    "9999.1.500",
+                    "9999.1.601",
+                    "9999.1.604-preview3",
+                    "9999.1.604",
+                    "9999.1.605-preview4",
+                    "9999.1.701",
+                    "9999.1.702-preview1",
+                    "9999.1.702",
+                    "9999.2.101",
+                    "9999.2.203",
+                    "9999.2.204-preview1",
+                    "10000.0.100-preview7",
+                    "10000.0.100",
+                };
+
+                // Array of (policy, expected) tuples
+                policies = new[] {
+                    ((string)null,    (string)null),
+                    ("patch",         (string)null),
+                    ("feature",       "9999.1.605-preview4"),
+                    ("minor",         "9999.1.605-preview4"),
+                    ("major",         "9999.1.605-preview4"),
+                    ("latestPatch",   (string)null),
+                    ("latestFeature", "9999.1.702"),
+                    ("latestMinor",   "9999.2.204-preview1"),
+                    ("latestMajor",   "10000.0.100"),
+                    ("disable",       (string)null),
+                    ("invalid",       "10000.0.100"),
+                };
+
+                foreach (var policy in policies)
+                {
+                    yield return new object[] {
+                        policy.Item1, // policy
+                        Requested,    // requested
+                        true,         // allow prerelease
+                        policy.Item2, // expected
+                        installed     // installed
+                    };
+                }
+
+                installed = new string[] {
+                    "9998.0.300",
+                    "9999.1.500",
+                    "9999.1.601",
+                    "9999.1.604-preview3",
+                    "9999.1.604",
+                    "9999.1.605-preview4",
+                    "9999.1.701",
+                    "9999.1.702-preview1",
+                    "9999.1.702",
+                    "9999.2.101",
+                    "9999.2.203",
+                    "9999.2.204-preview1",
+                    "10000.0.100-preview7",
+                    "10000.0.100",
+                };
+
+                // Array of (policy, expected) tuples
+                policies = new[] {
+                    ((string)null,    (string)null),
+                    ("patch",         (string)null),
+                    ("feature",       "9999.1.604"),
+                    ("minor",         "9999.1.604"),
+                    ("major",         "9999.1.604"),
+                    ("latestPatch",   (string)null),
+                    ("latestFeature", "9999.1.702"),
+                    ("latestMinor",   "9999.2.203"),
+                    ("latestMajor",   "10000.0.100"),
+                    ("disable",       (string)null),
+                    ("invalid",       "10000.0.100"),
+                };
+
+                foreach (var policy in policies)
+                {
+                    yield return new object[] {
+                        policy.Item1, // policy
+                        Requested,    // requested
+                        false,        // don't allow prerelease
+                        policy.Item2, // expected
+                        installed     // installed
+                    };
+                }
+
+                installed = new string[] {
+                    "9998.0.300",
+                    "9999.1.500",
+                    "9999.2.101-preview4",
+                    "9999.2.101",
+                    "9999.2.102-preview1",
+                    "9999.2.203",
+                    "9999.3.501",
+                    "9999.4.205-preview3",
+                    "10000.0.100",
+                    "10000.1.100-preview1"
+                };
+
+                // Array of (policy, expected) tuples
+                policies = new[] {
+                    ((string)null,    (string)null),
+                    ("patch",         (string)null),
+                    ("feature",       (string)null),
+                    ("minor",         "9999.2.102-preview1"),
+                    ("major",         "9999.2.102-preview1"),
+                    ("latestPatch",   (string)null),
+                    ("latestFeature", (string)null),
+                    ("latestMinor",   "9999.4.205-preview3"),
+                    ("latestMajor",   "10000.1.100-preview1"),
+                    ("disable",       (string)null),
+                    ("invalid",       "10000.1.100-preview1"),
+                };
+
+                foreach (var policy in policies)
+                {
+                    yield return new object[] {
+                        policy.Item1, // policy
+                        Requested,    // requested
+                        true,         // allow prerelease
+                        policy.Item2, // expected
+                        installed     // installed
+                    };
+                }
+
+                installed = new string[] {
+                    "9998.0.300",
+                    "9999.1.500",
+                    "9999.2.101-preview4",
+                    "9999.2.101",
+                    "9999.2.102-preview1",
+                    "9999.2.203",
+                    "9999.3.501",
+                    "9999.4.205-preview3",
+                    "10000.0.100",
+                    "10000.1.100-preview1"
+                };
+
+                // Array of (policy, expected) tuples
+                policies = new[] {
+                    ((string)null,    (string)null),
+                    ("patch",         (string)null),
+                    ("feature",       (string)null),
+                    ("minor",         "9999.2.101"),
+                    ("major",         "9999.2.101"),
+                    ("latestPatch",   (string)null),
+                    ("latestFeature", (string)null),
+                    ("latestMinor",   "9999.3.501"),
+                    ("latestMajor",   "10000.0.100"),
+                    ("disable",       (string)null),
+                    ("invalid",       "10000.1.100-preview1"),
+                };
+
+                foreach (var policy in policies)
+                {
+                    yield return new object[] {
+                        policy.Item1, // policy
+                        Requested,    // requested
+                        false,        // don't allow prerelease
+                        policy.Item2, // expected
+                        installed     // installed
+                    };
+                }
+
+                installed = new string[] {
+                    "9998.0.300",
+                    "9999.1.500",
+                    "10000.0.100",
+                    "10000.0.105-preview1",
+                    "10000.0.105",
+                    "10000.0.106-preview1",
+                    "10000.1.102",
+                    "10000.1.107",
+                    "10000.3.100",
+                    "10000.3.102-preview3",
+                };
+
+                // Array of (policy, expected) tuples
+                policies = new[] {
+                    ((string)null,    (string)null),
+                    ("patch",         (string)null),
+                    ("feature",       (string)null),
+                    ("minor",         (string)null),
+                    ("major",         "10000.0.106-preview1"),
+                    ("latestPatch",   (string)null),
+                    ("latestFeature", (string)null),
+                    ("latestMinor",   (string)null),
+                    ("latestMajor",   "10000.3.102-preview3"),
+                    ("disable",       (string)null),
+                    ("invalid",       "10000.3.102-preview3"),
+                };
+
+                foreach (var policy in policies)
+                {
+                    yield return new object[] {
+                        policy.Item1, // policy
+                        Requested,    // requested
+                        true,         // allow prerelease
+                        policy.Item2, // expected
+                        installed     // installed
+                    };
+                }
+
+                installed = new string[] {
+                    "9998.0.300",
+                    "9999.1.500",
+                    "10000.0.100",
+                    "10000.0.105-preview1",
+                    "10000.0.105",
+                    "10000.0.106-preview1",
+                    "10000.1.102",
+                    "10000.1.107",
+                    "10000.3.100",
+                    "10000.3.102-preview3",
+                };
+
+                // Array of (policy, expected) tuples
+                policies = new[] {
+                    ((string)null,    (string)null),
+                    ("patch",         (string)null),
+                    ("feature",       (string)null),
+                    ("minor",         (string)null),
+                    ("major",         "10000.0.105"),
+                    ("latestPatch",   (string)null),
+                    ("latestFeature", (string)null),
+                    ("latestMinor",   (string)null),
+                    ("latestMajor",   "10000.3.100"),
+                    ("disable",       (string)null),
+                    ("invalid",       "10000.3.102-preview3"),
+                };
+
+                foreach (var policy in policies)
+                {
+                    yield return new object[] {
+                        policy.Item1, // policy
+                        Requested,    // requested
+                        false,        // don't allow prerelease
+                        policy.Item2, // expected
+                        installed     // installed
+                    };
+                }
+            }
+        }
+
         // This method adds a list of new sdk version folders in the specified directory.
         // The actual contents are 'fake' and the mininum required for SDK discovery.
         // The dotnet.runtimeconfig.json created uses a dummy framework version (9999.0.0)
@@ -578,13 +1278,27 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
         }
 
         // Put a global.json file in the cwd in order to specify a CLI
-        private void SetGlobalJsonVersion(string globalJsonFileName)
+        private void CopyGlobalJson(string globalJsonFileName)
         {
             string destFile = Path.Combine(_currentWorkingDir, "global.json");
             string srcFile = Path.Combine(RepoDirectories.RepoRoot, "src", "test", "Assets", "TestUtils",
                 "SDKLookup", globalJsonFileName);
 
             File.Copy(srcFile, destFile, true);
+        }
+
+        private void CreateGlobalJson(string version = null, string policy = null, bool? allowPrerelease = null)
+        {
+            version = version == null ? "null" : string.Format("\"{0}\"", version);
+            policy = policy == null ? "null" : string.Format("\"{0}\"", policy);
+            string allow = allowPrerelease.HasValue ? (allowPrerelease.Value ? "true" : "false") : "null";
+
+            WriteGlobalJson($@"{{ ""sdk"": {{ ""version"": {version}, ""rollForward"": {policy}, ""allowPrerelease"": {allow} }} }}");
+        }
+
+        private void WriteGlobalJson(string contents)
+        {
+            File.WriteAllText(Path.Combine(_currentWorkingDir, "global.json"), contents);
         }
     }
 }


### PR DESCRIPTION
This PR implements additional roll-forward policies for resolving a .NET
Core SDK based upon new SDK settings in `global.json`.

Two new values are now supported in `global.json` in the `sdk` settings:

* `rollForward` - the roll-forward policy to use (see below).
* `allowPrerelease` - controls whether or not preview SDKS may be resolved
(defaults to `true` to allow resolving prerelease SDKs).  


The new roll-forward policies are:

* `patch` - If the requested SDK is installed, use it. Otherwise, use the
  latest installed patch level that matches the requested major, minor, and
  feature band.
* `feature` - If the requested major, minor, and feature band is installed, use
the latest patch level for the specified feature band.  Otherwise, roll-forward
to the next available feature band and use the latest patch level for that
feature band.
* `minor` - If the requested major, minor, and feature band is installed, use
the latest patch level for the specified feature band.  Otherwise, roll-forward
to the next available feature band available for the same major version and use
the latest patch level for that feature band.
* `major` - If the requested major, minor, and feature band is installed, use
the latest patch level for the specified feature band.  Otherwise, roll-forward
to the next available feature band available without restriction and use the
latest patch level for that feature band.
* `latestPatch` - Use the latest installed patch level that matches the
requested major, minor, and feature band.
* `latestFeature` - Use the latest installed patch level for the latest
installed feature band that matches the requested major and minor version.
* `latestMinor` - Use the latest installed patch level for the latest installed
feature band for the latest installed minor version that matches the requested
major version.
* `latestMajor` - Use the absolutely latest .NET Core SDK available.

For backwards compatibility, the policy when a `version` is not specified in
`global.json` will be `latestMajor`.  The default policy when a `version` is
specified but `rollForward` is not specified will be `patch`.