### PR TITLE
Make Microsoft.NET.HostModel.AppHost.ResourceUpdater public

### DIFF
--- a/src/managed/Microsoft.NET.HostModel/AppHost/ResourceUpdater.cs
+++ b/src/managed/Microsoft.NET.HostModel/AppHost/ResourceUpdater.cs
@@ -13,7 +13,7 @@ namespace Microsoft.NET.HostModel
     /// in a PE image. It currently only works on Windows, because it
     /// requires various kernel32 APIs.
     /// </summary>
-    internal class ResourceUpdater : IDisposable
+    public class ResourceUpdater : IDisposable
     {
         private sealed class Kernel32
         {


### PR DESCRIPTION
Make Microsoft.NET.HostModel.AppHost.ResourceUpdater class public,
so that it can be consumed from the SDK repo.
