### PR TITLE
[release/3.0] Fix release/3.0 official build Latest channel

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -17,7 +17,7 @@
     <!-- Disable SemVer v2 until after 3.0.0. -->
     <SemanticVersioningV1 Condition="&#xA;      $(MajorVersion) &lt; 3 or&#xA;      '$(MajorVersion).$(MinorVersion).$(PatchVersion)' == '3.0.0'">true</SemanticVersioningV1>
     <!-- "Latest" channel to publish to. -->
-    <Channel>master</Channel>
+    <Channel>release/3.0</Channel>
     <ContainerName>dotnet</ContainerName>
     <ChecksumContainerName>$(ContainerName)</ChecksumContainerName>
     <!-- Max version of NETCoreApp, used by test projects. -->


### PR DESCRIPTION
I didn't account for the latest channel branding change in the Arcade migration, so both `release/3.0` and `master` are copying to the `master` latest channel and the 3.0 readme column is out of date. This PR fixes it.