### PR TITLE
[dev/arcade-migration] Remove TODO: Don't always skip sourcelink: use a targeted fix

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -137,12 +137,7 @@
     <DebugType Condition="'$(DebugType)' == ''">Portable</DebugType>
   </PropertyGroup>
 
-  <!--
-    TODO: (arcade) Enable sourcelink.
-    Always disable sourcelink for now:
-    error MSB4057: The target "InitializeSourceControlInformationFromSourceControlManager" does not exist in the project. [/work/src/corehost/build.proj]
-  -->
-  <PropertyGroup Condition="'$(DisableSourceLink)' == 'true' or true">
+  <PropertyGroup Condition="'$(DisableSourceLink)' == 'true'">
     <EnableSourceLink>false</EnableSourceLink>
     <EnableSourceControlManagerQueries>false</EnableSourceControlManagerQueries>
     <DeterministicSourcePaths>false</DeterministicSourcePaths>

--- a/eng/DisableSourceControlManagement.targets
+++ b/eng/DisableSourceControlManagement.targets
@@ -1,4 +1,9 @@
 <Project>
+
+  <PropertyGroup>
+    <DisableSourceControlManagementTargetsImported>true</DisableSourceControlManagementTargetsImported>
+  </PropertyGroup>
+
   <PropertyGroup>
     <EnableSourceControlManagerQueries>false</EnableSourceControlManagerQueries>
   </PropertyGroup>
@@ -12,4 +17,5 @@
       <SourceRevisionId>unknown</SourceRevisionId>
     </PropertyGroup>
   </Target>
+
 </Project>

--- a/src/corehost/build.proj
+++ b/src/corehost/build.proj
@@ -2,6 +2,13 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), Directory.Build.props))\Directory.Build.props" />
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), Directory.Build.targets))\Directory.Build.targets" />
 
+  <!--
+    Always disable sourcelink in this project so that Arcade doesn't complain about 'The target
+    "InitializeSourceControlInformationFromSourceControlManager" does not exist in the project.'.
+  -->
+  <Import Project="$(RepositoryEngineeringDir)/DisableSourceControlManagement.targets"
+          Condition="'$(DisableSourceControlManagementTargetsImported)' != 'true'" />
+
   <!-- Target that builds dotnet, hostfxr and hostpolicy with the same version as what NetCoreApp will be built for
        since the build produced artifacts should always version the same (even if they may not get used).
   -->


### PR DESCRIPTION
It turns out the errors were all from the corehost project attempting to build repeatedly because MSBuild doesn't cache failed builds. Remove the global disable and only disable sourcelink in that location. It appears to be [possible to get sourcelink working with a VC++ project](https://github.com/dotnet/sourcelink/blob/master/README.md#using-source-link-in-c-projects), but this is not a VC++ project.

Uses a `DisableSourceControlManagementTargetsImported` import guard to easily cooperate with the other import of the targets file in the root `Directory.Build.targets`.