### PR TITLE
[release/3.0] Fix official build MSI signing

### DIFF
--- a/src/pkg/packaging/dir.proj
+++ b/src/pkg/packaging/dir.proj
@@ -216,7 +216,7 @@
 
   <Target Name="GenerateVSNugetPackages"
           Condition="'$(OS)' == 'Windows_NT' AND '$(TargetArchitecture)' != 'arm' AND '$(TargetArchitecture)' != 'arm64'"
-          DependsOnTargets="SetupVSNugetPackages;GenerateInstallers;GenerateProjectInstallers;GenerateCombinedInstallers"
+          DependsOnTargets="SetupVSNugetPackages"
           Inputs="@(SdkMsiComponent->'%(MsiInstallerFile)');
                     $(NuSpecFile);
                     $(GenerateNupkgPowershellScript)"


### PR DESCRIPTION
Conflictless port of https://github.com/dotnet/core-setup/pull/7032:

> Removes `GenerateVSNugetPackages` target dependencies causing MSIs to be built again after they were signed, overwriting the signed copies.
> 
> #7031
> 
> I missed this when I reviewed #6913.
> 
> I haven't run a mock test build for this yet, working on that now.
> 
> /cc @johnbeisner @leecow @wtgodbe