### PR TITLE
[dev/arcade-migration] Fix regressions found in MSI diff

### DIFF
--- a/src/pkg/Directory.Build.targets
+++ b/src/pkg/Directory.Build.targets
@@ -111,7 +111,8 @@
   <Target Name="GenerateMsiVersionString">
     <PropertyGroup>
       <VersionPadding Condition="'$(VersionPadding)'==''">5</VersionPadding>
-      <VersionComparisonDate>2016-01-01</VersionComparisonDate>
+      <!-- Using the following default comparison date will produce versions that align with our internal build system. -->
+      <VersionComparisonDate Condition="'$(VersionComparisonDate)'==''">1996-04-01</VersionComparisonDate>
     </PropertyGroup>
 
     <GenerateCurrentVersion

--- a/src/pkg/packaging-tools/packaging-tools.props
+++ b/src/pkg/packaging-tools/packaging-tools.props
@@ -43,7 +43,6 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(FrameworkPackType)' != ''">
-    <Version>$(ProductVersion)</Version>
     <PackageType>DotnetPlatform</PackageType>
 
     <!--
@@ -68,7 +67,6 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(IsFrameworkPackage)' == 'true'">
-    <Version>$(ProductVersion)</Version>
     <OmitDependencies>true</OmitDependencies>
     <SkipValidatePackage>true</SkipValidatePackage>
   </PropertyGroup>

--- a/src/pkg/packaging-tools/packaging-tools.targets
+++ b/src/pkg/packaging-tools/packaging-tools.targets
@@ -51,6 +51,10 @@
       <WixProductMoniker>$(SharedFrameworkBrandName)</WixProductMoniker>
     </PropertyGroup>
 
+    <Error
+      Text="InstallerName starts with a '-': missing ShortFrameworkName value."
+      Condition="$(InstallerName.StartsWith('-'))" />
+
     <PropertyGroup>
       <MacOSComponentName>com.microsoft.$(ShortFrameworkName).pack.$(FrameworkPackType).$(ProductVersion).component.osx.x64</MacOSComponentName>
       <MacOSSharedInstallDir>/usr/local/share/dotnet</MacOSSharedInstallDir>

--- a/src/pkg/projects/Directory.Build.targets
+++ b/src/pkg/projects/Directory.Build.targets
@@ -43,6 +43,21 @@
     </PropertyGroup>
   </Target>
 
+  <Target Name="SetTargetBasedPackageVersion"
+          Condition="'$(VersionProp)' == ''"
+          BeforeTargets="GenerateNuSpec"
+          DependsOnTargets="GetProductVersions">
+    <PropertyGroup>
+      <Version>$(ProductVersion)</Version>
+      <!--
+        PackageVersion is normally calculated using Version during static property evaluation, but
+        we need some info from GetProductVersions, so it's too late to rely on that. We need to set
+        both in target evaluation, here.
+      -->
+      <PackageVersion>$(ProductVersion)</PackageVersion>
+    </PropertyGroup>
+  </Target>
+
   <!--
     Remove duplicate files returned by restore. The resolve task performs extra detection to pick up
     a PDB file for any file listed in the assets file. This causes duplicates if the assets file

--- a/src/pkg/projects/netcoreapp/Directory.Build.props
+++ b/src/pkg/projects/netcoreapp/Directory.Build.props
@@ -1,0 +1,8 @@
+<Project>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory).., Directory.Build.props))\Directory.Build.props" />
+
+  <PropertyGroup>
+    <ShortFrameworkName>dotnet</ShortFrameworkName>
+  </PropertyGroup>
+
+</Project>

--- a/src/pkg/projects/netcoreapp/pkg/Directory.Build.props
+++ b/src/pkg/projects/netcoreapp/pkg/Directory.Build.props
@@ -1,7 +1,6 @@
 <Project>
   <PropertyGroup>
     <IsFrameworkPackage>true</IsFrameworkPackage>
-    <ShortFrameworkName>dotnet</ShortFrameworkName>
   </PropertyGroup>
 
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory).., Directory.Build.props))\Directory.Build.props" />

--- a/src/pkg/projects/windowsdesktop/Directory.Build.props
+++ b/src/pkg/projects/windowsdesktop/Directory.Build.props
@@ -1,6 +1,5 @@
 <Project>
   <PropertyGroup>
-    <ShortFrameworkName>windowsdesktop</ShortFrameworkName>
     <ProductBrandPrefix>Microsoft Windows Desktop</ProductBrandPrefix>
 
     <RIDPropsFile>$(MSBuildThisFileDirectory)windowsdesktopRIDs.props</RIDPropsFile>
@@ -9,6 +8,8 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory).., Directory.Build.props))\Directory.Build.props" />
 
   <PropertyGroup>
+    <ShortFrameworkName>windowsdesktop</ShortFrameworkName>
+
     <FrameworkPackageName>Microsoft.WindowsDesktop.App</FrameworkPackageName>
 
     <!--

--- a/src/test/Microsoft.DotNet.CoreSetup.Packaging.Tests/NETStandardTests.cs
+++ b/src/test/Microsoft.DotNet.CoreSetup.Packaging.Tests/NETStandardTests.cs
@@ -22,6 +22,14 @@ namespace Microsoft.DotNet.CoreSetup.Packaging.Tests
                     "data/FrameworkList.xml");
 
                 tester.IsTargetingPack();
+
+                // Most artifacts in the repo use the global Major.Minor, this package doesn't. Test
+                // this to make sure infra doesn't regress and cause netstandard to lose its special
+                // 2.1 version. The versioning difference is because netstandard targeting pack
+                // creation doesn't actually belong in Core-Setup: https://github.com/dotnet/standard/issues/1209
+                Assert.Equal(
+                    (2, 1),
+                    (tester.PackageVersion.Major, tester.PackageVersion.Minor));
             }
         }
     }

--- a/src/test/Microsoft.DotNet.CoreSetup.Packaging.Tests/NuGetArtifactTester.cs
+++ b/src/test/Microsoft.DotNet.CoreSetup.Packaging.Tests/NuGetArtifactTester.cs
@@ -5,6 +5,7 @@
 using Microsoft.DotNet.CoreSetup.Test;
 using NuGet.Packaging;
 using NuGet.Packaging.Core;
+using NuGet.Versioning;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -61,11 +62,14 @@ namespace Microsoft.DotNet.CoreSetup.Packaging.Tests
             return new NuGetArtifactTester(nupkgPath);
         }
 
+        public NuGetVersion PackageVersion { get; }
+
         private readonly PackageArchiveReader _reader;
 
         public NuGetArtifactTester(string file)
         {
             _reader = new PackageArchiveReader(ZipFile.Open(file, ZipArchiveMode.Read));
+            PackageVersion = _reader.NuspecReader.GetVersion();
         }
 
         public void Dispose()


### PR DESCRIPTION
Fixes issues I found while diffing `dark` outputs on MSIs: https://github.com/dotnet/core-setup/issues/7212.

This fixes a general issue with `NETStandard.Library.Ref` artifacts (including nupkgs) having 3.0 rather than 2.1 versions. Added a regression test.