### PR TITLE
Use SemVer v2 versioning

### DIFF
--- a/dir.props
+++ b/dir.props
@@ -79,6 +79,14 @@
     <VersionSuffix></VersionSuffix>
     <VersionSuffix Condition="'$(IncludePreReleaseLabelInPackageVersion)' == 'true'">$(PreReleaseLabel)</VersionSuffix>
     <VersionSuffix Condition="'$(IncludeBuildNumberInPackageVersion)' == 'true'">$(VersionSuffix).$(BuildNumberMajor).$(BuildNumberMinorTrimmedLeadingZero)</VersionSuffix>
+    <!--
+      During BuildTools init, VersionSuffix is used even though the build numbers aren't
+      initialized. With SemVer v1, this is benign: dash-dash-zero at the end is valid. (It has not
+      been confirmed that this is the exact version.) With SemVer v2, we get '..0' at the end. The
+      periods make the version invalid, and fails the build. To work around this, replace '..0' at
+      the end of the suffix with nothingness to avoid making an invalid version.
+    -->
+    <VersionSuffix>$(VersionSuffix.Replace('..0', ''))</VersionSuffix>
 
     <ProductVersionSuffix Condition="'$(IncludePreReleaseLabelInPackageVersion)' == 'true'">-$(VersionSuffix)</ProductVersionSuffix>
     <ProductBandVersion Condition="'$(ProductBandVersion)' == ''">$(MajorVersion).$(MinorVersion)</ProductBandVersion>

--- a/dir.props
+++ b/dir.props
@@ -73,9 +73,12 @@
 
   <!-- Versioning -->
   <PropertyGroup>
+    <BuildNumberMinorTrimmedLeadingZero>$(BuildNumberMinor.TrimStart('0'))</BuildNumberMinorTrimmedLeadingZero>
+    <BuildNumberMinorTrimmedLeadingZero Condition="'$(BuildNumberMinorTrimmedLeadingZero)' == ''">0</BuildNumberMinorTrimmedLeadingZero>
+
     <VersionSuffix></VersionSuffix>
     <VersionSuffix Condition="'$(IncludePreReleaseLabelInPackageVersion)' == 'true'">$(PreReleaseLabel)</VersionSuffix>
-    <VersionSuffix Condition="'$(IncludeBuildNumberInPackageVersion)' == 'true'">$(VersionSuffix)-$(BuildNumberMajor)-$(BuildNumberMinor)</VersionSuffix>
+    <VersionSuffix Condition="'$(IncludeBuildNumberInPackageVersion)' == 'true'">$(VersionSuffix).$(BuildNumberMajor).$(BuildNumberMinorTrimmedLeadingZero)</VersionSuffix>
 
     <ProductVersionSuffix Condition="'$(IncludePreReleaseLabelInPackageVersion)' == 'true'">-$(VersionSuffix)</ProductVersionSuffix>
     <ProductBandVersion Condition="'$(ProductBandVersion)' == ''">$(MajorVersion).$(MinorVersion)</ProductBandVersion>

--- a/src/managed/CommonManaged.props
+++ b/src/managed/CommonManaged.props
@@ -16,6 +16,8 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <!-- Managed API isn't completely documented yet. TODO: https://github.com/dotnet/core-setup/issues/5108 -->
     <NoWarn>$(NoWarn);CS1591</NoWarn>
+    <!-- Allow SemVer v2 -->
+    <NoWarn>$(NoWarn);NU5105</NoWarn>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
This is an attempt to create SemVer v2 artifacts using BuildTools. We want this for 5.0.0-... builds to avoid getting locked into SemVer v1. (Discussion at https://github.com/dotnet/core-setup/issues/6825.)