### PR TITLE
[release/3.0] Enable push to VS insertion feed

### DIFF
--- a/eng/jobs/windows-build.yml
+++ b/eng/jobs/windows-build.yml
@@ -37,6 +37,7 @@ jobs:
       MsbuildSigningArguments: >-
         /p:CertificateId=400
         /p:DotNetSignType=$(SignType)
+      TargetArchitecture: ${{ parameters.targetArchitecture }}
 
     steps:
 
@@ -60,6 +61,16 @@ jobs:
         $(CommonMSBuildArgs)
         $(MsbuildSigningArguments)
       displayName: Build
+
+    - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest'), ne(variables['DisableVSPublish'], 'true')) }}:
+      - task: NuGetCommand@2
+        displayName: Push Visual Studio NuPkgs
+        inputs:
+          command: push
+          packagesToPush: '$(Build.SourcesDirectory)/artifacts/packages/$(_BuildConfig)/*/VS.Redist.Common.*.nupkg'
+          nuGetFeedType: external
+          publishFeedCredentials: 'DevDiv - VS package feed'
+        condition: and(succeeded(), or(eq(variables['TargetArchitecture'], 'x64'), eq(variables['TargetArchitecture'], 'x86')), eq(variables['_BuildConfig'], 'Release'))
 
     - template: steps/upload-job-artifacts.yml
       parameters:


### PR DESCRIPTION
Clean cherry-pick of https://github.com/dotnet/core-setup/pull/7397. This removes a manual part of VS insertion.

Confirmed this works in an official build: https://dev.azure.com/dnceng/internal/_build/results?buildId=281685

Thanks again @johnbeisner! 😄 