### PR TITLE
Fixes couple of places in the bundle runner where we might leak memory.

### DIFF
--- a/src/corehost/cli/apphost/bundle/bundle_runner.cpp
+++ b/src/corehost/cli/apphost/bundle/bundle_runner.cpp
@@ -277,7 +277,7 @@ StatusCode bundle_runner_t::extract()
 
         // Read the bundle header
         seek(m_bundle_stream, marker_t::header_offset(), SEEK_SET);
-        m_header = std::move(header_t::read(m_bundle_stream));
+        m_header = header_t::read(m_bundle_stream);
 
         // Determine if embedded files are already extracted, and available for reuse
         determine_extraction_dir();
@@ -305,10 +305,10 @@ StatusCode bundle_runner_t::extract()
         
         create_working_extraction_dir();
 
-        m_manifest = std::move(manifest_t::read(m_bundle_stream, num_embedded_files()));
+        m_manifest = manifest_t::read(m_bundle_stream, num_embedded_files());
 
-        for (std::unique_ptr<file_entry_t> & entry : m_manifest->files) {
-            extract_file(*entry.get());
+        for (const file_entry_t & entry : m_manifest.files) {
+            extract_file(entry);
         }
 
         // Commit files to the final extraction directory

--- a/src/corehost/cli/apphost/bundle/bundle_runner.cpp
+++ b/src/corehost/cli/apphost/bundle/bundle_runner.cpp
@@ -234,14 +234,14 @@ FILE* bundle_runner_t::create_extraction_file(const pal::string_t& relative_path
 }
 
 // Extract one file from the bundle to disk.
-void bundle_runner_t::extract_file(file_entry_t *entry)
+void bundle_runner_t::extract_file(const file_entry_t& entry)
 {
-    FILE* file = create_extraction_file(entry->relative_path());
+    FILE* file = create_extraction_file(entry.relative_path());
     const int64_t buffer_size = 8 * 1024; // Copy the file in 8KB chunks
     uint8_t buffer[buffer_size];
-    int64_t file_size = entry->size();
+    int64_t file_size = entry.size();
 
-    seek(m_bundle_stream, entry->offset(), SEEK_SET);
+    seek(m_bundle_stream, entry.offset(), SEEK_SET);
     do {
         int64_t copy_size = (file_size <= buffer_size) ? file_size : buffer_size;
         read(buffer, copy_size, m_bundle_stream);
@@ -277,7 +277,7 @@ StatusCode bundle_runner_t::extract()
 
         // Read the bundle header
         seek(m_bundle_stream, marker_t::header_offset(), SEEK_SET);
-        m_header.reset(header_t::read(m_bundle_stream));
+        m_header = std::move(header_t::read(m_bundle_stream));
 
         // Determine if embedded files are already extracted, and available for reuse
         determine_extraction_dir();
@@ -305,10 +305,10 @@ StatusCode bundle_runner_t::extract()
         
         create_working_extraction_dir();
 
-        m_manifest.reset(manifest_t::read(m_bundle_stream, num_embedded_files()));
+        m_manifest = std::move(manifest_t::read(m_bundle_stream, num_embedded_files()));
 
-        for (file_entry_t* entry : m_manifest->files) {
-            extract_file(entry);
+        for (std::unique_ptr<file_entry_t> & entry : m_manifest->files) {
+            extract_file(*entry.get());
         }
 
         // Commit files to the final extraction directory

--- a/src/corehost/cli/apphost/bundle/bundle_runner.h
+++ b/src/corehost/cli/apphost/bundle/bundle_runner.h
@@ -48,7 +48,7 @@ namespace bundle
         bool can_reuse_extraction();
 
         FILE* create_extraction_file(const pal::string_t& relative_path);
-        void extract_file(file_entry_t* entry);
+        void extract_file(const file_entry_t& entry);
 
         FILE* m_bundle_stream;
         std::unique_ptr<header_t> m_header;

--- a/src/corehost/cli/apphost/bundle/bundle_runner.h
+++ b/src/corehost/cli/apphost/bundle/bundle_runner.h
@@ -40,8 +40,8 @@ namespace bundle
         void reopen_host_for_reading();
         static void seek(FILE* stream, long offset, int origin);
 
-        int32_t num_embedded_files() { return m_header->num_embedded_files(); }
-        const pal::string_t& bundle_id() { return m_header->bundle_id(); }
+        int32_t num_embedded_files() { return m_header.num_embedded_files(); }
+        const pal::string_t& bundle_id() { return m_header.bundle_id(); }
 
         void determine_extraction_dir();
         void create_working_extraction_dir();
@@ -51,8 +51,8 @@ namespace bundle
         void extract_file(const file_entry_t& entry);
 
         FILE* m_bundle_stream;
-        std::unique_ptr<header_t> m_header;
-        std::unique_ptr<manifest_t> m_manifest;
+        header_t m_header;
+        manifest_t m_manifest;
         pal::string_t m_bundle_path;
         pal::string_t m_extraction_dir;
         pal::string_t m_working_extraction_dir;

--- a/src/corehost/cli/apphost/bundle/file_entry.cpp
+++ b/src/corehost/cli/apphost/bundle/file_entry.cpp
@@ -16,9 +16,9 @@ bool file_entry_t::is_valid()
         static_cast<file_type_t>(m_data.type) < file_type_t::__last;
 }
 
-file_entry_t* file_entry_t::read(FILE* stream)
+std::unique_ptr<file_entry_t> file_entry_t::read(FILE* stream)
 {
-    file_entry_t* entry = new file_entry_t();
+    std::unique_ptr<file_entry_t> entry{ new file_entry_t() };
 
     // First read the fixed-sized portion of file-entry
     bundle_runner_t::read(&entry->m_data, sizeof(entry->m_data), stream);
@@ -49,5 +49,3 @@ file_entry_t* file_entry_t::read(FILE* stream)
 
     return entry;
 }
-
-

--- a/src/corehost/cli/apphost/bundle/file_entry.cpp
+++ b/src/corehost/cli/apphost/bundle/file_entry.cpp
@@ -16,13 +16,13 @@ bool file_entry_t::is_valid()
         static_cast<file_type_t>(m_data.type) < file_type_t::__last;
 }
 
-std::unique_ptr<file_entry_t> file_entry_t::read(FILE* stream)
+file_entry_t file_entry_t::read(FILE* stream)
 {
-    std::unique_ptr<file_entry_t> entry{ new file_entry_t() };
+    file_entry_t entry;
 
     // First read the fixed-sized portion of file-entry
-    bundle_runner_t::read(&entry->m_data, sizeof(entry->m_data), stream);
-    if (!entry->is_valid())
+    bundle_runner_t::read(&entry.m_data, sizeof(entry.m_data), stream);
+    if (!entry.is_valid())
     {
         trace::error(_X("Failure processing application bundle; possible file corruption."));
         trace::error(_X("Invalid FileEntry detected."));
@@ -30,10 +30,10 @@ std::unique_ptr<file_entry_t> file_entry_t::read(FILE* stream)
     }
 
     size_t path_length =
-        bundle_runner_t::get_path_length(entry->m_data.path_length_byte_1, stream);
+        bundle_runner_t::get_path_length(entry.m_data.path_length_byte_1, stream);
 
     // Read the relative-path, given its length 
-    pal::string_t& path = entry->m_relative_path;
+    pal::string_t& path = entry.m_relative_path;
     bundle_runner_t::read_string(path, path_length, stream);
 
     // Fixup the relative-path to have current platform's directory separator.

--- a/src/corehost/cli/apphost/bundle/file_entry.h
+++ b/src/corehost/cli/apphost/bundle/file_entry.h
@@ -43,17 +43,12 @@ namespace bundle
         pal::string_t m_relative_path; // Path of an embedded file, relative to the extraction directory.
 
     public:
-        file_entry_t()
-            : m_data(), m_relative_path()
-        {
-        }
-
         const pal::string_t& relative_path() const { return m_relative_path; }
         int64_t offset() const { return m_data.offset; }
         int64_t size() const { return m_data.size; }
         file_type_t type() const { return m_data.type; }
 
-        static std::unique_ptr<file_entry_t> read(FILE* stream);
+        static file_entry_t read(FILE* stream);
 
     private:
         static const pal::char_t bundle_dir_separator = '/';

--- a/src/corehost/cli/apphost/bundle/file_entry.h
+++ b/src/corehost/cli/apphost/bundle/file_entry.h
@@ -44,16 +44,16 @@ namespace bundle
 
     public:
         file_entry_t()
-            :m_data(), m_relative_path()
+            : m_data(), m_relative_path()
         {
         }
 
-        const pal::string_t& relative_path() { return m_relative_path; }
-        int64_t offset() { return m_data.offset; }
-        int64_t size() { return m_data.size; }
-        file_type_t type() { return m_data.type; }
+        const pal::string_t& relative_path() const { return m_relative_path; }
+        int64_t offset() const { return m_data.offset; }
+        int64_t size() const { return m_data.size; }
+        file_type_t type() const { return m_data.type; }
 
-        static file_entry_t* read(FILE* stream);
+        static std::unique_ptr<file_entry_t> read(FILE* stream);
 
     private:
         static const pal::char_t bundle_dir_separator = '/';

--- a/src/corehost/cli/apphost/bundle/header.cpp
+++ b/src/corehost/cli/apphost/bundle/header.cpp
@@ -16,13 +16,13 @@ bool header_t::is_valid()
             (m_data.major_version == current_major_version && m_data.minor_version <= current_minor_version));
 }
 
-std::unique_ptr<header_t> header_t::read(FILE* stream)
+header_t header_t::read(FILE* stream)
 {
-    std::unique_ptr<header_t> header{ new header_t() };
+    header_t header;
 
     // First read the fixed size portion of the header
-    bundle_runner_t::read(&header->m_data, sizeof(header->m_data), stream);
-    if (!header->is_valid())
+    bundle_runner_t::read(&header.m_data, sizeof(header.m_data), stream);
+    if (!header.is_valid())
     {
         trace::error(_X("Failure processing application bundle."));
         trace::error(_X("Bundle header version compatibility check failed"));
@@ -32,10 +32,10 @@ std::unique_ptr<header_t> header_t::read(FILE* stream)
 
     // bundle_id is a component of the extraction path
     size_t bundle_id_length = 
-        bundle_runner_t::get_path_length(header->m_data.bundle_id_length_byte_1, stream);
+        bundle_runner_t::get_path_length(header.m_data.bundle_id_length_byte_1, stream);
      
     // Next read the bundle-ID string, given its length
-    bundle_runner_t::read_string(header->m_bundle_id, bundle_id_length, stream);
+    bundle_runner_t::read_string(header.m_bundle_id, bundle_id_length, stream);
 
     return header;
 }

--- a/src/corehost/cli/apphost/bundle/header.cpp
+++ b/src/corehost/cli/apphost/bundle/header.cpp
@@ -16,9 +16,9 @@ bool header_t::is_valid()
             (m_data.major_version == current_major_version && m_data.minor_version <= current_minor_version));
 }
 
-header_t* header_t::read(FILE* stream)
+std::unique_ptr<header_t> header_t::read(FILE* stream)
 {
-    header_t* header = new header_t();
+    std::unique_ptr<header_t> header{ new header_t() };
 
     // First read the fixed size portion of the header
     bundle_runner_t::read(&header->m_data, sizeof(header->m_data), stream);

--- a/src/corehost/cli/apphost/bundle/header.h
+++ b/src/corehost/cli/apphost/bundle/header.h
@@ -22,13 +22,8 @@ namespace bundle
     struct header_t
     {
     public:
-        header_t()
-            :m_data(), m_bundle_id()
-        {
-        }
-
         bool is_valid();
-        static std::unique_ptr<header_t> read(FILE* stream);
+        static header_t read(FILE* stream);
         const pal::string_t& bundle_id() { return m_bundle_id; }
         int32_t num_embedded_files() { return m_data.num_embedded_files;  }
 
@@ -44,8 +39,8 @@ namespace bundle
 #pragma pack(pop)
         pal::string_t m_bundle_id;
 
-        const uint32_t current_major_version = 1;
-        const uint32_t current_minor_version = 0;
+        static const uint32_t current_major_version = 1;
+        static const uint32_t current_minor_version = 0;
     };
 }
 #endif // __HEADER_H__

--- a/src/corehost/cli/apphost/bundle/header.h
+++ b/src/corehost/cli/apphost/bundle/header.h
@@ -28,7 +28,7 @@ namespace bundle
         }
 
         bool is_valid();
-        static header_t* read(FILE* stream);
+        static std::unique_ptr<header_t> read(FILE* stream);
         const pal::string_t& bundle_id() { return m_bundle_id; }
         int32_t num_embedded_files() { return m_data.num_embedded_files;  }
 

--- a/src/corehost/cli/apphost/bundle/manifest.cpp
+++ b/src/corehost/cli/apphost/bundle/manifest.cpp
@@ -10,19 +10,19 @@
 
 using namespace bundle;
 
-manifest_t* manifest_t::read(FILE* stream, int32_t num_files)
+std::unique_ptr<manifest_t> manifest_t::read(FILE* stream, int32_t num_files)
 {
-    manifest_t* manifest = new manifest_t();
+    std::unique_ptr<manifest_t> manifest{ new manifest_t() };
 
     for (int32_t i = 0; i < num_files; i++)
     {
-        file_entry_t* entry = file_entry_t::read(stream);
+        std::unique_ptr<file_entry_t> entry = file_entry_t::read(stream);
         if (entry == nullptr)
         {
             return nullptr;
         }
 
-        manifest->files.push_back(entry);
+        manifest->files.emplace_back(std::move(entry));
     }
 
     return manifest;

--- a/src/corehost/cli/apphost/bundle/manifest.cpp
+++ b/src/corehost/cli/apphost/bundle/manifest.cpp
@@ -10,19 +10,13 @@
 
 using namespace bundle;
 
-std::unique_ptr<manifest_t> manifest_t::read(FILE* stream, int32_t num_files)
+manifest_t manifest_t::read(FILE* stream, int32_t num_files)
 {
-    std::unique_ptr<manifest_t> manifest{ new manifest_t() };
+    manifest_t manifest;
 
     for (int32_t i = 0; i < num_files; i++)
     {
-        std::unique_ptr<file_entry_t> entry = file_entry_t::read(stream);
-        if (entry == nullptr)
-        {
-            return nullptr;
-        }
-
-        manifest->files.emplace_back(std::move(entry));
+        manifest.files.emplace_back(file_entry_t::read(stream));
     }
 
     return manifest;

--- a/src/corehost/cli/apphost/bundle/manifest.h
+++ b/src/corehost/cli/apphost/bundle/manifest.h
@@ -17,7 +17,7 @@ namespace bundle
     class manifest_t
     {
     public:
-        std::list<file_entry_t> files;
+        std::vector<file_entry_t> files;
 
         static manifest_t read(FILE* host, int32_t num_files);
     };

--- a/src/corehost/cli/apphost/bundle/manifest.h
+++ b/src/corehost/cli/apphost/bundle/manifest.h
@@ -21,9 +21,9 @@ namespace bundle
             :files()
         {}
 
-        std::list<file_entry_t*> files;
+        std::list<std::unique_ptr<file_entry_t>> files;
 
-        static manifest_t* read(FILE* host, int32_t num_files);
+        static std::unique_ptr<manifest_t> read(FILE* host, int32_t num_files);
     };
 }
 #endif // __MANIFEST_H__

--- a/src/corehost/cli/apphost/bundle/manifest.h
+++ b/src/corehost/cli/apphost/bundle/manifest.h
@@ -17,13 +17,9 @@ namespace bundle
     class manifest_t
     {
     public:
-        manifest_t()
-            :files()
-        {}
+        std::list<file_entry_t> files;
 
-        std::list<std::unique_ptr<file_entry_t>> files;
-
-        static std::unique_ptr<manifest_t> read(FILE* host, int32_t num_files);
+        static manifest_t read(FILE* host, int32_t num_files);
     };
 }
 #endif // __MANIFEST_H__

--- a/src/corehost/cli/apphost/bundle/marker.cpp
+++ b/src/corehost/cli/apphost/bundle/marker.cpp
@@ -27,7 +27,8 @@ int64_t marker_t::header_offset()
         0xee, 0x3b, 0x2d, 0xce, 0x24, 0xb3, 0x6a, 0xae
     };
 
-    volatile marker_t* marker = (volatile marker_t*)placeholder;
+    // const_cast can "cast away" both const or volatile.
+    marker_t* marker = reinterpret_cast<marker_t *>(const_cast<uint8_t *>(placeholder));
 
     return marker->locator.bundle_header_offset;
 }

--- a/src/corehost/cli/apphost/bundle/marker.cpp
+++ b/src/corehost/cli/apphost/bundle/marker.cpp
@@ -27,8 +27,7 @@ int64_t marker_t::header_offset()
         0xee, 0x3b, 0x2d, 0xce, 0x24, 0xb3, 0x6a, 0xae
     };
 
-    // const_cast can "cast away" both const or volatile.
-    marker_t* marker = reinterpret_cast<marker_t *>(const_cast<uint8_t *>(placeholder));
+    volatile marker_t* marker = reinterpret_cast<volatile marker_t *>(placeholder);
 
     return marker->locator.bundle_header_offset;
 }


### PR DESCRIPTION
Note that in reality this is a non-issue: The leaks are only present if something fails and in case of failure the process will immediately exit anyway.

I know that @swaroop-sridhar has plans to rewrite most of this using file mapping, so the code as-is will mostly go away. I did this mostly for my own education on how to write this correctly. And since I had the changes read, we might as well merge it.