### PR TITLE
[release/3.0] Fix PlatformManifestProjectReference ordering to fix flakiness

### DIFF
--- a/src/pkg/packaging-tools/framework.dependency.targets
+++ b/src/pkg/packaging-tools/framework.dependency.targets
@@ -468,7 +468,8 @@
           DependsOnTargets="ResolveReferences"
           Returns="@(ReferenceCopyLocalPaths -> '%(Filename)')" />
 
-  <Target Name="BuildDependencyProjectReferences">
+  <Target Name="BuildDependencyProjectReferences"
+          DependsOnTargets="GetDefaultOrderProjectReferences">
     <MSBuild Projects="@(OrderProjectReference)" Targets="Build" />
   </Target>
 

--- a/src/pkg/packaging-tools/framework.packaging.targets
+++ b/src/pkg/packaging-tools/framework.packaging.targets
@@ -192,7 +192,8 @@
             (
               '$(BuildRidSpecificPacks)' == 'true' or
               ('$(FrameworkPackType)' == '' and '$(BuildRuntimePackages)' == 'true')
-            )">
+            )"
+          DependsOnTargets="GetDefaultOrderProjectReferences">
     <!--
       Ensure all project references are built to make sure dependencies (e.g. native build and
       depproj's crossgen) runs first. The global properties mean we can't let the inner build handle

--- a/src/pkg/packaging-tools/framework.sharedfx.targets
+++ b/src/pkg/packaging-tools/framework.sharedfx.targets
@@ -234,7 +234,8 @@
     we're using its nupkg directly. In the future, this will be handled in shared tooling to
     generate shared frameworks in the Arcade SDK.
   -->
-  <Target Name="BuildPkgProjectReferences">
+  <Target Name="BuildPkgProjectReferences"
+          DependsOnTargets="GetDefaultOrderProjectReferences">
     <MSBuild
       Projects="
         $(RepoRoot)signing\SignBinaries.proj;

--- a/src/pkg/packaging-tools/packaging-tools.props
+++ b/src/pkg/packaging-tools/packaging-tools.props
@@ -81,9 +81,4 @@
     <OutputName>$(InstallerFileNameWithoutExtension)</OutputName>
   </PropertyGroup>
 
-  <ItemGroup>
-    <!-- Ensure depproj has had a chance to build the platform manifest. -->
-    <OrderProjectReference Include="@(PlatformManifestProjectReference)" />
-  </ItemGroup>
-
 </Project>

--- a/src/pkg/packaging-tools/packaging-tools.targets
+++ b/src/pkg/packaging-tools/packaging-tools.targets
@@ -136,6 +136,13 @@
     </ItemGroup>
   </Target>
 
+  <Target Name="GetDefaultOrderProjectReferences">
+    <ItemGroup>
+      <!-- Ensure depproj has had a chance to build the platform manifest. -->
+      <OrderProjectReference Include="@(PlatformManifestProjectReference)" />
+    </ItemGroup>
+  </Target>
+
   <Target Name="ResolvePlatformManifestProjectReferences"
           Condition="'@(PlatformManifestProjectReference)' != ''"
           BeforeTargets="ResolveProjectReferences">


### PR DESCRIPTION
Props file import order meant `OrderProjectReference Include="@(PlatformManifestProjectReference)"` was being evaluated before PlatformManifestProjectReference was set. Solve this by moving the include to a new GetDefaultOrderProjectReferences target so the static prop order doesn't matter.

Fixes Windows job CI flakiness introduced with https://github.com/dotnet/core-setup/pull/7372.

An alternative would be to change where the `PlatformManifestProjectReference` is defined to put it before it's needed, but I find relying on static order makes the build harder to understand and debug, and less flexible.

Somehow this didn't affect the initial PR... a lot of (all?) other 3.0 PRs are currently hitting this issue in CI, though.