### PR TITLE
[release/3.0] Reference WPF theme assemblies by default

### DIFF
--- a/src/pkg/projects/windowsdesktop/pkg/Directory.Build.props
+++ b/src/pkg/projects/windowsdesktop/pkg/Directory.Build.props
@@ -24,13 +24,13 @@
     <FrameworkListFileClass Include="Microsoft.Win32.Registry.dll" Profile="WindowsForms;WPF" />
     <FrameworkListFileClass Include="Microsoft.Win32.SystemEvents.dll" Profile="WindowsForms;WPF" />
     <FrameworkListFileClass Include="PresentationCore.dll" Profile="WPF" />
-    <FrameworkListFileClass Include="PresentationFramework.Aero.dll" Profile="WPF" ReferencedByDefault="false" />
-    <FrameworkListFileClass Include="PresentationFramework.Aero2.dll" Profile="WPF" ReferencedByDefault="false" />
-    <FrameworkListFileClass Include="PresentationFramework.AeroLite.dll" Profile="WPF" ReferencedByDefault="false" />
-    <FrameworkListFileClass Include="PresentationFramework.Classic.dll" Profile="WPF" ReferencedByDefault="false" />
+    <FrameworkListFileClass Include="PresentationFramework.Aero.dll" Profile="WPF" />
+    <FrameworkListFileClass Include="PresentationFramework.Aero2.dll" Profile="WPF" />
+    <FrameworkListFileClass Include="PresentationFramework.AeroLite.dll" Profile="WPF" />
+    <FrameworkListFileClass Include="PresentationFramework.Classic.dll" Profile="WPF" />
     <FrameworkListFileClass Include="PresentationFramework.dll" Profile="WPF" />
-    <FrameworkListFileClass Include="PresentationFramework.Luna.dll" Profile="WPF" ReferencedByDefault="false" />
-    <FrameworkListFileClass Include="PresentationFramework.Royale.dll" Profile="WPF" ReferencedByDefault="false" />
+    <FrameworkListFileClass Include="PresentationFramework.Luna.dll" Profile="WPF" />
+    <FrameworkListFileClass Include="PresentationFramework.Royale.dll" Profile="WPF" />
     <FrameworkListFileClass Include="ReachFramework.dll" Profile="WPF" />
     <FrameworkListFileClass Include="System.CodeDom.dll" Profile="WindowsForms;WPF" />
     <FrameworkListFileClass Include="System.Configuration.ConfigurationManager.dll" Profile="WindowsForms;WPF" />

--- a/src/test/Microsoft.DotNet.CoreSetup.Packaging.Tests/WindowsDesktopTests.cs
+++ b/src/test/Microsoft.DotNet.CoreSetup.Packaging.Tests/WindowsDesktopTests.cs
@@ -56,7 +56,7 @@ namespace Microsoft.DotNet.CoreSetup.Packaging.Tests
                 var files = fxList.Element("FileList").Elements("File").ToArray();
 
                 // Sanity check: did any elements we expect make it into the final file?
-                foreach (var attributeName in new[] { "Profile", "ReferencedByDefault" })
+                foreach (var attributeName in new[] { "Profile" })
                 {
                     Assert.True(
                         files.Any(x => !string.IsNullOrEmpty(x.Attribute(attributeName)?.Value)),


### PR DESCRIPTION
Port https://github.com/dotnet/core-setup/pull/7601 to `release/3.0`, for https://github.com/dotnet/sdk/issues/3512.

Described and approved in mail thread "Ask-Mode: Re-adding WPF Theme assembly references".