### PR TITLE
[dev/arcade-migration] Add simple sharedfx package test project, fix PlatformManifest creation

### DIFF
--- a/Microsoft.DotNet.CoreSetup.sln
+++ b/Microsoft.DotNet.CoreSetup.sln
@@ -31,6 +31,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.NET.HostModel.Bun
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "BundleHelper", "src\test\BundleTests\Helpers\BundleHelper.csproj", "{8116F946-FB24-4524-9028-43F5A3A80EE3}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.DotNet.CoreSetup.Packaging.Tests", "src\test\Microsoft.DotNet.CoreSetup.Packaging.Tests\Microsoft.DotNet.CoreSetup.Packaging.Tests.csproj", "{F1584324-A41A-4CE7-B23F-DB2252CFE276}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -187,6 +189,22 @@ Global
 		{8116F946-FB24-4524-9028-43F5A3A80EE3}.RelWithDebInfo|Any CPU.Build.0 = Release|Any CPU
 		{8116F946-FB24-4524-9028-43F5A3A80EE3}.RelWithDebInfo|x64.ActiveCfg = Release|Any CPU
 		{8116F946-FB24-4524-9028-43F5A3A80EE3}.RelWithDebInfo|x64.Build.0 = Release|Any CPU
+		{F1584324-A41A-4CE7-B23F-DB2252CFE276}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F1584324-A41A-4CE7-B23F-DB2252CFE276}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F1584324-A41A-4CE7-B23F-DB2252CFE276}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{F1584324-A41A-4CE7-B23F-DB2252CFE276}.Debug|x64.Build.0 = Debug|Any CPU
+		{F1584324-A41A-4CE7-B23F-DB2252CFE276}.MinSizeRel|Any CPU.ActiveCfg = Debug|Any CPU
+		{F1584324-A41A-4CE7-B23F-DB2252CFE276}.MinSizeRel|Any CPU.Build.0 = Debug|Any CPU
+		{F1584324-A41A-4CE7-B23F-DB2252CFE276}.MinSizeRel|x64.ActiveCfg = Debug|Any CPU
+		{F1584324-A41A-4CE7-B23F-DB2252CFE276}.MinSizeRel|x64.Build.0 = Debug|Any CPU
+		{F1584324-A41A-4CE7-B23F-DB2252CFE276}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F1584324-A41A-4CE7-B23F-DB2252CFE276}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F1584324-A41A-4CE7-B23F-DB2252CFE276}.Release|x64.ActiveCfg = Release|Any CPU
+		{F1584324-A41A-4CE7-B23F-DB2252CFE276}.Release|x64.Build.0 = Release|Any CPU
+		{F1584324-A41A-4CE7-B23F-DB2252CFE276}.RelWithDebInfo|Any CPU.ActiveCfg = Release|Any CPU
+		{F1584324-A41A-4CE7-B23F-DB2252CFE276}.RelWithDebInfo|Any CPU.Build.0 = Release|Any CPU
+		{F1584324-A41A-4CE7-B23F-DB2252CFE276}.RelWithDebInfo|x64.ActiveCfg = Release|Any CPU
+		{F1584324-A41A-4CE7-B23F-DB2252CFE276}.RelWithDebInfo|x64.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -201,6 +219,7 @@ Global
 		{2745A51D-3425-4F68-8349-A8B8BC27DD87} = {5CE8410C-3100-4F41-8FA9-E6B4132D9703}
 		{1E76A78E-9E39-480D-8CD3-B7D0A858FECB} = {5CE8410C-3100-4F41-8FA9-E6B4132D9703}
 		{8116F946-FB24-4524-9028-43F5A3A80EE3} = {5CE8410C-3100-4F41-8FA9-E6B4132D9703}
+		{F1584324-A41A-4CE7-B23F-DB2252CFE276} = {5CE8410C-3100-4F41-8FA9-E6B4132D9703}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {28B9726D-802B-478D-AF7A-B9243B9E180B}

--- a/eng/Build.props
+++ b/eng/Build.props
@@ -27,6 +27,7 @@
     <ProjectToBuild Include="$(RepoRoot)src\test\BundleTests\AppHost.Bundle.Tests\AppHost.Bundle.Tests.csproj" />
     <ProjectToBuild Include="$(RepoRoot)src\test\BundleTests\Microsoft.NET.HostModel.Bundle.Tests\Microsoft.NET.HostModel.Bundle.Tests.csproj" />
     <ProjectToBuild Include="$(RepoRoot)src\test\HostActivation.Tests\HostActivation.Tests.csproj" />
+    <ProjectToBuild Include="$(RepoRoot)src\test\Microsoft.DotNet.CoreSetup.Packaging.Tests\Microsoft.DotNet.CoreSetup.Packaging.Tests.csproj" />
     <ProjectToBuild Include="$(RepoRoot)src\test\Microsoft.Extensions.DependencyModel.Tests\Microsoft.Extensions.DependencyModel.Tests.csproj" />
   </ItemGroup>
 

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -83,6 +83,7 @@
     <MicrosoftBuildUtilitiesCorePackageVersion>$(MicrosoftBuildPackageVersion)</MicrosoftBuildUtilitiesCorePackageVersion>
     <MicrosoftDotNetPlatformAbstractionsPackageVersion>1.1.1</MicrosoftDotNetPlatformAbstractionsPackageVersion>
     <NugetProjectModelPackageVersion>4.9.4</NugetProjectModelPackageVersion>
+    <NugetPackagingPackageVersion>4.9.4</NugetPackagingPackageVersion>
     <MicrosoftTargetingPackPrivateWinRTPackageVersion>1.0.5</MicrosoftTargetingPackPrivateWinRTPackageVersion>
     <MicrosoftDiaSymReaderNativePackageVersion>1.7.0</MicrosoftDiaSymReaderNativePackageVersion>
     <!-- Infrastructure and test-only. -->

--- a/eng/configure-toolset.ps1
+++ b/eng/configure-toolset.ps1
@@ -1,0 +1,9 @@
+# Disable using the globally installed SDK. Using the global install can cause
+# roll-forward to a newer SDK that may not work.
+$script:useInstalledDotNetCli = $false
+
+# Always use the local repo packages directory instead of the user's NuGet cache
+# to keep the same between "ci" and non-"ci" builds. If the efficiency gain is
+# required and it's worth maintaining the different types of build, this can be
+# removed.
+$script:useGlobalNuGetCache = $false

--- a/eng/configure-toolset.sh
+++ b/eng/configure-toolset.sh
@@ -1,0 +1,9 @@
+# Disable using the globally installed SDK. Using the global install can cause
+# roll-forward to a newer SDK that may not work.
+use_installed_dotnet_cli=false
+
+# Always use the local repo packages directory instead of the user's NuGet cache
+# to keep the same between "ci" and non-"ci" builds. If the efficiency gain is
+# required and it's worth maintaining the different types of build, this can be
+# removed.
+use_global_nuget_cache=false

--- a/eng/jobs/windows-build.yml
+++ b/eng/jobs/windows-build.yml
@@ -26,14 +26,13 @@ jobs:
     workspace:
       clean: all
     variables: 
-        # TODO: (arcade) fix up artifacts:
-        # /p:BuildFullPlatformManifest=${{ parameters.buildFullPlatformManifest }}
       CommonMSBuildArgs: >-
         /p:Configuration=$(_BuildConfig)
         /p:OfficialBuildId=$(OfficialBuildId)
         /p:TargetArchitecture=${{ parameters.targetArchitecture }}
         /p:PortableBuild=true
         /p:SkipTests=${{ parameters.skipTests }}
+        /p:BuildFullPlatformManifest=${{ parameters.buildFullPlatformManifest }}
       MsbuildSigningArguments: >-
         /p:CertificateId=400
         /p:DotNetSignType=$(SignType)

--- a/src/pkg/packaging-tools/framework.dependency.targets
+++ b/src/pkg/packaging-tools/framework.dependency.targets
@@ -436,9 +436,15 @@
 
   <Target Name="Build"
           DependsOnTargets="
+            GetSkipBuildProps;
+            BuildDepprojArtifacts" />
+
+  <Target Name="BuildDepprojArtifacts"
+          DependsOnTargets="
             GetFilesToPackage;
             CrossGen;
             GenerateHashVersionsFile;
-            GenerateFileVersionProps" />
+            GenerateFileVersionProps"
+          Condition="'$(SkipBuild)' != 'true'" />
 
 </Project>

--- a/src/pkg/packaging-tools/framework.dependency.targets
+++ b/src/pkg/packaging-tools/framework.dependency.targets
@@ -22,11 +22,11 @@
       </RidSpecificFilesToPackage>
     </ItemGroup>
 
-    <ItemGroup Condition="'$(NuGetRuntimeIdentifier)' != ''">
+    <ItemGroup Condition="'$(PackageTargetRuntime)' != ''">
       <FilesToPackage Include="@(RidSpecificFilesToPackage)" />
     </ItemGroup>
 
-    <ItemGroup Condition="'$(NuGetRuntimeIdentifier)' == ''">
+    <ItemGroup Condition="'$(PackageTargetRuntime)' == ''">
       <!-- Not RID-specific: include all reference files. -->
       <FilesToPackage Include="@(Reference)">
         <TargetPath>ref/$(PackageTargetFramework)</TargetPath>
@@ -87,6 +87,73 @@
                        File="$(IntermediateOutputPath)\$(FrameworkPackageName).versions.txt"
                        Overwrite="true"/>
   </Target>
+
+  <Target Name="SetupGenerateFileVersionProps"
+          Condition="'$(FrameworkPackageName)' != ''">
+    <PropertyGroup>
+      <PropsFile>$(IntermediateOutputPath)$(MSBuildProjectName).props</PropsFile>
+      <PlatformManifestFile>$(IntermediateOutputPath)$(MSBuildProjectName).PlatformManifest.txt</PlatformManifestFile>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <DepprojDataFile Include="$(PropsFile)" PropsFile="true" />
+      <DepprojDataFile Include="$(PlatformManifestFile)" PlatformManifestFile="true" />
+    </ItemGroup>
+  </Target>
+
+  <!--
+    Creates the platform manifest and props file. Set properties "IncludePlatformManifestFile" and
+    "IncludeFileVersionPropsFile" to true to include them, respectively.
+  -->
+  <Target Name="GenerateFileVersionProps"
+          Condition="'$(FrameworkPackageName)' != ''"
+          DependsOnTargets="SetupGenerateFileVersionProps">
+    <PropertyGroup>
+      <!-- During an official build when we can guarantee that all RID-specific dependencies have been built,
+          restore all of those dependencies and gather the prospective content of the RID-specific Core.App
+          packages.  This is needed so that we have a complete platform manifest in the shipping version of
+          the Microsoft.NETCore.App (RID-agnostic/identity package). -->
+      <IncludeAllRuntimePackagesInPlatformManifest
+        Condition="'$(IncludeAllRuntimePackagesInPlatformManifest)' == '' AND
+                   '$(BuildFullPlatformManifest)' == 'true'">true</IncludeAllRuntimePackagesInPlatformManifest>
+    </PropertyGroup>
+
+    <ItemGroup >
+      <RuntimeIdentifiers Include="$(RuntimeIdentifiers)" Condition="'$(IncludeAllRuntimePackagesInPlatformManifest)' == 'true'" />
+      <RuntimeIdentifiers Include="$(RuntimeIdentifier)" Condition="'$(IncludeAllRuntimePackagesInPlatformManifest)' != 'true'" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <RidSpecificGetPackageFilesProject
+        Include="$(MSBuildProjectFullPath)"
+        AdditionalProperties="RuntimeIdentifier=%(RuntimeIdentifiers.Identity)" />
+    </ItemGroup>
+
+    <MSBuild Projects="@(RidSpecificGetPackageFilesProject)"
+             Targets="GetFilesToPackage">
+      <Output TaskParameter="TargetOutputs" ItemName="SharedFrameworkRuntimeFiles" />
+    </MSBuild>
+
+    <!--
+      Workaround: zero-versioned Microsoft.VisualBasic.dll in non-Windows CoreFX transport package.
+      See https://github.com/dotnet/corefx/issues/36630
+    -->
+    <PropertyGroup Condition="'$(OSGroup)' != 'Windows_NT'">
+      <PermitDllAndExeFilesLackingFileVersion>true</PermitDllAndExeFilesLackingFileVersion>
+    </PropertyGroup>
+
+    <GenerateFileVersionProps Files="@(SharedFrameworkRuntimeFiles)"
+                              PackageId="$(FrameworkPackageName)"
+                              PackageVersion="$(Version)"
+                              PlatformManifestFile="$(PlatformManifestFile)"
+                              PropsFile="$(PropsFile)"
+                              PreferredPackages="$(Id);@(RuntimeDependency)"
+                              PermitDllAndExeFilesLackingFileVersion="$(PermitDllAndExeFilesLackingFileVersion)" />
+  </Target>
+
+  <Target Name="GetDataFiles"
+          DependsOnTargets="SetupGenerateFileVersionProps"
+          Returns="@(DepprojDataFile)" />
 
   <Target Name="AddCrossgenToolPackageReferences"
           BeforeTargets="CollectPackageReferences">
@@ -242,7 +309,7 @@
       </_filesToCrossGen>
     </ItemGroup>
 
-    <ItemGroup Condition="'$(NuGetRuntimeIdentifier)' != ''">
+    <ItemGroup Condition="'$(PackageTargetRuntime)' != ''">
       <FilesToPackage Remove="@(_filesToCrossGen)" />
       <FilesToPackage Include="@(_filesToCrossGen->'%(CrossGenedPath)')" />
     </ItemGroup>
@@ -258,7 +325,6 @@
   </Target>
 
   <Target Name="CrossGen"
-          BeforeTargets="Build"
           DependsOnTargets="
             PrepareForCrossGen;
             CreateCrossGenImages;
@@ -368,6 +434,11 @@
 
   <!-- Target overrides (can't be shared with pkgproj) -->
 
-  <Target Name="Build" DependsOnTargets="GenerateHashVersionsFile;GetFilesToPackage" />
+  <Target Name="Build"
+          DependsOnTargets="
+            GetFilesToPackage;
+            CrossGen;
+            GenerateHashVersionsFile;
+            GenerateFileVersionProps" />
 
 </Project>

--- a/src/pkg/packaging-tools/framework.packaging.targets
+++ b/src/pkg/packaging-tools/framework.packaging.targets
@@ -146,6 +146,20 @@
       IgnoredTypes="@(IgnoredDuplicateType)" />
   </Target>
 
+  <Target Name="GetBuildRidSpecificPackageProps">
+    <!--
+      If PackageRID should be built for the current package, PackageBuildRID is set to PackageRID.
+      Otherwise, PackageBuildRID is left empty.
+    -->
+    <PropertyGroup>
+      <PackageBuildRID Condition="'%(Identity)' == '$(PackageRID)'">@(BuildRID)</PackageBuildRID>
+    </PropertyGroup>
+
+    <PropertyGroup Condition="'$(BuildRidSpecificPacks)' == 'true'">
+      <RidSpecificPackProperties>BaseId=$(MSBuildProjectName).$(PackageBuildRID);IdPrefix=</RidSpecificPackProperties>
+    </PropertyGroup>
+  </Target>
+
   <!-- Target overrides (can't be shared with other package projects) -->
 
   <!--
@@ -158,6 +172,7 @@
   <Target Name="Build"
           DependsOnTargets="
             BuildRidAgnosticPackage;
+            GetBuildRidSpecificPackageProps;
             BuildRidSpecificPackage;
             GenerateInstallers" />
 
@@ -167,19 +182,13 @@
     <Message Text="$(MSBuildProjectName) -> $(NuSpecPath)" Importance="high" />
   </Target>
 
-  <Target Name="BuildRidSpecificPackage">
-    <!--
-      If PackageRID should be built for the current package, PackageBuildRID is set to PackageRID.
-      Otherwise, PackageBuildRID is left empty.
-    -->
-    <PropertyGroup>
-      <PackageBuildRID Condition="'%(Identity)' == '$(PackageRID)'">@(BuildRID)</PackageBuildRID>
-    </PropertyGroup>
-
-    <PropertyGroup Condition="'$(BuildRidSpecificPacks)' == 'true'">
-      <RidSpecificPackProperties>BaseId=$(MSBuildProjectName).$(PackageBuildRID);IdPrefix=</RidSpecificPackProperties>
-    </PropertyGroup>
-
+  <Target Name="BuildRidSpecificPackage"
+          Condition="
+            '$(PackageBuildRID)' != '' and
+            (
+              '$(BuildRidSpecificPacks)' == 'true' or
+              ('$(FrameworkPackType)' == '' and '$(BuildRuntimePackages)' == 'true')
+            )">
     <!--
       Ensure all project references are built to make sure dependencies (e.g. native build and
       depproj's crossgen) runs first. The global properties mean we can't let the inner build handle
@@ -190,19 +199,13 @@
       Targets="Build" />
 
     <MSBuild
-      Condition="
-        '$(PackageBuildRID)' != '' and
-        (
-          '$(BuildRidSpecificPacks)' == 'true' or
-          ('$(FrameworkPackType)' == '' and '$(BuildRuntimePackages)' == 'true')
-        )"
       Projects="$(MSBuildProjectFullPath)"
       Targets="InnerBuildRidSpecificPackage"
       Properties="
         BuildPackageLibraryReferences=false;
         DisableOrderDependencies=true;
         PackageTargetRuntime=$(PackageBuildRID);
-        NuGetRuntimeIdentifier=$(PackageBuildRID);
+        RuntimeIdentifier=$(PackageBuildRID);
         $(RidSpecificPackProperties)" />
   </Target>
 

--- a/src/pkg/packaging-tools/framework.packaging.targets
+++ b/src/pkg/packaging-tools/framework.packaging.targets
@@ -171,6 +171,7 @@
   -->
   <Target Name="Build"
           DependsOnTargets="
+            GetSkipBuildProps;
             BuildRidAgnosticPackage;
             GetBuildRidSpecificPackageProps;
             BuildRidSpecificPackage;
@@ -178,12 +179,15 @@
 
   <Target Name="BuildRidAgnosticPackage"
           DependsOnTargets="$(BuildDependsOn)"
-          Condition="'$(BuildLineupPackage)' == 'true'">
+          Condition="
+            '$(SkipBuild)' != 'true' and
+            '$(BuildLineupPackage)' == 'true'">
     <Message Text="$(MSBuildProjectName) -> $(NuSpecPath)" Importance="high" />
   </Target>
 
   <Target Name="BuildRidSpecificPackage"
           Condition="
+            '$(SkipBuild)' != 'true' and
             '$(PackageBuildRID)' != '' and
             (
               '$(BuildRidSpecificPacks)' == 'true' or

--- a/src/pkg/packaging-tools/framework.sharedfx.targets
+++ b/src/pkg/packaging-tools/framework.sharedfx.targets
@@ -221,11 +221,17 @@
   -->
   <Target Name="Build"
           DependsOnTargets="
+            GetSkipBuildProps;
+            BuildSfxprojArtifacts" />
+
+  <Target Name="BuildSfxprojArtifacts"
+          DependsOnTargets="
             BuildPkgProjectReferences;
             SetPublishDir;
             CleanPackages;
             Restore;
             Publish;
-            GenerateInstallers" />
+            GenerateInstallers"
+          Condition="'$(SkipBuild)' != 'true'" />
 
 </Project>

--- a/src/pkg/packaging-tools/packaging-tools.targets
+++ b/src/pkg/packaging-tools/packaging-tools.targets
@@ -105,6 +105,14 @@
     </PropertyGroup>
   </Target>
 
+  <Target Name="GetSkipBuildProps">
+    <PropertyGroup>
+      <!-- Avoid building a project when none of the possible BuildRIDs is the current RID. -->
+      <_packageRIDInBuildRIDList Condition="'%(BuildRID.Identity)' == '$(PackageRID)'">true</_packageRIDInBuildRIDList>
+      <SkipBuild Condition="'$(_packageRIDInBuildRIDList)' != 'true'">true</SkipBuild>
+    </PropertyGroup>
+  </Target>
+
   <!--
     By default, shared frameworks are generated based on the package. This can be overridden by the
     project, and in the future, the runtime pack is likely to be used to assemble the sfx.

--- a/src/pkg/projects/Directory.Build.props
+++ b/src/pkg/projects/Directory.Build.props
@@ -8,7 +8,7 @@
     <!-- This property must be set to the same value as $(PackageOutputPath) for the nuspecs and nupkgs to be binplaced to the intended location. -->
     <OutputPath>$(PackageOutputPath)</OutputPath>
     
-    <PackageTargetRuntime Condition="'$(PackageTargetRuntime)' == '' AND '$(MSBuildProjectExtension)' == '.depproj'">$(NuGetRuntimeIdentifier)</PackageTargetRuntime>
+    <PackageTargetRuntime Condition="'$(PackageTargetRuntime)' == '' AND '$(MSBuildProjectExtension)' == '.depproj'">$(RuntimeIdentifier)</PackageTargetRuntime>
 
     <IsLineupPackage Condition="'$(PackageTargetRuntime)' == ''">true</IsLineupPackage>
 
@@ -95,8 +95,6 @@
   <Import Project="$(PackagingToolsDir)packaging-tools.props" />
 
   <PropertyGroup Condition="'$(MSBuildProjectExtension)' == '.depproj'">
-    <!-- we intentionally don't want to produce output -->
-    <OutputPath>unused</OutputPath>
     <!--
       we don't want any analyzers by ResolveNuGetPackageAssets
       null-refs when this isn't set and an analyzer is in the packages
@@ -107,7 +105,7 @@
     <PackageTargetFramework>$(NETCoreAppFramework)</PackageTargetFramework>
     <CrossGenOutputPath>$(CrossGenRootPath)$(MSBuildProjectName)\</CrossGenOutputPath>
     <ContainsPackageReferences>true</ContainsPackageReferences>
-    <RidSpecificAssets Condition="'$(NuGetRuntimeIdentifier)' != ''">true</RidSpecificAssets>
+    <RidSpecificAssets Condition="'$(RuntimeIdentifier)' != ''">true</RidSpecificAssets>
     <CrossGenSymbolsOutputPath>$(PackageSymbolsBinDir)/$(MSBuildProjectName)</CrossGenSymbolsOutputPath>
   </PropertyGroup>
 
@@ -165,7 +163,7 @@
       <Platform Condition="'%(Platform)' == ''">x64</Platform>
       <BuildRID>%(Identity)</BuildRID>
       <PackageTargetRuntime>%(BuildRID)</PackageTargetRuntime>
-      <AdditionalProperties>PackageTargetRuntime=%(BuildRID);NuGetRuntimeIdentifier=%(BuildRID);Platform=%(Platform)</AdditionalProperties>
+      <AdditionalProperties>PackageTargetRuntime=%(BuildRID);RuntimeIdentifier=%(BuildRID);Platform=%(Platform)</AdditionalProperties>
     </_project>
 
     <RuntimeProject Include="@(_project->'$(RuntimeProjectFile)')" />

--- a/src/pkg/projects/Directory.Build.targets
+++ b/src/pkg/projects/Directory.Build.targets
@@ -196,70 +196,44 @@
     </MSBuild>
   </Target>
 
-  <!--
-    Creates the platform manifest and props file. Set properties "IncludePlatformManifestFile" and
-    "IncludeFileVersionPropsFile" to true to include them, respectively.
-  -->
-  <Target Name="GenerateFileVersionProps">
-    <PropertyGroup>
-      <PropsFile>$(IntermediateOutputPath)$(MSBuildProjectName).props</PropsFile>
-      <PlatformManifestFile>$(IntermediateOutputPath)$(MSBuildProjectName).PlatformManifest.txt</PlatformManifestFile>
-
-      <!-- During an official build when we can guarantee that all RID-specific dependencies have been built,
-          restore all of those dependencies and gather the prospective content of the RID-specific Core.App
-          packages.  This is needed so that we have a complete platform manifest in the shipping version of
-          the Microsoft.NETCore.App (RID-agnostic/identity package). -->
-      <IncludeAllRuntimePackagesInPlatformManifest
-        Condition="'$(IncludeAllRuntimePackagesInPlatformManifest)' == '' AND
-                   '$(BuildFullPlatformManifest)' == 'true'">true</IncludeAllRuntimePackagesInPlatformManifest>
+  <Target Name="GetDependencyDataFileInclusionDefaults">
+    <PropertyGroup Condition="'$(BuildTargetPath)' != ''">
+      <FileVersionPropsTargetPath Condition="'$(FileVersionPropsTargetPath)' == ''">$(BuildTargetPath)$(Id).props</FileVersionPropsTargetPath>
+      <PlatformManifestTargetPath Condition="'$(PlatformManifestTargetPath)' == ''">$(BuildTargetPath)$(Id).props</PlatformManifestTargetPath>
     </PropertyGroup>
+  </Target>
 
-    <MSBuild Projects="@(ProjectReference)"
-             Condition="'%(ProjectReference.PackageTargetRuntime)' == '$(PackageRID)' OR
-                        '%(ProjectReference.BuidOnRID)' == '$(PackageRID)' OR
-                        ('$(IncludeAllRuntimePackagesInPlatformManifest)' == 'true' AND
-                         '%(ProjectReference.PackageTargetRuntime)' != '' AND
-                         '%(ProjectReference.ExcludeFromPlatformManifest)' != 'true')"
-             Targets="GetPackageFiles">
-      <Output TaskParameter="TargetOutputs" ItemName="SharedFrameworkRuntimeFiles" />
+  <!-- Get data files (platform manifest, file version props) from depproj dependencies. -->
+  <Target Name="GetDepprojDependencyDataFiles">
+    <MSBuild
+      Projects="@(ProjectReference)"
+      Targets="GetDataFiles"
+      SkipNonExistentTargets="true">
+      <Output TaskParameter="TargetOutputs" ItemName="_depprojDataFile" />
     </MSBuild>
-
-    <!--
-      Workaround: zero-versioned Microsoft.VisualBasic.dll in non-Windows CoreFX transport package.
-      See https://github.com/dotnet/corefx/issues/36630
-    -->
-    <PropertyGroup Condition="'$(OSGroup)' != 'Windows_NT'">
-      <PermitDllAndExeFilesLackingFileVersion>true</PermitDllAndExeFilesLackingFileVersion>
-    </PropertyGroup>
-
-    <GenerateFileVersionProps Files="@(SharedFrameworkRuntimeFiles)"
-                              PackageId="$(Id)"
-                              PackageVersion="$(Version)"
-                              PlatformManifestFile="$(PlatformManifestFile)"
-                              PropsFile="$(PropsFile)"
-                              PreferredPackages="$(Id);@(RuntimeDependency)"
-                              PermitDllAndExeFilesLackingFileVersion="$(PermitDllAndExeFilesLackingFileVersion)" />
   </Target>
 
   <Target Name="IncludeFileVersionPropsFile"
-          DependsOnTargets="GenerateFileVersionProps"
+          DependsOnTargets="GetDepprojDependencyDataFiles;GetDependencyDataFileInclusionDefaults"
           BeforeTargets="GetFiles"
           Condition="'$(PackageTargetRuntime)' == '' AND '$(FileVersionPropsTargetPath)' != ''">
     <ItemGroup>
-      <File Include="$(PropsFile)">
-        <TargetPath>$(FileVersionPropsTargetPath)</TargetPath>
-      </File>
+      <File
+        Include="@(_depprojDataFile)"
+        Condition="'%(_depprojDataFile.PropsFile)' == 'true'"
+        TargetPath="$(FileVersionPropsTargetPath)" />
     </ItemGroup>
   </Target>
 
   <Target Name="IncludePlatformManifestFile"
-          DependsOnTargets="GenerateFileVersionProps"
+          DependsOnTargets="GetDepprojDependencyDataFiles;GetDependencyDataFileInclusionDefaults"
           BeforeTargets="GetFiles"
           Condition="'$(PackageTargetRuntime)' == '' AND '$(PlatformManifestTargetPath)' != ''">
     <ItemGroup>
-      <File Include="$(PlatformManifestFile)">
-        <TargetPath>$(PlatformManifestTargetPath)</TargetPath>
-      </File>
+      <File
+        Include="@(_depprojDataFile)"
+        Condition="'%(_depprojDataFile.PlatformManifestFile)' == 'true'"
+        TargetPath="$(PlatformManifestTargetPath)" />
     </ItemGroup>
   </Target>
 

--- a/src/pkg/projects/netcoreapp/pkg/Directory.Build.props
+++ b/src/pkg/projects/netcoreapp/pkg/Directory.Build.props
@@ -16,7 +16,7 @@
   <!-- Redistribute package content from other nuget packages. -->
   <ItemGroup Condition="'$(FrameworkPackType)' != 'apphost' AND '$(ExcludeDepprojReference)' != 'true'">
     <ProjectReference Include="$(MSBuildThisFileDirectory)..\src\netcoreapp.depproj">
-      <AdditionalProperties Condition="'$(PackageTargetRuntime)' != ''">NuGetRuntimeIdentifier=$(PackageTargetRuntime)</AdditionalProperties>
+      <AdditionalProperties Condition="'$(PackageTargetRuntime)' != ''">RuntimeIdentifier=$(PackageTargetRuntime)</AdditionalProperties>
     </ProjectReference>
   </ItemGroup>
 </Project>

--- a/src/pkg/projects/netcoreapp/pkg/legacy/Directory.Build.props
+++ b/src/pkg/projects/netcoreapp/pkg/legacy/Directory.Build.props
@@ -3,9 +3,7 @@
 
   <PropertyGroup>
     <PreventImplementationReference Condition="'$(PackageTargetRuntime)' != ''">true</PreventImplementationReference>
-    <BuildTargetPath>build/$(NETCoreAppFramework)</BuildTargetPath>
-    <PlatformManifestTargetPath>$(BuildTargetPath)</PlatformManifestTargetPath>
-    <FileVersionPropsTargetPath>$(BuildTargetPath)</FileVersionPropsTargetPath>
+    <BuildTargetPath>build/$(NETCoreAppFramework)/</BuildTargetPath>
   </PropertyGroup>
 
   <!-- Identity / Reference package content -->

--- a/src/pkg/projects/netcoreapp/src/netcoreapp.depproj
+++ b/src/pkg/projects/netcoreapp/src/netcoreapp.depproj
@@ -13,7 +13,7 @@
     <PackageReference Include="NETStandard.Library" Version="$(NETStandardLibraryPackageVersion)" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(NuGetRuntimeIdentifier)' == ''">
+  <ItemGroup Condition="'$(PackageTargetRuntime)' == ''">
     <!-- Bring in Platforms for RID graph, NETStandard.Library for build-tools,
          Targets for an empty runtime.json to reduce conflicts from 1.x packages -->
     <DependenciesToPackage Include="NETStandard.Library" />
@@ -24,7 +24,7 @@
   <!-- get paths from packages that are needed for cross-gen and other includes,
        only relevant for runtime-specific builds -->
   <Target Name="GetPackagePaths"
-          Condition="'$(NuGetRuntimeIdentifier)' != ''"
+          Condition="'$(PackageTargetRuntime)' != ''"
           DependsOnTargets="GetCorePackagePaths" />
 
   <Target Name="GetDependencyVersionFiles" DependsOnTargets="ResolveReferences;GetPackagePaths">
@@ -35,7 +35,7 @@
         Name="corefx" />
       <_coreClrVersionFile
         Include="$(_runtimePackageDir)version.txt"
-        Condition="'$(NuGetRuntimeIdentifier)' != ''"
+        Condition="'$(PackageTargetRuntime)' != ''"
         Name="coreclr" />
 
       <DependencyVersionFile Include="@(_coreFxVersionFile);@(_coreClrVersionFile)" />
@@ -46,7 +46,7 @@
       Text="Failed to locate corefx version.txt file." />
 
     <Error
-      Condition="'@(_coreClrVersionFile)' == '' AND '$(NuGetRuntimeIdentifier)' != ''"
+      Condition="'@(_coreClrVersionFile)' == '' AND '$(PackageTargetRuntime)' != ''"
       Text="Failed to locate coreclr version.txt file." />
   </Target>
 
@@ -54,7 +54,7 @@
   <Target Name="GetRuntimeFilesFromPackages"
           BeforeTargets="GetRuntimeFilesToPackage"
           DependsOnTargets="GetCorePackagePaths">
-    <ItemGroup Condition="'$(NuGetRuntimeIdentifier)' != ''">
+    <ItemGroup Condition="'$(PackageTargetRuntime)' != ''">
       <_ToolsToPackage Include="$(_runtimePackageDir)tools/**/*.*"/>
       <FilesToPackage Include="@(_ToolsToPackage)">
         <NuGetPackageId>$(_runtimePackageId)</NuGetPackageId>

--- a/src/pkg/projects/netstandard/pkg/Directory.Build.props
+++ b/src/pkg/projects/netstandard/pkg/Directory.Build.props
@@ -20,7 +20,7 @@
   <!-- Redistribute package content from other nuget packages. -->
   <ItemGroup>
     <ProjectReference Include="..\src\netstandard.depproj">
-      <AdditionalProperties Condition="'$(PackageTargetRuntime)' != ''">NuGetRuntimeIdentifier=$(PackageTargetRuntime)</AdditionalProperties>
+      <AdditionalProperties Condition="'$(PackageTargetRuntime)' != ''">RuntimeIdentifier=$(PackageTargetRuntime)</AdditionalProperties>
     </ProjectReference>
   </ItemGroup>
 </Project>

--- a/src/pkg/projects/windowsdesktop/pkg/Directory.Build.props
+++ b/src/pkg/projects/windowsdesktop/pkg/Directory.Build.props
@@ -74,7 +74,7 @@
   <!-- Redistribute package content from other nuget packages. -->
   <ItemGroup>
     <ProjectReference Include="..\src\windowsdesktop.depproj">
-      <AdditionalProperties Condition="'$(PackageTargetRuntime)' != ''">NuGetRuntimeIdentifier=$(PackageTargetRuntime)</AdditionalProperties>
+      <AdditionalProperties Condition="'$(PackageTargetRuntime)' != ''">RuntimeIdentifier=$(PackageTargetRuntime)</AdditionalProperties>
     </ProjectReference>
   </ItemGroup>
 </Project>

--- a/src/pkg/projects/windowsdesktop/pkg/Directory.Build.props
+++ b/src/pkg/projects/windowsdesktop/pkg/Directory.Build.props
@@ -13,14 +13,6 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <!--
-      Only build WindowsDesktop assets if this is on Windows and we know WD assets are available
-      and supported. This lets us skip them on the non-Windows official build legs.
-    -->
-    <BuildOnUnknownPlatforms>false</BuildOnUnknownPlatforms>
-  </PropertyGroup>
-
-  <PropertyGroup>
     <BuildDebPackage>false</BuildDebPackage>
     <BuildRpmPackage>false</BuildRpmPackage>
     <GeneratePkg>false</GeneratePkg>

--- a/src/pkg/projects/windowsdesktop/pkg/Microsoft.WindowsDesktop.App.pkgproj
+++ b/src/pkg/projects/windowsdesktop/pkg/Microsoft.WindowsDesktop.App.pkgproj
@@ -3,9 +3,7 @@
 
   <PropertyGroup>
     <PreventImplementationReference Condition="'$(PackageTargetRuntime)' != ''">true</PreventImplementationReference>
-    <BuildTargetPath>build/$(NETCoreAppFramework)</BuildTargetPath>
-    <PlatformManifestTargetPath>$(BuildTargetPath)</PlatformManifestTargetPath>
-    <FileVersionPropsTargetPath>$(BuildTargetPath)</FileVersionPropsTargetPath>
+    <BuildTargetPath>build/$(NETCoreAppFramework)/</BuildTargetPath>
 
     <FrameworkListTargetPath>data/</FrameworkListTargetPath>
 

--- a/src/pkg/projects/windowsdesktop/windowsdesktopRIDs.props
+++ b/src/pkg/projects/windowsdesktop/windowsdesktopRIDs.props
@@ -3,6 +3,12 @@
 
   <PropertyGroup>
     <PackageRID Condition="'$(PackageRID)' == ''">$(OutputRid)</PackageRID>
+
+    <!--
+      Only build WindowsDesktop assets if this is on Windows and we know WD assets are available
+      and supported. This lets us skip them on the non-Windows official build legs.
+    -->
+    <BuildOnUnknownPlatforms>false</BuildOnUnknownPlatforms>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/test/Directory.Build.targets
+++ b/src/test/Directory.Build.targets
@@ -21,12 +21,59 @@
       SourceFiles="@(SharedFrameworkPublishFiles)"
       DestinationFiles="@(SharedFrameworkPublishFiles->'$(TestsOutputDir)sharedFrameworkPublish/%(RecursiveDir)%(Filename)%(Extension)')" />
 
-    <!-- Create file with a name that describes what a test dir is. Useful if path abbreviated. -->
+    <!-- Create files with a name that describes what a test dir is. Useful if path abbreviated. -->
     <WriteLinesToFile
       File="$(TestsOutputRootDir)$(TestsOutputName)-is-$(MSBuildProjectName).txt"
       Overwrite="true"
       Lines="$(MSBuildProjectName) intermediates are located in '$(TestsOutputName)'. Abbreviated to work around path limits on Windows."
       Condition="'$(TestsOutputName)' != '$(MSBuildProjectName)'" />
+    <WriteLinesToFile
+      File="$(TestsOutputDir)$(MSBuildProjectName).txt"
+      Overwrite="true"
+      Lines="$(MSBuildProjectName) intermediates are located in '$(TestsOutputName)'. Abbreviated to work around path limits on Windows."
+      Condition="'$(TestsOutputName)' != '$(MSBuildProjectName)'" />
+  </Target>
+
+  <Target Name="SetupTestContextVariables"
+          DependsOnTargets="
+            GetProductVersions;
+            DetermineTestOutputDirectory"
+          BeforeTargets="Build">
+    <PropertyGroup>
+      <!--
+        The tests use the TEST_ARTIFACTS variable to determine the artifacts folder and then later
+        compare that path to its expected path. So, the TEST_ARTIFACTS variable has to have system
+        specific path separators or the string compoarison will fail.
+      -->
+      <DirectorySeparatorChar>$([System.IO.Path]::DirectorySeparatorChar)</DirectorySeparatorChar>
+      <SystemPathTestsOutputDir>$([System.String]::Copy('$(TestsOutputDir)').Replace('/', '$(DirectorySeparatorChar)'))</SystemPathTestsOutputDir>
+      <SystemPathTestsOutputDir>$([System.String]::Copy('$(SystemPathTestsOutputDir)').Replace('\', '$(DirectorySeparatorChar)'))</SystemPathTestsOutputDir>
+
+      <!-- This is defined when building in Visual Studio, not DotNetRoot. -->
+      <DotNetRoot Condition="'$(DotNetRoot)' == ''">$(NetCoreRoot)</DotNetRoot>
+    </PropertyGroup>
+
+    <!--
+      Set up properties used inside tests. Write them to a text file so that they can be found
+      inside the VS Test Explorer context the same way as the XUnit runner will find them.
+      See https://github.com/dotnet/arcade/issues/3077.
+    -->
+    <ItemGroup>
+      <TestContextVariable Include="NUGET_PACKAGES=$(TestRestorePackagesPath)" />
+      <TestContextVariable Include="TEST_ARTIFACTS=$(SystemPathTestsOutputDir)" />
+      <TestContextVariable Include="TEST_TARGETRID=$(TestTargetRid)" />
+      <TestContextVariable Include="BUILDRID=$(OutputRid)" />
+      <TestContextVariable Include="BUILD_ARCHITECTURE=$(TargetArchitecture)" />
+      <TestContextVariable Include="BUILD_CONFIGURATION=$(ConfigurationGroup)" />
+      <TestContextVariable Include="MNA_VERSION=$(ProductVersion)" />
+      <TestContextVariable Include="MNA_TFM=$(NETCoreAppFramework)" />
+      <TestContextVariable Include="DOTNET_SDK_PATH=$(DotNetRoot)" />
+    </ItemGroup>
+
+    <WriteLinesToFile
+      File="$(OutDir)TestContextVariables.txt"
+      Overwrite="true"
+      Lines="@(TestContextVariable)" />
   </Target>
 
   <Target Name="DetermineTestOutputDirectory">
@@ -43,147 +90,5 @@
     </PropertyGroup>
   </Target>
 
-  <Target Name="SetupTextFixtureEnvironment"
-          Condition="'$(SkipTests)' != 'true'"
-          DependsOnTargets="
-            GetProductVersions;
-            DetermineTestOutputDirectory"
-          BeforeTargets="RunTests">
-    <PropertyGroup>
-      <!-- The tests use the TEST_ARTIFACTS env variable to determine the artifacts folder and then later compare that path to its expected path.
-           So, the TEST_ARTIFACTS variable has to have system specific path separators or the string compoarison will fail. -->
-      <DirectorySeparatorChar>$([System.IO.Path]::DirectorySeparatorChar)</DirectorySeparatorChar>
-      <SystemPathTestsOutputDir>$([System.String]::Copy('$(TestsOutputDir)').Replace('/', '$(DirectorySeparatorChar)'))</SystemPathTestsOutputDir>
-      <SystemPathTestsOutputDir>$([System.String]::Copy('$(SystemPathTestsOutputDir)').Replace('\', '$(DirectorySeparatorChar)'))</SystemPathTestsOutputDir>
-    </PropertyGroup>
-
-    <!-- Set properties used inside tests as environment variables. -->
-    <ItemGroup>
-      <TestRunnerEnvironmentVariable Include="NUGET_PACKAGES=$(TestRestorePackagesPath)" />
-      <TestRunnerEnvironmentVariable Include="TEST_ARTIFACTS=$(SystemPathTestsOutputDir)" />
-      <TestRunnerEnvironmentVariable Include="TEST_TARGETRID=$(TestTargetRid)" />
-      <TestRunnerEnvironmentVariable Include="BUILDRID=$(OutputRid)" />
-      <TestRunnerEnvironmentVariable Include="BUILD_ARCHITECTURE=$(TargetArchitecture)" />
-      <TestRunnerEnvironmentVariable Include="BUILD_CONFIGURATION=$(ConfigurationGroup)" />
-      <TestRunnerEnvironmentVariable Include="MNA_VERSION=$(ProductVersion)" />
-      <TestRunnerEnvironmentVariable Include="MNA_TFM=$(NETCoreAppFramework)" />
-      <TestRunnerEnvironmentVariable Include="DOTNET_SDK_PATH=$(DotNetRoot)" />
-    </ItemGroup>
-  </Target>
-
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory).., Directory.Build.targets))\Directory.Build.targets" />
-
-  <!--
-    Rewrite Arcade RunTests target to add TestRunnerEnvironmentVariable support. In the future we
-    should switch to a file to transfer this information, or derive the info from information on
-    disk. Env vars are not likely to be supported in upstream Arcade.
-
-    See https://github.com/dotnet/arcade/issues/3077.
-  -->
-  <!-- <OVERRIDE> https://github.com/dotnet/arcade/blob/dc538a29793fd56618d0fa3186e2388d47d00c19/src/Microsoft.DotNet.Arcade.Sdk/tools/XUnit/XUnit.targets#L25-L120 -->
-  <!-- 
-    Include '*' target to force running tests even if the input assemblies haven't changed and the outputs are present.
-    This matches the common expectations that test command always runs all tests in scope.
-  -->
-  <Target Name="RunTests"
-          Inputs="@(TestToRun);*"
-          Outputs="%(TestToRun.ResultsStdOutPath);%(TestToRun.ResultsXmlPath);%(TestToRun.ResultsHtmlPath)">
-
-    <PropertyGroup>
-      <_TestEnvironment>%(TestToRun.EnvironmentDisplay)</_TestEnvironment>
-      <_TestAssembly>%(TestToRun.Identity)</_TestAssembly>
-      <_TestRuntime>%(TestToRun.TestRuntime)</_TestRuntime>
-      <_TestRunnerAdditionalArguments>%(TestToRun.TestRunnerAdditionalArguments)</_TestRunnerAdditionalArguments>
-
-      <!-- Always use net472 for desktop to enable displaying source location from Portable PDBs in stack traces -->
-      <_TestRunnerTargetFramework>net472</_TestRunnerTargetFramework>
-      <_TestRunnerTargetFramework Condition="'$(_TestRuntime)' == 'Core'">netcoreapp2.0</_TestRunnerTargetFramework>
-      <_TestRunnerTargetFramework Condition="%(TestToRun.TargetFramework) == 'netcoreapp1.1' or %(TestToRun.TargetFramework) == 'netcoreapp1.0'">netcoreapp1.0</_TestRunnerTargetFramework>
-    </PropertyGroup>
-
-    <PropertyGroup Condition="'$(_TestRuntime)' == 'Core'">
-      <_TargetFileNameNoExt>$([System.IO.Path]::GetFileNameWithoutExtension('$(_TestAssembly)'))</_TargetFileNameNoExt>
-      <_TargetDir>$([System.IO.Path]::GetDirectoryName('$(_TestAssembly)'))\</_TargetDir>
-      <_CoreRuntimeConfigPath>$(_TargetDir)$(_TargetFileNameNoExt).runtimeconfig.json</_CoreRuntimeConfigPath>
-      <_CoreDepsPath>$(_TargetDir)$(_TargetFileNameNoExt).deps.json</_CoreDepsPath>
-      
-      <_TestRunner Condition="'%(TestToRun.Architecture)'=='x86' And Exists('$(DotNetRoot)x86\dotnet.exe')">$(DotNetRoot)x86\dotnet.exe</_TestRunner>
-      <_TestRunner Condition="'$(_TestRunner)'==''">$(DotNetTool)</_TestRunner>
-      
-      <_TestRunnerArgs>exec --depsfile "$(_CoreDepsPath)" --runtimeconfig "$(_CoreRuntimeConfigPath)" $(TestRuntimeAdditionalArguments) "$(NuGetPackageRoot)xunit.runner.console/$(XUnitVersion)/tools/$(_TestRunnerTargetFramework)/xunit.console.dll" "$(_TestAssembly)" -noautoreporters -xml "%(TestToRun.ResultsXmlPath)" -html "%(TestToRun.ResultsHtmlPath)" $(_TestRunnerAdditionalArguments)</_TestRunnerArgs>
-    </PropertyGroup>
-
-    <PropertyGroup Condition="'$(_TestRuntime)' != 'Core'">
-      <_XUnitConsoleExe>xunit.console.exe</_XUnitConsoleExe>
-      <_XUnitConsoleExe Condition="'%(TestToRun.Architecture)' == 'x86'">xunit.console.x86.exe</_XUnitConsoleExe>
-      <_XUnitConsoleExePath>$(NuGetPackageRoot)xunit.runner.console\$(XUnitVersion)\tools\$(_TestRunnerTargetFramework)\$(_XUnitConsoleExe)</_XUnitConsoleExePath>
-
-      <_TestRunnerArgs>"$(_TestAssembly)" -noshadow -xml "%(TestToRun.ResultsXmlPath)" -html "%(TestToRun.ResultsHtmlPath)" $(_TestRunnerAdditionalArguments)</_TestRunnerArgs>
-      <_TestRunnerArgs Condition="'$(_TestRuntime)' == 'Mono'">$(TestRuntimeAdditionalArguments) "$(_XUnitConsoleExePath)" $(_TestRunnerArgs)</_TestRunnerArgs>
-
-      <_TestRunner Condition="'$(_TestRuntime)' == 'Mono'">$(MonoTool)</_TestRunner>
-      <_TestRunner Condition="'$(_TestRuntime)' != 'Mono'">$(_XUnitConsoleExePath)</_TestRunner>
-    </PropertyGroup>
-
-    <PropertyGroup>
-      <_TestRunnerCommand>"$(_TestRunner)" $(_TestRunnerArgs)</_TestRunnerCommand>
-
-      <!-- 
-        Redirect std output of the runner.
-        Note that xUnit outputs failure info to both STDOUT (stack trace, message) and STDERR (failed test name) 
-      -->
-      <_TestRunnerCommand Condition="'$(TestCaptureOutput)' != 'false'">$(_TestRunnerCommand) > "%(TestToRun.ResultsStdOutPath)" 2>&amp;1</_TestRunnerCommand>
-    </PropertyGroup>
-
-    <ItemGroup>
-      <_OutputFiles Include="%(TestToRun.ResultsXmlPath)" />
-      <_OutputFiles Include="%(TestToRun.ResultsHtmlPath)" />
-      <_OutputFiles Include="%(TestToRun.ResultsStdOutPath)" />
-    </ItemGroup>
-
-    <MakeDir Directories="@(_OutputFiles->'%(RootDir)%(Directory)')"/>
-    <Delete Files="@(_OutputFiles)" />
-
-    <Message Text="Running tests: $(_TestAssembly) [$(_TestEnvironment)]" Importance="high"/>
-    <!-- <CHANGE> Add env var parameter, taking TestRunnerEnvironmentVariable items. -->
-    <Exec
-      Command='$(_TestRunnerCommand)'
-      EnvironmentVariables="@(TestRunnerEnvironmentVariable)"
-      LogStandardErrorAsError="false"
-      WorkingDirectory="$(_TargetDir)"
-      IgnoreExitCode="true">
-    <!-- </CHANGE> -->
-      <Output TaskParameter="ExitCode" PropertyName="_TestErrorCode" />
-    </Exec>
-
-    <!--
-      Add command line to the log.
-    -->
-    <WriteLinesToFile File="%(TestToRun.ResultsStdOutPath)" 
-                      Overwrite="false" 
-                      Lines=";=== COMMAND LINE ===;$(_TestRunnerCommand)"
-                      Condition="'$(TestCaptureOutput)' != 'false'" />
-
-    <!--
-      Report test status.
-    -->
-    <Message Text="Tests succeeded: $(_TestAssembly) [$(_TestEnvironment)]" Condition="'$(_TestErrorCode)' == '0'" Importance="high" />
-
-    <PropertyGroup>
-      <_ResultsFileToDisplay>%(TestToRun.ResultsHtmlPath)</_ResultsFileToDisplay>
-      <_ResultsFileToDisplay Condition="!Exists('$(_ResultsFileToDisplay)')">%(TestToRun.ResultsStdOutPath)</_ResultsFileToDisplay>
-    </PropertyGroup>
-
-    <!-- 
-      Ideally we would set ContinueOnError="ErrorAndContinue" so that when a test fails in multi-targeted test project
-      we'll still run tests for all target frameworks. ErrorAndContinue doesn't work well on Linux though: https://github.com/Microsoft/msbuild/issues/3961.
-    -->
-    <Error Text="Tests failed: $(_ResultsFileToDisplay) [$(_TestEnvironment)]" Condition="'$(_TestErrorCode)' != '0'" File="XUnit" />
-
-    <ItemGroup>
-      <FileWrites Include="@(_OutputFiles)"/>
-    </ItemGroup>
-  </Target>
-  <!-- </OVERRIDE> -->
-
 </Project>

--- a/src/test/HostActivation.Tests/DotnetTestXunit.cs
+++ b/src/test/HostActivation.Tests/DotnetTestXunit.cs
@@ -85,7 +85,7 @@ namespace Microsoft.DotNet.Tools.Publish.Tests
             if ( ! File.Exists(dotnetTestXunitDll))
             {
                 throw new Exception(
-                    $"Unable to find dotnet-test-xunit.dll, ensure {nameof(DotnetTestXunitVersion)} is updated to the version in Portable/StandaloneTestApp");
+                    $"Unable to find '{dotnetTestXunitDll}', ensure {nameof(DotnetTestXunitVersion)} is updated to the version in Portable/StandaloneTestApp");
             }
 
             return dotnetTestXunitDll;

--- a/src/test/HostActivation.Tests/LightupAppActivation.cs
+++ b/src/test/HostActivation.Tests/LightupAppActivation.cs
@@ -30,7 +30,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
 
             // From the artifacts dir, it's possible to find where the sharedFrameworkPublish folder is. We need
             // to locate it because we'll copy its contents into other folders
-            string artifactsDir = Environment.GetEnvironmentVariable("TEST_ARTIFACTS");
+            string artifactsDir = new RepoDirectoriesProvider().GetTestContextVariable("TEST_ARTIFACTS");
             string builtDotnet = Path.Combine(artifactsDir, "sharedFrameworkPublish");
 
             // The dotnetLightupSharedFxLookup dir will contain some folders and files that will be necessary to perform the tests

--- a/src/test/HostActivation.Tests/MultilevelSharedFxLookup.cs
+++ b/src/test/HostActivation.Tests/MultilevelSharedFxLookup.cs
@@ -48,7 +48,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
         {
             // From the artifacts dir, it's possible to find where the sharedFrameworkPublish folder is. We need
             // to locate it because we'll copy its contents into other folders
-            string artifactsDir = Environment.GetEnvironmentVariable("TEST_ARTIFACTS");
+            string artifactsDir = new RepoDirectoriesProvider().GetTestContextVariable("TEST_ARTIFACTS");
             _builtDotnet = Path.Combine(artifactsDir, "sharedFrameworkPublish");
 
             // The dotnetMultilevelSharedFxLookup dir will contain some folders and files that will be

--- a/src/test/HostActivation.Tests/SharedFxLookup.cs
+++ b/src/test/HostActivation.Tests/SharedFxLookup.cs
@@ -34,7 +34,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
         {
             // From the artifacts dir, it's possible to find where the sharedFrameworkPublish folder is. We need
             // to locate it because we'll copy its contents into other folders
-            string artifactsDir = Environment.GetEnvironmentVariable("TEST_ARTIFACTS");
+            string artifactsDir = new RepoDirectoriesProvider().GetTestContextVariable("TEST_ARTIFACTS");
             _builtDotnet = Path.Combine(artifactsDir, "sharedFrameworkPublish");
 
             // The dotnetSharedFxLookup dir will contain some folders and files that will be

--- a/src/test/Microsoft.DotNet.CoreSetup.Packaging.Tests/Microsoft.DotNet.CoreSetup.Packaging.Tests.csproj
+++ b/src/test/Microsoft.DotNet.CoreSetup.Packaging.Tests/Microsoft.DotNet.CoreSetup.Packaging.Tests.csproj
@@ -1,0 +1,37 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>$(NETCoreAppFramework)</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(BuildingInsideVisualStudio)' == 'true'">
+    <LangVersion>7.1</LangVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="NuGet.Packaging" Version="$(NugetPackagingPackageVersion)" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\TestUtils\TestUtils.csproj" />
+    <OrderProjectReference Include="$(SourceDir)pkg\projects\**\*.pkgproj" />
+  </ItemGroup>
+
+  <!--
+    Ensure the packaging projects build first. Don't do this in VS: the build takes too long and
+    isn't incremental.
+  -->
+  <Target Name="EnsureOrder"
+          Condition="
+            '$(SkipBuildingSharedFrameworkTestDependencies)' != 'true' and
+            '$(BuildingInsideVisualStudio)' != 'true'"
+          BeforeTargets="Build">
+    <MSBuild
+      Projects="@(OrderProjectReference)"
+      Targets="Build"
+      BuildInParallel="$(BuildInParallel)" />
+  </Target>
+
+</Project>

--- a/src/test/Microsoft.DotNet.CoreSetup.Packaging.Tests/NETCoreTests.cs
+++ b/src/test/Microsoft.DotNet.CoreSetup.Packaging.Tests/NETCoreTests.cs
@@ -1,0 +1,54 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.DotNet.CoreSetup.Test;
+using Xunit;
+
+namespace Microsoft.DotNet.CoreSetup.Packaging.Tests
+{
+    public class NETCoreTests
+    {
+        private readonly RepoDirectoriesProvider dirs = new RepoDirectoriesProvider();
+
+        [Fact]
+        public void NETCoreTargetingPackIsValid()
+        {
+            using (var tester = NuGetArtifactTester.Open(
+                dirs,
+                "Microsoft.NETCore.App.Ref"))
+            {
+                tester.HasOnlyTheseDataFiles(
+                    "data/FrameworkList.xml",
+                    "data/PlatformManifest.txt");
+
+                tester.IsTargetingPack();
+                tester.HasGoodPlatformManifest();
+            }
+        }
+
+        [Fact]
+        public void NETCoreAppHostPackIsValid()
+        {
+            using (var tester = NuGetArtifactTester.Open(
+                dirs,
+                "Microsoft.NETCore.App.Host",
+                $"Microsoft.NETCore.App.Host.{dirs.BuildRID}"))
+            {
+                tester.IsAppHostPack();
+            }
+        }
+
+        [Fact]
+        public void NETCoreRuntimePackIsValid()
+        {
+            using (var tester = NuGetArtifactTester.Open(
+                dirs,
+                "Microsoft.NETCore.App.Runtime",
+                $"Microsoft.NETCore.App.Runtime.{dirs.BuildRID}"))
+            {
+                tester.IsRuntimePack();
+            }
+        }
+    }
+}

--- a/src/test/Microsoft.DotNet.CoreSetup.Packaging.Tests/NETStandardTests.cs
+++ b/src/test/Microsoft.DotNet.CoreSetup.Packaging.Tests/NETStandardTests.cs
@@ -1,0 +1,28 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.DotNet.CoreSetup.Test;
+using Xunit;
+
+namespace Microsoft.DotNet.CoreSetup.Packaging.Tests
+{
+    public class NETStandardTests
+    {
+        private readonly RepoDirectoriesProvider dirs = new RepoDirectoriesProvider();
+
+        [Fact]
+        public void NETStandardTargetingPackIsValid()
+        {
+            using (var tester = NuGetArtifactTester.Open(
+                dirs,
+                "NETStandard.Library.Ref"))
+            {
+                tester.HasOnlyTheseDataFiles(
+                    "data/FrameworkList.xml");
+
+                tester.IsTargetingPack();
+            }
+        }
+    }
+}

--- a/src/test/Microsoft.DotNet.CoreSetup.Packaging.Tests/NuGetArtifactTester.cs
+++ b/src/test/Microsoft.DotNet.CoreSetup.Packaging.Tests/NuGetArtifactTester.cs
@@ -1,0 +1,166 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.DotNet.CoreSetup.Test;
+using NuGet.Packaging;
+using NuGet.Packaging.Core;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.IO.Compression;
+using System.Linq;
+using System.Xml.Linq;
+using Xunit;
+
+namespace Microsoft.DotNet.CoreSetup.Packaging.Tests
+{
+    public class NuGetArtifactTester : IDisposable
+    {
+        public static NuGetArtifactTester Open(
+            RepoDirectoriesProvider dirs,
+            string project,
+            string id = null)
+        {
+            var tester = OpenOrNull(dirs, project, id);
+            Assert.NotNull(tester);
+            return tester;
+        }
+
+        public static NuGetArtifactTester OpenOrNull(
+            RepoDirectoriesProvider dirs,
+            string project,
+            string id = null)
+        {
+            id = id ?? project;
+
+            string nuspecPath = Path.Combine(
+                dirs.BaseBinFolder,
+                project,
+                dirs.Configuration,
+                "specs",
+                $"{id}.nuspec");
+
+            if (!File.Exists(nuspecPath))
+            {
+                return null;
+            }
+
+            PackageIdentity builtIdentity = new NuspecReader(nuspecPath).GetIdentity();
+
+            string nupkgPath = Path.Combine(
+                dirs.BaseArtifactsFolder,
+                "packages",
+                dirs.Configuration,
+                "Shipping",
+                $"{builtIdentity}.nupkg");
+
+            // If the nuspec exists, the nupkg should exist.
+            Assert.True(File.Exists(nupkgPath));
+
+            return new NuGetArtifactTester(nupkgPath);
+        }
+
+        private readonly PackageArchiveReader _reader;
+
+        public NuGetArtifactTester(string file)
+        {
+            _reader = new PackageArchiveReader(ZipFile.Open(file, ZipArchiveMode.Read));
+        }
+
+        public void Dispose()
+        {
+            _reader.Dispose();
+        }
+
+        public void IsTargetingPack()
+        {
+            IsFrameworkPack();
+
+            Assert.NotEmpty(_reader.GetFiles("ref"));
+            Assert.Empty(_reader.GetFiles("runtimes"));
+            Assert.Empty(_reader.GetFiles("lib"));
+
+            ContainsFrameworkList("FrameworkList.xml");
+        }
+
+        public void IsAppHostPack()
+        {
+            IsRuntimeSpecificPack();
+        }
+
+        public void IsRuntimePack()
+        {
+            IsRuntimeSpecificPack();
+
+            HasOnlyTheseDataFiles("data/RuntimeList.xml");
+
+            ContainsFrameworkList("RuntimeList.xml");
+        }
+
+        public void HasOnlyTheseDataFiles(params string[] expectedDataFiles)
+        {
+            HashSet<string> dataFileSet = _reader.GetFiles("data").ToHashSet();
+
+            Assert.True(
+                dataFileSet.SetEquals(expectedDataFiles),
+                "Invalid set of data files: " +
+                    $"expected '{string.Join(", ", expectedDataFiles)}', " +
+                    $"actual '{string.Join(", ", dataFileSet)}'");
+        }
+
+        public void HasGoodPlatformManifest()
+        {
+            string platformManifestContent = ReadEntryContent(
+                _reader.GetEntry("data/PlatformManifest.txt"));
+
+            // Sanity: check if the manifest has some content.
+            Assert.Contains(".dll", platformManifestContent);
+        }
+
+        private void IsFrameworkPack()
+        {
+            Assert.Empty(_reader.GetPackageDependencies());
+
+            var expectedTypes = new[] { new PackageType("DotnetPlatform", new Version(0, 0)) };
+            var types = _reader.GetPackageTypes().ToArray();
+            Assert.Equal(expectedTypes, types);
+        }
+
+        private void IsRuntimeSpecificPack()
+        {
+            IsFrameworkPack();
+
+            Assert.Empty(_reader.GetFiles("ref"));
+            Assert.NotEmpty(_reader.GetFiles("runtimes"));
+            Assert.Empty(_reader.GetFiles("lib"));
+        }
+
+        private void ContainsFrameworkList(string name)
+        {
+            XDocument frameworkList = ReadEntryXDocument(
+                _reader.GetEntry($"data/{name}"));
+
+            XElement[] frameworkListFiles = frameworkList
+                .Element("FileList")
+                .Elements("File")
+                .ToArray();
+
+            // Sanity: check if the list has some content.
+            Assert.NotEmpty(frameworkListFiles);
+        }
+
+        private static string ReadEntryContent(ZipArchiveEntry entry)
+        {
+            using (var reader = new StreamReader(entry.Open()))
+            {
+                return reader.ReadToEnd();
+            }
+        }
+
+        private static XDocument ReadEntryXDocument(ZipArchiveEntry entry)
+        {
+            return XDocument.Parse(ReadEntryContent(entry));
+        }
+    }
+}

--- a/src/test/Microsoft.DotNet.CoreSetup.Packaging.Tests/WindowsDesktopTests.cs
+++ b/src/test/Microsoft.DotNet.CoreSetup.Packaging.Tests/WindowsDesktopTests.cs
@@ -1,0 +1,70 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.DotNet.CoreSetup.Test;
+using System.Linq;
+using Xunit;
+
+namespace Microsoft.DotNet.CoreSetup.Packaging.Tests
+{
+    public class WindowsDesktopTests
+    {
+        private readonly RepoDirectoriesProvider dirs = new RepoDirectoriesProvider();
+
+        [Fact]
+        public void WindowsDesktopTargetingPackIsValid()
+        {
+            // Use "OrNull" variant to get null if this nupkg doesn't exist. WindowsDesktop is only
+            // built on officially supported platforms.
+            using (var tester = NuGetArtifactTester.OpenOrNull(
+                dirs,
+                "Microsoft.WindowsDesktop.App.Ref"))
+            {
+                if (CurrentRidShouldCreateNupkg)
+                {
+                    Assert.NotNull(tester);
+
+                    tester.HasOnlyTheseDataFiles(
+                        "data/FrameworkList.xml",
+                        "data/PlatformManifest.txt");
+
+                    tester.IsTargetingPack();
+                    tester.HasGoodPlatformManifest();
+                }
+                else
+                {
+                    Assert.Null(tester);
+                }
+            }
+        }
+
+        [Fact]
+        public void WindowsDesktopRuntimePackIsValid()
+        {
+            using (var tester = NuGetArtifactTester.OpenOrNull(
+                dirs,
+                "Microsoft.WindowsDesktop.App.Runtime",
+                $"Microsoft.WindowsDesktop.App.Runtime.{dirs.BuildRID}"))
+            {
+                if (CurrentRidShouldCreateNupkg)
+                {
+                    Assert.NotNull(tester);
+
+                    tester.IsRuntimePack();
+                }
+                else
+                {
+                    Assert.Null(tester);
+                }
+            }
+        }
+
+        private bool CurrentRidShouldCreateNupkg =>
+            new[]
+            {
+                "win-x64",
+                "win-x86"
+            }.Contains(dirs.BuildRID);
+    }
+}

--- a/src/test/TestUtils/Command.cs
+++ b/src/test/TestUtils/Command.cs
@@ -251,7 +251,7 @@ namespace Microsoft.DotNet.Cli.Build.Framework
         public Command WithUserProfile(string userprofile)
         {
             string userDir;
-            if (RuntimeEnvironment.OperatingSystemPlatform == Platform.Windows)
+            if (InternalAbstractions.RuntimeEnvironment.OperatingSystemPlatform == Platform.Windows)
             {
                 userDir = "USERPROFILE";
             }

--- a/src/test/TestUtils/RepoDirectoriesProvider.cs
+++ b/src/test/TestUtils/RepoDirectoriesProvider.cs
@@ -1,6 +1,9 @@
 using System;
 using System.Collections;
+using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.IO;
+using System.Linq;
 
 namespace Microsoft.DotNet.CoreSetup.Test
 {
@@ -10,13 +13,20 @@ namespace Microsoft.DotNet.CoreSetup.Test
         public string BuildArchitecture { get; }
         public string TargetRID { get; }
         public string MicrosoftNETCoreAppVersion { get; }
+        public string Configuration { get; }
         public string RepoRoot { get; }
+        public string BaseArtifactsFolder { get; }
+        public string BaseBinFolder { get; }
+        public string BaseObjFolder { get; }
         public string Artifacts { get; }
         public string HostArtifacts { get; }
         public string BuiltDotnet { get; }
         public string NugetPackages { get; }
         public string CorehostPackages { get; }
         public string DotnetSDK { get; }
+
+        private string _testContextVariableFilePath { get; }
+        private ImmutableDictionary<string, string> _testContextVariables { get; }
 
         public RepoDirectoriesProvider(
             string repoRoot = null,
@@ -29,34 +39,72 @@ namespace Microsoft.DotNet.CoreSetup.Test
         {
             RepoRoot = repoRoot ?? GetRepoRootDirectory();
 
-            string baseArtifactsFolder = artifacts ?? Path.Combine(RepoRoot, "artifacts");
-            string baseBinFolder = artifacts ?? Path.Combine(baseArtifactsFolder, "bin");
-            string baseObjFolder = artifacts ?? Path.Combine(baseArtifactsFolder, "obj");
+            _testContextVariableFilePath = Path.Combine(
+                Directory.GetCurrentDirectory(),
+                "TestContextVariables.txt");
 
-            TargetRID = Environment.GetEnvironmentVariable("TEST_TARGETRID");
-            BuildRID = Environment.GetEnvironmentVariable("BUILDRID");
-            BuildArchitecture = Environment.GetEnvironmentVariable("BUILD_ARCHITECTURE");
-            MicrosoftNETCoreAppVersion = microsoftNETCoreAppVersion ?? Environment.GetEnvironmentVariable("MNA_VERSION");
+            _testContextVariables = File.ReadAllLines(_testContextVariableFilePath)
+                .ToImmutableDictionary(
+                    line => line.Substring(0, line.IndexOf('=')),
+                    line => line.Substring(line.IndexOf('=') + 1),
+                    StringComparer.OrdinalIgnoreCase);
 
-            string configuration = Environment.GetEnvironmentVariable("BUILD_CONFIGURATION");
-            string osPlatformConfig = $"{BuildRID}.{configuration}";
+            BaseArtifactsFolder = artifacts ?? Path.Combine(RepoRoot, "artifacts");
+            BaseBinFolder = artifacts ?? Path.Combine(BaseArtifactsFolder, "bin");
+            BaseObjFolder = artifacts ?? Path.Combine(BaseArtifactsFolder, "obj");
 
-            DotnetSDK = dotnetSdk ?? Environment.GetEnvironmentVariable("DOTNET_SDK_PATH");
+            TargetRID = GetTestContextVariable("TEST_TARGETRID");
+            BuildRID = GetTestContextVariable("BUILDRID");
+            BuildArchitecture = GetTestContextVariable("BUILD_ARCHITECTURE");
+            MicrosoftNETCoreAppVersion = microsoftNETCoreAppVersion ?? GetTestContextVariable("MNA_VERSION");
+
+            Configuration = GetTestContextVariable("BUILD_CONFIGURATION");
+            string osPlatformConfig = $"{BuildRID}.{Configuration}";
+
+            DotnetSDK = dotnetSdk ?? GetTestContextVariable("DOTNET_SDK_PATH");
 
             if (!Directory.Exists(DotnetSDK))
             {
                 throw new InvalidOperationException("ERROR: Test SDK folder not found.");
             }
 
-            Artifacts = Path.Combine(baseBinFolder, osPlatformConfig);
+            Artifacts = Path.Combine(BaseBinFolder, osPlatformConfig);
             HostArtifacts = artifacts ?? Path.Combine(Artifacts, "corehost");
 
             NugetPackages = nugetPackages ??
-                Environment.GetEnvironmentVariable("NUGET_PACKAGES") ??
+                GetTestContextVariable("NUGET_PACKAGES") ??
                 Path.Combine(RepoRoot, ".packages");
 
             CorehostPackages = corehostPackages ?? Path.Combine(Artifacts, "corehost");
-            BuiltDotnet = builtDotnet ?? Path.Combine(baseObjFolder, osPlatformConfig, "sharedFrameworkPublish");
+            BuiltDotnet = builtDotnet ?? Path.Combine(BaseObjFolder, osPlatformConfig, "sharedFrameworkPublish");
+        }
+
+        public string GetTestContextVariable(string name)
+        {
+            return GetTestContextVariableOrNull(name) ?? throw new ArgumentException(
+                $"Unable to find variable '{name}' in " +
+                $"test context variable file '{_testContextVariableFilePath}'");
+        }
+
+        public string GetTestContextVariableOrNull(string name)
+        {
+            // Allow env var override, although normally the test context variables file is used.
+            // Don't accept NUGET_PACKAGES env override specifically: Arcade sets this and it leaks
+            // in during build.cmd/sh runs, replacing the test-specific dir.
+            if (!name.Equals("NUGET_PACKAGES", StringComparison.OrdinalIgnoreCase))
+            {
+                if (Environment.GetEnvironmentVariable(name) is string envValue)
+                {
+                    return envValue;
+                }
+            }
+
+            if (_testContextVariables.TryGetValue(name, out string value))
+            {
+                return value;
+            }
+
+            return null;
         }
 
         private static string GetRepoRootDirectory()

--- a/src/test/TestUtils/TestArtifact.cs
+++ b/src/test/TestUtils/TestArtifact.cs
@@ -10,20 +10,21 @@ namespace Microsoft.DotNet.CoreSetup.Test
 {
     public class TestArtifact : IDisposable
     {
+        private static readonly Lazy<RepoDirectoriesProvider> _repoDirectoriesProvider =
+            new Lazy<RepoDirectoriesProvider>(() => new RepoDirectoriesProvider());
+
+        private static readonly Lazy<bool> _preserveTestRuns = new Lazy<bool>(() =>
+            _repoDirectoriesProvider.Value.GetTestContextVariableOrNull("PRESERVE_TEST_RUNS") == "1");
+
         private static readonly string TestArtifactDirectoryEnvironmentVariable = "TEST_ARTIFACTS";
         private static readonly Lazy<string> _testArtifactsPath = new Lazy<string>(() =>
         {
-            return Environment.GetEnvironmentVariable(TestArtifactDirectoryEnvironmentVariable)
+            return _repoDirectoriesProvider.Value.GetTestContextVariable(TestArtifactDirectoryEnvironmentVariable)
                    ?? Path.Combine(AppContext.BaseDirectory, TestArtifactDirectoryEnvironmentVariable);
         });
 
-        public static string TestArtifactsPath
-        {
-            get
-            {
-                return _testArtifactsPath.Value;
-            }
-        }
+        public static bool PreserveTestRuns() => _preserveTestRuns.Value;
+        public static string TestArtifactsPath => _testArtifactsPath.Value;
 
         public string Location { get; }
         public string Name { get; }
@@ -64,11 +65,6 @@ namespace Microsoft.DotNet.CoreSetup.Test
             }
 
             _copies.Clear();
-        }
-
-        public static bool PreserveTestRuns()
-        {
-            return Environment.GetEnvironmentVariable("PRESERVE_TEST_RUNS") == "1";
         }
 
         protected static string GetNewTestArtifactPath(string artifactName)

--- a/src/test/TestUtils/TestProjectFixture.cs
+++ b/src/test/TestUtils/TestProjectFixture.cs
@@ -36,9 +36,9 @@ namespace Microsoft.DotNet.CoreSetup.Test
         {
             ValidateRequiredDirectories(repoDirectoriesProvider);
 
-            Framework = framework ?? Environment.GetEnvironmentVariable("MNA_TFM");
-
             RepoDirProvider = repoDirectoriesProvider;
+
+            Framework = framework ?? RepoDirProvider.GetTestContextVariable("MNA_TFM");
 
             SdkDotnet = new DotNetCli(repoDirectoriesProvider.DotnetSDK);
             CurrentRid = repoDirectoriesProvider.TargetRID;


### PR DESCRIPTION
Adds some simple tests for the packages (as final product nupkgs) and fixes platform manifest generation and inclusion. Also:
* Simplifies the way test variables are passed in so I could debug them in VS and remove a workaround, per https://github.com/dotnet/arcade/issues/3077.
* Fix the WindowsDesktop packages building on unexpected platforms. (Was breaking the tests.)
* Disable Arcade's `use_installed_dotnet_cli` and `use_global_nuget_cache` to make the build and dev experience more consistent. This is copied from dotnet/coreclr.