### PR TITLE
Fix platform manifest package id column, include in runtime pack

### DIFF
--- a/src/pkg/packaging-tools/packaging-tools.props
+++ b/src/pkg/packaging-tools/packaging-tools.props
@@ -23,8 +23,11 @@
     <FrameworkPackType>runtime</FrameworkPackType>
     <BuildRidSpecificPacks>true</BuildRidSpecificPacks>
 
-    <!-- Include a list of runtime files in the data dir. -->
+    <!-- Create a list of runtime files in the data dir using framework list infra. -->
     <FrameworkListFilename>RuntimeList.xml</FrameworkListFilename>
+
+    <!-- Include manifests in the data dir. -->
+    <PlatformManifestTargetPath>data/PlatformManifest.txt</PlatformManifestTargetPath>
     <FrameworkListTargetPath>data/</FrameworkListTargetPath>
   </PropertyGroup>
 

--- a/src/pkg/projects/Directory.Build.targets
+++ b/src/pkg/projects/Directory.Build.targets
@@ -262,10 +262,29 @@
   <Target Name="IncludePlatformManifestFile"
           DependsOnTargets="GetDepprojDependencyDataFiles;GetDependencyDataFileInclusionDefaults"
           BeforeTargets="GetFiles">
-    <ItemGroup Condition="'$(PackageTargetRuntime)' == '' AND '$(PlatformManifestTargetPath)' != ''">
+    <!-- Create a copy with some per-pkgproj templates replaced. -->
+    <PropertyGroup>
+      <_platformManifestFileTemplateFile Condition="'%(_depprojDataFile.PlatformManifestFile)' == 'true'">%(_depprojDataFile.Identity)</_platformManifestFileTemplateFile>
+    </PropertyGroup>
+
+    <PropertyGroup Condition="Exists('$(_platformManifestFileTemplateFile)')">
+      <_runtimeDependencyItems>@(RuntimeDependency)</_runtimeDependencyItems>
+      <_filledPlatformManifestFileContent>$([System.IO.File]::ReadAllText('$(_platformManifestFileTemplateFile)')
+        .Replace("__PackageId__", "$(Id)"))
+      </_filledPlatformManifestFileContent>
+
+      <_filledPlatformManifestFile>$(IntermediateOutputPath)PlatformManifest.txt</_filledPlatformManifestFile>
+    </PropertyGroup>
+
+    <WriteLinesToFile
+      Condition="'$(_filledPlatformManifestFile)' != ''"
+      File="$(_filledPlatformManifestFile)"
+      Lines="$(_filledPlatformManifestFileContent)"
+      Overwrite="true" />
+
+    <ItemGroup Condition="'$(PlatformManifestTargetPath)' != ''">
       <File
-        Include="@(_depprojDataFile)"
-        Condition="'%(_depprojDataFile.PlatformManifestFile)' == 'true'"
+        Include="$(_filledPlatformManifestFile)"
         TargetPath="$(PlatformManifestTargetPath)" />
     </ItemGroup>
   </Target>

--- a/src/test/Microsoft.DotNet.CoreSetup.Packaging.Tests/NETCoreTests.cs
+++ b/src/test/Microsoft.DotNet.CoreSetup.Packaging.Tests/NETCoreTests.cs
@@ -18,12 +18,7 @@ namespace Microsoft.DotNet.CoreSetup.Packaging.Tests
                 dirs,
                 "Microsoft.NETCore.App.Ref"))
             {
-                tester.HasOnlyTheseDataFiles(
-                    "data/FrameworkList.xml",
-                    "data/PlatformManifest.txt");
-
-                tester.IsTargetingPack();
-                tester.HasGoodPlatformManifest();
+                tester.IsTargetingPackForPlatform();
             }
         }
 

--- a/src/test/Microsoft.DotNet.CoreSetup.Packaging.Tests/NuGetArtifactTester.cs
+++ b/src/test/Microsoft.DotNet.CoreSetup.Packaging.Tests/NuGetArtifactTester.cs
@@ -62,6 +62,7 @@ namespace Microsoft.DotNet.CoreSetup.Packaging.Tests
             return new NuGetArtifactTester(nupkgPath);
         }
 
+        public PackageIdentity Identity { get; }
         public NuGetVersion PackageVersion { get; }
 
         private readonly PackageArchiveReader _reader;
@@ -69,6 +70,7 @@ namespace Microsoft.DotNet.CoreSetup.Packaging.Tests
         public NuGetArtifactTester(string file)
         {
             _reader = new PackageArchiveReader(ZipFile.Open(file, ZipArchiveMode.Read));
+            Identity = _reader.NuspecReader.GetIdentity();
             PackageVersion = _reader.NuspecReader.GetVersion();
         }
 
@@ -88,6 +90,17 @@ namespace Microsoft.DotNet.CoreSetup.Packaging.Tests
             ContainsFrameworkList("FrameworkList.xml");
         }
 
+        public void IsTargetingPackForPlatform()
+        {
+            IsFrameworkPack();
+
+            HasOnlyTheseDataFiles(
+                "data/FrameworkList.xml",
+                "data/PlatformManifest.txt");
+
+            HasGoodPlatformManifest();
+        }
+
         public void IsAppHostPack()
         {
             IsRuntimeSpecificPack();
@@ -97,7 +110,11 @@ namespace Microsoft.DotNet.CoreSetup.Packaging.Tests
         {
             IsRuntimeSpecificPack();
 
-            HasOnlyTheseDataFiles("data/RuntimeList.xml");
+            HasOnlyTheseDataFiles(
+                "data/RuntimeList.xml",
+                "data/PlatformManifest.txt");
+
+            HasGoodPlatformManifest();
 
             ContainsFrameworkList("RuntimeList.xml");
         }
@@ -120,6 +137,18 @@ namespace Microsoft.DotNet.CoreSetup.Packaging.Tests
 
             // Sanity: check if the manifest has some content.
             Assert.Contains(".dll", platformManifestContent);
+
+            // Check that the lines contain the package ID where they're supposed to.
+            foreach (var parts in platformManifestContent
+                .Split('\r', '\n')
+                .Select(line => line.Split("|"))
+                .Where(parts => parts.Length > 1))
+            {
+                Assert.True(
+                    parts[1] == Identity.Id,
+                    $"Platform manifest package id column '{parts[1]}' doesn't match " +
+                        $"actual package id '{Identity.Id}'");
+            }
         }
 
         private void IsFrameworkPack()

--- a/src/test/Microsoft.DotNet.CoreSetup.Packaging.Tests/WindowsDesktopTests.cs
+++ b/src/test/Microsoft.DotNet.CoreSetup.Packaging.Tests/WindowsDesktopTests.cs
@@ -25,12 +25,7 @@ namespace Microsoft.DotNet.CoreSetup.Packaging.Tests
                 {
                     Assert.NotNull(tester);
 
-                    tester.HasOnlyTheseDataFiles(
-                        "data/FrameworkList.xml",
-                        "data/PlatformManifest.txt");
-
-                    tester.IsTargetingPack();
-                    tester.HasGoodPlatformManifest();
+                    tester.IsTargetingPackForPlatform();
                 }
                 else
                 {


### PR DESCRIPTION
Fixes `__PackageId__` placeholder appearing in outputs. Added test to ensure this doesn't happen.

Example:
```diff
-libcoreclr.so|__PackageId__||0.0.0.0
+libcoreclr.so|Microsoft.NETCore.App.Runtime.win-x64||0.0.0.0
```

Also adds platform manifest to runtime packs. (https://github.com/dotnet/core-setup/issues/6509.)

/cc @dsplaisted @nguerrera