### PR TITLE
Always build full platform manifest

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -139,7 +139,6 @@ stages:
   # Windows x64
   - template: /eng/jobs/windows-build.yml
     parameters:
-      buildFullPlatformManifest: true
       name: Windows_x64
       publishRidAgnosticPackages: true
       targetArchitecture: x64
@@ -147,7 +146,6 @@ stages:
   # Windows x86
   - template: /eng/jobs/windows-build.yml
     parameters:
-      buildFullPlatformManifest: true
       name: Windows_x86
       targetArchitecture: x86
 

--- a/eng/jobs/windows-build.yml
+++ b/eng/jobs/windows-build.yml
@@ -1,6 +1,5 @@
 parameters:
   additionalMSBuildArguments: ''
-  buildFullPlatformManifest: false
   displayName: ''
   publishRidAgnosticPackages: false
   skipTests: $(SkipTests)
@@ -34,7 +33,6 @@ jobs:
         /p:TargetArchitecture=${{ parameters.targetArchitecture }}
         /p:PortableBuild=true
         /p:SkipTests=${{ parameters.skipTests }}
-        /p:BuildFullPlatformManifest=${{ parameters.buildFullPlatformManifest }}
       MsbuildSigningArguments: >-
         /p:CertificateId=400
         /p:DotNetSignType=$(SignType)

--- a/src/pkg/packaging-tools/framework.dependency.targets
+++ b/src/pkg/packaging-tools/framework.dependency.targets
@@ -110,7 +110,18 @@
   <Target Name="GenerateFileVersionProps"
           Condition="'$(FrameworkPackageName)' != ''"
           DependsOnTargets="SetupGenerateFileVersionProps">
+    <!--
+      Building the full platform manifest gathers information from the packages of all known RIDs,
+      which we can't do while building from source because the entire product needs to build on a
+      single machine (single RID) without access to prebuilts.
+    -->
+    <PropertyGroup Condition="'$(DotNetBuildFromSource)' == 'true'">
+      <BuildFullPlatformManifest Condition="'$(BuildFullPlatformManifest)' == ''">false</BuildFullPlatformManifest>
+    </PropertyGroup>
+
     <PropertyGroup>
+      <BuildFullPlatformManifest Condition="'$(BuildFullPlatformManifest)' == ''">true</BuildFullPlatformManifest>
+
       <!-- During an official build when we can guarantee that all RID-specific dependencies have been built,
           restore all of those dependencies and gather the prospective content of the RID-specific Core.App
           packages.  This is needed so that we have a complete platform manifest in the shipping version of


### PR DESCRIPTION
Unless intentionally disabled or building from source, always create the full platform manifest that lists assets from all platforms. With the platform manifest included in runtime packs, it needs to be generated the same across all official build jobs. Producing it locally during a default build also reduces the diff from dev to official builds.

For https://github.com/dotnet/core-setup/issues/7269.