### PR TITLE
Incorporate source-build patch: Disable overriding CentOS as RHEL

### DIFF
--- a/src/corehost/build.sh
+++ b/src/corehost/build.sh
@@ -21,9 +21,6 @@ init_rid_plat()
         __rid_plat=""
         if [ -e /etc/os-release ]; then
             source /etc/os-release
-            if [[ "$ID" == "centos" ]]; then
-                ID="rhel"
-            fi
             if [[ "$ID" == "rhel" ]]; then
                 # remove the last version number
                 VERSION_ID=${VERSION_ID%.*}


### PR DESCRIPTION
Needed for https://github.com/dotnet/core-setup/issues/6762, everything else no longer applies after the Arcade SDK migration.