### PR TITLE
[release/3.0] Fix up the set of Windows compatibility libraries exposed in WindowsDesktop

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -121,6 +121,19 @@
       <Uri>https://dev.azure.com/dnceng/internal/_git/dotnet-wpf-int</Uri>
       <Sha>d6cdc6daf9ddfeee3731ca75c8205589195d7adb</Sha>
     </Dependency>
+    <!-- TODO: Sort these into the above. These are out of the way at the moment to make it easier to resolve conflicts. -->
+    <Dependency Name="System.IO.FileSystem.AccessControl" Version="5.0.0-alpha1.19372.3">
+      <Uri>https://github.com/dotnet/corefx</Uri>
+      <Sha>3c3b9ceee6e1416db6f1ddbc1ab0d0ffb67c16fa</Sha>
+    </Dependency>
+    <Dependency Name="System.Diagnostics.PerformanceCounter" Version="5.0.0-alpha1.19372.3">
+      <Uri>https://github.com/dotnet/corefx</Uri>
+      <Sha>3c3b9ceee6e1416db6f1ddbc1ab0d0ffb67c16fa</Sha>
+    </Dependency>
+    <Dependency Name="System.IO.Pipes.AccessControl" Version="4.5.1">
+      <Uri>https://github.com/dotnet/corefx</Uri>
+      <Sha>7ee84596d92e178bce54c986df31ccc52479e772 </Sha>
+    </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>
     <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="1.0.0-beta.19364.1">

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -122,11 +122,11 @@
       <Sha>d6cdc6daf9ddfeee3731ca75c8205589195d7adb</Sha>
     </Dependency>
     <!-- TODO: Sort these into the above. These are out of the way at the moment to make it easier to resolve conflicts. -->
-    <Dependency Name="System.IO.FileSystem.AccessControl" Version="5.0.0-alpha1.19372.3">
+    <Dependency Name="System.IO.FileSystem.AccessControl" Version="4.6.0-preview8.19372.8">
       <Uri>https://github.com/dotnet/corefx</Uri>
       <Sha>3c3b9ceee6e1416db6f1ddbc1ab0d0ffb67c16fa</Sha>
     </Dependency>
-    <Dependency Name="System.Diagnostics.PerformanceCounter" Version="5.0.0-alpha1.19372.3">
+    <Dependency Name="System.Diagnostics.PerformanceCounter" Version="4.6.0-preview8.19372.8">
       <Uri>https://github.com/dotnet/corefx</Uri>
       <Sha>3c3b9ceee6e1416db6f1ddbc1ab0d0ffb67c16fa</Sha>
     </Dependency>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -94,8 +94,8 @@
     <!-- Infrastructure and test-only. -->
     <MicrosoftSourceLinkVersion>1.0.0-beta2-18618-05</MicrosoftSourceLinkVersion>
     <!-- TODO: Sort these into the above. These are out of the way at the moment to make it easier to resolve conflicts. -->
-    <MicrosoftWin32RegistryAccessControlVersion>5.0.0-alpha1.19372.3</MicrosoftWin32RegistryAccessControlVersion>
-    <SystemDiagnosticsPerformanceCounter>5.0.0-alpha1.19372.3</SystemDiagnosticsPerformanceCounter>
+    <MicrosoftWin32RegistryAccessControlVersion>4.6.0-preview8.19372.8</MicrosoftWin32RegistryAccessControlVersion>
+    <SystemDiagnosticsPerformanceCounter>4.6.0-preview8.19372.8</SystemDiagnosticsPerformanceCounter>
     <SystemIOPipesAccessControl>4.5.1</SystemIOPipesAccessControl>
   </PropertyGroup>
   <!--Package names-->

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -93,6 +93,10 @@
     <MicrosoftDiaSymReaderNativePackageVersion>1.7.0</MicrosoftDiaSymReaderNativePackageVersion>
     <!-- Infrastructure and test-only. -->
     <MicrosoftSourceLinkVersion>1.0.0-beta2-18618-05</MicrosoftSourceLinkVersion>
+    <!-- TODO: Sort these into the above. These are out of the way at the moment to make it easier to resolve conflicts. -->
+    <MicrosoftWin32RegistryAccessControlVersion>5.0.0-alpha1.19372.3</MicrosoftWin32RegistryAccessControlVersion>
+    <SystemDiagnosticsPerformanceCounter>5.0.0-alpha1.19372.3</SystemDiagnosticsPerformanceCounter>
+    <SystemIOPipesAccessControl>4.5.1</SystemIOPipesAccessControl>
   </PropertyGroup>
   <!--Package names-->
   <PropertyGroup>

--- a/src/pkg/packaging-tools/framework.dependency.targets
+++ b/src/pkg/packaging-tools/framework.dependency.targets
@@ -94,7 +94,7 @@
           Condition="'$(FrameworkPackageName)' != ''">
     <PropertyGroup>
       <PropsFile>$(IntermediateOutputPath)$(FrameworkPackageName).props</PropsFile>
-      <PlatformManifestFile>$(IntermediateOutputPath)$(FrameworkPackageName).PlatformManifest.txt</PlatformManifestFile>
+      <PlatformManifestFile>$(BaseIntermediateOutputPath)$(FrameworkPackageName).PlatformManifest.txt</PlatformManifestFile>
     </PropertyGroup>
 
     <ItemGroup>
@@ -468,6 +468,10 @@
           DependsOnTargets="ResolveReferences"
           Returns="@(ReferenceCopyLocalPaths -> '%(Filename)')" />
 
+  <Target Name="BuildDependencyProjectReferences">
+    <MSBuild Projects="@(OrderProjectReference)" Targets="Build" />
+  </Target>
+
   <!-- Target overrides (can't be shared with pkgproj) -->
 
   <Target Name="Build"
@@ -477,6 +481,7 @@
 
   <Target Name="BuildDepprojArtifacts"
           DependsOnTargets="
+            BuildDependencyProjectReferences;
             GetFilesToPackage;
             CrossGen;
             GenerateHashVersionsFile;

--- a/src/pkg/packaging-tools/framework.dependency.targets
+++ b/src/pkg/packaging-tools/framework.dependency.targets
@@ -464,6 +464,10 @@
           DependsOnTargets="ResolveReferences"
           Returns="@(Reference -> '%(Filename)')" />
 
+  <Target Name="GetReferenceCopyLocalPathsFilenames"
+          DependsOnTargets="ResolveReferences"
+          Returns="@(ReferenceCopyLocalPaths -> '%(Filename)')" />
+
   <!-- Target overrides (can't be shared with pkgproj) -->
 
   <Target Name="Build"

--- a/src/pkg/packaging-tools/framework.sharedfx.targets
+++ b/src/pkg/packaging-tools/framework.sharedfx.targets
@@ -34,6 +34,9 @@
     PackageConflictPlatformManifests item. This causes NuGet to remove files from publish output
     because they're "already" defined in the shared framework. But we're creating a shared framework
     here, so we need to remove the PackageConflictPlatformManifests items before they're used.
+
+    If we have a PlatformManifestProjectReference (WindowsDesktop), keep that platform manifest. It
+    ensures we don't carry items that the base framework (NETCoreApp) already has.
   -->
   <Target Name="RemovePlatformManifests"
           BeforeTargets="
@@ -41,6 +44,7 @@
             _HandlePackageFileConflicts">
     <ItemGroup>
       <PackageConflictPlatformManifests Remove="@(PackageConflictPlatformManifests)" />
+      <PackageConflictPlatformManifests Include="@(ProjectReferencePlatformManifestFile)" />
     </ItemGroup>
   </Target>
 
@@ -259,7 +263,6 @@
   <Target Name="BuildSfxprojArtifacts"
           DependsOnTargets="
             BuildPkgProjectReferences;
-            ResolvePlatformManifestProjectReferences;
             SetPublishDir;
             CleanPackages;
             Restore;

--- a/src/pkg/packaging-tools/framework.sharedfx.targets
+++ b/src/pkg/packaging-tools/framework.sharedfx.targets
@@ -231,8 +231,12 @@
     generate shared frameworks in the Arcade SDK.
   -->
   <Target Name="BuildPkgProjectReferences">
-    <MSBuild Projects="$(RepoRoot)signing\SignBinaries.proj" Targets="Build" />
-    <MSBuild Projects="@(PkgProjectReference)" Targets="Build" />
+    <MSBuild
+      Projects="
+        $(RepoRoot)signing\SignBinaries.proj;
+        @(PkgProjectReference);
+        @(OrderProjectReference)"
+      Targets="Build" />
   </Target>
 
   <Target Name="SetPublishDir"
@@ -255,6 +259,7 @@
   <Target Name="BuildSfxprojArtifacts"
           DependsOnTargets="
             BuildPkgProjectReferences;
+            ResolvePlatformManifestProjectReferences;
             SetPublishDir;
             CleanPackages;
             Restore;

--- a/src/pkg/packaging-tools/packaging-tools.props
+++ b/src/pkg/packaging-tools/packaging-tools.props
@@ -81,4 +81,9 @@
     <OutputName>$(InstallerFileNameWithoutExtension)</OutputName>
   </PropertyGroup>
 
+  <ItemGroup>
+    <!-- Ensure depproj has had a chance to build the platform manifest. -->
+    <OrderProjectDependency Include="@(PlatformManifestProjectReference)" />
+  </ItemGroup>
+
 </Project>

--- a/src/pkg/packaging-tools/packaging-tools.props
+++ b/src/pkg/packaging-tools/packaging-tools.props
@@ -83,7 +83,7 @@
 
   <ItemGroup>
     <!-- Ensure depproj has had a chance to build the platform manifest. -->
-    <OrderProjectDependency Include="@(PlatformManifestProjectReference)" />
+    <OrderProjectReference Include="@(PlatformManifestProjectReference)" />
   </ItemGroup>
 
 </Project>

--- a/src/pkg/packaging-tools/packaging-tools.targets
+++ b/src/pkg/packaging-tools/packaging-tools.targets
@@ -136,6 +136,23 @@
     </ItemGroup>
   </Target>
 
+  <Target Name="ResolvePlatformManifestProjectReferences"
+          Condition="'@(PlatformManifestProjectReference)' != ''"
+          BeforeTargets="ResolveProjectReferences">
+    <MSBuild
+      Projects="@(PlatformManifestProjectReference)"
+      Targets="GetDataFiles"
+      SkipNonexistentTargets="true">
+      <Output TaskParameter="TargetOutputs" ItemName="ProjectReferenceDataFile" />
+    </MSBuild>
+
+    <ItemGroup>
+      <PackageConflictPlatformManifests
+        Include="@(ProjectReferenceDataFile)"
+        Condition="'%(ProjectReferenceDataFile.PlatformManifestFile)' == 'true'" />
+    </ItemGroup>
+  </Target>
+
   <!--
     By default, shared frameworks are generated based on the package. This can be overridden by the
     project, and in the future, the runtime pack is likely to be used to assemble the sfx.

--- a/src/pkg/packaging-tools/packaging-tools.targets
+++ b/src/pkg/packaging-tools/packaging-tools.targets
@@ -147,16 +147,20 @@
     </MSBuild>
 
     <ItemGroup>
-      <!--
-        Add the platform manifest, if it exists. It may not exist if this is, for example, an x64
-        GetFilesToPackage build running under TargetArchitecture=x86.
-      -->
-      <PackageConflictPlatformManifests
+      <ProjectReferencePlatformManifestFile
         Include="@(ProjectReferenceDataFile)"
-        Condition="
-          '%(ProjectReferenceDataFile.PlatformManifestFile)' == 'true' and
-          Exists('%(ProjectReferenceDataFile.Identity)')" />
+        Condition="'%(ProjectReferenceDataFile.PlatformManifestFile)' == 'true'" />
+
+      <PackageConflictPlatformManifests Include="@(ProjectReferencePlatformManifestFile)" />
     </ItemGroup>
+
+    <Error
+      Condition="'@(ProjectReferencePlatformManifestFile)' == ''"
+      Text="No ProjectReferencePlatformManifestFile found in @(PlatformManifestProjectReference)" />
+
+    <Error
+      Condition="!Exists('%(ProjectReferencePlatformManifestFile.Identity)')"
+      Text="ProjectReferencePlatformManifestFile does not exist: '@(ProjectReferencePlatformManifestFile)' in @(PlatformManifestProjectReference)" />
   </Target>
 
   <!--

--- a/src/pkg/packaging-tools/packaging-tools.targets
+++ b/src/pkg/packaging-tools/packaging-tools.targets
@@ -147,9 +147,15 @@
     </MSBuild>
 
     <ItemGroup>
+      <!--
+        Add the platform manifest, if it exists. It may not exist if this is, for example, an x64
+        GetFilesToPackage build running under TargetArchitecture=x86.
+      -->
       <PackageConflictPlatformManifests
         Include="@(ProjectReferenceDataFile)"
-        Condition="'%(ProjectReferenceDataFile.PlatformManifestFile)' == 'true'" />
+        Condition="
+          '%(ProjectReferenceDataFile.PlatformManifestFile)' == 'true' and
+          Exists('%(ProjectReferenceDataFile.Identity)')" />
     </ItemGroup>
   </Target>
 

--- a/src/pkg/projects/Directory.Build.props
+++ b/src/pkg/projects/Directory.Build.props
@@ -41,13 +41,11 @@
     <RestoreAllBuildRids>true</RestoreAllBuildRids>
   </PropertyGroup>
 
-  <!-- Most packages need the host to be built first. -->
-  <ItemGroup Condition="'$(DisableOrderDependencies)' != 'true'">
+  <ItemGroup Condition="'$(DisableOrderDependencies)' != 'true' and '$(MSBuildProjectExtension)' == '.pkgproj'">
+    <!-- Most packages need the host to be built first. -->
     <OrderProjectReference Include="@(CorehostProjectToBuild)" />
     <!-- Pkgproj requires its depproj crossgen outputs to be signed.-->
-    <OrderProjectReference
-      Condition="'$(MSBuildProjectExtension)' == '.pkgproj'"
-      Include="$(RepoRoot)signing\SignBinaries.proj" />
+    <OrderProjectReference Include="$(RepoRoot)signing\SignBinaries.proj" />
   </ItemGroup>
 
   <!-- In *.builds projects, the current phase's name is the same as the project name. -->

--- a/src/pkg/projects/windowsdesktop/Directory.Build.props
+++ b/src/pkg/projects/windowsdesktop/Directory.Build.props
@@ -7,6 +7,10 @@
 
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory).., Directory.Build.props))\Directory.Build.props" />
 
+  <ItemGroup>
+    <PlatformManifestProjectReference Include="$(MSBuildThisFileDirectory)..\netcoreapp\src\netcoreapp.depproj" />
+  </ItemGroup>
+
   <PropertyGroup>
     <ShortFrameworkName>windowsdesktop</ShortFrameworkName>
 

--- a/src/pkg/projects/windowsdesktop/pkg/Directory.Build.props
+++ b/src/pkg/projects/windowsdesktop/pkg/Directory.Build.props
@@ -20,6 +20,7 @@
 
   <ItemGroup Condition="'$(PackageTargetRuntime)' == ''">
     <FrameworkListFileClass Include="Accessibility.dll" Profile="WindowsForms;WPF" />
+    <FrameworkListFileClass Include="Microsoft.Win32.Registry.AccessControl.dll" Profile="WindowsForms;WPF" />
     <FrameworkListFileClass Include="Microsoft.Win32.Registry.dll" Profile="WindowsForms;WPF" />
     <FrameworkListFileClass Include="Microsoft.Win32.SystemEvents.dll" Profile="WindowsForms;WPF" />
     <FrameworkListFileClass Include="PresentationCore.dll" Profile="WPF" />
@@ -34,10 +35,15 @@
     <FrameworkListFileClass Include="System.CodeDom.dll" Profile="WindowsForms;WPF" />
     <FrameworkListFileClass Include="System.Configuration.ConfigurationManager.dll" Profile="WindowsForms;WPF" />
     <FrameworkListFileClass Include="System.Design.dll" Profile="WindowsForms" />
+    <FrameworkListFileClass Include="System.Diagnostics.EventLog.dll" Profile="WindowsForms;WPF" />
+    <FrameworkListFileClass Include="System.Diagnostics.PerformanceCounter.dll" Profile="WindowsForms;WPF" />
+    <FrameworkListFileClass Include="System.DirectoryServices.dll" Profile="WindowsForms;WPF" />
     <FrameworkListFileClass Include="System.Drawing.Common.dll" Profile="WindowsForms" />
     <FrameworkListFileClass Include="System.Drawing.Design.dll" Profile="WindowsForms" />
     <FrameworkListFileClass Include="System.Drawing.dll" Profile="WindowsForms" />
+    <FrameworkListFileClass Include="System.IO.FileSystem.AccessControl.dll" Profile="WindowsForms;WPF" />
     <FrameworkListFileClass Include="System.IO.Packaging.dll" Profile="WindowsForms;WPF" />
+    <FrameworkListFileClass Include="System.IO.Pipes.AccessControl.dll" Profile="WindowsForms;WPF" />
     <FrameworkListFileClass Include="System.Printing.dll" Profile="WPF" />
     <FrameworkListFileClass Include="System.Resources.Extensions.dll" Profile="WindowsForms;WPF" />
     <FrameworkListFileClass Include="System.Security.AccessControl.dll" Profile="WindowsForms;WPF" />
@@ -45,8 +51,8 @@
     <FrameworkListFileClass Include="System.Security.Cryptography.Pkcs.dll" Profile="WindowsForms;WPF" />
     <FrameworkListFileClass Include="System.Security.Cryptography.ProtectedData.dll" Profile="WindowsForms;WPF" />
     <FrameworkListFileClass Include="System.Security.Cryptography.Xml.dll" Profile="WindowsForms;WPF" />
-    <FrameworkListFileClass Include="System.Security.Permissions.dll" Profile="WindowsForms;WPF" />
     <FrameworkListFileClass Include="System.Security.Principal.Windows.dll" Profile="WindowsForms;WPF" />
+    <FrameworkListFileClass Include="System.Threading.AccessControl.dll" Profile="WindowsForms;WPF" />
     <FrameworkListFileClass Include="System.Windows.Controls.Ribbon.dll" Profile="WPF" />
     <FrameworkListFileClass Include="System.Windows.Extensions.dll" Profile="WindowsForms;WPF" />
     <FrameworkListFileClass Include="System.Windows.Forms.Design.dll" Profile="WindowsForms" />

--- a/src/pkg/projects/windowsdesktop/pkg/Directory.Build.props
+++ b/src/pkg/projects/windowsdesktop/pkg/Directory.Build.props
@@ -51,6 +51,7 @@
     <FrameworkListFileClass Include="System.Security.Cryptography.Pkcs.dll" Profile="WindowsForms;WPF" />
     <FrameworkListFileClass Include="System.Security.Cryptography.ProtectedData.dll" Profile="WindowsForms;WPF" />
     <FrameworkListFileClass Include="System.Security.Cryptography.Xml.dll" Profile="WindowsForms;WPF" />
+    <FrameworkListFileClass Include="System.Security.Permissions.dll" Profile="WindowsForms;WPF" />
     <FrameworkListFileClass Include="System.Security.Principal.Windows.dll" Profile="WindowsForms;WPF" />
     <FrameworkListFileClass Include="System.Threading.AccessControl.dll" Profile="WindowsForms;WPF" />
     <FrameworkListFileClass Include="System.Windows.Controls.Ribbon.dll" Profile="WPF" />

--- a/src/pkg/projects/windowsdesktop/pkg/Microsoft.WindowsDesktop.App.pkgproj
+++ b/src/pkg/projects/windowsdesktop/pkg/Microsoft.WindowsDesktop.App.pkgproj
@@ -53,11 +53,21 @@
     <IgnoredReference Condition="'$(PackageTargetRuntime)' == ''" Include="DirectWriteForwarder" />
   </ItemGroup>
 
-  <Target Name="GetNETCoreAppIgnoredReference" BeforeTargets="VerifyClosure">
+  <Target Name="GetNETCoreAppIgnoredReference"
+          BeforeTargets="VerifyClosure">
     <MSBuild
+      Condition="'$(PackageTargetRuntime)' == ''"
       Projects="../../netcoreapp/src/netcoreapp.depproj"
       Properties="Configuration=netcoreapp"
       Targets="GetReferenceFilenames">
+      <Output TaskParameter="TargetOutputs" ItemName="IgnoredReference" />
+    </MSBuild>
+
+    <MSBuild
+      Condition="'$(PackageTargetRuntime)' != ''"
+      Projects="../../netcoreapp/src/netcoreapp.depproj"
+      Properties="Configuration=netcoreapp"
+      Targets="GetReferenceCopyLocalPathsFilenames">
       <Output TaskParameter="TargetOutputs" ItemName="IgnoredReference" />
     </MSBuild>
   </Target>

--- a/src/pkg/projects/windowsdesktop/pkg/Microsoft.WindowsDesktop.App.pkgproj
+++ b/src/pkg/projects/windowsdesktop/pkg/Microsoft.WindowsDesktop.App.pkgproj
@@ -51,9 +51,6 @@
 
     <!-- We don't have a ref assembly for DirectWriteForwarder -->
     <IgnoredReference Condition="'$(PackageTargetRuntime)' == ''" Include="DirectWriteForwarder" />
-
-    <!-- We want to intentionally exclude the ref assembly for System.Security.Permissions. -->
-    <IgnoredReference Condition="'$(PackageTargetRuntime)' == ''" Include="System.Security.Permissions" />
   </ItemGroup>
 
   <Target Name="GetNETCoreAppIgnoredReference" BeforeTargets="VerifyClosure">

--- a/src/pkg/projects/windowsdesktop/pkg/Microsoft.WindowsDesktop.App.pkgproj
+++ b/src/pkg/projects/windowsdesktop/pkg/Microsoft.WindowsDesktop.App.pkgproj
@@ -51,6 +51,9 @@
 
     <!-- We don't have a ref assembly for DirectWriteForwarder -->
     <IgnoredReference Condition="'$(PackageTargetRuntime)' == ''" Include="DirectWriteForwarder" />
+
+    <!-- We want to intentionally exclude the ref assembly for System.Security.Permissions. -->
+    <IgnoredReference Condition="'$(PackageTargetRuntime)' == ''" Include="System.Security.Permissions" />
   </ItemGroup>
 
   <Target Name="GetNETCoreAppIgnoredReference" BeforeTargets="VerifyClosure">

--- a/src/pkg/projects/windowsdesktop/src/windowsdesktop.depproj
+++ b/src/pkg/projects/windowsdesktop/src/windowsdesktop.depproj
@@ -16,7 +16,6 @@
     <PackageReference Include="System.Drawing.Common" Version="$(SystemDrawingCommonVersion)" />
     <PackageReference Include="System.IO.FileSystem.AccessControl" Version="$(SystemIOFileSystemAccessControlVersion)" />
     <PackageReference Include="System.IO.Packaging" Version="$(SystemIOPackagingVersion)" />
-    <PackageReference Include="System.IO.Pipes.AccessControl" Version="$(SystemIOPipesAccessControl)" />
     <PackageReference Include="System.Resources.Extensions" Version="$(SystemResourcesExtensionsPackageVersion)" />
     <PackageReference Include="System.Security.AccessControl" Version="$(SystemSecurityAccessControlVersion)" />
     <PackageReference Include="System.Security.Cryptography.Cng" Version="$(SystemSecurityCryptographyCngVersion)" />
@@ -29,6 +28,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <RefOnlyPackageReference Include="System.IO.Pipes.AccessControl" Version="$(SystemIOPipesAccessControl)" />
+
+    <PackageReference Include="@(RefOnlyPackageReference)" ExcludeAssets="Runtime" />
+
     <RuntimeOnlyPackageReference Include="System.Security.Permissions" Version="$(SystemSecurityPermissionsVersion)" />
 
     <PackageReference Include="@(RuntimeOnlyPackageReference)" ExcludeAssets="Compile" />

--- a/src/pkg/projects/windowsdesktop/src/windowsdesktop.depproj
+++ b/src/pkg/projects/windowsdesktop/src/windowsdesktop.depproj
@@ -22,6 +22,7 @@
     <PackageReference Include="System.Security.Cryptography.Pkcs" Version="$(SystemSecurityCryptographyPkcsVersion)" />
     <PackageReference Include="System.Security.Cryptography.ProtectedData" Version="$(SystemSecurityCryptographyProtectedDataVersion)" />
     <PackageReference Include="System.Security.Cryptography.Xml" Version="$(SystemSecurityCryptographyXmlVersion)" />
+    <PackageReference Include="System.Security.Permissions" Version="$(SystemSecurityPermissionsVersion)" />
     <PackageReference Include="System.Security.Principal.Windows" Version="$(SystemSecurityPrincipalWindowsVersion)" />
     <PackageReference Include="System.Threading.AccessControl" Version="$(SystemThreadingAccessControlVersion)" />
     <PackageReference Include="System.Windows.Extensions" Version="$(SystemWindowsExtensionsPackageVersion)" />
@@ -31,10 +32,6 @@
     <RefOnlyPackageReference Include="System.IO.Pipes.AccessControl" Version="$(SystemIOPipesAccessControl)" />
 
     <PackageReference Include="@(RefOnlyPackageReference)" ExcludeAssets="Runtime" />
-
-    <RuntimeOnlyPackageReference Include="System.Security.Permissions" Version="$(SystemSecurityPermissionsVersion)" />
-
-    <PackageReference Include="@(RuntimeOnlyPackageReference)" ExcludeAssets="Compile" />
   </ItemGroup>
 
   <!--

--- a/src/pkg/projects/windowsdesktop/src/windowsdesktop.depproj
+++ b/src/pkg/projects/windowsdesktop/src/windowsdesktop.depproj
@@ -5,28 +5,31 @@
     <PackageReference Include="Microsoft.DotNet.Wpf.GitHub" Version="$(MicrosoftDotNetWpfGitHubPackageVersion)" />
     <PackageReference Include="Microsoft.Private.Winforms" Version="$(MicrosoftPrivateWinformsPackageVersion)" />
 
+    <PackageReference Include="Microsoft.Win32.Registry.AccessControl" Version="$(MicrosoftWin32RegistryAccessControlVersion)" />
     <PackageReference Include="Microsoft.Win32.Registry" Version="$(MicrosoftWin32RegistryVersion)" />
     <PackageReference Include="Microsoft.Win32.SystemEvents" Version="$(MicrosoftWin32SystemEventsVersion)" />
     <PackageReference Include="System.CodeDom" Version="$(SystemCodeDomVersion)" />
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="$(SystemConfigurationConfigurationManagerVersion)" />
+    <PackageReference Include="System.Diagnostics.EventLog" Version="$(SystemDiagnosticsEventLogVersion)" />
+    <PackageReference Include="System.Diagnostics.PerformanceCounter" Version="$(SystemDiagnosticsPerformanceCounter)" />
+    <PackageReference Include="System.DirectoryServices" Version="$(SystemDirectoryServicesVersion)" />
     <PackageReference Include="System.Drawing.Common" Version="$(SystemDrawingCommonVersion)" />
+    <PackageReference Include="System.IO.FileSystem.AccessControl" Version="$(SystemIOFileSystemAccessControlVersion)" />
     <PackageReference Include="System.IO.Packaging" Version="$(SystemIOPackagingVersion)" />
+    <PackageReference Include="System.IO.Pipes.AccessControl" Version="$(SystemIOPipesAccessControl)" />
     <PackageReference Include="System.Resources.Extensions" Version="$(SystemResourcesExtensionsPackageVersion)" />
     <PackageReference Include="System.Security.AccessControl" Version="$(SystemSecurityAccessControlVersion)" />
     <PackageReference Include="System.Security.Cryptography.Cng" Version="$(SystemSecurityCryptographyCngVersion)" />
     <PackageReference Include="System.Security.Cryptography.Pkcs" Version="$(SystemSecurityCryptographyPkcsVersion)" />
     <PackageReference Include="System.Security.Cryptography.ProtectedData" Version="$(SystemSecurityCryptographyProtectedDataVersion)" />
     <PackageReference Include="System.Security.Cryptography.Xml" Version="$(SystemSecurityCryptographyXmlVersion)" />
-    <PackageReference Include="System.Security.Permissions" Version="$(SystemSecurityPermissionsVersion)" />
     <PackageReference Include="System.Security.Principal.Windows" Version="$(SystemSecurityPrincipalWindowsVersion)" />
+    <PackageReference Include="System.Threading.AccessControl" Version="$(SystemThreadingAccessControlVersion)" />
     <PackageReference Include="System.Windows.Extensions" Version="$(SystemWindowsExtensionsPackageVersion)" />
   </ItemGroup>
 
   <ItemGroup>
-    <RuntimeOnlyPackageReference Include="System.Diagnostics.EventLog" Version="$(SystemDiagnosticsEventLogVersion)" />
-    <RuntimeOnlyPackageReference Include="System.DirectoryServices" Version="$(SystemDirectoryServicesVersion)" />
-    <RuntimeOnlyPackageReference Include="System.IO.FileSystem.AccessControl" Version="$(SystemIOFileSystemAccessControlVersion)" />
-    <RuntimeOnlyPackageReference Include="System.Threading.AccessControl" Version="$(SystemThreadingAccessControlVersion)" />
+    <RuntimeOnlyPackageReference Include="System.Security.Permissions" Version="$(SystemSecurityPermissionsVersion)" />
 
     <PackageReference Include="@(RuntimeOnlyPackageReference)" ExcludeAssets="Compile" />
   </ItemGroup>

--- a/src/pkg/projects/windowsdesktop/src/windowsdesktop.depproj
+++ b/src/pkg/projects/windowsdesktop/src/windowsdesktop.depproj
@@ -16,6 +16,7 @@
     <PackageReference Include="System.Drawing.Common" Version="$(SystemDrawingCommonVersion)" />
     <PackageReference Include="System.IO.FileSystem.AccessControl" Version="$(SystemIOFileSystemAccessControlVersion)" />
     <PackageReference Include="System.IO.Packaging" Version="$(SystemIOPackagingVersion)" />
+    <PackageReference Include="System.IO.Pipes.AccessControl" Version="$(SystemIOPipesAccessControl)" />
     <PackageReference Include="System.Resources.Extensions" Version="$(SystemResourcesExtensionsPackageVersion)" />
     <PackageReference Include="System.Security.AccessControl" Version="$(SystemSecurityAccessControlVersion)" />
     <PackageReference Include="System.Security.Cryptography.Cng" Version="$(SystemSecurityCryptographyCngVersion)" />
@@ -26,12 +27,6 @@
     <PackageReference Include="System.Security.Principal.Windows" Version="$(SystemSecurityPrincipalWindowsVersion)" />
     <PackageReference Include="System.Threading.AccessControl" Version="$(SystemThreadingAccessControlVersion)" />
     <PackageReference Include="System.Windows.Extensions" Version="$(SystemWindowsExtensionsPackageVersion)" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <RefOnlyPackageReference Include="System.IO.Pipes.AccessControl" Version="$(SystemIOPipesAccessControl)" />
-
-    <PackageReference Include="@(RefOnlyPackageReference)" ExcludeAssets="Runtime" />
   </ItemGroup>
 
   <!--


### PR DESCRIPTION
Port of https://github.com/dotnet/core-setup/pull/7324 to `release/3.0`. For https://github.com/dotnet/core-setup/issues/7290.

The WindowsBase version issue is not a problem in `release/3.0`. WindowsDesktop has:

```
WindowsBase.dll|Microsoft.WindowsDesktop.App.Runtime.win-x64|4.0.0.0|4.800.19.37306
```

and NETCoreApp has:

```
WindowsBase.dll|Microsoft.NETCore.App.Runtime.win-x64|4.0.0.0|4.700.19.37208
```

---

After the port, a new error exposed an issue where `netcoreapp.depproj` was building for `win-x86`, which doesn't match the set platform ,`x64`. In `master`, this issue didn't result in an error, maybe because the Arcade SDK version is different. I think it probably caused undesired behavior that just wasn't as easy to see. To fix this, I changed how `PlatformManifestProjectReference` works a bit:

* Before: when `windowsdesktop.depproj` builds `netcoreapp.depproj` *inside* the RID-specific MSBuild call, the forced `RuntimeIdentifier` prop causes the `netcoreapp.depproj` build to fail.
* Fix: I avoid doing this by instead using `OrderProjectReference`, which builds *before* the RID-specific package build, so the build runs with the default `RuntimeIdentifier` and it hits the MSBuild cache.