### PR TITLE
Fix up the set of Windows compatibility libraries exposed in WindowsDesktop

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -121,6 +121,19 @@
       <Uri>https://dev.azure.com/dnceng/internal/_git/dotnet-wpf-int</Uri>
       <Sha>f5533f92b506e2892187d77272f25ad343c4e489</Sha>
     </Dependency>
+    <!-- TODO: Sort these into the above. These are out of the way at the moment to make it easier to resolve conflicts. -->
+    <Dependency Name="System.IO.FileSystem.AccessControl" Version="5.0.0-alpha1.19372.3">
+      <Uri>https://github.com/dotnet/corefx</Uri>
+      <Sha>3c3b9ceee6e1416db6f1ddbc1ab0d0ffb67c16fa</Sha>
+    </Dependency>
+    <Dependency Name="System.Diagnostics.PerformanceCounter" Version="5.0.0-alpha1.19372.3">
+      <Uri>https://github.com/dotnet/corefx</Uri>
+      <Sha>3c3b9ceee6e1416db6f1ddbc1ab0d0ffb67c16fa</Sha>
+    </Dependency>
+    <Dependency Name="System.IO.Pipes.AccessControl" Version="4.5.1">
+      <Uri>https://github.com/dotnet/corefx</Uri>
+      <Sha>7ee84596d92e178bce54c986df31ccc52479e772 </Sha>
+    </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>
     <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="1.0.0-beta.19369.2">

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -88,6 +88,10 @@
     <MicrosoftDiaSymReaderNativePackageVersion>1.7.0</MicrosoftDiaSymReaderNativePackageVersion>
     <!-- Infrastructure and test-only. -->
     <MicrosoftSourceLinkVersion>1.0.0-beta2-18618-05</MicrosoftSourceLinkVersion>
+    <!-- TODO: Sort these into the above. These are out of the way at the moment to make it easier to resolve conflicts. -->
+    <MicrosoftWin32RegistryAccessControlVersion>5.0.0-alpha1.19372.3</MicrosoftWin32RegistryAccessControlVersion>
+    <SystemDiagnosticsPerformanceCounter>5.0.0-alpha1.19372.3</SystemDiagnosticsPerformanceCounter>
+    <SystemIOPipesAccessControl>4.5.1</SystemIOPipesAccessControl>
   </PropertyGroup>
   <!--Package names-->
   <PropertyGroup>

--- a/src/pkg/packaging-tools/framework.dependency.targets
+++ b/src/pkg/packaging-tools/framework.dependency.targets
@@ -453,6 +453,10 @@
           DependsOnTargets="ResolveReferences"
           Returns="@(Reference -> '%(Filename)')" />
 
+  <Target Name="GetReferenceCopyLocalPathsFilenames"
+          DependsOnTargets="ResolveReferences"
+          Returns="@(ReferenceCopyLocalPaths -> '%(Filename)')" />
+
   <!-- Target overrides (can't be shared with pkgproj) -->
 
   <Target Name="Build"

--- a/src/pkg/packaging-tools/packaging-tools.targets
+++ b/src/pkg/packaging-tools/packaging-tools.targets
@@ -136,6 +136,28 @@
     </ItemGroup>
   </Target>
 
+  <Target Name="ResolvePlatformManifestProjectReferences"
+          Condition="'@(PlatformManifestProjectReference)' != ''"
+          BeforeTargets="ResolveProjectReferences">
+    <!-- Ensure depproj has had a chance to build the platform manifest. -->
+    <MSBuild
+      Projects="@(PlatformManifestProjectReference)"
+      Targets="Build" />
+
+    <MSBuild
+      Projects="@(PlatformManifestProjectReference)"
+      Targets="GetDataFiles"
+      SkipNonexistentTargets="true">
+      <Output TaskParameter="TargetOutputs" ItemName="ProjectReferenceDataFile" />
+    </MSBuild>
+
+    <ItemGroup>
+      <PackageConflictPlatformManifests
+        Include="@(ProjectReferenceDataFile)"
+        Condition="'%(ProjectReferenceDataFile.PlatformManifestFile)' == 'true'" />
+    </ItemGroup>
+  </Target>
+
   <!--
     By default, shared frameworks are generated based on the package. This can be overridden by the
     project, and in the future, the runtime pack is likely to be used to assemble the sfx.

--- a/src/pkg/projects/windowsdesktop/Directory.Build.props
+++ b/src/pkg/projects/windowsdesktop/Directory.Build.props
@@ -7,6 +7,10 @@
 
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory).., Directory.Build.props))\Directory.Build.props" />
 
+  <ItemGroup>
+    <PlatformManifestProjectReference Include="$(MSBuildThisFileDirectory)..\netcoreapp\src\netcoreapp.depproj" />
+  </ItemGroup>
+
   <PropertyGroup>
     <ShortFrameworkName>windowsdesktop</ShortFrameworkName>
 

--- a/src/pkg/projects/windowsdesktop/pkg/Directory.Build.props
+++ b/src/pkg/projects/windowsdesktop/pkg/Directory.Build.props
@@ -20,6 +20,7 @@
 
   <ItemGroup Condition="'$(PackageTargetRuntime)' == ''">
     <FrameworkListFileClass Include="Accessibility.dll" Profile="WindowsForms;WPF" />
+    <FrameworkListFileClass Include="Microsoft.Win32.Registry.AccessControl.dll" Profile="WindowsForms;WPF" />
     <FrameworkListFileClass Include="Microsoft.Win32.Registry.dll" Profile="WindowsForms;WPF" />
     <FrameworkListFileClass Include="Microsoft.Win32.SystemEvents.dll" Profile="WindowsForms;WPF" />
     <FrameworkListFileClass Include="PresentationCore.dll" Profile="WPF" />
@@ -34,10 +35,15 @@
     <FrameworkListFileClass Include="System.CodeDom.dll" Profile="WindowsForms;WPF" />
     <FrameworkListFileClass Include="System.Configuration.ConfigurationManager.dll" Profile="WindowsForms;WPF" />
     <FrameworkListFileClass Include="System.Design.dll" Profile="WindowsForms" />
+    <FrameworkListFileClass Include="System.Diagnostics.EventLog.dll" Profile="WindowsForms;WPF" />
+    <FrameworkListFileClass Include="System.Diagnostics.PerformanceCounter.dll" Profile="WindowsForms;WPF" />
+    <FrameworkListFileClass Include="System.DirectoryServices.dll" Profile="WindowsForms;WPF" />
     <FrameworkListFileClass Include="System.Drawing.Common.dll" Profile="WindowsForms" />
     <FrameworkListFileClass Include="System.Drawing.Design.dll" Profile="WindowsForms" />
     <FrameworkListFileClass Include="System.Drawing.dll" Profile="WindowsForms" />
+    <FrameworkListFileClass Include="System.IO.FileSystem.AccessControl.dll" Profile="WindowsForms;WPF" />
     <FrameworkListFileClass Include="System.IO.Packaging.dll" Profile="WindowsForms;WPF" />
+    <FrameworkListFileClass Include="System.IO.Pipes.AccessControl.dll" Profile="WindowsForms;WPF" />
     <FrameworkListFileClass Include="System.Printing.dll" Profile="WPF" />
     <FrameworkListFileClass Include="System.Resources.Extensions.dll" Profile="WindowsForms;WPF" />
     <FrameworkListFileClass Include="System.Security.AccessControl.dll" Profile="WindowsForms;WPF" />
@@ -45,8 +51,8 @@
     <FrameworkListFileClass Include="System.Security.Cryptography.Pkcs.dll" Profile="WindowsForms;WPF" />
     <FrameworkListFileClass Include="System.Security.Cryptography.ProtectedData.dll" Profile="WindowsForms;WPF" />
     <FrameworkListFileClass Include="System.Security.Cryptography.Xml.dll" Profile="WindowsForms;WPF" />
-    <FrameworkListFileClass Include="System.Security.Permissions.dll" Profile="WindowsForms;WPF" />
     <FrameworkListFileClass Include="System.Security.Principal.Windows.dll" Profile="WindowsForms;WPF" />
+    <FrameworkListFileClass Include="System.Threading.AccessControl.dll" Profile="WindowsForms;WPF" />
     <FrameworkListFileClass Include="System.Windows.Controls.Ribbon.dll" Profile="WPF" />
     <FrameworkListFileClass Include="System.Windows.Extensions.dll" Profile="WindowsForms;WPF" />
     <FrameworkListFileClass Include="System.Windows.Forms.Design.dll" Profile="WindowsForms" />

--- a/src/pkg/projects/windowsdesktop/pkg/Directory.Build.props
+++ b/src/pkg/projects/windowsdesktop/pkg/Directory.Build.props
@@ -51,6 +51,7 @@
     <FrameworkListFileClass Include="System.Security.Cryptography.Pkcs.dll" Profile="WindowsForms;WPF" />
     <FrameworkListFileClass Include="System.Security.Cryptography.ProtectedData.dll" Profile="WindowsForms;WPF" />
     <FrameworkListFileClass Include="System.Security.Cryptography.Xml.dll" Profile="WindowsForms;WPF" />
+    <FrameworkListFileClass Include="System.Security.Permissions.dll" Profile="WindowsForms;WPF" />
     <FrameworkListFileClass Include="System.Security.Principal.Windows.dll" Profile="WindowsForms;WPF" />
     <FrameworkListFileClass Include="System.Threading.AccessControl.dll" Profile="WindowsForms;WPF" />
     <FrameworkListFileClass Include="System.Windows.Controls.Ribbon.dll" Profile="WPF" />

--- a/src/pkg/projects/windowsdesktop/pkg/Microsoft.WindowsDesktop.App.pkgproj
+++ b/src/pkg/projects/windowsdesktop/pkg/Microsoft.WindowsDesktop.App.pkgproj
@@ -53,11 +53,21 @@
     <IgnoredReference Condition="'$(PackageTargetRuntime)' == ''" Include="DirectWriteForwarder" />
   </ItemGroup>
 
-  <Target Name="GetNETCoreAppIgnoredReference" BeforeTargets="VerifyClosure">
+  <Target Name="GetNETCoreAppIgnoredReference"
+          BeforeTargets="VerifyClosure">
     <MSBuild
+      Condition="'$(PackageTargetRuntime)' == ''"
       Projects="../../netcoreapp/src/netcoreapp.depproj"
       Properties="Configuration=netcoreapp"
       Targets="GetReferenceFilenames">
+      <Output TaskParameter="TargetOutputs" ItemName="IgnoredReference" />
+    </MSBuild>
+
+    <MSBuild
+      Condition="'$(PackageTargetRuntime)' != ''"
+      Projects="../../netcoreapp/src/netcoreapp.depproj"
+      Properties="Configuration=netcoreapp"
+      Targets="GetReferenceCopyLocalPathsFilenames">
       <Output TaskParameter="TargetOutputs" ItemName="IgnoredReference" />
     </MSBuild>
   </Target>

--- a/src/pkg/projects/windowsdesktop/pkg/Microsoft.WindowsDesktop.App.pkgproj
+++ b/src/pkg/projects/windowsdesktop/pkg/Microsoft.WindowsDesktop.App.pkgproj
@@ -51,9 +51,6 @@
 
     <!-- We don't have a ref assembly for DirectWriteForwarder -->
     <IgnoredReference Condition="'$(PackageTargetRuntime)' == ''" Include="DirectWriteForwarder" />
-
-    <!-- We want to intentionally exclude the ref assembly for System.Security.Permissions. -->
-    <IgnoredReference Condition="'$(PackageTargetRuntime)' == ''" Include="System.Security.Permissions" />
   </ItemGroup>
 
   <Target Name="GetNETCoreAppIgnoredReference" BeforeTargets="VerifyClosure">

--- a/src/pkg/projects/windowsdesktop/pkg/Microsoft.WindowsDesktop.App.pkgproj
+++ b/src/pkg/projects/windowsdesktop/pkg/Microsoft.WindowsDesktop.App.pkgproj
@@ -51,6 +51,9 @@
 
     <!-- We don't have a ref assembly for DirectWriteForwarder -->
     <IgnoredReference Condition="'$(PackageTargetRuntime)' == ''" Include="DirectWriteForwarder" />
+
+    <!-- We want to intentionally exclude the ref assembly for System.Security.Permissions. -->
+    <IgnoredReference Condition="'$(PackageTargetRuntime)' == ''" Include="System.Security.Permissions" />
   </ItemGroup>
 
   <Target Name="GetNETCoreAppIgnoredReference" BeforeTargets="VerifyClosure">

--- a/src/pkg/projects/windowsdesktop/src/windowsdesktop.depproj
+++ b/src/pkg/projects/windowsdesktop/src/windowsdesktop.depproj
@@ -16,7 +16,6 @@
     <PackageReference Include="System.Drawing.Common" Version="$(SystemDrawingCommonVersion)" />
     <PackageReference Include="System.IO.FileSystem.AccessControl" Version="$(SystemIOFileSystemAccessControlVersion)" />
     <PackageReference Include="System.IO.Packaging" Version="$(SystemIOPackagingVersion)" />
-    <PackageReference Include="System.IO.Pipes.AccessControl" Version="$(SystemIOPipesAccessControl)" />
     <PackageReference Include="System.Resources.Extensions" Version="$(SystemResourcesExtensionsPackageVersion)" />
     <PackageReference Include="System.Security.AccessControl" Version="$(SystemSecurityAccessControlVersion)" />
     <PackageReference Include="System.Security.Cryptography.Cng" Version="$(SystemSecurityCryptographyCngVersion)" />
@@ -29,6 +28,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <RefOnlyPackageReference Include="System.IO.Pipes.AccessControl" Version="$(SystemIOPipesAccessControl)" />
+
+    <PackageReference Include="@(RefOnlyPackageReference)" ExcludeAssets="Runtime" />
+
     <RuntimeOnlyPackageReference Include="System.Security.Permissions" Version="$(SystemSecurityPermissionsVersion)" />
 
     <PackageReference Include="@(RuntimeOnlyPackageReference)" ExcludeAssets="Compile" />

--- a/src/pkg/projects/windowsdesktop/src/windowsdesktop.depproj
+++ b/src/pkg/projects/windowsdesktop/src/windowsdesktop.depproj
@@ -22,6 +22,7 @@
     <PackageReference Include="System.Security.Cryptography.Pkcs" Version="$(SystemSecurityCryptographyPkcsVersion)" />
     <PackageReference Include="System.Security.Cryptography.ProtectedData" Version="$(SystemSecurityCryptographyProtectedDataVersion)" />
     <PackageReference Include="System.Security.Cryptography.Xml" Version="$(SystemSecurityCryptographyXmlVersion)" />
+    <PackageReference Include="System.Security.Permissions" Version="$(SystemSecurityPermissionsVersion)" />
     <PackageReference Include="System.Security.Principal.Windows" Version="$(SystemSecurityPrincipalWindowsVersion)" />
     <PackageReference Include="System.Threading.AccessControl" Version="$(SystemThreadingAccessControlVersion)" />
     <PackageReference Include="System.Windows.Extensions" Version="$(SystemWindowsExtensionsPackageVersion)" />
@@ -31,10 +32,6 @@
     <RefOnlyPackageReference Include="System.IO.Pipes.AccessControl" Version="$(SystemIOPipesAccessControl)" />
 
     <PackageReference Include="@(RefOnlyPackageReference)" ExcludeAssets="Runtime" />
-
-    <RuntimeOnlyPackageReference Include="System.Security.Permissions" Version="$(SystemSecurityPermissionsVersion)" />
-
-    <PackageReference Include="@(RuntimeOnlyPackageReference)" ExcludeAssets="Compile" />
   </ItemGroup>
 
   <!--

--- a/src/pkg/projects/windowsdesktop/src/windowsdesktop.depproj
+++ b/src/pkg/projects/windowsdesktop/src/windowsdesktop.depproj
@@ -5,28 +5,31 @@
     <PackageReference Include="Microsoft.DotNet.Wpf.GitHub" Version="$(MicrosoftDotNetWpfGitHubPackageVersion)" />
     <PackageReference Include="Microsoft.Private.Winforms" Version="$(MicrosoftPrivateWinformsPackageVersion)" />
 
+    <PackageReference Include="Microsoft.Win32.Registry.AccessControl" Version="$(MicrosoftWin32RegistryAccessControlVersion)" />
     <PackageReference Include="Microsoft.Win32.Registry" Version="$(MicrosoftWin32RegistryVersion)" />
     <PackageReference Include="Microsoft.Win32.SystemEvents" Version="$(MicrosoftWin32SystemEventsVersion)" />
     <PackageReference Include="System.CodeDom" Version="$(SystemCodeDomVersion)" />
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="$(SystemConfigurationConfigurationManagerVersion)" />
+    <PackageReference Include="System.Diagnostics.EventLog" Version="$(SystemDiagnosticsEventLogVersion)" />
+    <PackageReference Include="System.Diagnostics.PerformanceCounter" Version="$(SystemDiagnosticsPerformanceCounter)" />
+    <PackageReference Include="System.DirectoryServices" Version="$(SystemDirectoryServicesVersion)" />
     <PackageReference Include="System.Drawing.Common" Version="$(SystemDrawingCommonVersion)" />
+    <PackageReference Include="System.IO.FileSystem.AccessControl" Version="$(SystemIOFileSystemAccessControlVersion)" />
     <PackageReference Include="System.IO.Packaging" Version="$(SystemIOPackagingVersion)" />
+    <PackageReference Include="System.IO.Pipes.AccessControl" Version="$(SystemIOPipesAccessControl)" />
     <PackageReference Include="System.Resources.Extensions" Version="$(SystemResourcesExtensionsPackageVersion)" />
     <PackageReference Include="System.Security.AccessControl" Version="$(SystemSecurityAccessControlVersion)" />
     <PackageReference Include="System.Security.Cryptography.Cng" Version="$(SystemSecurityCryptographyCngVersion)" />
     <PackageReference Include="System.Security.Cryptography.Pkcs" Version="$(SystemSecurityCryptographyPkcsVersion)" />
     <PackageReference Include="System.Security.Cryptography.ProtectedData" Version="$(SystemSecurityCryptographyProtectedDataVersion)" />
     <PackageReference Include="System.Security.Cryptography.Xml" Version="$(SystemSecurityCryptographyXmlVersion)" />
-    <PackageReference Include="System.Security.Permissions" Version="$(SystemSecurityPermissionsVersion)" />
     <PackageReference Include="System.Security.Principal.Windows" Version="$(SystemSecurityPrincipalWindowsVersion)" />
+    <PackageReference Include="System.Threading.AccessControl" Version="$(SystemThreadingAccessControlVersion)" />
     <PackageReference Include="System.Windows.Extensions" Version="$(SystemWindowsExtensionsPackageVersion)" />
   </ItemGroup>
 
   <ItemGroup>
-    <RuntimeOnlyPackageReference Include="System.Diagnostics.EventLog" Version="$(SystemDiagnosticsEventLogVersion)" />
-    <RuntimeOnlyPackageReference Include="System.DirectoryServices" Version="$(SystemDirectoryServicesVersion)" />
-    <RuntimeOnlyPackageReference Include="System.IO.FileSystem.AccessControl" Version="$(SystemIOFileSystemAccessControlVersion)" />
-    <RuntimeOnlyPackageReference Include="System.Threading.AccessControl" Version="$(SystemThreadingAccessControlVersion)" />
+    <RuntimeOnlyPackageReference Include="System.Security.Permissions" Version="$(SystemSecurityPermissionsVersion)" />
 
     <PackageReference Include="@(RuntimeOnlyPackageReference)" ExcludeAssets="Compile" />
   </ItemGroup>

--- a/src/pkg/projects/windowsdesktop/src/windowsdesktop.depproj
+++ b/src/pkg/projects/windowsdesktop/src/windowsdesktop.depproj
@@ -16,6 +16,7 @@
     <PackageReference Include="System.Drawing.Common" Version="$(SystemDrawingCommonVersion)" />
     <PackageReference Include="System.IO.FileSystem.AccessControl" Version="$(SystemIOFileSystemAccessControlVersion)" />
     <PackageReference Include="System.IO.Packaging" Version="$(SystemIOPackagingVersion)" />
+    <PackageReference Include="System.IO.Pipes.AccessControl" Version="$(SystemIOPipesAccessControl)" />
     <PackageReference Include="System.Resources.Extensions" Version="$(SystemResourcesExtensionsPackageVersion)" />
     <PackageReference Include="System.Security.AccessControl" Version="$(SystemSecurityAccessControlVersion)" />
     <PackageReference Include="System.Security.Cryptography.Cng" Version="$(SystemSecurityCryptographyCngVersion)" />
@@ -26,12 +27,6 @@
     <PackageReference Include="System.Security.Principal.Windows" Version="$(SystemSecurityPrincipalWindowsVersion)" />
     <PackageReference Include="System.Threading.AccessControl" Version="$(SystemThreadingAccessControlVersion)" />
     <PackageReference Include="System.Windows.Extensions" Version="$(SystemWindowsExtensionsPackageVersion)" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <RefOnlyPackageReference Include="System.IO.Pipes.AccessControl" Version="$(SystemIOPipesAccessControl)" />
-
-    <PackageReference Include="@(RefOnlyPackageReference)" ExcludeAssets="Runtime" />
   </ItemGroup>
 
   <!--


### PR DESCRIPTION
For https://github.com/dotnet/core-setup/issues/7290.

This PR assumes that we should use `System.IO.Pipes.AccessControl` `4.5.1`. (https://github.com/dotnet/core-setup/issues/7290#issuecomment-513926657)