### PR TITLE
[dev/arcade-migration] Introduce GetFilesToPackage cache

### DIFF
--- a/src/pkg/packaging-tools/framework.dependency.targets
+++ b/src/pkg/packaging-tools/framework.dependency.targets
@@ -3,6 +3,9 @@
     Shared targets specific to dependency projects (depproj).
   -->
 
+  <UsingTask TaskName="LoadItems" AssemblyFile="$(LocalBuildToolsTaskFile)" />
+  <UsingTask TaskName="SaveItems" AssemblyFile="$(ArcadeSdkBuildTasksAssembly)" />
+
   <!-- Fetches all the file items from the packages that we want to redist -->
   <Target Name="GetFilesFromPackages">
     <ItemGroup>
@@ -48,8 +51,28 @@
     </ItemGroup>
   </Target>
 
-  <Target Name="GetFilesToPackage"
+  <PropertyGroup>
+    <FilesToPackageCache>$(IntermediateOutputPath)FilesToPackage.RIDless.cache.props</FilesToPackageCache>
+    <FilesToPackageCache Condition="'$(PackageTargetRuntime)' != ''">$(IntermediateOutputPath)FilesToPackage.$(PackageTargetRuntime).cache.props</FilesToPackageCache>
+  </PropertyGroup>
+
+  <Target Name="GetFilesToPackageAndPopulateCache"
           DependsOnTargets="ResolveReferences;GetFilesFromPackages"
+          Returns="@(FilesToPackage)">
+    <SaveItems
+      ItemName="FilesToPackage"
+      Items="@(FilesToPackage)"
+      File="$(FilesToPackageCache)" />
+  </Target>
+
+  <Target Name="ReadFilesToPackageCache">
+    <LoadItems File="$(FilesToPackageCache)">
+      <Output TaskParameter="Items" ItemName="FilesToPackage" />
+    </LoadItems>
+  </Target>
+
+  <Target Name="GetFilesToPackage"
+          DependsOnTargets="ReadFilesToPackageCache"
           Returns="@(FilesToPackage)" />
 
   <Target Name="GetDependenciesToPackage"
@@ -130,7 +153,7 @@
     </ItemGroup>
 
     <MSBuild Projects="@(RidSpecificGetPackageFilesProject)"
-             Targets="GetFilesToPackage">
+             Targets="GetFilesToPackageAndPopulateCache">
       <Output TaskParameter="TargetOutputs" ItemName="SharedFrameworkRuntimeFiles" />
     </MSBuild>
 
@@ -425,7 +448,7 @@
   </Target>
 
   <Target Name="GetRuntimeFilesToPackage"
-          BeforeTargets="GetFilesToPackage"
+          BeforeTargets="GetFilesToPackageAndPopulateCache"
           DependsOnTargets="PrepareForCrossGen;GetCrossGenSymbolsFiles" />
 
   <Target Name="GetReferenceFilenames"
@@ -441,7 +464,7 @@
 
   <Target Name="BuildDepprojArtifacts"
           DependsOnTargets="
-            GetFilesToPackage;
+            GetFilesToPackageAndPopulateCache;
             CrossGen;
             GenerateHashVersionsFile;
             GenerateFileVersionProps"

--- a/tools-local/tasks/Arcade/LoadItems.cs
+++ b/tools-local/tasks/Arcade/LoadItems.cs
@@ -1,0 +1,46 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using Microsoft.Build.Construction;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+using System.Linq;
+
+namespace Microsoft.DotNet.Arcade.Sdk
+{
+    /// <summary>
+    /// This task reads msbuild Items with their metadata from a props file. Useful when SaveItems
+    /// has been used to persist some items to disk, but it's inconvenient to load them statically.
+    /// </summary>
+    public class LoadItems : Task
+    {
+        [Required]
+        public string File { get; set; }
+
+        /// <summary>
+        /// Item name (type) to read. If not set, all items are read.
+        /// </summary>
+        public string ItemName { get; set; }
+
+        [Output]
+        public ITaskItem[] Items { get; set; }
+
+        public override bool Execute()
+        {
+            var project = ProjectRootElement.Open(File);
+
+            Items = project.Items
+                .Where(i =>
+                    string.IsNullOrEmpty(ItemName) ||
+                    i.ItemType.Equals(ItemName, StringComparison.OrdinalIgnoreCase))
+                .Select(i => new TaskItem(
+                    i.Include,
+                    i.Metadata.ToDictionary(m => m.Name, m => m.Value)))
+                .ToArray();
+            
+            return !Log.HasLoggedErrors;
+        }
+    }
+}

--- a/tools-local/tasks/core-setup.tasks.csproj
+++ b/tools-local/tasks/core-setup.tasks.csproj
@@ -12,6 +12,7 @@
   <ItemGroup>
     <Compile Include="*.cs" />
     <Compile Include="BuildTools.Publish\**\*.cs" />
+    <Compile Include="Arcade\**\*.cs" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Generating the cache once in Build then using it multiple times in parallel strictly afterwords is simple and safe.

Previously, we would call ResolvePackageAssets multiple times in parallel, which may not be as safe. It has failed before, but unfortunately only on CI machines, and very rarely. (https://github.com/dotnet/core-setup/issues/7128. It only happened then, and one other time.)

---

I'm creating this draft PR to link it to https://github.com/dotnet/core-setup/issues/7128 in a way that makes it very easy to find these changes again. I'm not sure I want to do this without good reason: it adds complexity.