### PR TITLE
[release/3.0] Remove macOS pkg signing: fails in real-sign mode

### DIFF
--- a/eng/Signing.props
+++ b/eng/Signing.props
@@ -50,7 +50,6 @@
     <DownloadedSymbolPackages Include="$(DownloadDirectory)**\*.symbols.nupkg" />
     <ItemsToSign Include="$(DownloadDirectory)**\*.nupkg" Exclude="@(DownloadedSymbolPackages)" />
 
-    <ItemsToSign Include="$(DownloadDirectory)**\*.pkg" />
     <ItemsToSign Include="$(DownloadDirectory)**\*.deb" />
     <ItemsToSign Include="$(DownloadDirectory)**\*.rpm" />
   </ItemGroup>


### PR DESCRIPTION
Ports official build break fix https://github.com/dotnet/core-setup/pull/7306 to `release/3.0`.

Cherry picked from commit 250a92e29b95e263e24ab416fdac24245111a35b

