### PR TITLE
Make apphost.exe and comhost.dll MSI id stable

### DIFF
--- a/src/pkg/packaging-tools/windows/wix.targets
+++ b/src/pkg/packaging-tools/windows/wix.targets
@@ -6,6 +6,8 @@
     this file and switch to wixproj. See https://github.com/wixtoolset/issues/issues/5627
   -->
 
+  <UsingTask TaskName="StabilizeWixFileId" AssemblyFile="$(LocalBuildToolsTaskFile)" />
+
   <!--
     If UpgradeCode isn't manually set, generate based on installer full path. Not suitable for
     bundles.
@@ -85,6 +87,17 @@
 
     <Message Importance="High" Text="Heat '$(MSBuildProjectName)'" />
     <Exec Command="%(DirectoryToHarvest.Command)" WorkingDirectory="$(WixToolsDir)" />
+
+    <!--
+      Currently FileElementToStabilize assumes a single DirectoryToHarvest. If there were multiple,
+      the task would expect exactly one match in each file, which isn't likely to be the case. But,
+      there is no known scenario to have multiple DirectoryToHarvest and use FileElementToStabilize.
+    -->
+    <StabilizeWixFileId
+      Condition="'@(HeatOutputFileElementToStabilize)' != ''"
+      SourceFile="%(DirectoryToHarvest.WixSourceFile)"
+      OutputFile="%(DirectoryToHarvest.WixSourceFile)"
+      FileElementToStabilize="@(HeatOutputFileElementToStabilize)" />
   </Target>
 
   <Target Name="RunCandleCompiler"

--- a/src/pkg/projects/netcoreapp/pkg/Microsoft.NETCore.App.Host.pkgproj
+++ b/src/pkg/projects/netcoreapp/pkg/Microsoft.NETCore.App.Host.pkgproj
@@ -6,4 +6,16 @@
   -->
   <Import Project="..\..\Microsoft.NETCore.DotNetAppHost\Microsoft.NETCore.DotNetAppHost.props" />
 
+  <!--
+    These files are not signed, because they're templates: they are modified by the SDK on the
+    user's machine before use. We have a signing validation exception for Visual Studio insertion's
+    signature validation. However, the exceptions are based on the file IDs, which are not stable
+    because product version is in the path. We need to force these IDs to be stable by modifying
+    the WiX source file. https://github.com/dotnet/core-setup/issues/7327
+  -->
+  <ItemGroup>
+    <HeatOutputFileElementToStabilize Include="native\apphost.exe" ReplacementId="apphosttemplateapphostexe" />
+    <HeatOutputFileElementToStabilize Include="native\comhost.dll" ReplacementId="comhosttemplatecomhostdll" />
+  </ItemGroup>
+
 </Project>

--- a/tools-local/tasks/StabilizeWixFileId.cs
+++ b/tools-local/tasks/StabilizeWixFileId.cs
@@ -54,7 +54,7 @@ namespace Microsoft.DotNet.Build.Tasks
             XDocument content = XDocument.Load(SourceFile);
 
             XNamespace rootNamespace = content.Root.GetDefaultNamespace();
-            XName N(string name) => rootNamespace.GetName(name);
+            XName GetQualifiedName(string name) => rootNamespace.GetName(name);
 
             foreach (var file in FileElementToStabilize)
             {
@@ -66,11 +66,11 @@ namespace Microsoft.DotNet.Build.Tasks
                     continue;
                 }
 
-                XElement[] matchingFileElements = content.Element(N("Wix"))
-                    .Elements(N("Fragment"))
-                    .SelectMany(f => f.Elements(N("ComponentGroup")))
-                    .SelectMany(cg => cg.Elements(N("Component")))
-                    .SelectMany(c => c.Elements(N("File")))
+                XElement[] matchingFileElements = content.Element(GetQualifiedName("Wix"))
+                    .Elements(GetQualifiedName("Fragment"))
+                    .SelectMany(f => f.Elements(GetQualifiedName("ComponentGroup")))
+                    .SelectMany(cg => cg.Elements(GetQualifiedName("Component")))
+                    .SelectMany(c => c.Elements(GetQualifiedName("File")))
                     .Where(f => f.Attribute("Source")?.Value
                         ?.EndsWith(file.ItemSpec, StringComparison.OrdinalIgnoreCase) == true)
                     .ToArray();

--- a/tools-local/tasks/StabilizeWixFileId.cs
+++ b/tools-local/tasks/StabilizeWixFileId.cs
@@ -1,0 +1,107 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Build.Framework;
+using System;
+using System.Diagnostics;
+using System.Linq;
+using System.Xml.Linq;
+
+namespace Microsoft.DotNet.Build.Tasks
+{
+    /// <summary>
+    /// In a WiX source file, replaces the Id of a File with some given string in order to stabilize
+    /// it. This allows external tooling such as signature validators to rely on a stable identifier
+    /// for certain files.
+    /// </summary>
+    public class StabilizeWixFileId : BuildTask
+    {
+        /// <summary>
+        /// File to read from. This is expected to be an output from heat.exe.
+        /// 
+        /// Expected format:
+        /// 
+        ///   <?xml version="1.0" encoding="utf-8"?>
+        ///   <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
+        ///       <Fragment>
+        ///           <ComponentGroup Id="InstallFiles">
+        ///               <Component Id="cmp680C9..." Directory="dir14B9F..." Guid="{C31...}">
+        ///                   <File Id="filE57B7..." KeyPath="yes" Source="$(var.PackSrc)\packs\...\native\apphost.exe" />
+        ///                   ...
+        /// </summary>
+        [Required]
+        public string SourceFile { get; set; }
+
+        /// <summary>
+        /// File to write to. May be the same as SourceFile.
+        /// </summary>
+        [Required]
+        public string OutputFile { get; set; }
+
+        /// <summary>
+        /// Set of files to stabilize. This matches the end of the "Source" attribute in the WiX
+        /// source file. If exactly one match isn't found in the WiX source file, this task fails.
+        /// 
+        /// %(Identity): The file source to replace.
+        /// %(ReplacementId): The replacement for Id that won't change per-build.
+        /// </summary>
+        [Required]
+        public ITaskItem[] FileElementToStabilize { get; set; }
+
+        public override bool Execute()
+        {
+            XDocument content = XDocument.Load(SourceFile);
+
+            XNamespace rootNamespace = content.Root.GetDefaultNamespace();
+            XName N(string name) => rootNamespace.GetName(name);
+
+            foreach (var file in FileElementToStabilize)
+            {
+                string replacement = file.GetMetadata("ReplacementId");
+
+                if (string.IsNullOrEmpty(replacement))
+                {
+                    Log.LogError($"{nameof(FileElementToStabilize)} {file.ItemSpec} has null/empty ReplacementId metadata.");
+                    continue;
+                }
+
+                XElement[] matchingFileElements = content.Element(N("Wix"))
+                    .Elements(N("Fragment"))
+                    .SelectMany(f => f.Elements(N("ComponentGroup")))
+                    .SelectMany(cg => cg.Elements(N("Component")))
+                    .SelectMany(c => c.Elements(N("File")))
+                    .Where(f => f.Attribute("Source")?.Value
+                        ?.EndsWith(file.ItemSpec, StringComparison.OrdinalIgnoreCase) == true)
+                    .ToArray();
+
+                if (matchingFileElements.Length != 1)
+                {
+                    Log.LogError(
+                        $"Expected 1 match for '{file.ItemSpec}', found {matchingFileElements.Length}: " +
+                        string.Join(", ", matchingFileElements.Select(e => e.ToString())));
+
+                    continue;
+                }
+
+                XAttribute nameAttribute = matchingFileElements[0].Attribute("Id");
+
+                if (nameAttribute is null)
+                {
+                    Log.LogError($"Match has no Id attribute: {matchingFileElements[0]}");
+                    continue;
+                }
+
+                Log.LogMessage(
+                    $"Setting '{file.ItemSpec}' Id to '{replacement}' for File with Source " +
+                    matchingFileElements[0].Attribute("Source").Value);
+
+                nameAttribute.Value = replacement;
+            }
+
+            content.Save(OutputFile);
+
+            return !Log.HasLoggedErrors;
+        }
+    }
+}


### PR DESCRIPTION
For https://github.com/dotnet/core-setup/issues/7327.

[Core-SDK has an `xslt`](https://github.com/dotnet/core-sdk/blob/c15fdd6b2b899eaf8c1f34c5e3e1cd1c198f2cc9/src/redist/targets/packaging/windows/clisdk/StableFileIdForApphostTransform.xslt) to do this to a single `File`, but IMO it's better to implement a clear build task than for me to learn and introduce a new technology to the repo (and other repos once these tools are shared).

Example file table for a `dotnet-apphost-pack-5.0.0-dev-win-x64.msi` built with this change:

File | Component_ | FileName | FileSize | Version | Language | Attributes | Sequence
--- | --- | --- | --- | --- | --- | --- | ---
apphosttemplateapphostexe | cmp680C9770566E399B0F071F78C6F898CC | apphost.exe | 2291200 |  |  | 512 | 1
comhosttemplatecomhostdll | cmp32712694AB07CC787C868110099932EE | comhost.dll | 2036736 | 42.42.42.42424 | 1033 | 512 | 2
fil06E4E13D55CE2ECD89A337A420C96A4E | cmp76863AC956DD5DD65C8EBBADF7FFC8C3 | ijwhost.dll | 2269184 | 42.42.42.42424 | 1033 | 512 | 3
fil2155E724E9CA6C9089BAB7E00CF4F8F0 | cmp4645D466AF4C5CFD2F0AAB09947BE103 | nethost.h | 2803 |  |  | 512 | 4
fil8CAD6E0DA97FDE80B7FABC1F377F7E78 | cmpD0F4A07181EB518988CBA5F70EE3ABAB | ijwhost.lib | 1716 |  |  | 512 | 5
filC3F1E5B468881FCE5FC6FED7650E4EB6 | cmpF7606CAF069829F1E698F8E37C248326 | nethost.dll | 1630208 | 42.42.42.42424 | 1033 | 512 | 6
filE17BA6B727678761F86E9F558310EEDC | cmp6DC5E23C214B2284EEF991D1CF4A2948 | nethost.lib | 1742 |  |  | 512 | 7

I'll be porting this to `release/3.0` as soon as it goes in, this is important to reduce the pain of VS insertion.