### PR TITLE
Explicitly set DOTNET_MULTILEVEL_LOOKUP in tests

### DIFF
--- a/src/test/HostActivation.Tests/CommandExtensions.cs
+++ b/src/test/HostActivation.Tests/CommandExtensions.cs
@@ -36,6 +36,18 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
                 .CaptureStdErr();
         }
 
+        public static Command DotNetRoot(this Command command, string dotNetRoot)
+        {
+            return command
+                .EnvironmentVariable("DOTNET_ROOT", dotNetRoot)
+                .EnvironmentVariable("DOTNET_ROOT(x86)", dotNetRoot);
+        }
+
+        public static Command MultilevelLookup(this Command command, bool enable)
+        {
+            return command.EnvironmentVariable(Constants.MultilevelLookup.EnvironmentVariable, enable ? "1" : "0");
+        }
+
         public static Command RuntimeId(this Command command, string rid)
         {
             return command.EnvironmentVariable(Constants.RuntimeId.EnvironmentVariable, rid);

--- a/src/test/HostActivation.Tests/DependencyResolution/ComponentDependencyResolutionBase.cs
+++ b/src/test/HostActivation.Tests/DependencyResolution/ComponentDependencyResolutionBase.cs
@@ -60,7 +60,8 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.DependencyResolution
                 };
 
                 Command command = Command.Create(NativeHostPath, args)
-                    .EnableTracingAndCaptureOutputs();
+                    .EnableTracingAndCaptureOutputs()
+                    .MultilevelLookup(false);
                 commandCustomizer?.Invoke(command);
 
                 return command.Execute()
@@ -86,6 +87,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.DependencyResolution
 
                 return Command.Create(NativeHostPath, args)
                     .EnableTracingAndCaptureOutputs()
+                    .MultilevelLookup(false)
                     .Execute();
             }
 

--- a/src/test/HostActivation.Tests/FrameworkResolution/FrameworkResolutionBase.cs
+++ b/src/test/HostActivation.Tests/FrameworkResolution/FrameworkResolutionBase.cs
@@ -46,11 +46,9 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.FrameworkResolution
                 }
 
                 CommandResult result = command
-                    .EnvironmentVariable("COREHOST_TRACE", "1")
-                    .EnvironmentVariable("DOTNET_MULTILEVEL_LOOKUP", multiLevelLookup ? "1" : "0")
+                    .EnableTracingAndCaptureOutputs()
+                    .MultilevelLookup(multiLevelLookup)
                     .Environment(settings.Environment)
-                    .CaptureStdOut()
-                    .CaptureStdErr()
                     .Execute();
 
                 resultAction?.Invoke(result);

--- a/src/test/HostActivation.Tests/MockCoreClrSanity.cs
+++ b/src/test/HostActivation.Tests/MockCoreClrSanity.cs
@@ -54,6 +54,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
             DotNet.Exec("--roll-forward-on-no-candidate-fx", "2", appDll, "argumentOne", "arg2")
                 .CaptureStdOut()
                 .CaptureStdErr()
+                .MultilevelLookup(false)
                 .Execute()
                 .Should().Pass()
                 .And.HaveStdOutContaining("mock coreclr_initialize() called")

--- a/src/test/HostActivation.Tests/NativeHosting/Comhost.cs
+++ b/src/test/HostActivation.Tests/NativeHosting/Comhost.cs
@@ -31,12 +31,14 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.NativeHosting
                 return;
             }
 
-            string scenario = synchronous ? "synchronous" : "concurrent";
-            string args = $"comhost {scenario} {count} {sharedState.ComHostPath} {sharedState.ClsidString}";
-            CommandResult result = Command.Create(sharedState.NativeHostPath, args)
-                .EnableTracingAndCaptureOutputs()
-                .DotNetRoot(sharedState.ComLibraryFixture.BuiltDotnet.BinPath)
-                .MultilevelLookup(false)
+            string [] args = {
+                "comhost",
+                synchronous ? "synchronous" : "concurrent",
+                $"{count}",
+                sharedState.ComHostPath,
+                sharedState.ClsidString
+            };
+            CommandResult result = sharedState.CreateNativeHostCommand(args, sharedState.ComLibraryFixture.BuiltDotnet.BinPath)
                 .Execute();
 
             result.Should().Pass()
@@ -64,11 +66,14 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.NativeHosting
                     fixture.TestProject.BuiltApp.Location,
                     $"{ fixture.TestProject.AssemblyName }.comhost.dll");
 
-                string args = $"comhost synchronous 1 {comHostWithAppLocalFxr} {sharedState.ClsidString}";
-                CommandResult result = Command.Create(sharedState.NativeHostPath, args)
-                    .EnableTracingAndCaptureOutputs()
-                    .DotNetRoot(fixture.BuiltDotnet.BinPath)
-                    .MultilevelLookup(false)
+                string[] args = {
+                    "comhost",
+                    "synchronous",
+                    "1",
+                    comHostWithAppLocalFxr,
+                    sharedState.ClsidString
+                    };
+                CommandResult result = sharedState.CreateNativeHostCommand(args, fixture.BuiltDotnet.BinPath)
                     .Execute();
 
                 result.Should().Pass()
@@ -98,11 +103,14 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.NativeHosting
                     fixture.TestProject.BuiltApp.Location,
                     $"{ fixture.TestProject.AssemblyName }.comhost.dll");
 
-                string args = $"comhost errorinfo 1 {comHost} {sharedState.ClsidString}";
-                CommandResult result = Command.Create(sharedState.NativeHostPath, args)
-                    .EnableTracingAndCaptureOutputs()
-                    .DotNetRoot(fixture.BuiltDotnet.BinPath)
-                    .MultilevelLookup(false)
+                string[] args = {
+                    "comhost",
+                    "errorinfo",
+                    "1",
+                    comHost,
+                    sharedState.ClsidString
+                };
+                CommandResult result = sharedState.CreateNativeHostCommand(args, fixture.BuiltDotnet.BinPath)
                     .Execute();
 
                 result.Should().Pass()

--- a/src/test/HostActivation.Tests/NativeHosting/Comhost.cs
+++ b/src/test/HostActivation.Tests/NativeHosting/Comhost.cs
@@ -35,8 +35,8 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.NativeHosting
             string args = $"comhost {scenario} {count} {sharedState.ComHostPath} {sharedState.ClsidString}";
             CommandResult result = Command.Create(sharedState.NativeHostPath, args)
                 .EnableTracingAndCaptureOutputs()
-                .EnvironmentVariable("DOTNET_ROOT", sharedState.ComLibraryFixture.BuiltDotnet.BinPath)
-                .EnvironmentVariable("DOTNET_ROOT(x86)", sharedState.ComLibraryFixture.BuiltDotnet.BinPath)
+                .DotNetRoot(sharedState.ComLibraryFixture.BuiltDotnet.BinPath)
+                .MultilevelLookup(false)
                 .Execute();
 
             result.Should().Pass()
@@ -67,8 +67,8 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.NativeHosting
                 string args = $"comhost synchronous 1 {comHostWithAppLocalFxr} {sharedState.ClsidString}";
                 CommandResult result = Command.Create(sharedState.NativeHostPath, args)
                     .EnableTracingAndCaptureOutputs()
-                    .EnvironmentVariable("DOTNET_ROOT", fixture.BuiltDotnet.BinPath)
-                    .EnvironmentVariable("DOTNET_ROOT(x86)", fixture.BuiltDotnet.BinPath)
+                    .DotNetRoot(fixture.BuiltDotnet.BinPath)
+                    .MultilevelLookup(false)
                     .Execute();
 
                 result.Should().Pass()
@@ -101,8 +101,8 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.NativeHosting
                 string args = $"comhost errorinfo 1 {comHost} {sharedState.ClsidString}";
                 CommandResult result = Command.Create(sharedState.NativeHostPath, args)
                     .EnableTracingAndCaptureOutputs()
-                    .EnvironmentVariable("DOTNET_ROOT", fixture.BuiltDotnet.BinPath)
-                    .EnvironmentVariable("DOTNET_ROOT(x86)", fixture.BuiltDotnet.BinPath)
+                    .DotNetRoot(fixture.BuiltDotnet.BinPath)
+                    .MultilevelLookup(false)
                     .Execute();
 
                 result.Should().Pass()

--- a/src/test/HostActivation.Tests/NativeHosting/ComponentActivation.cs
+++ b/src/test/HostActivation.Tests/NativeHosting/ComponentActivation.cs
@@ -38,10 +38,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.NativeHosting
                 validType ? sharedState.ComponentTypeName : $"Component.BadType, {componentProject.AssemblyName}",
                 validMethod ? sharedState.ComponentEntryPoint1 : "BadMethod",
             };
-            CommandResult result = Command.Create(sharedState.NativeHostPath, args)
-                .EnableTracingAndCaptureOutputs()
-                .DotNetRoot(sharedState.DotNetRoot)
-                .MultilevelLookup(false)
+            CommandResult result = sharedState.CreateNativeHostCommand(args, sharedState.DotNetRoot)
                 .Execute();
 
             result.Should()
@@ -88,10 +85,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.NativeHosting
                 args = args.Concat(componentInfo);
             }
 
-            CommandResult result = Command.Create(sharedState.NativeHostPath, args)
-                .EnableTracingAndCaptureOutputs()
-                .DotNetRoot(sharedState.DotNetRoot)
-                .MultilevelLookup(false)
+            CommandResult result = sharedState.CreateNativeHostCommand(args, sharedState.DotNetRoot)
                 .Execute();
 
             result.Should().Pass()
@@ -135,10 +129,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.NativeHosting
                 args = args.Concat(componentInfo);
             }
 
-            CommandResult result = Command.Create(sharedState.NativeHostPath, args)
-                .EnableTracingAndCaptureOutputs()
-                .DotNetRoot(sharedState.DotNetRoot)
-                .MultilevelLookup(false)
+            CommandResult result = sharedState.CreateNativeHostCommand(args, sharedState.DotNetRoot)
                 .Execute();
 
             result.Should().Pass()

--- a/src/test/HostActivation.Tests/NativeHosting/ComponentActivation.cs
+++ b/src/test/HostActivation.Tests/NativeHosting/ComponentActivation.cs
@@ -39,11 +39,9 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.NativeHosting
                 validMethod ? sharedState.ComponentEntryPoint1 : "BadMethod",
             };
             CommandResult result = Command.Create(sharedState.NativeHostPath, args)
-                .CaptureStdErr()
-                .CaptureStdOut()
-                .EnvironmentVariable("COREHOST_TRACE", "1")
-                .EnvironmentVariable("DOTNET_ROOT", sharedState.DotNetRoot)
-                .EnvironmentVariable("DOTNET_ROOT(x86)", sharedState.DotNetRoot)
+                .EnableTracingAndCaptureOutputs()
+                .DotNetRoot(sharedState.DotNetRoot)
+                .MultilevelLookup(false)
                 .Execute();
 
             result.Should()
@@ -91,11 +89,9 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.NativeHosting
             }
 
             CommandResult result = Command.Create(sharedState.NativeHostPath, args)
-                .CaptureStdErr()
-                .CaptureStdOut()
-                .EnvironmentVariable("COREHOST_TRACE", "1")
-                .EnvironmentVariable("DOTNET_ROOT", sharedState.DotNetRoot)
-                .EnvironmentVariable("DOTNET_ROOT(x86)", sharedState.DotNetRoot)
+                .EnableTracingAndCaptureOutputs()
+                .DotNetRoot(sharedState.DotNetRoot)
+                .MultilevelLookup(false)
                 .Execute();
 
             result.Should().Pass()
@@ -140,11 +136,9 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.NativeHosting
             }
 
             CommandResult result = Command.Create(sharedState.NativeHostPath, args)
-                .CaptureStdErr()
-                .CaptureStdOut()
-                .EnvironmentVariable("COREHOST_TRACE", "1")
-                .EnvironmentVariable("DOTNET_ROOT", sharedState.DotNetRoot)
-                .EnvironmentVariable("DOTNET_ROOT(x86)", sharedState.DotNetRoot)
+                .EnableTracingAndCaptureOutputs()
+                .DotNetRoot(sharedState.DotNetRoot)
+                .MultilevelLookup(false)
                 .Execute();
 
             result.Should().Pass()

--- a/src/test/HostActivation.Tests/NativeHosting/HostContext.cs
+++ b/src/test/HostActivation.Tests/NativeHosting/HostContext.cs
@@ -138,10 +138,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.NativeHosting
                 SharedTestState.AppPropertyName,
                 newPropertyName
             };
-            CommandResult result = Command.Create(sharedState.NativeHostPath, args.Concat(commandArgs).Concat(appArgs))
-                .EnableTracingAndCaptureOutputs()
-                .DotNetRoot(sharedState.DotNetRoot)
-                .MultilevelLookup(false)
+            CommandResult result = sharedState.CreateNativeHostCommand(args.Concat(commandArgs).Concat(appArgs), sharedState.DotNetRoot)
                 .Execute();
 
             result.Should().Pass()
@@ -174,10 +171,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.NativeHosting
                 SharedTestState.ConfigPropertyName,
                 newPropertyName
             };
-            CommandResult result = Command.Create(sharedState.NativeHostPath, args)
-                .EnableTracingAndCaptureOutputs()
-                .DotNetRoot(sharedState.DotNetRoot)
-                .MultilevelLookup(false)
+            CommandResult result = sharedState.CreateNativeHostCommand(args, sharedState.DotNetRoot)
                 .Execute();
 
             result.Should().Pass()
@@ -199,10 +193,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.NativeHosting
                 sharedState.SelfContainedHostFxrPath,
                 sharedState.SelfContainedConfigPath
             };
-            CommandResult result = Command.Create(sharedState.NativeHostPath, args)
-                .EnableTracingAndCaptureOutputs()
-                .DotNetRoot(sharedState.DotNetRoot)
-                .MultilevelLookup(false)
+            CommandResult result = sharedState.CreateNativeHostCommand(args, sharedState.DotNetRoot)
                 .Execute();
 
             result.Should().Fail()
@@ -230,10 +221,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.NativeHosting
                 SharedTestState.ConfigPropertyName,
                 SharedTestState.SecondaryConfigPropertyName
             };
-            CommandResult result = Command.Create(sharedState.NativeHostPath, args)
-                .EnableTracingAndCaptureOutputs()
-                .DotNetRoot(sharedState.DotNetRoot)
-                .MultilevelLookup(false)
+            CommandResult result = sharedState.CreateNativeHostCommand(args, sharedState.DotNetRoot)
                 .Execute();
 
             result.Should().Pass()
@@ -281,10 +269,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.NativeHosting
                 SharedTestState.AppPropertyName,
                 SharedTestState.ConfigPropertyName
             };
-            CommandResult result = Command.Create(sharedState.NativeHostPath, args.Concat(appArgs))
-                .EnableTracingAndCaptureOutputs()
-                .DotNetRoot(sharedState.DotNetRoot)
-                .MultilevelLookup(false)
+            CommandResult result = sharedState.CreateNativeHostCommand(args.Concat(appArgs), sharedState.DotNetRoot)
                 .EnvironmentVariable("COREHOST_TRACE_VERBOSITY", "3")
                 .EnvironmentVariable("TEST_BLOCK_MOCK_EXECUTE_ASSEMBLY", $"{sharedState.AppPath}.block")
                 .EnvironmentVariable("TEST_SIGNAL_MOCK_EXECUTE_ASSEMBLY", $"{sharedState.AppPath}.signal")
@@ -370,10 +355,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.NativeHosting
             CommandResult result;
             try
             {
-                result = Command.Create(sharedState.NativeHostPath, args)
-                    .EnableTracingAndCaptureOutputs()
-                    .DotNetRoot(sharedState.DotNetRoot)
-                    .MultilevelLookup(false)
+                result = sharedState.CreateNativeHostCommand(args, sharedState.DotNetRoot)
                     .EnvironmentVariable("COREHOST_TRACE_VERBOSITY", "3")
                     .EnvironmentVariable("TEST_BLOCK_MOCK_EXECUTE_ASSEMBLY", $"{sharedState.AppPath}.block")
                     .EnvironmentVariable("TEST_SIGNAL_MOCK_EXECUTE_ASSEMBLY", $"{sharedState.AppPath}.signal")
@@ -464,10 +446,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.NativeHosting
             CommandResult result;
             try
             {
-                result = Command.Create(sharedState.NativeHostPath, args)
-                    .EnableTracingAndCaptureOutputs()
-                    .DotNetRoot(sharedState.DotNetRoot)
-                    .MultilevelLookup(false)
+                result = sharedState.CreateNativeHostCommand(args, sharedState.DotNetRoot)
                     .EnvironmentVariable("COREHOST_TRACE_VERBOSITY", "3")
                     .EnvironmentVariable("TEST_BLOCK_MOCK_EXECUTE_ASSEMBLY", $"{sharedState.AppPath}.block")
                     .EnvironmentVariable("TEST_SIGNAL_MOCK_EXECUTE_ASSEMBLY", $"{sharedState.AppPath}.signal")

--- a/src/test/HostActivation.Tests/NativeHosting/HostContext.cs
+++ b/src/test/HostActivation.Tests/NativeHosting/HostContext.cs
@@ -139,11 +139,9 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.NativeHosting
                 newPropertyName
             };
             CommandResult result = Command.Create(sharedState.NativeHostPath, args.Concat(commandArgs).Concat(appArgs))
-                .CaptureStdErr()
-                .CaptureStdOut()
-                .EnvironmentVariable("COREHOST_TRACE", "1")
-                .EnvironmentVariable("DOTNET_ROOT", sharedState.DotNetRoot)
-                .EnvironmentVariable("DOTNET_ROOT(x86)", sharedState.DotNetRoot)
+                .EnableTracingAndCaptureOutputs()
+                .DotNetRoot(sharedState.DotNetRoot)
+                .MultilevelLookup(false)
                 .Execute();
 
             result.Should().Pass()
@@ -177,11 +175,9 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.NativeHosting
                 newPropertyName
             };
             CommandResult result = Command.Create(sharedState.NativeHostPath, args)
-                .CaptureStdErr()
-                .CaptureStdOut()
-                .EnvironmentVariable("COREHOST_TRACE", "1")
-                .EnvironmentVariable("DOTNET_ROOT", sharedState.DotNetRoot)
-                .EnvironmentVariable("DOTNET_ROOT(x86)", sharedState.DotNetRoot)
+                .EnableTracingAndCaptureOutputs()
+                .DotNetRoot(sharedState.DotNetRoot)
+                .MultilevelLookup(false)
                 .Execute();
 
             result.Should().Pass()
@@ -204,11 +200,9 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.NativeHosting
                 sharedState.SelfContainedConfigPath
             };
             CommandResult result = Command.Create(sharedState.NativeHostPath, args)
-                .CaptureStdErr()
-                .CaptureStdOut()
-                .EnvironmentVariable("COREHOST_TRACE", "1")
-                .EnvironmentVariable("DOTNET_ROOT", sharedState.DotNetRoot)
-                .EnvironmentVariable("DOTNET_ROOT(x86)", sharedState.DotNetRoot)
+                .EnableTracingAndCaptureOutputs()
+                .DotNetRoot(sharedState.DotNetRoot)
+                .MultilevelLookup(false)
                 .Execute();
 
             result.Should().Fail()
@@ -237,11 +231,9 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.NativeHosting
                 SharedTestState.SecondaryConfigPropertyName
             };
             CommandResult result = Command.Create(sharedState.NativeHostPath, args)
-                .CaptureStdErr()
-                .CaptureStdOut()
-                .EnvironmentVariable("COREHOST_TRACE", "1")
-                .EnvironmentVariable("DOTNET_ROOT", sharedState.DotNetRoot)
-                .EnvironmentVariable("DOTNET_ROOT(x86)", sharedState.DotNetRoot)
+                .EnableTracingAndCaptureOutputs()
+                .DotNetRoot(sharedState.DotNetRoot)
+                .MultilevelLookup(false)
                 .Execute();
 
             result.Should().Pass()
@@ -290,12 +282,10 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.NativeHosting
                 SharedTestState.ConfigPropertyName
             };
             CommandResult result = Command.Create(sharedState.NativeHostPath, args.Concat(appArgs))
-                .CaptureStdErr()
-                .CaptureStdOut()
-                .EnvironmentVariable("COREHOST_TRACE", "1")
+                .EnableTracingAndCaptureOutputs()
+                .DotNetRoot(sharedState.DotNetRoot)
+                .MultilevelLookup(false)
                 .EnvironmentVariable("COREHOST_TRACE_VERBOSITY", "3")
-                .EnvironmentVariable("DOTNET_ROOT", sharedState.DotNetRoot)
-                .EnvironmentVariable("DOTNET_ROOT(x86)", sharedState.DotNetRoot)
                 .EnvironmentVariable("TEST_BLOCK_MOCK_EXECUTE_ASSEMBLY", $"{sharedState.AppPath}.block")
                 .EnvironmentVariable("TEST_SIGNAL_MOCK_EXECUTE_ASSEMBLY", $"{sharedState.AppPath}.signal")
                 .Execute();
@@ -381,12 +371,10 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.NativeHosting
             try
             {
                 result = Command.Create(sharedState.NativeHostPath, args)
-                    .CaptureStdErr()
-                    .CaptureStdOut()
-                    .EnvironmentVariable("COREHOST_TRACE", "1")
+                    .EnableTracingAndCaptureOutputs()
+                    .DotNetRoot(sharedState.DotNetRoot)
+                    .MultilevelLookup(false)
                     .EnvironmentVariable("COREHOST_TRACE_VERBOSITY", "3")
-                    .EnvironmentVariable("DOTNET_ROOT", sharedState.DotNetRoot)
-                    .EnvironmentVariable("DOTNET_ROOT(x86)", sharedState.DotNetRoot)
                     .EnvironmentVariable("TEST_BLOCK_MOCK_EXECUTE_ASSEMBLY", $"{sharedState.AppPath}.block")
                     .EnvironmentVariable("TEST_SIGNAL_MOCK_EXECUTE_ASSEMBLY", $"{sharedState.AppPath}.signal")
                     .Execute();
@@ -477,12 +465,10 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.NativeHosting
             try
             {
                 result = Command.Create(sharedState.NativeHostPath, args)
-                    .CaptureStdErr()
-                    .CaptureStdOut()
-                    .EnvironmentVariable("COREHOST_TRACE", "1")
+                    .EnableTracingAndCaptureOutputs()
+                    .DotNetRoot(sharedState.DotNetRoot)
+                    .MultilevelLookup(false)
                     .EnvironmentVariable("COREHOST_TRACE_VERBOSITY", "3")
-                    .EnvironmentVariable("DOTNET_ROOT", sharedState.DotNetRoot)
-                    .EnvironmentVariable("DOTNET_ROOT(x86)", sharedState.DotNetRoot)
                     .EnvironmentVariable("TEST_BLOCK_MOCK_EXECUTE_ASSEMBLY", $"{sharedState.AppPath}.block")
                     .EnvironmentVariable("TEST_SIGNAL_MOCK_EXECUTE_ASSEMBLY", $"{sharedState.AppPath}.signal")
                     .Execute();

--- a/src/test/HostActivation.Tests/NativeHosting/Nethost.cs
+++ b/src/test/HostActivation.Tests/NativeHosting/Nethost.cs
@@ -35,8 +35,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.NativeHosting
             string dotNetRoot = isValid ? Path.Combine(sharedState.ValidInstallRoot, "dotnet") : sharedState.InvalidInstallRoot;
             CommandResult result = Command.Create(sharedState.NativeHostPath, $"{GetHostFxrPath} {explicitLoad} {(useAssemblyPath ? sharedState.TestAssemblyPath : string.Empty)}")
                 .EnableTracingAndCaptureOutputs()
-                .EnvironmentVariable("DOTNET_ROOT", dotNetRoot)
-                .EnvironmentVariable("DOTNET_ROOT(x86)", dotNetRoot)
+                .DotNetRoot(dotNetRoot)
                 .Execute();
 
             result.Should().HaveStdErrContaining("Using environment variable");

--- a/src/test/HostActivation.Tests/NativeHosting/SharedTestStateBase.cs
+++ b/src/test/HostActivation.Tests/NativeHosting/SharedTestStateBase.cs
@@ -2,7 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using Microsoft.DotNet.Cli.Build.Framework;
 using System;
+using System.Collections.Generic;
 using System.IO;
 
 namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.NativeHosting
@@ -35,6 +37,14 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.NativeHosting
             File.Copy(
                 Path.Combine(RepoDirectories.CorehostPackages, nethostName),
                 NethostPath);
+        }
+
+        public Command CreateNativeHostCommand(IEnumerable<string> args, string dotNetRoot)
+        {
+            return Command.Create(NativeHostPath, args)
+                .EnableTracingAndCaptureOutputs()
+                .DotNetRoot(dotNetRoot)
+                .MultilevelLookup(false);
         }
 
         public void Dispose()

--- a/src/test/HostActivation.Tests/PortableAppActivation.cs
+++ b/src/test/HostActivation.Tests/PortableAppActivation.cs
@@ -150,10 +150,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
                     "exec",
                     "--additionalprobingpath", additionalProbingPath,
                     appDll)
-                .EnvironmentVariable("COREHOST_TRACE", "1")
-                .EnvironmentVariable("DOTNET_MULTILEVEL_LOOKUP", "0")
-                .CaptureStdErr()
-                .CaptureStdOut()
+                .EnableTracingAndCaptureOutputs()
                 .Execute()
                 .Should().Pass()
                 .And.HaveStdOutContaining("Hello World")
@@ -279,8 +276,8 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
             Command.Create(appExe)
                 .CaptureStdErr()
                 .CaptureStdOut()
-                .EnvironmentVariable("DOTNET_ROOT", builtDotnet)
-                .EnvironmentVariable("DOTNET_ROOT(x86)", builtDotnet)
+                .DotNetRoot(builtDotnet)
+                .MultilevelLookup(false)
                 .Execute()
                 .Should().Pass()
                 .And.HaveStdOutContaining("Hello World")
@@ -290,8 +287,8 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
             // Verify running from within the working directory
             Command.Create(appExe)
                 .WorkingDirectory(fixture.TestProject.OutputDirectory)
-                .EnvironmentVariable("DOTNET_ROOT", builtDotnet)
-                .EnvironmentVariable("DOTNET_ROOT(x86)", builtDotnet)
+                .DotNetRoot(builtDotnet)
+                .MultilevelLookup(false)
                 .CaptureStdErr()
                 .CaptureStdOut()
                 .Execute()
@@ -347,6 +344,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
                 Command.Create(appExe)
                     .CaptureStdErr()
                     .CaptureStdOut()
+                    .MultilevelLookup(false)
                     .ApplyRegisteredInstallLocationOverride(registeredInstallLocationOverride)
                     .EnvironmentVariable(Constants.TestOnlyEnvironmentVariables.DefaultInstallPath, useRegisteredLocation ? null : builtDotnet)
                     .Execute()
@@ -358,6 +356,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
                 Command.Create(appExe)
                     .CaptureStdErr()
                     .CaptureStdOut()
+                    .MultilevelLookup(false)
                     .WorkingDirectory(fixture.TestProject.OutputDirectory)
                     .ApplyRegisteredInstallLocationOverride(registeredInstallLocationOverride)
                     .EnvironmentVariable(Constants.TestOnlyEnvironmentVariables.DefaultInstallPath, useRegisteredLocation ? null : builtDotnet)
@@ -378,9 +377,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
             var appDll = fixture.TestProject.AppDll;
 
             dotnet.Exec(appDll)
-                .EnvironmentVariable("COREHOST_TRACE", "1")
-                .CaptureStdErr()
-                .CaptureStdOut()
+                .EnableTracingAndCaptureOutputs()
                 .Execute()
                 .Should().Pass()
                 .And.HaveStdErrMatching($"Property TRUSTED_PLATFORM_ASSEMBLIES = .*[^{Path.PathSeparator}]$", System.Text.RegularExpressions.RegexOptions.Multiline);

--- a/src/test/TestUtils/DotNetCli.cs
+++ b/src/test/TestUtils/DotNetCli.cs
@@ -67,7 +67,8 @@ namespace Microsoft.DotNet.Cli.Build
             }
 
             return Command.Create(DotnetExecutablePath, newArgs)
-                .EnvironmentVariable("DOTNET_SKIP_FIRST_TIME_EXPERIENCE", "1");
+                .EnvironmentVariable("DOTNET_SKIP_FIRST_TIME_EXPERIENCE", "1")
+                .EnvironmentVariable("DOTNET_MULTILEVEL_LOOKUP", "0"); // Avoid looking at machine state by default
         }
 
         public Command Restore(params string[] args) => Exec("restore", args);


### PR DESCRIPTION
When running through the build scripts, the scripts set `DOTNET_MULTILEVEL_LOOKUP=0`, but if just running in VS or explicit dotnet vstest command, that environment variable won't be set by default. Makes tests that rely on framework/sdk lookup explicitly set the environment variable when launching a child test process.

I didn't see a simple way of setting an environment variable for all our tests through xUnit configuration or fixtures (specifying collection definition and fixture just for this seemed awkward/cumbersome to me), so if anyone knows of one...