### PR TITLE
HostModel: Retry ResourceUpdate on Win32 File-Lock error

### DIFF
--- a/src/managed/Microsoft.NET.HostModel/AppHost/HResultException.cs
+++ b/src/managed/Microsoft.NET.HostModel/AppHost/HResultException.cs
@@ -1,0 +1,22 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.IO;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+
+namespace Microsoft.NET.HostModel
+{
+    /// <summary>
+    /// Represents an exception thrown because of a Win32 error
+    /// </summary>
+    public class HResultException : Exception
+    {
+        public readonly int Win32HResult;
+        public HResultException(int hResult) : base(hResult.ToString("X4"))
+        {
+            Win32HResult = hResult;
+        }
+    }
+}

--- a/src/managed/Microsoft.NET.HostModel/AppHost/ResourceUpdater.cs
+++ b/src/managed/Microsoft.NET.HostModel/AppHost/ResourceUpdater.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.IO;
 using System.Diagnostics;
 using System.Runtime.InteropServices;
 
@@ -420,13 +419,6 @@ namespace Microsoft.NET.HostModel
         private class ResourceNotAvailableException : Exception
         {
             public ResourceNotAvailableException(string message) : base(message)
-            {
-            }
-        }
-
-        private class HResultException : Exception
-        {
-            public HResultException(int hResult) : base(hResult.ToString("X4"))
             {
             }
         }

--- a/src/managed/Microsoft.NET.HostModel/AppHost/RetryUtil.cs
+++ b/src/managed/Microsoft.NET.HostModel/AppHost/RetryUtil.cs
@@ -10,7 +10,7 @@ using System.Threading;
 namespace Microsoft.NET.HostModel
 {
     /// <summary>
-    /// HowtModel library implements several services for updating the AppHost DLL.
+    /// HostModel library implements several services for updating the AppHost DLL.
     /// These updates involve multiple file open/close operations.
     /// An Antivirus scanner may intercept in-between and lock the file, 
     /// causing the operations to fail with IO-Error.

--- a/src/managed/Microsoft.NET.HostModel/AppHost/RetryUtil.cs
+++ b/src/managed/Microsoft.NET.HostModel/AppHost/RetryUtil.cs
@@ -1,0 +1,71 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.IO;
+using System.IO.MemoryMappedFiles;
+using System.Text;
+using System.Threading;
+
+namespace Microsoft.NET.HostModel
+{
+    /// <summary>
+    /// HowtModel library implements several services for updating the AppHost DLL.
+    /// These updates involve multiple file open/close operations.
+    /// An Antivirus scanner may intercept in-between and lock the file, 
+    /// causing the operations to fail with IO-Error.
+    /// So, the operations are retried a few times on failures such as
+    /// - IOException 
+    /// - Failure with Win32 errors indicating file-lock
+    /// </summary>
+    public static class RetryUtil
+    {
+        public const int NumberOfRetries = 500;
+        public const int NumMilliSecondsToWait = 100;
+
+        public static void RetryOnIOError(Action func)
+        {
+            for (int i = 1; i <= NumberOfRetries; i++)
+            {
+                try
+                {
+                    func();
+                    break;
+                }
+                catch (IOException) when (i < NumberOfRetries)
+                {
+                    Thread.Sleep(NumMilliSecondsToWait);
+                }
+            }
+        }
+
+        public static void RetryOnWin32Error(Action func)
+        {
+            bool IsWin32FileLockError(int hresult)
+            {
+                // Error codes are defined in winerror.h
+                const int ErrorLockViolation = 33;
+                const int ErrorDriveLocked = 108;
+
+                // The error code is stored in the lowest 16 bits of the HResult
+                int errorCode = hresult & 0xffff;
+
+                return errorCode == ErrorLockViolation || errorCode == ErrorDriveLocked;
+            }
+
+            for (int i = 1; i <= NumberOfRetries; i++)
+            {
+                try
+                {
+                    func();
+                    break;
+                }
+                catch (HResultException hrex)
+                    when (i < NumberOfRetries && IsWin32FileLockError(hrex.Win32HResult))
+                {
+                    Thread.Sleep(NumMilliSecondsToWait);
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
On Win32 PE files, the SDK copies resources on the AppHost binary
from the intermediate assembly.

This update is performed using native Win32 operations.
This change retries the resource update if the operation fails
because the file is locked (say because of AntiVirus scan).

This change is similar to: https://github.com/dotnet/core-setup/pull/7617
which handles failures in managed code via IOException.

The Retry logic is factored out to the RetryUtil class. Currently the
HostWriter is the only client for the class. But it is made public
because other components (like Bundler) may use it in future.
