### PR TITLE
Add parameters struct to nethost get_hostfxr_path

### DIFF
--- a/Documentation/design-docs/native-hosting.md
+++ b/Documentation/design-docs/native-hosting.md
@@ -8,24 +8,24 @@ Native hosting is the ability to host the .NET Core runtime in an arbitrary proc
 * "host context" - state which `hostfxr` creates and maintains and represents a logical operation on the hosting components.
 
 ## Scenarios
-* **Hosting managed components**  
+* **Hosting managed components**
 Native host which wants to load managed assembly and call into it for some functionality. Must support loading multiple such components side by side.
-* **Hosting managed apps**  
+* **Hosting managed apps**
 Native host which wants to run a managed app in-proc. Basically a different implementation of the existing .NET Core hosts (`dotnet.exe` or `apphost`). The intent is the ability to modify how the runtime starts and how the managed app is executed (and where it starts from).
-* **App using other .NET Core hosting services**  
+* **App using other .NET Core hosting services**
 App (native or .NET Core both) which needs to use some of the other services provided by the .NET Core hosting layer. For example the ability to locate available SDKs and so on.
 
 
 ## Existing support
-* **C-style ABI in `coreclr`**  
+* **C-style ABI in `coreclr`**
 `coreclr` exposes ABI to host the .NET Core runtime and run managed code already using C-style APIs. See this [header file](https://github.com/dotnet/coreclr/blob/master/src/coreclr/hosts/inc/coreclrhost.h) for the exposed functions.
 This API requires the native host to locate the runtime and to fully specify all startup parameters for the runtime. There's no inherent interoperability between these APIs and the .NET Core SDK.
-* **COM-style ABI in `coreclr`**  
+* **COM-style ABI in `coreclr`**
 `coreclr` exposes COM-style ABI to host the .NET Core runtime and perform a wide range of operations on it. See this [header file](https://github.com/dotnet/coreclr/blob/master/src/pal/prebuilt/inc/mscoree.h) for more details.
 Similarly to the C-style ABI the COM-style ABI also requires the native host to locate the runtime and to fully specify all startup parameters.
-There's no inherent interoperability between these APIs and the .NET Core SDK.  
+There's no inherent interoperability between these APIs and the .NET Core SDK.
 The COM-style ABI is deprecated and should not be used going forward.
-* **`hostfxr` and `hostpolicy` APIs**  
+* **`hostfxr` and `hostpolicy` APIs**
 The hosting layer of .NET Core already exposes some functionality as C-style ABI on either the `hostfxr` or `hostpolicy` libraries. These can execute application, determine available SDKs, determine native dependency locations, resolve component dependencies and so on.
 Unlike the above `coreclr` based APIs these don't require the caller to fully specify all startup parameters, instead these APIs understand artifacts produced by .NET Core SDK making it much easier to consume SDK produced apps/libraries.
 The native host is still required to locate the `hostfxr` or `hostpolicy` libraries. These APIs are also designed for specific narrow scenarios, any usage outside of these bounds is typically not possible.
@@ -71,7 +71,7 @@ The binary itself should be signed by Microsoft as there will be no support for 
 ### Locate `hostfxr`
 ``` C++
 struct get_hostfxr_parameters {
-    size_t version;
+    size_t size;
     const char_t * assembly_path;
     const char_t * dotnet_root;
 };
@@ -87,10 +87,11 @@ This API locates the `hostfxr` library and returns its path by populating `resul
 * `result_buffer` - Buffer that will be populated with the hostfxr path, including a null terminator.
 * `buffer_size` - On input this points to the size of the `result_buffer` in `char_t` units. On output this points to the number of `char_t` units used from the `result_buffer` (including the null terminator). If `result_buffer` is `nullptr` the input value is ignored and only the minimum required size in `char_t` units is set on output.
 * `parameters` - Optional. Additional parameters that modify the behaviour for locating the `hostfxr` library. If `nullptr`, `hostfxr` is located using the environment variable or global registration
+  * `size` - Size of the structure. This is used for versioning and should be set to `sizeof(get_hostfxr_parameters)`.
   * `assembly_path` - Optional. Path to the application or to the component's assembly.
-  * If specified, `hostfxr` is located as if the `assembly_path` is an application with `apphost`
+    * If specified, `hostfxr` is located as if the `assembly_path` is an application with `apphost`
   * `dotnet_root` - Optional. Path to the root of a .NET Core installation (i.e. folder containing the dotnet executable).
-    * If specified, `hostfxr` is located under this path and `assembly_path` is ignored.
+    * If specified, `hostfxr` is located as if an application is started using `dotnet app.dll`, which means it will be searched for under the `dotnet_root` path and the `assembly_path` is ignored.
 
 `nethost` library uses the `__stdcall` calling convention.
 
@@ -213,7 +214,7 @@ The function returns specific return code for the first initialized host context
 
 #### Runtime properties
 These functions allow the native host to inspect and modify runtime properties.
-* If the `host_context_handle` represents the first initialized context in the process, these functions expose all properties from runtime configurations as well as those computed by the hosting layer components. These functions will allow modification of the properties via `hostfxr_set_runtime_property_value`. 
+* If the `host_context_handle` represents the first initialized context in the process, these functions expose all properties from runtime configurations as well as those computed by the hosting layer components. These functions will allow modification of the properties via `hostfxr_set_runtime_property_value`.
 * If the `host_context_handle` represents any other context (so not the first one), these functions expose only properties from runtime configuration. These functions won't allow modification of the properties.
 
 It is possible to access runtime properties of the first initialized context in the process at any time (for reading only), by specifying `nullptr` as the `host_context_handle`.
@@ -302,7 +303,7 @@ Starts the runtime and returns a function pointer to specified functionality of 
   * `hdt_winrt_activation` - WinRT activation entry-point - see [WinRT activation](https://github.com/dotnet/core-setup/blob/master/Documentation/design-docs/WinRT-activation.md) for more details.
 * `delegate` - when successful, the native function pointer to the requested runtime functionality.
 
-Initially the function will only work if `hostfxr_initialize_for_runtime_config` was used to initialize the host context. Later on this could be relaxed to allow being used in combination with `hostfxr_initialize_for_dotnet_command_line`.  
+Initially the function will only work if `hostfxr_initialize_for_runtime_config` was used to initialize the host context. Later on this could be relaxed to allow being used in combination with `hostfxr_initialize_for_dotnet_command_line`.
 
 Initially there might be a limitation of calling this function only once on a given host context to simplify the implementation. Currently we don't have a scenario where it would be absolutely required to support multiple calls.
 
@@ -397,7 +398,7 @@ It should really only happen that `hostfxr` is equal or newer than `hostpolicy`.
 
 The interesting case is 3.0 `hostfxr` using 2.* `hostpolicy`. This will be very common, basically any 2.* app running on a machine with 3.0 installed will be in that situation. This case has two sub-cases:
 * `hostfxr` is invoked using one of the 2.* APIs. In this case the simple solution is to keep using the 2.* `hostpolicy` APIs always.
-* `hostfxr` is invoked using one of the new 3.0 APIs (like `hostfxr_initialize...`). In this case it's not possible to completely support the new APIs, since they require new functionality from `hostpolicy`. For now the `hostfxr` should simply fail.  
+* `hostfxr` is invoked using one of the new 3.0 APIs (like `hostfxr_initialize...`). In this case it's not possible to completely support the new APIs, since they require new functionality from `hostpolicy`. For now the `hostfxr` should simply fail.
 It is in theory possible to support some kind of emulation mode where for some scenarios the new APIs would work even with old `hostpolicy`, but for simplicity it's better to start with just failing.
 
 #### Implementation of existing 2.* APIs in `hostfxr`

--- a/Documentation/design-docs/native-hosting.md
+++ b/Documentation/design-docs/native-hosting.md
@@ -70,19 +70,27 @@ The binary itself should be signed by Microsoft as there will be no support for 
 
 ### Locate `hostfxr`
 ``` C++
+struct get_hostfxr_parameters {
+    size_t version;
+    const char_t * assembly_path;
+    const char_t * dotnet_root;
+};
+
 int get_hostfxr_path(
     char_t * result_buffer,
     size_t * buffer_size,
-    const char_t * assembly_path);
+    const get_hostfxr_parameters * parameters);
 ```
 
-This API locates the `hostfxr` and returns its path by calling the `result` function.
+This API locates the `hostfxr` library and returns its path by populating `result_buffer`.
 
 * `result_buffer` - Buffer that will be populated with the hostfxr path, including a null terminator.
 * `buffer_size` - On input this points to the size of the `result_buffer` in `char_t` units. On output this points to the number of `char_t` units used from the `result_buffer` (including the null terminator). If `result_buffer` is `nullptr` the input value is ignored and only the minimum required size in `char_t` units is set on output.
-* `assembly_path` - Optional. Path to the component's assembly. Whether or not this is specified determines the behavior for locating the hostfxr library.
-  * If `nullptr`, `hostfxr` is located using the environment variable or global registration
+* `parameters` - Optional. Additional parameters that modify the behaviour for locating the `hostfxr` library. If `nullptr`, `hostfxr` is located using the environment variable or global registration
+  * `assembly_path` - Optional. Path to the component's assembly.
   * If specified, `hostfxr` is located as if the `assembly_path` is an application with `apphost`
+  * `dotnet_root` - Optional. Path to the root of a .NET Core installation (i.e. folder containing the dotnet executable).
+    * If specified, `hostfxr` is located under this path and `assembly_path` is ignored.
 
 `nethost` library uses the `__stdcall` calling convention.
 

--- a/Documentation/design-docs/native-hosting.md
+++ b/Documentation/design-docs/native-hosting.md
@@ -87,7 +87,7 @@ This API locates the `hostfxr` library and returns its path by populating `resul
 * `result_buffer` - Buffer that will be populated with the hostfxr path, including a null terminator.
 * `buffer_size` - On input this points to the size of the `result_buffer` in `char_t` units. On output this points to the number of `char_t` units used from the `result_buffer` (including the null terminator). If `result_buffer` is `nullptr` the input value is ignored and only the minimum required size in `char_t` units is set on output.
 * `parameters` - Optional. Additional parameters that modify the behaviour for locating the `hostfxr` library. If `nullptr`, `hostfxr` is located using the environment variable or global registration
-  * `assembly_path` - Optional. Path to the component's assembly.
+  * `assembly_path` - Optional. Path to the application or to the component's assembly.
   * If specified, `hostfxr` is located as if the `assembly_path` is an application with `apphost`
   * `dotnet_root` - Optional. Path to the root of a .NET Core installation (i.e. folder containing the dotnet executable).
     * If specified, `hostfxr` is located under this path and `assembly_path` is ignored.

--- a/src/corehost/cli/fxr_resolver.cpp
+++ b/src/corehost/cli/fxr_resolver.cpp
@@ -55,7 +55,6 @@ namespace
 
 bool fxr_resolver::try_get_path(const pal::string_t& root_path, pal::string_t* out_dotnet_root, pal::string_t* out_fxr_path)
 {
-    pal::string_t fxr_dir;
 #if defined(FEATURE_APPHOST) || defined(FEATURE_LIBHOST)
     // For apphost and libhost, root_path is expected to be a directory.
     // For libhost, it may be empty if app-local search is not desired (e.g. com/ijw/winrt hosts, nethost when no assembly path is specified)
@@ -88,7 +87,7 @@ bool fxr_resolver::try_get_path(const pal::string_t& root_path, pal::string_t* o
         }
     }
 
-    fxr_dir = *out_dotnet_root;
+    pal::string_t fxr_dir = *out_dotnet_root;
     append_path(&fxr_dir, _X("host"));
     append_path(&fxr_dir, _X("fxr"));
     if (!pal::directory_exists(fxr_dir))
@@ -120,6 +119,11 @@ bool fxr_resolver::try_get_path(const pal::string_t& root_path, pal::string_t* o
             self_registered_message.c_str());
         return false;
     }
+
+    if (!get_latest_fxr(std::move(fxr_dir), out_fxr_path))
+        return false;
+
+    return true;
 #else // !FEATURE_APPHOST && !FEATURE_LIBHOST
     // For non-apphost and non-libhost (i.e. muxer), root_path is expected to be the full path to the host
     pal::string_t host_dir;
@@ -127,7 +131,13 @@ bool fxr_resolver::try_get_path(const pal::string_t& root_path, pal::string_t* o
 
     out_dotnet_root->assign(host_dir);
 
-    fxr_dir = *out_dotnet_root;
+    return fxr_resolver::try_get_path_from_dotnet_root(*out_dotnet_root, out_fxr_path);
+#endif // !FEATURE_APPHOST && !FEATURE_LIBHOST
+}
+
+bool fxr_resolver::try_get_path_from_dotnet_root(const pal::string_t &dotnet_root, pal::string_t *out_fxr_path)
+{
+    pal::string_t fxr_dir = dotnet_root;
     append_path(&fxr_dir, _X("host"));
     append_path(&fxr_dir, _X("fxr"));
     if (!pal::directory_exists(fxr_dir))
@@ -135,7 +145,6 @@ bool fxr_resolver::try_get_path(const pal::string_t& root_path, pal::string_t* o
         trace::error(_X("A fatal error occurred. The folder [%s] does not exist"), fxr_dir.c_str());
         return false;
     }
-#endif // !FEATURE_APPHOST && !FEATURE_LIBHOST
 
     if (!get_latest_fxr(std::move(fxr_dir), out_fxr_path))
         return false;

--- a/src/corehost/cli/fxr_resolver.cpp
+++ b/src/corehost/cli/fxr_resolver.cpp
@@ -120,10 +120,7 @@ bool fxr_resolver::try_get_path(const pal::string_t& root_path, pal::string_t* o
         return false;
     }
 
-    if (!get_latest_fxr(std::move(fxr_dir), out_fxr_path))
-        return false;
-
-    return true;
+    return get_latest_fxr(std::move(fxr_dir), out_fxr_path);
 #else // !FEATURE_APPHOST && !FEATURE_LIBHOST
     // For non-apphost and non-libhost (i.e. muxer), root_path is expected to be the full path to the host
     pal::string_t host_dir;
@@ -146,10 +143,7 @@ bool fxr_resolver::try_get_path_from_dotnet_root(const pal::string_t &dotnet_roo
         return false;
     }
 
-    if (!get_latest_fxr(std::move(fxr_dir), out_fxr_path))
-        return false;
-
-    return true;
+    return get_latest_fxr(std::move(fxr_dir), out_fxr_path);
 }
 
 bool fxr_resolver::try_get_existing_fxr(pal::dll_t *out_fxr, pal::string_t *out_fxr_path)

--- a/src/corehost/cli/fxr_resolver.h
+++ b/src/corehost/cli/fxr_resolver.h
@@ -14,6 +14,7 @@
 namespace fxr_resolver
 {
     bool try_get_path(const pal::string_t& root_path, pal::string_t* out_dotnet_root, pal::string_t* out_fxr_path);
+    bool try_get_path_from_dotnet_root(const pal::string_t& dotnet_root, pal::string_t* out_fxr_path);
     bool try_get_existing_fxr(pal::dll_t *out_fxr, pal::string_t *out_fxr_path);
 }
 

--- a/src/corehost/cli/nethost/nethost.cpp
+++ b/src/corehost/cli/nethost/nethost.cpp
@@ -21,7 +21,7 @@ namespace
 NETHOST_API int NETHOST_CALLTYPE get_hostfxr_path(
     char_t * buffer,
     size_t * buffer_size,
-    const char_t * assembly_path)
+    const struct get_hostfxr_parameters *parameters)
 {
     if (buffer_size == nullptr)
         return StatusCode::InvalidArgFailure;
@@ -29,17 +29,27 @@ NETHOST_API int NETHOST_CALLTYPE get_hostfxr_path(
     trace::setup();
     error_writer_scope_t writer_scope(swallow_trace);
 
-    pal::string_t root_path;
-    if (assembly_path != nullptr)
-        root_path = get_directory(assembly_path);
-
     pal::dll_t fxr;
     pal::string_t fxr_path;
     if (!fxr_resolver::try_get_existing_fxr(&fxr, &fxr_path))
     {
-        pal::string_t dotnet_root;
-        if(!fxr_resolver::try_get_path(root_path, &dotnet_root, &fxr_path))
-            return StatusCode::CoreHostLibMissingFailure;
+        if (parameters != nullptr && parameters->dotnet_root != nullptr)
+        {
+            pal::string_t dotnet_root = parameters->dotnet_root;
+            trace::info(_X("Using dotnet root parameter [%s] as runtime location."), dotnet_root.c_str());
+            if (!fxr_resolver::try_get_path_from_dotnet_root(dotnet_root, &fxr_path))
+                return StatusCode::CoreHostLibMissingFailure;
+        }
+        else
+        {
+            pal::string_t root_path;
+            if (parameters != nullptr && parameters->assembly_path != nullptr)
+                root_path = get_directory(parameters->assembly_path);
+
+            pal::string_t dotnet_root;
+            if (!fxr_resolver::try_get_path(root_path, &dotnet_root, &fxr_path))
+                return StatusCode::CoreHostLibMissingFailure;
+        }
     }
 
     size_t len = fxr_path.length();

--- a/src/corehost/cli/nethost/nethost.cpp
+++ b/src/corehost/cli/nethost/nethost.cpp
@@ -29,10 +29,10 @@ NETHOST_API int NETHOST_CALLTYPE get_hostfxr_path(
     trace::setup();
     error_writer_scope_t writer_scope(swallow_trace);
 
-    size_t min_parameters_version = offsetof(get_hostfxr_parameters, dotnet_root) + sizeof(const char_t*);
-    if (parameters != nullptr && parameters->version < min_parameters_version)
+    size_t min_parameters_size = offsetof(get_hostfxr_parameters, dotnet_root) + sizeof(const char_t*);
+    if (parameters != nullptr && parameters->size < min_parameters_size)
     {
-        trace::error(_X("Invalid version for get_hostfxr_parameters. Expected at least %d"), min_parameters_version);
+        trace::error(_X("Invalid size for get_hostfxr_parameters. Expected at least %d"), min_parameters_size);
         return StatusCode::InvalidArgFailure;
     }
 

--- a/src/corehost/cli/nethost/nethost.cpp
+++ b/src/corehost/cli/nethost/nethost.cpp
@@ -29,6 +29,13 @@ NETHOST_API int NETHOST_CALLTYPE get_hostfxr_path(
     trace::setup();
     error_writer_scope_t writer_scope(swallow_trace);
 
+    size_t min_parameters_version = offsetof(get_hostfxr_parameters, dotnet_root) + sizeof(const char_t*);
+    if (parameters != nullptr && parameters->version < min_parameters_version)
+    {
+        trace::error(_X("Invalid version for get_hostfxr_parameters. Expected at least %d"), min_parameters_version);
+        return StatusCode::InvalidArgFailure;
+    }
+
     pal::dll_t fxr;
     pal::string_t fxr_path;
     if (!fxr_resolver::try_get_existing_fxr(&fxr, &fxr_path))

--- a/src/corehost/cli/nethost/nethost.h
+++ b/src/corehost/cli/nethost/nethost.h
@@ -38,8 +38,8 @@ extern "C" {
 // Parameters for get_hostfxr_path
 //
 // Fields:
-//   version
-//     Version of the struct. This should be set to the size of the struct.
+//   size
+//     Size of the struct. This is used for versioning.
 //
 //   assembly_path
 //     Path to the compenent's assembly.
@@ -50,7 +50,7 @@ extern "C" {
 //     If specified, hostfxr is located under this path and assembly_path is ignored.
 //
 struct get_hostfxr_parameters {
-    size_t version;
+    size_t size;
     const char_t *assembly_path;
     const char_t *dotnet_root;
 };

--- a/src/corehost/cli/nethost/nethost.h
+++ b/src/corehost/cli/nethost/nethost.h
@@ -35,6 +35,23 @@
 extern "C" {
 #endif
 
+// Parameters for get_hostfxr_path
+//
+// Fields:
+//   assembly_path
+//     Path to the compenent's assembly.
+//     If specified, hostfxr is located as if the assembly_path is the apphost
+//
+//   dotnet_root
+//     Path to directory containing the dotnet executable.
+//     If specified, hostfxr is located under this path and assembly_path is ignored.
+//
+struct get_hostfxr_parameters {
+    size_t version;
+    const char_t *assembly_path;
+    const char_t *dotnet_root;
+};
+
 //
 // Get the path to the hostfxr library
 //
@@ -48,11 +65,9 @@ extern "C" {
 //           or buffer is nullptr, this is populated with the minimum required size
 //           in char_t units for a buffer to hold the hostfxr path
 //
-//   assembly_path
-//     Optional. Path to the compenent's assembly. Whether or not this is specified
-//     determines the behaviour for locating the hostfxr library.
+//   get_hostfxr_parameters
+//     Optional. Parameters that modify the behaviour for locating the hostfxr library.
 //     If nullptr, hostfxr is located using the enviroment variable or global registration
-//     If specified, hostfxr is located as if the assembly_path is the apphost
 //
 // Return value:
 //   0 on success, otherwise failure
@@ -65,7 +80,7 @@ extern "C" {
 NETHOST_API int NETHOST_CALLTYPE get_hostfxr_path(
     char_t * buffer,
     size_t * buffer_size,
-    const char_t * assembly_path);
+    const struct get_hostfxr_parameters *parameters);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/src/corehost/cli/nethost/nethost.h
+++ b/src/corehost/cli/nethost/nethost.h
@@ -38,6 +38,9 @@ extern "C" {
 // Parameters for get_hostfxr_path
 //
 // Fields:
+//   version
+//     Version of the struct. This should be set to the size of the struct.
+//
 //   assembly_path
 //     Path to the compenent's assembly.
 //     If specified, hostfxr is located as if the assembly_path is the apphost

--- a/src/corehost/cli/nethost/nethost.h
+++ b/src/corehost/cli/nethost/nethost.h
@@ -47,7 +47,9 @@ extern "C" {
 //
 //   dotnet_root
 //     Path to directory containing the dotnet executable.
-//     If specified, hostfxr is located under this path and assembly_path is ignored.
+//     If specified, hostfxr is located as if an application is started using
+//     'dotnet app.dll', which means it will be searched for under the dotnet_root
+//     path and the assembly_path is ignored.
 //
 struct get_hostfxr_parameters {
     size_t size;

--- a/src/corehost/cli/test/nativehost/nativehost.cpp
+++ b/src/corehost/cli/test/nativehost/nativehost.cpp
@@ -100,7 +100,7 @@ int main(const int argc, const pal::char_t *argv[])
 
         // Make version invalid for error case
         if (assembly_path != nullptr && pal::strcmp(assembly_path, _X("[error]")) == 0)
-            parameters.version = parameters.version - 1;
+            parameters.size = parameters.size - 1;
 
         const get_hostfxr_parameters *parameters_ptr = assembly_path != nullptr || dotnet_root != nullptr ? &parameters : nullptr;
 

--- a/src/corehost/cli/test/nativehost/nativehost.cpp
+++ b/src/corehost/cli/test/nativehost/nativehost.cpp
@@ -36,18 +36,22 @@ int main(const int argc, const pal::char_t *argv[])
     const pal::char_t *command = argv[1];
     if (pal::strcmp(command, _X("get_hostfxr_path")) == 0)
     {
-        // args: ... [<explicit_load>] [<assembly_path>] [<hostfxr_to_load>]
+        // args: ... [<explicit_load>] [<assembly_path>] [<dotnet_root>] [<hostfxr_to_load>]
         bool explicit_load = false;
         if (argc >= 3)
             explicit_load = pal::strcmp(pal::to_lower(pal::string_t{argv[2]}).c_str(), _X("true")) == 0;
 
         const pal::char_t *assembly_path = nullptr;
-        if (argc >= 4)
+        if (argc >= 4 && pal::strcmp(argv[3], _X("nullptr")) != 0)
             assembly_path = argv[3];
 
-        if (argc >= 5)
+        const pal::char_t *dotnet_root = nullptr;
+        if (argc >= 5 && pal::strcmp(argv[4], _X("nullptr")) != 0)
+            dotnet_root = argv[4];
+
+        if (argc >= 6)
         {
-            pal::string_t to_load = argv[4];
+            pal::string_t to_load = argv[5];
             pal::dll_t fxr;
             if (!pal::load_library(&to_load, &fxr))
             {
@@ -88,13 +92,21 @@ int main(const int argc, const pal::char_t *argv[])
             get_hostfxr_path_fn = get_hostfxr_path;
         }
 
+        get_hostfxr_parameters parameters {
+            sizeof(get_hostfxr_parameters),
+            assembly_path,
+            dotnet_root
+        };
+
+        const get_hostfxr_parameters *parameters_ptr = assembly_path != nullptr || dotnet_root != nullptr ? &parameters : nullptr;
+
         pal::string_t fxr_path;
         size_t len = fxr_path.size();
-        int res = get_hostfxr_path_fn(nullptr, &len, assembly_path);
+        int res = get_hostfxr_path_fn(nullptr, &len, parameters_ptr);
         if (static_cast<StatusCode>(res) == StatusCode::HostApiBufferTooSmall)
         {
             fxr_path.resize(len);
-            res = get_hostfxr_path_fn(&fxr_path[0], &len, assembly_path);
+            res = get_hostfxr_path_fn(&fxr_path[0], &len, parameters_ptr);
         }
 
         if (static_cast<StatusCode>(res) == StatusCode::Success)

--- a/src/corehost/cli/test/nativehost/nativehost.cpp
+++ b/src/corehost/cli/test/nativehost/nativehost.cpp
@@ -98,6 +98,10 @@ int main(const int argc, const pal::char_t *argv[])
             dotnet_root
         };
 
+        // Make version invalid for error case
+        if (assembly_path != nullptr && pal::strcmp(assembly_path, _X("[error]")) == 0)
+            parameters.version = parameters.version - 1;
+
         const get_hostfxr_parameters *parameters_ptr = assembly_path != nullptr || dotnet_root != nullptr ? &parameters : nullptr;
 
         pal::string_t fxr_path;

--- a/src/test/HostActivationTests/Constants.cs
+++ b/src/test/HostActivationTests/Constants.cs
@@ -72,5 +72,11 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
             public const string TraceLevelEnvironmentVariable = "COREHOST_TRACE";
             public const string TraceFileEnvironmentVariable = "COREHOST_TRACEFILE";
         }
+
+        public static class ErrorCode
+        {
+            public const int InvalidArgFailure = unchecked((int)0x80008081);
+            public const int CoreHostLibMissingFailure = unchecked((int)0x80008083);
+        }
     }
 }

--- a/src/test/HostActivationTests/NativeHosting/Nethost.cs
+++ b/src/test/HostActivationTests/NativeHosting/Nethost.cs
@@ -12,8 +12,6 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.NativeHosting
     public class Nethost : IClassFixture<Nethost.SharedTestState>
     {
         private const string GetHostFxrPath = "get_hostfxr_path";
-        private const int CoreHostLibMissingFailure = unchecked((int)0x80008083);
-        private const int InvalidArgFailure = unchecked((int)0x80008081);
 
         private static readonly string HostFxrName = RuntimeInformationExtensions.GetSharedLibraryFileNameForCurrentPlatform("hostfxr");
         private readonly SharedTestState sharedState;
@@ -36,9 +34,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.NativeHosting
         {
             string dotNetRoot = isValid ? Path.Combine(sharedState.ValidInstallRoot, "dotnet") : sharedState.InvalidInstallRoot;
             CommandResult result = Command.Create(sharedState.NativeHostPath, $"{GetHostFxrPath} {explicitLoad} {(useAssemblyPath ? sharedState.TestAssemblyPath : string.Empty)}")
-                .CaptureStdErr()
-                .CaptureStdOut()
-                .EnvironmentVariable("COREHOST_TRACE", "1")
+                .EnableTracingAndCaptureOutputs()
                 .EnvironmentVariable("DOTNET_ROOT", dotNetRoot)
                 .EnvironmentVariable("DOTNET_ROOT(x86)", dotNetRoot)
                 .Execute();
@@ -54,7 +50,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.NativeHosting
             {
                 result.Should().Fail()
                     .And.ExitWith(1)
-                    .And.HaveStdOutContaining($"{GetHostFxrPath} failed: 0x{CoreHostLibMissingFailure.ToString("x")}")
+                    .And.HaveStdOutContaining($"{GetHostFxrPath} failed: 0x{Constants.ErrorCode.CoreHostLibMissingFailure.ToString("x")}")
                     .And.HaveStdErrContaining($"The required library {HostFxrName} could not be found");
             }
         }
@@ -86,7 +82,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.NativeHosting
             {
                 result.Should().Fail()
                     .And.ExitWith(1)
-                    .And.HaveStdOutContaining($"{GetHostFxrPath} failed: 0x{CoreHostLibMissingFailure.ToString("x")}")
+                    .And.HaveStdOutContaining($"{GetHostFxrPath} failed: 0x{Constants.ErrorCode.CoreHostLibMissingFailure.ToString("x")}")
                     .And.HaveStdErrContaining($"The folder [{Path.Combine(dotNetRoot, "host", "fxr")}] does not exist");
             }
         }
@@ -143,7 +139,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.NativeHosting
             {
                 result.Should().Fail()
                     .And.ExitWith(1)
-                    .And.HaveStdOutContaining($"{GetHostFxrPath} failed: 0x{CoreHostLibMissingFailure.ToString("x")}")
+                    .And.HaveStdOutContaining($"{GetHostFxrPath} failed: 0x{Constants.ErrorCode.CoreHostLibMissingFailure.ToString("x")}")
                     .And.HaveStdErrContaining($"The required library {HostFxrName} could not be found");
             }
         }
@@ -224,7 +220,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.NativeHosting
                 {
                     result.Should().Fail()
                         .And.ExitWith(1)
-                        .And.HaveStdOutContaining($"{GetHostFxrPath} failed: 0x{CoreHostLibMissingFailure.ToString("x")}")
+                        .And.HaveStdOutContaining($"{GetHostFxrPath} failed: 0x{Constants.ErrorCode.CoreHostLibMissingFailure.ToString("x")}")
                         .And.HaveStdErrContaining($"The required library {HostFxrName} could not be found");
                 }
             }
@@ -237,7 +233,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.NativeHosting
                 .EnableTracingAndCaptureOutputs()
                 .Execute()
                 .Should().Fail()
-                .And.HaveStdOutContaining($"{GetHostFxrPath} failed: 0x{InvalidArgFailure.ToString("x")}")
+                .And.HaveStdOutContaining($"{GetHostFxrPath} failed: 0x{Constants.ErrorCode.InvalidArgFailure.ToString("x")}")
                 .And.HaveStdErrContaining("Invalid size for get_hostfxr_parameters");
         }
 

--- a/src/test/HostActivationTests/NativeHosting/Nethost.cs
+++ b/src/test/HostActivationTests/NativeHosting/Nethost.cs
@@ -238,7 +238,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.NativeHosting
                 .Execute()
                 .Should().Fail()
                 .And.HaveStdOutContaining($"{GetHostFxrPath} failed: 0x{InvalidArgFailure.ToString("x")}")
-                .And.HaveStdErrContaining("Invalid version for get_hostfxr_parameters");
+                .And.HaveStdErrContaining("Invalid size for get_hostfxr_parameters");
         }
 
         [Fact]


### PR DESCRIPTION
Allow specifying dotnet_root to find the appropriate hostfxr under the
specified root

Fix #6958