### PR TITLE
[release/3.0] Add missing Microsoft.Win32.Registry.AccessControl Version.Details.xml entry

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -13,6 +13,10 @@
       <Uri>https://github.com/dotnet/corefx</Uri>
       <Sha>ae28da289ecb09197cfc16b619db0fc1df86bc42</Sha>
     </Dependency>
+    <Dependency Name="Microsoft.Win32.Registry.AccessControl" Version="4.6.0-preview8.19375.15">
+      <Uri>https://github.com/dotnet/corefx</Uri>
+      <Sha>ae28da289ecb09197cfc16b619db0fc1df86bc42</Sha>
+    </Dependency>
     <Dependency Name="Microsoft.Win32.Registry" Version="4.6.0-preview8.19375.15">
       <Uri>https://github.com/dotnet/corefx</Uri>
       <Sha>ae28da289ecb09197cfc16b619db0fc1df86bc42</Sha>


### PR DESCRIPTION
This Dependency entry wasn't added when the version prop was added in https://github.com/dotnet/core-setup/pull/7372.

Quick fix to make sure Maestro++ upgrades it along with the other packages.

/cc @MichaelSimons 