### PR TITLE
Update NETStandard.Library.Ref to 2.2

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -177,7 +177,7 @@
     <PropertyGroup>
       <TargetingPackInstallerFile>$(AssetOutputPath)dotnet-targeting-pack-$(ProductMoniker)$(InstallerExtension)</TargetingPackInstallerFile>
       <AppHostPackInstallerFile>$(AssetOutputPath)dotnet-apphost-pack-$(ProductMoniker)$(InstallerExtension)</AppHostPackInstallerFile>
-      <NetStandardProductBandVersion>2.1</NetStandardProductBandVersion>
+      <NetStandardProductBandVersion>2.2</NetStandardProductBandVersion>
       <NetStandardProductMoniker>$(NetStandardProductBandVersion).$(PatchVersion)$(ProductVersionSuffix)-$(PackageTargetRid)</NetStandardProductMoniker>
       <NetStandardTargetingPackInstallerFile>$(AssetOutputPath)netstandard-targeting-pack-$(NetStandardProductMoniker)$(InstallerExtension)</NetStandardTargetingPackInstallerFile>
       <WindowsDesktopSharedFrameworkInstallerFile>$(AssetOutputPath)windowsdesktop-runtime-$(ProductMoniker)$(InstallerExtension)</WindowsDesktopSharedFrameworkInstallerFile>

--- a/src/pkg/projects/netstandard/pkg/Directory.Build.props
+++ b/src/pkg/projects/netstandard/pkg/Directory.Build.props
@@ -4,16 +4,16 @@
     <ShortFrameworkName>netstandard</ShortFrameworkName>
     <ProductBrandPrefix>Microsoft .NET Standard</ProductBrandPrefix>
 
-    <ProductBandVersion>2.1</ProductBandVersion>
+    <ProductBandVersion>2.2</ProductBandVersion>
     <ProductionVersion>$(ProductBandVersion).0</ProductionVersion>
   </PropertyGroup>
 
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory).., Directory.Build.props))\Directory.Build.props" />
 
   <PropertyGroup>
-    <FrameworkListName>.NET Standard 2.1</FrameworkListName>
+    <FrameworkListName>.NET Standard 2.2</FrameworkListName>
     <FrameworkListTargetFrameworkIdentifier>.NETStandard</FrameworkListTargetFrameworkIdentifier>
-    <FrameworkListTargetFrameworkVersion>2.1</FrameworkListTargetFrameworkVersion>
+    <FrameworkListTargetFrameworkVersion>2.2</FrameworkListTargetFrameworkVersion>
     <FrameworkListFrameworkName>NETStandard.Library</FrameworkListFrameworkName>
 
     <VSInsertionProductName>NetStandard</VSInsertionProductName>


### PR DESCRIPTION
For https://github.com/dotnet/core-setup/issues/7567.

Updates the package version to 2.2. Note that the targeting pack contents are still in `ref/netstandard2.1/`: `NETStandard.Library` has them in `build/netstandard2.1/ref/`.

/cc @JunTaoLuo 