### PR TITLE
[release/3.0] Stop signing apphost.exe and comhost.dll in AppHost pack nupkg

### DIFF
--- a/eng/Signing.props
+++ b/eng/Signing.props
@@ -14,6 +14,9 @@
       Arcade's Sign.proj multiple times for different sets of files as the build progresses.
     -->
     <ItemsToSign Remove="@(ItemsToSign)" />
+
+    <!-- apphost and comhost template files are not signed, by design. -->
+    <FileSignInfo Include="apphost.exe;comhost.dll" CertificateName="None" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(SignBinaries)' == 'true'">
@@ -23,7 +26,6 @@
     <ItemsToSign Include="$(BaseOutputRootPath)corehost/**/ijwhost.dll" />
     <ItemsToSign Include="$(BaseOutputRootPath)corehost/**/winrthost.dll" />
     <ItemsToSign Include="$(BaseOutputRootPath)corehost/**/nethost.dll" />
-    <!-- Note: apphost is not signed, by design. -->
 
     <ItemsToSign Include="$(CrossGenRootPath)**/*.dll" />
 


### PR DESCRIPTION
#### Description

This change ensures the `apphost.exe` and `comhost.dll` templates aren't signed. The Arcade migration unintentionally caused them to be signed in the NuGet package artifacts. These are used to assemble the 3.0 SDK, and they're pushed to the NuGet gallery to allow later SDKs (e.g. 5.0) to acquire the artifacts needed to build apps for earlier runtimes (3.0).

#### Customer Impact

https://github.com/dotnet/core-setup/issues/7550

> This prevents VS from being able to update to build using the 3.0 SDK Preview 8.

1. Build an app with an xcopy install of .NET Core Preview 8
2. Use SignTool.exe to sign the built .exe
3. Signing fails with `error: 0x800700C1`

#### Regression?

Yes, this is a regression from 3.0 preview 7 to 3.0 preview 8.

#### Risk

Minimal. This signing tool configuration setting is supported by Arcade.

/cc @JohnTortugo 

---

(cherry picked from commit 0245522f55e00bdf7c419ff84f62096c606a6f80) (https://github.com/dotnet/core-setup/pull/7547)

(cherry picked from commit 18e5616f62e7ef3438749cc54170cc3bc74138df) (https://github.com/dotnet/core-setup/pull/7548, typo fixup)