### PR TITLE
Update branding to 5.0

### DIFF
--- a/BranchInfo.props
+++ b/BranchInfo.props
@@ -7,12 +7,12 @@
     <StabilizePackageVersion Condition="'$(StabilizePackageVersion)' == ''">false</StabilizePackageVersion>
 
     <PreReleaseLabel Condition="'$(PackageVersionStamp)' != ''">$(PackageVersionStamp)</PreReleaseLabel>
-    <PreReleaseLabel Condition="'$(PreReleaseLabel)' == ''">preview0</PreReleaseLabel>
+    <PreReleaseLabel Condition="'$(PreReleaseLabel)' == ''">alpha1</PreReleaseLabel>
     <IncludePreReleaseLabelInPackageVersion Condition="'$(StabilizePackageVersion)' != 'true' or '$(PackageVersionStamp)' != ''">true</IncludePreReleaseLabelInPackageVersion>
     <IncludeBuildNumberInPackageVersion Condition="'$(StabilizePackageVersion)' != 'true'">true</IncludeBuildNumberInPackageVersion>
 
     <ReleaseSuffix>$(PreReleaseLabel)</ReleaseSuffix>
-    <ReleaseBrandSuffix>Preview 0</ReleaseBrandSuffix>
+    <ReleaseBrandSuffix>Alpha 1</ReleaseBrandSuffix>
     <Channel>master</Channel>
     <ContainerName>dotnet</ContainerName>
     <ChecksumContainerName>$(ContainerName)</ChecksumContainerName>

--- a/BranchInfo.props
+++ b/BranchInfo.props
@@ -1,18 +1,18 @@
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <MajorVersion>3</MajorVersion>
+    <MajorVersion>5</MajorVersion>
     <MinorVersion>0</MinorVersion>
     <PatchVersion>0</PatchVersion>
 
     <StabilizePackageVersion Condition="'$(StabilizePackageVersion)' == ''">false</StabilizePackageVersion>
 
     <PreReleaseLabel Condition="'$(PackageVersionStamp)' != ''">$(PackageVersionStamp)</PreReleaseLabel>
-    <PreReleaseLabel Condition="'$(PreReleaseLabel)' == ''">preview8</PreReleaseLabel>
+    <PreReleaseLabel Condition="'$(PreReleaseLabel)' == ''">preview0</PreReleaseLabel>
     <IncludePreReleaseLabelInPackageVersion Condition="'$(StabilizePackageVersion)' != 'true' or '$(PackageVersionStamp)' != ''">true</IncludePreReleaseLabelInPackageVersion>
     <IncludeBuildNumberInPackageVersion Condition="'$(StabilizePackageVersion)' != 'true'">true</IncludeBuildNumberInPackageVersion>
 
     <ReleaseSuffix>$(PreReleaseLabel)</ReleaseSuffix>
-    <ReleaseBrandSuffix>Preview 8</ReleaseBrandSuffix>
+    <ReleaseBrandSuffix>Preview 0</ReleaseBrandSuffix>
     <Channel>master</Channel>
     <ContainerName>dotnet</ContainerName>
     <ChecksumContainerName>$(ContainerName)</ChecksumContainerName>

--- a/dir.props
+++ b/dir.props
@@ -73,9 +73,20 @@
 
   <!-- Versioning -->
   <PropertyGroup>
+    <BuildNumberMinorTrimmedLeadingZero>$(BuildNumberMinor.TrimStart('0'))</BuildNumberMinorTrimmedLeadingZero>
+    <BuildNumberMinorTrimmedLeadingZero Condition="'$(BuildNumberMinorTrimmedLeadingZero)' == ''">0</BuildNumberMinorTrimmedLeadingZero>
+
     <VersionSuffix></VersionSuffix>
     <VersionSuffix Condition="'$(IncludePreReleaseLabelInPackageVersion)' == 'true'">$(PreReleaseLabel)</VersionSuffix>
-    <VersionSuffix Condition="'$(IncludeBuildNumberInPackageVersion)' == 'true'">$(VersionSuffix)-$(BuildNumberMajor)-$(BuildNumberMinor)</VersionSuffix>
+    <VersionSuffix Condition="'$(IncludeBuildNumberInPackageVersion)' == 'true'">$(VersionSuffix).$(BuildNumberMajor).$(BuildNumberMinorTrimmedLeadingZero)</VersionSuffix>
+    <!--
+      During BuildTools init, VersionSuffix is used even though the build numbers aren't
+      initialized. With SemVer v1, this is benign: dash-dash-zero at the end is valid. (It has not
+      been confirmed that this is the exact version.) With SemVer v2, we get '..0' at the end. The
+      periods make the version invalid, and fails the build. To work around this, replace '..0' at
+      the end of the suffix with nothingness to avoid making an invalid version.
+    -->
+    <VersionSuffix>$(VersionSuffix.Replace('..0', ''))</VersionSuffix>
 
     <ProductVersionSuffix Condition="'$(IncludePreReleaseLabelInPackageVersion)' == 'true'">-$(VersionSuffix)</ProductVersionSuffix>
     <ProductBandVersion Condition="'$(ProductBandVersion)' == ''">$(MajorVersion).$(MinorVersion)</ProductBandVersion>

--- a/src/managed/CommonManaged.props
+++ b/src/managed/CommonManaged.props
@@ -16,6 +16,8 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <!-- Managed API isn't completely documented yet. TODO: https://github.com/dotnet/core-setup/issues/5108 -->
     <NoWarn>$(NoWarn);CS1591</NoWarn>
+    <!-- Allow SemVer v2 -->
+    <NoWarn>$(NoWarn);NU5105</NoWarn>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/test/Assets/TestProjects/AppWithSubDirs/AppWithSubDirs.csproj
+++ b/src/test/Assets/TestProjects/AppWithSubDirs/AppWithSubDirs.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>$(NETCoreAppFramework)</TargetFramework>
     <OutputType>Exe</OutputType>
     <RuntimeIdentifier>$(TestTargetRid)</RuntimeIdentifier>
     <RuntimeFrameworkVersion>$(MNAVersion)</RuntimeFrameworkVersion>

--- a/tools-local/setuptools/dotnet-deb-tool/dotnet-deb-tool.csproj
+++ b/tools-local/setuptools/dotnet-deb-tool/dotnet-deb-tool.csproj
@@ -6,6 +6,8 @@
     <AssemblyName>dotnet-deb-tool</AssemblyName>
     <OutputType>Exe</OutputType>
     <PackageId>dotnet-deb-tool</PackageId>
+    <!-- Allow SemVer v2 -->
+    <NoWarn>$(NoWarn);NU5105</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Update branding in master to 5.0 - please don't merge before noon on 7/16. 

CC @dagood - we should think about what we might want/need to do to get semver2 in Core-Setup before it's "too late" - https://github.com/dotnet/core-setup/issues/6825