### PR TITLE
Remove DiaSymReader prebuilt in source-build

### DIFF
--- a/src/pkg/packaging-tools/framework.dependency.targets
+++ b/src/pkg/packaging-tools/framework.dependency.targets
@@ -168,8 +168,13 @@
     <ItemGroup>
       <CrossgenToolPackageReference Include="Microsoft.Private.CoreFx.NETCoreApp" Version="$(MicrosoftPrivateCoreFxNETCoreAppPackageVersion)" />
       <CrossgenToolPackageReference Include="transport.Microsoft.NETCore.Runtime.CoreCLR" Version="$(MicrosoftNETCoreRuntimeCoreCLRPackageVersion)" />
-      <CrossgenToolPackageReference Include="Microsoft.DiaSymReader.Native" Version="$(MicrosoftDiaSymReaderNativePackageVersion)" />
       <CrossgenToolPackageReference Include="$(MicrosoftTargetingPackPrivateWinRTPackage)" Version="$(MicrosoftTargetingPackPrivateWinRTPackageVersion)" />
+
+      <!-- This tool is a prebuilt not buildable from source. -->
+      <CrossgenToolPackageReference
+        Condition="'$(DotNetBuildFromSource)' != 'true'"
+        Include="Microsoft.DiaSymReader.Native"
+        Version="$(MicrosoftDiaSymReaderNativePackageVersion)" />
 
       <!--
         If any tool packages are missing, add them with ExcludeAssets=All. Be careful not to modify
@@ -249,6 +254,14 @@
 
     <PropertyGroup Condition="'@(_diaSymReaderAssembly)' != ''">
       <_diaSymReaderToolDir>%(_diaSymReaderAssembly.RootDir)%(_diaSymReaderAssembly.Directory)</_diaSymReaderToolDir>
+    </PropertyGroup>
+
+    <!--
+      DiaSymReader can't be built from source, so use an unrelated default directory in that case.
+      This is used as the working directory for crossgen calls.
+    -->
+    <PropertyGroup Condition="'$(DotNetBuildFromSource)' == 'true'">
+      <_diaSymReaderToolDir>$(IntermediateOutputPath)</_diaSymReaderToolDir>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/pkg/projects/netcoreapp/src/netcoreapp.depproj
+++ b/src/pkg/projects/netcoreapp/src/netcoreapp.depproj
@@ -7,10 +7,14 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Private.CoreFx.NETCoreApp" Version="$(MicrosoftPrivateCoreFxNETCoreAppPackageVersion)" />
     <PackageReference Include="transport.Microsoft.NETCore.Runtime.CoreCLR" Version="$(MicrosoftNETCoreRuntimeCoreCLRPackageVersion)" />
-    <PackageReference Include="Microsoft.DiaSymReader.Native" Version="$(MicrosoftDiaSymReaderNativePackageVersion)" />
     <PackageReference Include="Microsoft.NETCore.Platforms" Version="$(MicrosoftNETCorePlatformsPackageVersion)" />
     <PackageReference Include="Microsoft.NETCore.Targets" Version="$(MicrosoftNETCoreTargetsPackageVersion)" />
     <PackageReference Include="NETStandard.Library" Version="$(NETStandardLibraryPackageVersion)" />
+  </ItemGroup>
+
+  <!-- This tool is a prebuilt not buildable from source. -->
+  <ItemGroup Condition="'$(DotNetBuildFromSource)' != 'true'">
+    <PackageReference Include="Microsoft.DiaSymReader.Native" Version="$(MicrosoftDiaSymReaderNativePackageVersion)" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(PackageTargetRuntime)' == ''">


### PR DESCRIPTION
For https://github.com/dotnet/core-setup/issues/5297. I didn't realize when I wrote the issue that diasymreader is used for crossgen. This change may make Core-Setup not build from source on Windows.

A fresh `./build.sh /p:DotNetBuildFromSource=true` does still work on Linux after this change, and doesn't pull down the prebuilt.