### PR TITLE
[release/3.0] Leave any cross-targeting file off RuntimeList.xml

### DIFF
--- a/tools-local/tasks/CreateFrameworkListFile.cs
+++ b/tools-local/tasks/CreateFrameworkListFile.cs
@@ -104,6 +104,18 @@ namespace Microsoft.DotNet.Build.Tasks
 
                 string path = Path.Combine(f.TargetPath, f.Filename).Replace('\\', '/');
 
+                if (path.StartsWith("runtimes/"))
+                {
+                    var pathParts = path.Split('/');
+                    if (pathParts.Length > 1 && pathParts[1].Contains("_"))
+                    {
+                        // This file is a runtime file with a "rid" containing "_". This is assumed
+                        // to mean it's a cross-targeting tool and shouldn't be deployed in a
+                        // self-contained app. Leave it off the list.
+                        continue;
+                    }
+                }
+
                 var element = new XElement(
                     "File",
                     new XAttribute("Type", type),


### PR DESCRIPTION
Clean port of https://github.com/dotnet/core-setup/pull/7041:

> For #7039.
> 
> Detect the `_` in e.g. `runtimes/x64_arm/native/libclrjit.so` and don't include it in `RuntimeList.xml`.
> 
> I would prefer to change the input `TargetFilePrefixes` to use `runtimes/linux-arm/` rather than `runtimes/`, but that would take more validation work than the task-side workaround. I'll file an issue to follow up.
> 
> I'm running a mock build now to make sure this works.
> 
> /cc @wtgodbe @dsplaisted

