### PR TITLE
Enable hosted builds on arm64

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -94,7 +94,8 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <TargetArchitecture  Condition="'$(TargetArchitecture)' == ''">x64</TargetArchitecture>
+    <HostArch>$([System.Runtime.InteropServices.RuntimeInformation]::ProcessArchitecture.ToString().ToLowerInvariant())</HostArch>
+    <TargetArchitecture Condition="'$(TargetArchitecture)' == ''">$(HostArch)</TargetArchitecture>
     <Platform Condition="'$(Platform)'==''">$(TargetArchitecture)</Platform>
   </PropertyGroup>
   <!--

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -87,7 +87,7 @@
     <MicrosoftTargetingPackPrivateWinRTPackageVersion>1.0.5</MicrosoftTargetingPackPrivateWinRTPackageVersion>
     <MicrosoftDiaSymReaderNativePackageVersion>1.7.0</MicrosoftDiaSymReaderNativePackageVersion>
     <!-- Infrastructure and test-only. -->
-    <MicrosoftSourceLinkVersion>1.0.0-beta2-18618-05</MicrosoftSourceLinkVersion>
+    <MicrosoftSourceLinkVersion>1.0.0-beta2-19367-01</MicrosoftSourceLinkVersion>
   </PropertyGroup>
   <!--Package names-->
   <PropertyGroup>

--- a/src/pkg/packaging-tools/framework.dependency.targets
+++ b/src/pkg/packaging-tools/framework.dependency.targets
@@ -217,7 +217,8 @@
     <PropertyGroup>
       <_crossDir Condition="'$(TargetArchitecture)' == 'arm' AND '$(OS)' == 'Windows_NT'">/x86_arm</_crossDir>
       <_crossDir Condition="'$(TargetArchitecture)' == 'arm' AND '$(OS)' != 'Windows_NT'">/x64_arm</_crossDir>
-      <_crossDir Condition="'$(TargetArchitecture)' == 'arm64'">/x64_arm64</_crossDir>
+      <!-- Only use x64_arm64 when cross compiling. Use normal executible when compiling on arm64 itself. -->
+      <_crossDir Condition="'$(TargetArchitecture)' == 'arm64' AND '$(HostArch)' != 'arm64'">/x64_arm64</_crossDir>
     </PropertyGroup>
 
     <ItemGroup>
@@ -235,7 +236,6 @@
       <!-- Find crossgen tool assets in package cache to allow ExcludeAssets=All. -->
       <_runtimeCLR Include="$(_runtimePackageDir)**/$(LibraryFilePrefix)coreclr$(LibraryFileExtension)" />
       <_runtimeCoreLib Include="$(_runtimePackageDir)**/native/System.Private.CoreLib.dll" />
-      <_runtimeJIT Include="$(_jitPackageDir)**/$(LibraryFilePrefix)clrjit$(LibraryFileExtension)" />
       <_fxSystemRuntime Include="$(_corefxPackageDir)**/System.Runtime.dll" />
       <_windowsWinMD Include="$(_winmdPackageDir)**/Windows.winmd" />
       <_diaSymReaderAssembly Include="$(_diaSymReaderPackageDir)**\Microsoft.DiaSymReader.Native.*.dll" />
@@ -250,8 +250,8 @@
       <_coreLibDirectory>%(_runtimeCoreLib.RootDir)%(_runtimeCoreLib.Directory)</_coreLibDirectory>
     </PropertyGroup>
 
-    <PropertyGroup Condition="'@(_runtimeJIT)' != ''">
-      <_jitPath>%(_runtimeJIT.FullPath)</_jitPath>
+    <PropertyGroup>
+      <_jitPath Condition="'$(_crossDir)' == ''">$(_jitPackageDir)runtimes/$(PackageRID)/native/$(LibraryFilePrefix)clrjit$(LibraryFileExtension)</_jitPath>
       <_jitPath Condition="'$(_crossDir)' != ''">$(_jitPackageDir)runtimes$(_crossDir)/native/$(LibraryFilePrefix)clrjit$(LibraryFileExtension)</_jitPath>
     </PropertyGroup>
 


### PR DESCRIPTION
To enable building core-setup on arm64 (hosted, not cross compiled), we need to do a few things:

- Set the right `TargetArchitecture`

  Use the currently running architecture to decide whether to default to `x64` or to switch to `arm64` when `TargetArchitecture` is not specified

- Use the right coreclr JIT

  If we are cross-compiling, we need to use the `x86_arm64` `libclrjit.so`. But if we are building on an arm64 host, we need to filter the list of   found `libclrjit.so` files to pick the normal-RID (eg, `linux-arm64`) `libclrjit.so` from the two:

    `./.packages/transport.runtime.linux-arm64.microsoft.netcore.jit/5.0.0-alpha1.19403.2/runtimes/linux-arm64/native/libclrjit.so`
    `./.packages/transport.runtime.linux-arm64.microsoft.netcore.jit/5.0.0-alpha1.19403.2/runtimes/x64_arm64/native/libclrjit.so`

- Use a version of SourceLink that supports arm64

  We need to upgrade SourceLink to a version that contains dotnet/sourcelink#288. This commit just updates it to the latest version.

Fixes #7653