### PR TITLE
[release/3.0] Fix post-arcade-migration preview8 build version: lower than pre-arcade

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -4,6 +4,12 @@
     <MajorVersion>3</MajorVersion>
     <MinorVersion>0</MinorVersion>
     <PatchVersion>0</PatchVersion>
+    <!--
+      TODO: When changing this to preview9, remove /p:_BuildNumberYY=28 workaround in the official
+      build yml files. These were added because we migrated to the Arcade SDK during preview8, and
+      needed to raise the version number to preserve continuity. In preview9 we should remove these
+      to conform to Arcade defaults. https://github.com/dotnet/core-setup/issues/7348
+    -->
     <PreReleaseVersionLabel>preview8</PreReleaseVersionLabel>
     <!-- Enable to remove prerelease label. -->
     <StabilizePackageVersion Condition="'$(StabilizePackageVersion)' == ''">false</StabilizePackageVersion>

--- a/eng/jobs/bash-build.yml
+++ b/eng/jobs/bash-build.yml
@@ -47,6 +47,7 @@ jobs:
         /p:Configuration=$(_BuildConfig)
         /p:OfficialBuildId=$(OfficialBuildId)
         /p:TargetArchitecture=${{ parameters.targetArchitecture }}
+        /p:_BuildNumberYY=28
 
       # Don't put additionalMSBuildArgs as the last line. It may or may not have extra args. If the
       # parameter is empty, AzDO replaces it with empty space without chomping the extra newline.

--- a/eng/jobs/finalize-publish.yml
+++ b/eng/jobs/finalize-publish.yml
@@ -135,6 +135,7 @@ jobs:
       $(_CommonPublishArgs)
       $(_SymbolServerArgs)
       $(_DotNetVersionsArgs)
+      /p:_BuildNumberYY=28
       /bl:$(Build.SourcesDirectory)\finalizepublish.binlog
     displayName: Publish
 

--- a/eng/jobs/osx-build.yml
+++ b/eng/jobs/osx-build.yml
@@ -20,6 +20,7 @@ jobs:
     CommonMSBuildArgs: >-
       /p:Configuration=$(_BuildConfig)
       /p:PortableBuild=true
+      /p:_BuildNumberYY=28
   steps:
   - script: >-
       $(Build.SourcesDirectory)/build.sh --ci --test

--- a/eng/jobs/windows-build.yml
+++ b/eng/jobs/windows-build.yml
@@ -35,6 +35,7 @@ jobs:
         /p:PortableBuild=true
         /p:SkipTests=${{ parameters.skipTests }}
         /p:BuildFullPlatformManifest=${{ parameters.buildFullPlatformManifest }}
+        /p:_BuildNumberYY=28
       MsbuildSigningArguments: >-
         /p:CertificateId=400
         /p:DotNetSignType=$(SignType)


### PR DESCRIPTION
Fix for ASP.NET Core auto-upgrade failure: https://github.com/dotnet/core-sdk/pull/3377.

Set `/p:_BuildNumberYY=28` in all official build commands so that we produce `28xxx-xx` versions, which is higher than the last BuildTools-based build, `27919-09`.

This is a nasty workaround: using global properties to prevent the MSBuild script from doing what it intends to do, and even further, `_`-prefixed props are meant to be private.

I don't see any obvious way to bump up the Arcade-generated version number: https://github.com/dotnet/arcade/blob/master/src/Microsoft.DotNet.Arcade.Sdk/tools/Version.BeforeCommonTargets.targets.

I hope there's a better way I'm missing. If not, we will have to take care to remove this before the first build of preview 9 or it's stuck there as well. (Ideally I'd have a way to apply a workaround that would automatically deactivate in preview 9, but I don't know if it's reasonable to implement that in AzDO yaml.)

Running a mock official build offline to see how it behaves end to end.

/cc @nguerrera 