### PR TITLE
Fix extra '>' typo in Signing.props

### DIFF
--- a/eng/Signing.props
+++ b/eng/Signing.props
@@ -21,7 +21,7 @@
 
     <!-- apphost and comhost template files are not signed, by design. -->
     <FileSignInfo Include="apphost.exe;comhost.dll" CertificateName="None" />
-  </ItemGroup>>
+  </ItemGroup>
 
   <ItemGroup Condition="'$(SignBinaries)' == 'true'">
     <ItemsToSign Include="$(BaseOutputRootPath)corehost/**/hostfxr.dll" />


### PR DESCRIPTION
Fix https://github.com/dotnet/core-setup/pull/7547#pullrequestreview-270385694 (typo in "Stop signing apphost.exe and comhost.dll in nupkg")