### PR TITLE
Add root "shared" dir to WindowsDesktop zip

### DIFF
--- a/src/pkg/packaging-tools/packaging-tools.targets
+++ b/src/pkg/packaging-tools/packaging-tools.targets
@@ -83,9 +83,15 @@
       <CompressedArchiveFile>$(AssetOutputPath)$(InstallerFileNameWithoutExtension)$(CompressedFileExtension)</CompressedArchiveFile>
     </PropertyGroup>
 
-    <!-- By default, a shared framework only has files in shared/, so archive that. -->
+    <!--
+      Set the directory containing contents to include in the archive (zip/tarball). This default
+      means the "shared" dir is inside the archive and it can be extracted directly into the dotnet
+      home dir. This allows the .NET Core Runtime archive to include files outside the "shared" dir,
+      such as the host, resolver, and license files, without special handling vs. WindowsDesktop and
+      ASP.NET Core sharedfx.
+    -->
     <PropertyGroup>
-      <SharedFrameworkArchiveSourceDir Condition="'$(SharedFrameworkArchiveSourceDir)' == ''">$(SharedFrameworkLayoutDir)shared/</SharedFrameworkArchiveSourceDir>
+      <SharedFrameworkArchiveSourceDir Condition="'$(SharedFrameworkArchiveSourceDir)' == ''">$(SharedFrameworkLayoutDir)</SharedFrameworkArchiveSourceDir>
     </PropertyGroup>
   </Target>
 

--- a/src/pkg/projects/netcoreapp/sfx/Microsoft.NETCore.App.SharedFx.sfxproj
+++ b/src/pkg/projects/netcoreapp/sfx/Microsoft.NETCore.App.SharedFx.sfxproj
@@ -15,6 +15,9 @@
     <!-- These components are installed by the root shared framework, but not others. -->
     <IncludeWerRelatedKeys>true</IncludeWerRelatedKeys>
     <IncludeBreadcrumbStoreFolder>true</IncludeBreadcrumbStoreFolder>
+
+    <!-- The zip/tarball is built by legacy infrastructure. -->
+    <GenerateCompressedArchive>false</GenerateCompressedArchive>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Also fix a small bug where both the new and old infrastructure were creating a zip for the NETCoreApp sfx. This wasn't causing a problem in parallel because they are ordered, but it made it unclear to a reader which infra was responsible for the zip.

This will need porting to 3.0.

For https://github.com/dotnet/core-setup/issues/6370.