### PR TITLE
[release/3.0] Fix how we determine line/column from a JsonReaderState (#7510)

### DIFF
--- a/src/managed/Microsoft.Extensions.DependencyModel/UnifiedJsonReader.Utf8JsonReader.cs
+++ b/src/managed/Microsoft.Extensions.DependencyModel/UnifiedJsonReader.Utf8JsonReader.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Reflection;
 using System.Text.Json;
 
 namespace Microsoft.Extensions.DependencyModel
@@ -148,8 +149,8 @@ namespace Microsoft.Extensions.DependencyModel
         {
             // Replace with public API once https://github.com/dotnet/corefx/issues/34768 is fixed
             object boxedState = reader.CurrentState;
-            long lineNumber = (long)(typeof(JsonReaderState).GetField("_lineNumber")?.GetValue(boxedState) ?? -1);
-            long bytePositionInLine = (long)(typeof(JsonReaderState).GetField("_bytePositionInLine")?.GetValue(boxedState) ?? -1);
+            long lineNumber = (long)(typeof(JsonReaderState).GetField("_lineNumber", BindingFlags.Instance | BindingFlags.NonPublic)?.GetValue(boxedState) ?? -1);
+            long bytePositionInLine = (long)(typeof(JsonReaderState).GetField("_bytePositionInLine", BindingFlags.Instance | BindingFlags.NonPublic)?.GetValue(boxedState) ?? -1);
 
             return new FormatException($"Unexpected character encountered, excepted '{expected}' " +
                                        $"at line {lineNumber} position {bytePositionInLine}");

--- a/src/test/Microsoft.Extensions.DependencyModel.Tests/DependencyContextJsonReaderTest.cs
+++ b/src/test/Microsoft.Extensions.DependencyModel.Tests/DependencyContextJsonReaderTest.cs
@@ -698,6 +698,20 @@ namespace Microsoft.Extensions.DependencyModel.Tests
         }
 
         [Fact]
+        public void FailsToReadInvalidDefines()
+        {
+            Assert.Throws<FormatException>(() => Read(
+@"{
+    ""compilationOptions"": {
+        ""defines"": ""MY"",
+    },
+    ""targets"": {
+        "".NETCoreApp,Version=v1.0/osx.10.10-x64"": {}
+    }
+}")).Message.Should().Contain("line 2 position 23");
+        }
+
+        [Fact]
         public void IgnoresUnknownPropertiesInCompilationOptions()
         {
             var context = Read(


### PR DESCRIPTION
#### Description
When there's a problem parsing the `.deps.json` in `Microsoft.Extensions.DependencyModel` the code should throw a `FormatException` which includes line/column numbers of the invalid token.
Previously we were using `Newtonsoft.Json` to parse the file which exposes line/column information on the reader as a public API and it worked like this.
In 3.0 we switched to `System.Text.Json` which does not expose line/column information as a public API. To workaround this limitation, we use private reflection to get to the fields which store this information. The way we call the private reflection is wrong though and we end up getting null which then fails to cast to a number. So the end result is that the product throws `InvalidCastException` with no indication of the original error condition.

#### Customer Impact
Hard to diagnose mysterious failures - there's no way for the customer to tell that the `.deps.json` was invalid - other then guessing it based on the callstack of the exception.
If the customer relied on `FormatException` in the application code (catching it for example), a different exception type is thrown now breaking the expected behavior of the application.

#### Regression?
This is a regression in 3.0

#### Risk
Pretty low, the code changes only affect code path which is executed when there's a problem parsing `.deps.json`. This in itself is a relatively rare scenario. The change itself is just a modification of existing logic there are no code flow changes.

Related to #7412

