### PR TITLE
Temporary build break fix: move eng/common symbol publish to a pool with space

### DIFF
--- a/eng/common/templates/post-build/channels/netcore-dev-5.yml
+++ b/eng/common/templates/post-build/channels/netcore-dev-5.yml
@@ -19,7 +19,8 @@ stages:
     variables:
       - group: DotNet-Symbol-Server-Pats
     pool:
-      vmImage: 'windows-2019'
+      name: NetCoreInternal-Pool
+      queue: buildpool.windows.10.amd64.vs2017
     steps:
       - task: DownloadBuildArtifacts@0
         displayName: Download Artifacts


### PR DESCRIPTION
Symbol publish is failing due to lack of space in the current agent pool. Move to a pool that is working for other jobs. This is temporary because Maestro++ will overwrite it with the next Arcade update.

This will hopefully let a build go through.

This doesn't reduce the need for https://github.com/dotnet/core-eng/issues/7448 because the change will be reverted by Maestro++ if not fixed in Arcade.

/cc @MichaelSimons @JohnTortugo 