### PR TITLE
[dev/arcade-migration] Remove TODO: Enable BAR publish

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -159,13 +159,12 @@ stages:
       parameters:
         PublishRidAgnosticPackagesFromJobName: Windows_x64
 
-  # TODO: (arcade) Turn BAR publish back on.
-  # - stage: Publish_BAR
-  #   dependsOn: Publish
-  #   jobs:
-  #   # Publish to Build Asset Registry
-  #   - template: /eng/common/templates/job/publish-build-assets.yml
-  #     parameters:
-  #       pool:
-  #         name: NetCoreInternal-Int-Pool
-  #         queue: buildpool.windows.10.amd64.vs2017
+  - stage: Publish_BAR
+    dependsOn: Publish
+    jobs:
+    # Publish to Build Asset Registry
+    - template: /eng/common/templates/job/publish-build-assets.yml
+      parameters:
+        pool:
+          name: NetCoreInternal-Int-Pool
+          queue: buildpool.windows.10.amd64.vs2017


### PR DESCRIPTION
Let official builds publish to BAR, removing a TODO. This prepares a little for the merge back to `master`.

This means my dev branch mock official builds will publish to BAR. This is fine: I've confirmed the manifest that's published contains the dev branch name, like `refs/heads/dev/dagood/sfx-tests`, and channel assignment is only automatic for `refs/heads/master` and `refs/heads/release/3.0` right now.