### PR TITLE
Remove WindowsDesktop bundle WelcomeDescription

### DIFF
--- a/src/pkg/projects/windowsdesktop/sfx/bundle.wxl
+++ b/src/pkg/projects/windowsdesktop/sfx/bundle.wxl
@@ -59,7 +59,7 @@ Ready? Set? Let's go!</String>
   <String Id="FilesInUseOkButton">&amp;OK</String>
   <String Id="FilesInUseCancelButton">&amp;Cancel</String>
   <String Id="WelcomeHeaderMessage">Windows Desktop Runtime</String>
-  <String Id="WelcomeDescription">.NET Core is a development platform that you can use to build command-line applications, microservices and modern websites. It is open source, cross-platform, and supported by Microsoft. We hope you enjoy it!</String>
+  <String Id="WelcomeDescription"></String>
   <String Id="LearnMoreTitle">Learn more about .NET Core</String>
   <String Id="SuccessInstallLocation">The following was installed at [DOTNETHOME]</String>
   <String Id="SuccessInstallProductName"> - [BUNDLEMONIKER] </String>

--- a/src/pkg/projects/windowsdesktop/sfx/theme/1028/bundle.wxl
+++ b/src/pkg/projects/windowsdesktop/sfx/theme/1028/bundle.wxl
@@ -59,7 +59,7 @@ Ready? Set? Let's go!</String>
   <String Id="FilesInUseOkButton">&amp;OK</String>
   <String Id="FilesInUseCancelButton">&amp;Cancel</String>
   <String Id="WelcomeHeaderMessage">Windows Desktop Runtime</String>
-  <String Id="WelcomeDescription">.NET Core is a development platform that you can use to build command-line applications, microservices and modern websites. It is open source, cross-platform, and supported by Microsoft. We hope you enjoy it!</String>
+  <String Id="WelcomeDescription"></String>
   <String Id="LearnMoreTitle">Learn more about .NET Core</String>
   <String Id="SuccessInstallLocation">The following was installed at [DOTNETHOME]</String>
   <String Id="SuccessInstallProductName"> - [BUNDLEMONIKER] </String>

--- a/src/pkg/projects/windowsdesktop/sfx/theme/1029/bundle.wxl
+++ b/src/pkg/projects/windowsdesktop/sfx/theme/1029/bundle.wxl
@@ -59,7 +59,7 @@ Ready? Set? Let's go!</String>
   <String Id="FilesInUseOkButton">&amp;OK</String>
   <String Id="FilesInUseCancelButton">&amp;Cancel</String>
   <String Id="WelcomeHeaderMessage">Windows Desktop Runtime</String>
-  <String Id="WelcomeDescription">.NET Core is a development platform that you can use to build command-line applications, microservices and modern websites. It is open source, cross-platform, and supported by Microsoft. We hope you enjoy it!</String>
+  <String Id="WelcomeDescription"></String>
   <String Id="LearnMoreTitle">Learn more about .NET Core</String>
   <String Id="SuccessInstallLocation">The following was installed at [DOTNETHOME]</String>
   <String Id="SuccessInstallProductName"> - [BUNDLEMONIKER] </String>

--- a/src/pkg/projects/windowsdesktop/sfx/theme/1031/bundle.wxl
+++ b/src/pkg/projects/windowsdesktop/sfx/theme/1031/bundle.wxl
@@ -59,7 +59,7 @@ Ready? Set? Let's go!</String>
   <String Id="FilesInUseOkButton">&amp;OK</String>
   <String Id="FilesInUseCancelButton">&amp;Cancel</String>
   <String Id="WelcomeHeaderMessage">Windows Desktop Runtime</String>
-  <String Id="WelcomeDescription">.NET Core is a development platform that you can use to build command-line applications, microservices and modern websites. It is open source, cross-platform, and supported by Microsoft. We hope you enjoy it!</String>
+  <String Id="WelcomeDescription"></String>
   <String Id="LearnMoreTitle">Learn more about .NET Core</String>
   <String Id="SuccessInstallLocation">The following was installed at [DOTNETHOME]</String>
   <String Id="SuccessInstallProductName"> - [BUNDLEMONIKER] </String>

--- a/src/pkg/projects/windowsdesktop/sfx/theme/1033/bundle.wxl
+++ b/src/pkg/projects/windowsdesktop/sfx/theme/1033/bundle.wxl
@@ -59,7 +59,7 @@ Ready? Set? Let's go!</String>
   <String Id="FilesInUseOkButton">&amp;OK</String>
   <String Id="FilesInUseCancelButton">&amp;Cancel</String>
   <String Id="WelcomeHeaderMessage">Windows Desktop Runtime</String>
-  <String Id="WelcomeDescription">.NET Core is a development platform that you can use to build command-line applications, microservices and modern websites. It is open source, cross-platform, and supported by Microsoft. We hope you enjoy it!</String>
+  <String Id="WelcomeDescription"></String>
   <String Id="LearnMoreTitle">Learn more about .NET Core</String>
   <String Id="SuccessInstallLocation">The following was installed at [DOTNETHOME]</String>
   <String Id="SuccessInstallProductName"> - [BUNDLEMONIKER] </String>

--- a/src/pkg/projects/windowsdesktop/sfx/theme/1036/bundle.wxl
+++ b/src/pkg/projects/windowsdesktop/sfx/theme/1036/bundle.wxl
@@ -59,7 +59,7 @@ Ready? Set? Let's go!</String>
   <String Id="FilesInUseOkButton">&amp;OK</String>
   <String Id="FilesInUseCancelButton">&amp;Cancel</String>
   <String Id="WelcomeHeaderMessage">Windows Desktop Runtime</String>
-  <String Id="WelcomeDescription">.NET Core is a development platform that you can use to build command-line applications, microservices and modern websites. It is open source, cross-platform, and supported by Microsoft. We hope you enjoy it!</String>
+  <String Id="WelcomeDescription"></String>
   <String Id="LearnMoreTitle">Learn more about .NET Core</String>
   <String Id="SuccessInstallLocation">The following was installed at [DOTNETHOME]</String>
   <String Id="SuccessInstallProductName"> - [BUNDLEMONIKER] </String>

--- a/src/pkg/projects/windowsdesktop/sfx/theme/1040/bundle.wxl
+++ b/src/pkg/projects/windowsdesktop/sfx/theme/1040/bundle.wxl
@@ -59,7 +59,7 @@ Ready? Set? Let's go!</String>
   <String Id="FilesInUseOkButton">&amp;OK</String>
   <String Id="FilesInUseCancelButton">&amp;Cancel</String>
   <String Id="WelcomeHeaderMessage">Windows Desktop Runtime</String>
-  <String Id="WelcomeDescription">.NET Core is a development platform that you can use to build command-line applications, microservices and modern websites. It is open source, cross-platform, and supported by Microsoft. We hope you enjoy it!</String>
+  <String Id="WelcomeDescription"></String>
   <String Id="LearnMoreTitle">Learn more about .NET Core</String>
   <String Id="SuccessInstallLocation">The following was installed at [DOTNETHOME]</String>
   <String Id="SuccessInstallProductName"> - [BUNDLEMONIKER] </String>

--- a/src/pkg/projects/windowsdesktop/sfx/theme/1041/bundle.wxl
+++ b/src/pkg/projects/windowsdesktop/sfx/theme/1041/bundle.wxl
@@ -59,7 +59,7 @@ Ready? Set? Let's go!</String>
   <String Id="FilesInUseOkButton">&amp;OK</String>
   <String Id="FilesInUseCancelButton">&amp;Cancel</String>
   <String Id="WelcomeHeaderMessage">Windows Desktop Runtime</String>
-  <String Id="WelcomeDescription">.NET Core is a development platform that you can use to build command-line applications, microservices and modern websites. It is open source, cross-platform, and supported by Microsoft. We hope you enjoy it!</String>
+  <String Id="WelcomeDescription"></String>
   <String Id="LearnMoreTitle">Learn more about .NET Core</String>
   <String Id="SuccessInstallLocation">The following was installed at [DOTNETHOME]</String>
   <String Id="SuccessInstallProductName"> - [BUNDLEMONIKER] </String>

--- a/src/pkg/projects/windowsdesktop/sfx/theme/1042/bundle.wxl
+++ b/src/pkg/projects/windowsdesktop/sfx/theme/1042/bundle.wxl
@@ -59,7 +59,7 @@ Ready? Set? Let's go!</String>
   <String Id="FilesInUseOkButton">&amp;OK</String>
   <String Id="FilesInUseCancelButton">&amp;Cancel</String>
   <String Id="WelcomeHeaderMessage">Windows Desktop Runtime</String>
-  <String Id="WelcomeDescription">.NET Core is a development platform that you can use to build command-line applications, microservices and modern websites. It is open source, cross-platform, and supported by Microsoft. We hope you enjoy it!</String>
+  <String Id="WelcomeDescription"></String>
   <String Id="LearnMoreTitle">Learn more about .NET Core</String>
   <String Id="SuccessInstallLocation">The following was installed at [DOTNETHOME]</String>
   <String Id="SuccessInstallProductName"> - [BUNDLEMONIKER] </String>

--- a/src/pkg/projects/windowsdesktop/sfx/theme/1045/bundle.wxl
+++ b/src/pkg/projects/windowsdesktop/sfx/theme/1045/bundle.wxl
@@ -59,7 +59,7 @@ Ready? Set? Let's go!</String>
   <String Id="FilesInUseOkButton">&amp;OK</String>
   <String Id="FilesInUseCancelButton">&amp;Cancel</String>
   <String Id="WelcomeHeaderMessage">Windows Desktop Runtime</String>
-  <String Id="WelcomeDescription">.NET Core is a development platform that you can use to build command-line applications, microservices and modern websites. It is open source, cross-platform, and supported by Microsoft. We hope you enjoy it!</String>
+  <String Id="WelcomeDescription"></String>
   <String Id="LearnMoreTitle">Learn more about .NET Core</String>
   <String Id="SuccessInstallLocation">The following was installed at [DOTNETHOME]</String>
   <String Id="SuccessInstallProductName"> - [BUNDLEMONIKER] </String>

--- a/src/pkg/projects/windowsdesktop/sfx/theme/1046/bundle.wxl
+++ b/src/pkg/projects/windowsdesktop/sfx/theme/1046/bundle.wxl
@@ -59,7 +59,7 @@ Ready? Set? Let's go!</String>
   <String Id="FilesInUseOkButton">&amp;OK</String>
   <String Id="FilesInUseCancelButton">&amp;Cancel</String>
   <String Id="WelcomeHeaderMessage">Windows Desktop Runtime</String>
-  <String Id="WelcomeDescription">.NET Core is a development platform that you can use to build command-line applications, microservices and modern websites. It is open source, cross-platform, and supported by Microsoft. We hope you enjoy it!</String>
+  <String Id="WelcomeDescription"></String>
   <String Id="LearnMoreTitle">Learn more about .NET Core</String>
   <String Id="SuccessInstallLocation">The following was installed at [DOTNETHOME]</String>
   <String Id="SuccessInstallProductName"> - [BUNDLEMONIKER] </String>

--- a/src/pkg/projects/windowsdesktop/sfx/theme/1049/bundle.wxl
+++ b/src/pkg/projects/windowsdesktop/sfx/theme/1049/bundle.wxl
@@ -59,7 +59,7 @@ Ready? Set? Let's go!</String>
   <String Id="FilesInUseOkButton">&amp;OK</String>
   <String Id="FilesInUseCancelButton">&amp;Cancel</String>
   <String Id="WelcomeHeaderMessage">Windows Desktop Runtime</String>
-  <String Id="WelcomeDescription">.NET Core is a development platform that you can use to build command-line applications, microservices and modern websites. It is open source, cross-platform, and supported by Microsoft. We hope you enjoy it!</String>
+  <String Id="WelcomeDescription"></String>
   <String Id="LearnMoreTitle">Learn more about .NET Core</String>
   <String Id="SuccessInstallLocation">The following was installed at [DOTNETHOME]</String>
   <String Id="SuccessInstallProductName"> - [BUNDLEMONIKER] </String>

--- a/src/pkg/projects/windowsdesktop/sfx/theme/1055/bundle.wxl
+++ b/src/pkg/projects/windowsdesktop/sfx/theme/1055/bundle.wxl
@@ -59,7 +59,7 @@ Ready? Set? Let's go!</String>
   <String Id="FilesInUseOkButton">&amp;OK</String>
   <String Id="FilesInUseCancelButton">&amp;Cancel</String>
   <String Id="WelcomeHeaderMessage">Windows Desktop Runtime</String>
-  <String Id="WelcomeDescription">.NET Core is a development platform that you can use to build command-line applications, microservices and modern websites. It is open source, cross-platform, and supported by Microsoft. We hope you enjoy it!</String>
+  <String Id="WelcomeDescription"></String>
   <String Id="LearnMoreTitle">Learn more about .NET Core</String>
   <String Id="SuccessInstallLocation">The following was installed at [DOTNETHOME]</String>
   <String Id="SuccessInstallProductName"> - [BUNDLEMONIKER] </String>

--- a/src/pkg/projects/windowsdesktop/sfx/theme/2052/bundle.wxl
+++ b/src/pkg/projects/windowsdesktop/sfx/theme/2052/bundle.wxl
@@ -59,7 +59,7 @@ Ready? Set? Let's go!</String>
   <String Id="FilesInUseOkButton">&amp;OK</String>
   <String Id="FilesInUseCancelButton">&amp;Cancel</String>
   <String Id="WelcomeHeaderMessage">Windows Desktop Runtime</String>
-  <String Id="WelcomeDescription">.NET Core is a development platform that you can use to build command-line applications, microservices and modern websites. It is open source, cross-platform, and supported by Microsoft. We hope you enjoy it!</String>
+  <String Id="WelcomeDescription"></String>
   <String Id="LearnMoreTitle">Learn more about .NET Core</String>
   <String Id="SuccessInstallLocation">The following was installed at [DOTNETHOME]</String>
   <String Id="SuccessInstallProductName"> - [BUNDLEMONIKER] </String>

--- a/src/pkg/projects/windowsdesktop/sfx/theme/3082/bundle.wxl
+++ b/src/pkg/projects/windowsdesktop/sfx/theme/3082/bundle.wxl
@@ -59,7 +59,7 @@ Ready? Set? Let's go!</String>
   <String Id="FilesInUseOkButton">&amp;OK</String>
   <String Id="FilesInUseCancelButton">&amp;Cancel</String>
   <String Id="WelcomeHeaderMessage">Windows Desktop Runtime</String>
-  <String Id="WelcomeDescription">.NET Core is a development platform that you can use to build command-line applications, microservices and modern websites. It is open source, cross-platform, and supported by Microsoft. We hope you enjoy it!</String>
+  <String Id="WelcomeDescription"></String>
   <String Id="LearnMoreTitle">Learn more about .NET Core</String>
   <String Id="SuccessInstallLocation">The following was installed at [DOTNETHOME]</String>
   <String Id="SuccessInstallProductName"> - [BUNDLEMONIKER] </String>


### PR DESCRIPTION
Currently it describes the .NET Core SDK, rather than the Windows Desktop runtime. Blank it out to avoid misleading users until we decide on the right description: https://github.com/dotnet/core-setup/issues/7530#issuecomment-518337736.