### PR TITLE
Stop signing apphost.exe and comhost.dll in nupkg

### DIFF
--- a/eng/Signing.props
+++ b/eng/Signing.props
@@ -18,7 +18,10 @@
     <!-- Find bundle artifacts, which need multiple stages to fully sign. -->
     <BundleInstallerEngineArtifact Include="$(ArtifactsPackagesDir)**/*engine.exe" />
     <BundleInstallerExeArtifact Include="$(ArtifactsPackagesDir)**/*.exe" />
-  </ItemGroup>
+
+    <!-- apphost and comhost template files are not signed, by design. -->
+    <FileSignInfo Include="apphost.exe;comhost.dll" CertificateName="None" />
+  </ItemGroup>>
 
   <ItemGroup Condition="'$(SignBinaries)' == 'true'">
     <ItemsToSign Include="$(BaseOutputRootPath)corehost/**/hostfxr.dll" />
@@ -27,9 +30,6 @@
     <ItemsToSign Include="$(BaseOutputRootPath)corehost/**/ijwhost.dll" />
     <ItemsToSign Include="$(BaseOutputRootPath)corehost/**/winrthost.dll" />
     <ItemsToSign Include="$(BaseOutputRootPath)corehost/**/nethost.dll" />
-    <!-- Note: apphost and comhost template files are not signed, by design. -->
-    <FileSignInfo Include="apphost.exe" CertificateName="None" />
-    <FileSignInfo Include="comhost.dll" CertificateName="None" />
 
     <ItemsToSign Include="$(CrossGenRootPath)**/*.dll" />
 

--- a/eng/Signing.props
+++ b/eng/Signing.props
@@ -27,7 +27,9 @@
     <ItemsToSign Include="$(BaseOutputRootPath)corehost/**/ijwhost.dll" />
     <ItemsToSign Include="$(BaseOutputRootPath)corehost/**/winrthost.dll" />
     <ItemsToSign Include="$(BaseOutputRootPath)corehost/**/nethost.dll" />
-    <!-- Note: apphost is not signed, by design. -->
+    <!-- Note: apphost and comhost template files are not signed, by design. -->
+    <FileSignInfo Include="apphost.exe" CertificateName="None" />
+    <FileSignInfo Include="comhost.dll" CertificateName="None" />
 
     <ItemsToSign Include="$(CrossGenRootPath)**/*.dll" />
 


### PR DESCRIPTION
The nupkg is recursively signed, so leaving `apphost.exe` and `comhost.dll` off the list of files to sign is not enough, and they still end up signed. We also need to set up `FileSignInfo` to tell recursive signing what to do.