### PR TITLE
Skip pal::realpath() error logging while probing directories

### DIFF
--- a/src/corehost/cli/fxr/fx_muxer.cpp
+++ b/src/corehost/cli/fxr/fx_muxer.cpp
@@ -216,7 +216,7 @@ void append_probe_realpath(const pal::string_t& path, std::vector<pal::string_t>
 {
     pal::string_t probe_path = path;
 
-    if (pal::realpath(&probe_path))
+    if (pal::realpath(&probe_path, true))
     {
         realpaths->push_back(probe_path);
     }
@@ -239,7 +239,7 @@ void append_probe_realpath(const pal::string_t& path, std::vector<pal::string_t>
             segment.append(tfm);
             probe_path.replace(pos_placeholder, placeholder.length(), segment);
 
-            if (pal::realpath(&probe_path))
+            if (pal::realpath(&probe_path, true))
             {
                 realpaths->push_back(probe_path);
             }


### PR DESCRIPTION
The issue is that in some cases the host would write errors into stderr even if there's no actual failure. The execution will continue with no issues (the code has fallback logic for all these cases). The errors written to stderr are just very confusing to users, and in some cases may cause a failure (some wrapper tools treat output to stderr as failure in itself).

The scenario where this can show up is typically when a debug build of an application is copied to a different machine where some of the paths in `.runtimeconfig.dev.json` don't exist. Other scenarios are docker related with restricted permissions (see #4038 for details).

The change only affects `hostfxr.dll`. 

Details:
Both paths calling pal::realpath() and check its return value to see if the probed paths actually exist in the filesystem; they do have logic to handle those paths not existing, and printing error messages while doing so isn't helpful for the user.

Happens when an application is published with one user but is executed with another user -- for instance, when using containers (see issue #4038 for details).