### PR TITLE
[release/3.0] HostModel: Retry ResourceUpdate on Win32 File-Lock error

### DIFF
--- a/src/managed/Microsoft.NET.HostModel/AppHost/HResultException.cs
+++ b/src/managed/Microsoft.NET.HostModel/AppHost/HResultException.cs
@@ -1,0 +1,22 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.IO;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+
+namespace Microsoft.NET.HostModel
+{
+    /// <summary>
+    /// Represents an exception thrown because of a Win32 error
+    /// </summary>
+    public class HResultException : Exception
+    {
+        public readonly int Win32HResult;
+        public HResultException(int hResult) : base(hResult.ToString("X4"))
+        {
+            Win32HResult = hResult;
+        }
+    }
+}

--- a/src/managed/Microsoft.NET.HostModel/AppHost/HostWriter.cs
+++ b/src/managed/Microsoft.NET.HostModel/AppHost/HostWriter.cs
@@ -31,7 +31,7 @@ namespace Microsoft.NET.HostModel.AppHost
         /// <param name="func">The action to retry on IO-Error</param>
         private static void RetryOnIOError(Action func)
         {
-            uint numberOfRetries = 256;
+            uint numberOfRetries = 500;
 
             for (uint i = 1; i <= numberOfRetries; i++)
             {
@@ -42,7 +42,7 @@ namespace Microsoft.NET.HostModel.AppHost
                 }
                 catch (IOException) when (i < numberOfRetries)
                 {
-                    Thread.Sleep(200);
+                    Thread.Sleep(100);
                 }
             }
         }

--- a/src/managed/Microsoft.NET.HostModel/AppHost/ResourceUpdater.cs
+++ b/src/managed/Microsoft.NET.HostModel/AppHost/ResourceUpdater.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.IO;
 using System.Diagnostics;
 using System.Runtime.InteropServices;
 
@@ -420,13 +419,6 @@ namespace Microsoft.NET.HostModel
         private class ResourceNotAvailableException : Exception
         {
             public ResourceNotAvailableException(string message) : base(message)
-            {
-            }
-        }
-
-        private class HResultException : Exception
-        {
-            public HResultException(int hResult) : base(hResult.ToString("X4"))
             {
             }
         }

--- a/src/managed/Microsoft.NET.HostModel/AppHost/RetryUtil.cs
+++ b/src/managed/Microsoft.NET.HostModel/AppHost/RetryUtil.cs
@@ -1,0 +1,71 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.IO;
+using System.IO.MemoryMappedFiles;
+using System.Text;
+using System.Threading;
+
+namespace Microsoft.NET.HostModel
+{
+    /// <summary>
+    /// HostModel library implements several services for updating the AppHost DLL.
+    /// These updates involve multiple file open/close operations.
+    /// An Antivirus scanner may intercept in-between and lock the file, 
+    /// causing the operations to fail with IO-Error.
+    /// So, the operations are retried a few times on failures such as
+    /// - IOException 
+    /// - Failure with Win32 errors indicating file-lock
+    /// </summary>
+    public static class RetryUtil
+    {
+        public const int NumberOfRetries = 500;
+        public const int NumMilliSecondsToWait = 100;
+
+        public static void RetryOnIOError(Action func)
+        {
+            for (int i = 1; i <= NumberOfRetries; i++)
+            {
+                try
+                {
+                    func();
+                    break;
+                }
+                catch (IOException) when (i < NumberOfRetries)
+                {
+                    Thread.Sleep(NumMilliSecondsToWait);
+                }
+            }
+        }
+
+        public static void RetryOnWin32Error(Action func)
+        {
+            bool IsWin32FileLockError(int hresult)
+            {
+                // Error codes are defined in winerror.h
+                const int ErrorLockViolation = 33;
+                const int ErrorDriveLocked = 108;
+
+                // The error code is stored in the lowest 16 bits of the HResult
+                int errorCode = hresult & 0xffff;
+
+                return errorCode == ErrorLockViolation || errorCode == ErrorDriveLocked;
+            }
+
+            for (int i = 1; i <= NumberOfRetries; i++)
+            {
+                try
+                {
+                    func();
+                    break;
+                }
+                catch (HResultException hrex)
+                    when (i < NumberOfRetries && IsWin32FileLockError(hrex.Win32HResult))
+                {
+                    Thread.Sleep(NumMilliSecondsToWait);
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
# HostModel: Retry ResourceUpdate on Win32 File-Lock error

This change ports the following commit from master branch https://github.com/dotnet/core-setup/commit/77adbdd3f78f1584b9e4f230fee322efb8ec9e0a (#7665)

This PR builds on PR #7617 to extend the retry-facility to resource-update operation after failure in Win32 file operations.

For Win32 PE files, the SDK copies resources to the AppHost binary from the intermediate assembly.
This update is performed using native Win32 operations. This change retries the resource update if the operation fails because the file is locked (say because of AntiVirus scan).

This change is similar to #7617 which handles failures in managed code via IOException.
