### PR TITLE
Update branding to preview9 and remove BuildNumberYY workaround

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -4,13 +4,8 @@
     <MajorVersion>3</MajorVersion>
     <MinorVersion>0</MinorVersion>
     <PatchVersion>0</PatchVersion>
-    <!--
-      TODO: When changing this to preview9, remove /p:_BuildNumberYY=28 workaround in the official
-      build yml files. These were added because we migrated to the Arcade SDK during preview8, and
-      needed to raise the version number to preserve continuity. In preview9 we should remove these
-      to conform to Arcade defaults. https://github.com/dotnet/core-setup/issues/7348
-    -->
-    <PreReleaseVersionLabel>preview8</PreReleaseVersionLabel>
+
+    <PreReleaseVersionLabel>preview9</PreReleaseVersionLabel>
     <!-- Enable to remove prerelease label. -->
     <StabilizePackageVersion Condition="'$(StabilizePackageVersion)' == ''">false</StabilizePackageVersion>
     <DotNetFinalVersionKind Condition="'$(StabilizePackageVersion)' == 'true'">release</DotNetFinalVersionKind>

--- a/eng/jobs/bash-build.yml
+++ b/eng/jobs/bash-build.yml
@@ -47,7 +47,6 @@ jobs:
         /p:Configuration=$(_BuildConfig)
         /p:OfficialBuildId=$(OfficialBuildId)
         /p:TargetArchitecture=${{ parameters.targetArchitecture }}
-        /p:_BuildNumberYY=28
 
       # Don't put additionalMSBuildArgs as the last line. It may or may not have extra args. If the
       # parameter is empty, AzDO replaces it with empty space without chomping the extra newline.

--- a/eng/jobs/finalize-publish.yml
+++ b/eng/jobs/finalize-publish.yml
@@ -135,7 +135,6 @@ jobs:
       $(_CommonPublishArgs)
       $(_SymbolServerArgs)
       $(_DotNetVersionsArgs)
-      /p:_BuildNumberYY=28
       /bl:$(Build.SourcesDirectory)\finalizepublish.binlog
     displayName: Publish
 

--- a/eng/jobs/osx-build.yml
+++ b/eng/jobs/osx-build.yml
@@ -20,7 +20,6 @@ jobs:
     CommonMSBuildArgs: >-
       /p:Configuration=$(_BuildConfig)
       /p:PortableBuild=true
-      /p:_BuildNumberYY=28
   steps:
   - script: >-
       $(Build.SourcesDirectory)/build.sh --ci --test

--- a/eng/jobs/windows-build.yml
+++ b/eng/jobs/windows-build.yml
@@ -33,7 +33,6 @@ jobs:
         /p:TargetArchitecture=${{ parameters.targetArchitecture }}
         /p:PortableBuild=true
         /p:SkipTests=${{ parameters.skipTests }}
-        /p:_BuildNumberYY=28
       MsbuildSigningArguments: >-
         /p:CertificateId=400
         /p:DotNetSignType=$(SignType)


### PR DESCRIPTION
We should merge this once a final build is declared for preview8. Also should resolve https://github.com/dotnet/core-setup/issues/7348. We'll also need to switch the default channel mapping for this repo back to ".Net Core 3 Dev".

CC @dagood @mmitche 