### PR TITLE
Use tracing infrastructure to log realpath() and getcwd() errors

### DIFF
--- a/src/corehost/common/pal.unix.cpp
+++ b/src/corehost/common/pal.unix.cpp
@@ -67,7 +67,8 @@ bool pal::getcwd(pal::string_t* recv)
         {
             return false;
         }
-        perror("getcwd()");
+
+        trace::error(_X("getcwd() failed: %s"), strerror(errno));
         return false;
     }
     recv->assign(buf);
@@ -730,7 +731,7 @@ bool pal::realpath(pal::string_t* path, bool skip_error_logging)
 
         if (!skip_error_logging)
         {
-            perror("realpath()");
+            trace::error(_X("realpath(%s) failed: %s"), path->c_str(), strerror(errno));
         }
 
         return false;


### PR DESCRIPTION
We have a nice tracing infrastructure; let's use it instead of sending messages to stderr with perror().  Also, if possible, give a little bit more context.

This is probably only for 5.0 as will change `dotnet` and it's too late for that at this point.