### PR TITLE
[release/3.0] Add root "shared" dir to WindowsDesktop zip

### DIFF
--- a/src/pkg/packaging-tools/packaging-tools.targets
+++ b/src/pkg/packaging-tools/packaging-tools.targets
@@ -88,9 +88,15 @@
       <CompressedArchiveFile>$(AssetOutputPath)$(InstallerFileNameWithoutExtension)$(CompressedFileExtension)</CompressedArchiveFile>
     </PropertyGroup>
 
-    <!-- By default, a shared framework only has files in shared/, so archive that. -->
+    <!--
+      Set the directory containing contents to include in the archive (zip/tarball). This default
+      means the "shared" dir is inside the archive and it can be extracted directly into the dotnet
+      home dir. This allows the .NET Core Runtime archive to include files outside the "shared" dir,
+      such as the host, resolver, and license files, without special handling vs. WindowsDesktop and
+      ASP.NET Core sharedfx.
+    -->
     <PropertyGroup>
-      <SharedFrameworkArchiveSourceDir Condition="'$(SharedFrameworkArchiveSourceDir)' == ''">$(SharedFrameworkLayoutDir)shared/</SharedFrameworkArchiveSourceDir>
+      <SharedFrameworkArchiveSourceDir Condition="'$(SharedFrameworkArchiveSourceDir)' == ''">$(SharedFrameworkLayoutDir)</SharedFrameworkArchiveSourceDir>
     </PropertyGroup>
 
     <!-- Only generate installers for packs and sfxproj. -->

--- a/src/pkg/projects/netcoreapp/sfx/Microsoft.NETCore.App.SharedFx.sfxproj
+++ b/src/pkg/projects/netcoreapp/sfx/Microsoft.NETCore.App.SharedFx.sfxproj
@@ -15,6 +15,9 @@
     <!-- These components are installed by the root shared framework, but not others. -->
     <IncludeWerRelatedKeys>true</IncludeWerRelatedKeys>
     <IncludeBreadcrumbStoreFolder>true</IncludeBreadcrumbStoreFolder>
+
+    <!-- The zip/tarball is built by legacy infrastructure. -->
+    <GenerateCompressedArchive>false</GenerateCompressedArchive>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
#### Description

This PR is to address https://github.com/dotnet/core-setup/issues/6370 in 3.0 Preview 9:

> When unzipping a WindowDesktop Runtime archive, it unzips to a "Microsoft.WidowsDesktop.App" folder instead of the expected "shared\Microsoft.WidowsDesktop.App" folder as do the SDK, Runtime, Asp.Net Runtime archives.
> 
> This should be standardized before the install scripts [install-dotnet.ps1] introduce support for installations of the WindowDesktop Runtime: dotnet/cli#11115

There is also a small, related infra fix to help maintainability. https://github.com/dotnet/core-setup/pull/7581:

> Also fix a small bug where both the new and old infrastructure were creating a zip for the NETCoreApp sfx. This wasn't causing a problem in parallel because they are ordered, but it made it unclear to a reader which infra was responsible for the zip.

#### Customer Impact

Without this change, adding WindowsDesktop support to `dotnet-install.ps1` would require logic in the script specific to each shared framework. This is undesirable, and work to add support is currently considered blocked on standardizing the layout.

`dotnet-install.ps1` support would be useful to install specific versions of WindowsDesktop on dev and CI machines, especially for testing scenarios. (https://github.com/dotnet/cli/issues/11115)

#### Regression?

No.

#### Risk

Low. The infra change is trivial, but dependent repos do need to update to account for it. If they don't, WindowsDesktop may end up in `<dotnet home>/shared/shared/Microsoft.WindowsDesktop.App/...`, breaking installs that use the zip. @johnbeisner is aware of this for Core-SDK.

This change was done in `master` with PR https://github.com/dotnet/core-setup/pull/7581, mitigating the risk. (This is a clean cherry-pick.) As of writing, it hasn't been ingested, and we should make sure that works before moving forward with this PR.

/cc @dleeapho 