### PR TITLE
Fix how we determine line/column from a JsonReaderState

### DIFF
--- a/src/managed/Microsoft.Extensions.DependencyModel/UnifiedJsonReader.Utf8JsonReader.cs
+++ b/src/managed/Microsoft.Extensions.DependencyModel/UnifiedJsonReader.Utf8JsonReader.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Reflection;
 using System.Text.Json;
 
 namespace Microsoft.Extensions.DependencyModel
@@ -148,8 +149,8 @@ namespace Microsoft.Extensions.DependencyModel
         {
             // Replace with public API once https://github.com/dotnet/corefx/issues/34768 is fixed
             object boxedState = reader.CurrentState;
-            long lineNumber = (long)(typeof(JsonReaderState).GetField("_lineNumber")?.GetValue(boxedState) ?? -1);
-            long bytePositionInLine = (long)(typeof(JsonReaderState).GetField("_bytePositionInLine")?.GetValue(boxedState) ?? -1);
+            long lineNumber = (long)(typeof(JsonReaderState).GetField("_lineNumber", BindingFlags.Instance | BindingFlags.NonPublic)?.GetValue(boxedState) ?? -1);
+            long bytePositionInLine = (long)(typeof(JsonReaderState).GetField("_bytePositionInLine", BindingFlags.Instance | BindingFlags.NonPublic)?.GetValue(boxedState) ?? -1);
 
             return new FormatException($"Unexpected character encountered, excepted '{expected}' " +
                                        $"at line {lineNumber} position {bytePositionInLine}");

--- a/src/test/Microsoft.Extensions.DependencyModel.Tests/DependencyContextJsonReaderTest.cs
+++ b/src/test/Microsoft.Extensions.DependencyModel.Tests/DependencyContextJsonReaderTest.cs
@@ -698,6 +698,20 @@ namespace Microsoft.Extensions.DependencyModel.Tests
         }
 
         [Fact]
+        public void FailsToReadInvalidDefines()
+        {
+            Assert.Throws<FormatException>(() => Read(
+@"{
+    ""compilationOptions"": {
+        ""defines"": ""MY"",
+    },
+    ""targets"": {
+        "".NETCoreApp,Version=v1.0/osx.10.10-x64"": {}
+    }
+}"));
+        }
+
+        [Fact]
         public void IgnoresUnknownPropertiesInCompilationOptions()
         {
             var context = Read(

--- a/src/test/Microsoft.Extensions.DependencyModel.Tests/DependencyContextJsonReaderTest.cs
+++ b/src/test/Microsoft.Extensions.DependencyModel.Tests/DependencyContextJsonReaderTest.cs
@@ -708,7 +708,7 @@ namespace Microsoft.Extensions.DependencyModel.Tests
     ""targets"": {
         "".NETCoreApp,Version=v1.0/osx.10.10-x64"": {}
     }
-}"));
+}")).Message.Should().Contain("line 2 position 23");
         }
 
         [Fact]


### PR DESCRIPTION
Previously these fields were public and so simple `.GetField("name")` worked. Now they are internal, so we need to use the overload which takes `BindingFlags` and ask for private reflection.

The manifestation of this bug is that instead of throwing `FormatException` with details about what is wrong, we throw `InvalidCastException` with cryptic message (can't cast `Int32` to `Int64`).

Related to #7412 