### PR TITLE
HostModel:Enable TestWithAdditionalContentAfterBundleMetadata

### DIFF
--- a/src/test/BundleTests/Microsoft.NET.HostModel.Bundle.Tests/BundlerConsistencyTests.cs
+++ b/src/test/BundleTests/Microsoft.NET.HostModel.Bundle.Tests/BundlerConsistencyTests.cs
@@ -143,7 +143,7 @@ namespace Microsoft.NET.HostModel.Tests
             bundleDir.Should().OnlyHaveFiles(expectedFiles);
         }
 
-        [Fact(Skip = "Disabled in master temporarily to avoid infra issues")]
+        [Fact]
         public void TestWithAdditionalContentAfterBundleMetadata()
         {
             var fixture = sharedTestState.TestFixture.Copy();


### PR DESCRIPTION
The above test was disabled in PR #6885 because the lab runs
showed failures because of "not enough disk space"

This PR tries to enable the test, and move the job to not
use the hosted pool, as suggested [here](https://github.com/dotnet/core-setup/pull/6885#issuecomment-505998739).
