### PR TITLE
[release/3.0] Make apphost.exe and comhost.dll MSI id stable

### DIFF
--- a/src/pkg/packaging-tools/windows/wix.targets
+++ b/src/pkg/packaging-tools/windows/wix.targets
@@ -6,6 +6,8 @@
     this file and switch to wixproj. See https://github.com/wixtoolset/issues/issues/5627
   -->
 
+  <UsingTask TaskName="StabilizeWixFileId" AssemblyFile="$(LocalBuildToolsTaskFile)" />
+
   <!--
     If UpgradeCode isn't manually set, generate based on installer full path. Not suitable for
     bundles.
@@ -85,6 +87,17 @@
 
     <Message Importance="High" Text="Heat '$(MSBuildProjectName)'" />
     <Exec Command="%(DirectoryToHarvest.Command)" WorkingDirectory="$(WixToolsDir)" />
+
+    <!--
+      Currently FileElementToStabilize assumes a single DirectoryToHarvest. If there were multiple,
+      the task would expect exactly one match in each file, which isn't likely to be the case. But,
+      there is no known scenario to have multiple DirectoryToHarvest and use FileElementToStabilize.
+    -->
+    <StabilizeWixFileId
+      Condition="'@(HeatOutputFileElementToStabilize)' != ''"
+      SourceFile="%(DirectoryToHarvest.WixSourceFile)"
+      OutputFile="%(DirectoryToHarvest.WixSourceFile)"
+      FileElementToStabilize="@(HeatOutputFileElementToStabilize)" />
   </Target>
 
   <Target Name="RunCandleCompiler"

--- a/src/pkg/projects/netcoreapp/pkg/Microsoft.NETCore.App.Host.pkgproj
+++ b/src/pkg/projects/netcoreapp/pkg/Microsoft.NETCore.App.Host.pkgproj
@@ -6,4 +6,16 @@
   -->
   <Import Project="..\..\Microsoft.NETCore.DotNetAppHost\Microsoft.NETCore.DotNetAppHost.props" />
 
+  <!--
+    These files are not signed, because they're templates: they are modified by the SDK on the
+    user's machine before use. We have a signing validation exception for Visual Studio insertion's
+    signature validation. However, the exceptions are based on the file IDs, which are not stable
+    because product version is in the path. We need to force these IDs to be stable by modifying
+    the WiX source file. https://github.com/dotnet/core-setup/issues/7327
+  -->
+  <ItemGroup>
+    <HeatOutputFileElementToStabilize Include="native\apphost.exe" ReplacementId="apphosttemplateapphostexe" />
+    <HeatOutputFileElementToStabilize Include="native\comhost.dll" ReplacementId="comhosttemplatecomhostdll" />
+  </ItemGroup>
+
 </Project>

--- a/tools-local/tasks/StabilizeWixFileId.cs
+++ b/tools-local/tasks/StabilizeWixFileId.cs
@@ -1,0 +1,107 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Build.Framework;
+using System;
+using System.Diagnostics;
+using System.Linq;
+using System.Xml.Linq;
+
+namespace Microsoft.DotNet.Build.Tasks
+{
+    /// <summary>
+    /// In a WiX source file, replaces the Id of a File with some given string in order to stabilize
+    /// it. This allows external tooling such as signature validators to rely on a stable identifier
+    /// for certain files.
+    /// </summary>
+    public class StabilizeWixFileId : BuildTask
+    {
+        /// <summary>
+        /// File to read from. This is expected to be an output from heat.exe.
+        /// 
+        /// Expected format:
+        /// 
+        ///   <?xml version="1.0" encoding="utf-8"?>
+        ///   <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
+        ///       <Fragment>
+        ///           <ComponentGroup Id="InstallFiles">
+        ///               <Component Id="cmp680C9..." Directory="dir14B9F..." Guid="{C31...}">
+        ///                   <File Id="filE57B7..." KeyPath="yes" Source="$(var.PackSrc)\packs\...\native\apphost.exe" />
+        ///                   ...
+        /// </summary>
+        [Required]
+        public string SourceFile { get; set; }
+
+        /// <summary>
+        /// File to write to. May be the same as SourceFile.
+        /// </summary>
+        [Required]
+        public string OutputFile { get; set; }
+
+        /// <summary>
+        /// Set of files to stabilize. This matches the end of the "Source" attribute in the WiX
+        /// source file. If exactly one match isn't found in the WiX source file, this task fails.
+        /// 
+        /// %(Identity): The file source to replace.
+        /// %(ReplacementId): The replacement for Id that won't change per-build.
+        /// </summary>
+        [Required]
+        public ITaskItem[] FileElementToStabilize { get; set; }
+
+        public override bool Execute()
+        {
+            XDocument content = XDocument.Load(SourceFile);
+
+            XNamespace rootNamespace = content.Root.GetDefaultNamespace();
+            XName GetQualifiedName(string name) => rootNamespace.GetName(name);
+
+            foreach (var file in FileElementToStabilize)
+            {
+                string replacement = file.GetMetadata("ReplacementId");
+
+                if (string.IsNullOrEmpty(replacement))
+                {
+                    Log.LogError($"{nameof(FileElementToStabilize)} {file.ItemSpec} has null/empty ReplacementId metadata.");
+                    continue;
+                }
+
+                XElement[] matchingFileElements = content.Element(GetQualifiedName("Wix"))
+                    .Elements(GetQualifiedName("Fragment"))
+                    .SelectMany(f => f.Elements(GetQualifiedName("ComponentGroup")))
+                    .SelectMany(cg => cg.Elements(GetQualifiedName("Component")))
+                    .SelectMany(c => c.Elements(GetQualifiedName("File")))
+                    .Where(f => f.Attribute("Source")?.Value
+                        ?.EndsWith(file.ItemSpec, StringComparison.OrdinalIgnoreCase) == true)
+                    .ToArray();
+
+                if (matchingFileElements.Length != 1)
+                {
+                    Log.LogError(
+                        $"Expected 1 match for '{file.ItemSpec}', found {matchingFileElements.Length}: " +
+                        string.Join(", ", matchingFileElements.Select(e => e.ToString())));
+
+                    continue;
+                }
+
+                XAttribute nameAttribute = matchingFileElements[0].Attribute("Id");
+
+                if (nameAttribute is null)
+                {
+                    Log.LogError($"Match has no Id attribute: {matchingFileElements[0]}");
+                    continue;
+                }
+
+                Log.LogMessage(
+                    $"Setting '{file.ItemSpec}' Id to '{replacement}' for File with Source " +
+                    matchingFileElements[0].Attribute("Source").Value);
+
+                nameAttribute.Value = replacement;
+            }
+
+            content.Save(OutputFile);
+
+            return !Log.HasLoggedErrors;
+        }
+    }
+}


### PR DESCRIPTION
#### Description

We have some files in the AppHost pack that are intentionally not signed. To pass VS insertion signing checks, we have an exception. Right now, the file identifiers in the MSI change build-to-build, so the exceptions have to be updated in every VS insertion PR. This fix makes the identifiers stable. https://github.com/dotnet/core-setup/issues/7327

#### Customer Impact

None.

#### Regression?

No.

#### Risk

Minimal. This is a clean port of https://github.com/dotnet/core-setup/pull/7387 to `release/3.0`. The changes are internal to the MSI and don't affect the files installed on disk.