### PR TITLE
Remove macOS pkg signing: fails in real-sign mode

### DIFF
--- a/eng/Signing.props
+++ b/eng/Signing.props
@@ -50,7 +50,6 @@
     <DownloadedSymbolPackages Include="$(DownloadDirectory)**\*.symbols.nupkg" />
     <ItemsToSign Include="$(DownloadDirectory)**\*.nupkg" Exclude="@(DownloadedSymbolPackages)" />
 
-    <ItemsToSign Include="$(DownloadDirectory)**\*.pkg" />
     <ItemsToSign Include="$(DownloadDirectory)**\*.deb" />
     <ItemsToSign Include="$(DownloadDirectory)**\*.rpm" />
   </ItemGroup>


### PR DESCRIPTION
Fixes a build break. macOS pkg signing works (at least, doesn't fail) in test signing mode, but not with real signing. This PR disables it: the change was only included in the Arcade SDK migration work because it seemed to work fine, it is not required. Further effort will be tracked by #7018.