### PR TITLE
Use existing .NET Core Runtime installer localization for Windows Desktop Runtime

### DIFF
--- a/src/pkg/projects/windowsdesktop/sfx/bundle.wxl
+++ b/src/pkg/projects/windowsdesktop/sfx/bundle.wxl
@@ -58,7 +58,7 @@ Ready? Set? Let's go!</String>
   <String Id="FilesInUseDontCloseRadioButton">&amp;Do not close applications. A reboot will be required.</String>
   <String Id="FilesInUseOkButton">&amp;OK</String>
   <String Id="FilesInUseCancelButton">&amp;Cancel</String>
-  <String Id="WelcomeHeaderMessage">Windows Desktop Runtime</String>
+  <String Id="WelcomeHeaderMessage"></String>
   <String Id="WelcomeDescription"></String>
   <String Id="LearnMoreTitle">Learn more about .NET Core</String>
   <String Id="SuccessInstallLocation">The following was installed at [DOTNETHOME]</String>

--- a/src/pkg/projects/windowsdesktop/sfx/theme/1028/bundle.wxl
+++ b/src/pkg/projects/windowsdesktop/sfx/theme/1028/bundle.wxl
@@ -1,74 +1,74 @@
 <?xml version="1.0" encoding="utf-8"?>
 <WixLocalization Culture="en-us" Language="1033" xmlns="http://schemas.microsoft.com/wix/2006/localization">
-  <String Id="Caption">[WixBundleName] Installer</String>
+  <String Id="Caption">[WixBundleName] 安裝程式</String>
   <String Id="Title">[BUNDLEMONIKER]</String>
-  <String Id="Motto">You just need a shell, a text editor and 10 minutes of your time.
+  <String Id="Motto">您只需要殼層、文字編輯器和 10 分鐘的時間。
 
-Ready? Set? Let's go!</String>
-  <String Id="ConfirmCancelMessage">Are you sure you want to cancel?</String>
-  <String Id="ExecuteUpgradeRelatedBundleMessage">Previous version</String>
-  <String Id="HelpHeader">Setup Help</String>
-  <String Id="HelpText">/install | /repair | /uninstall | /layout [directory] - installs, repairs, uninstalls or
-   creates a complete local copy of the bundle in directory. Install is the default.
+準備好了嗎? 讓我們開始吧!</String>
+  <String Id="ConfirmCancelMessage">您確定要取消嗎?</String>
+  <String Id="ExecuteUpgradeRelatedBundleMessage">前一版</String>
+  <String Id="HelpHeader">安裝程式說明</String>
+  <String Id="HelpText">/install | /repair | /uninstall | /layout [directory] - 在目錄中安裝、修復、解除安裝或
+   建立搭售方案的完整本機複本。預設為安裝。
 
-/passive | /quiet -  displays minimal UI with no prompts or displays no UI and
-   no prompts. By default UI and all prompts are displayed.
+/passive | /quiet -  顯示最少 UI 且不含提示，或者不顯示 UI，也
+   不顯示提示。預設會顯示 UI 和所有提示。
 
-/norestart   - suppress any attempts to restart. By default UI will prompt before restart.
-/log log.txt - logs to a specific file. By default a log file is created in %TEMP%.</String>
-  <String Id="HelpCloseButton">&amp;Close</String>
-  <String Id="InstallAcceptCheckbox">I &amp;agree to the license terms and conditions</String>
-  <String Id="InstallOptionsButton">&amp;Options</String>
-  <String Id="InstallInstallButton">&amp;Install</String>
-  <String Id="InstallCloseButton">&amp;Close</String>
-  <String Id="OptionsHeader">Setup Options</String>
-  <String Id="OptionsLocationLabel">Install location:</String>
-  <String Id="OptionsBrowseButton">&amp;Browse</String>
-  <String Id="OptionsOkButton">&amp;OK</String>
-  <String Id="OptionsCancelButton">&amp;Cancel</String>
-  <String Id="ProgressHeader">Setup Progress</String>
-  <String Id="ProgressLabel">Processing:</String>
-  <String Id="OverallProgressPackageText">Initializing...</String>
-  <String Id="ProgressCancelButton">&amp;Cancel</String>
-  <String Id="ModifyHeader">Modify Setup</String>
-  <String Id="ModifyRepairButton">&amp;Repair</String>
-  <String Id="ModifyUninstallButton">&amp;Uninstall</String>
-  <String Id="ModifyCloseButton">&amp;Close</String>
-  <String Id="SuccessRepairHeader">Repair Successfully Completed</String>
-  <String Id="SuccessUninstallHeader">Uninstall Successfully Completed</String>
-  <String Id="SuccessInstallHeader">Installation was successful</String>
-  <String Id="SuccessHeader">Setup Successful</String>
-  <String Id="SuccessLaunchButton">&amp;Launch</String>
-  <String Id="SuccessRestartText">You must restart your computer before you can use the software.</String>
-  <String Id="SuccessRestartButton">&amp;Restart</String>
-  <String Id="SuccessCloseButton">&amp;Close</String>
-  <String Id="FailureHeader">Setup Failed</String>
-  <String Id="FailureInstallHeader">Setup Failed</String>
-  <String Id="FailureUninstallHeader">Uninstall Failed</String>
-  <String Id="FailureRepairHeader">Repair Failed</String>
-  <String Id="FailureHyperlinkLogText">One or more issues caused the setup to fail. Please fix the issues and then retry setup. For more information see the &lt;a href="#"&gt;log file&lt;/a&gt;.</String>
-  <String Id="FailureRestartText">You must restart your computer to complete the rollback of the software.</String>
-  <String Id="FailureRestartButton">&amp;Restart</String>
-  <String Id="FailureCloseButton">&amp;Close</String>
-  <String Id="FailureNotSupportedCurrentOperatingSystem">The [PRODUCT_NAME] is not supported on this operating system. For more information, see [LINK_PREREQ_PAGE].</String>
-  <String Id="FailureNotSupportedX86OperatingSystem">The [PRODUCT_NAME] isn't supported on x86 operating systems. Please install using the corresponding x86 installer.</String>
-  <String Id="FilesInUseHeader">Files In Use</String>
-  <String Id="FilesInUseLabel">The following applications are using files that need to be updated:</String>
-  <String Id="FilesInUseCloseRadioButton">Close the &amp;applications and attempt to restart them.</String>
-  <String Id="FilesInUseDontCloseRadioButton">&amp;Do not close applications. A reboot will be required.</String>
-  <String Id="FilesInUseOkButton">&amp;OK</String>
-  <String Id="FilesInUseCancelButton">&amp;Cancel</String>
-  <String Id="WelcomeHeaderMessage">Windows Desktop Runtime</String>
+/norestart   - 隱藏任何重新啟動嘗試。根據預設，UI 會在重新啟動之前提示。
+/log log.txt - 記錄至特定檔案。預設會在 %TEMP% 建立記錄檔。</String>
+  <String Id="HelpCloseButton">關閉(&amp;C)</String>
+  <String Id="InstallAcceptCheckbox">我同意授權條款及條件(&amp;A)</String>
+  <String Id="InstallOptionsButton">選項(&amp;O)</String>
+  <String Id="InstallInstallButton">安裝(&amp;I)</String>
+  <String Id="InstallCloseButton">關閉(&amp;C)</String>
+  <String Id="OptionsHeader">安裝選項</String>
+  <String Id="OptionsLocationLabel">安裝位置: </String>
+  <String Id="OptionsBrowseButton">瀏覽(&amp;B)</String>
+  <String Id="OptionsOkButton">確定(&amp;O)</String>
+  <String Id="OptionsCancelButton">取消(&amp;C)</String>
+  <String Id="ProgressHeader">安裝進度</String>
+  <String Id="ProgressLabel">處理中: </String>
+  <String Id="OverallProgressPackageText">正在初始化...</String>
+  <String Id="ProgressCancelButton">取消(&amp;C)</String>
+  <String Id="ModifyHeader">修改安裝</String>
+  <String Id="ModifyRepairButton">修復(&amp;R)</String>
+  <String Id="ModifyUninstallButton">解除安裝(&amp;U)</String>
+  <String Id="ModifyCloseButton">關閉(&amp;C)</String>
+  <String Id="SuccessRepairHeader">修復已成功完成</String>
+  <String Id="SuccessUninstallHeader">解除安裝已成功完成</String>
+  <String Id="SuccessInstallHeader">安裝成功</String>
+  <String Id="SuccessHeader">設定成功</String>
+  <String Id="SuccessLaunchButton">啟動(&amp;L)</String>
+  <String Id="SuccessRestartText">必須重新啟動電腦，才能使用此軟體。</String>
+  <String Id="SuccessRestartButton">重新啟動(&amp;R)</String>
+  <String Id="SuccessCloseButton">關閉(&amp;C)</String>
+  <String Id="FailureHeader">設定失敗</String>
+  <String Id="FailureInstallHeader">安裝程式失敗</String>
+  <String Id="FailureUninstallHeader">解除安裝失敗</String>
+  <String Id="FailureRepairHeader">修復失敗</String>
+  <String Id="FailureHyperlinkLogText">有一個或多個問題導致安裝程式失敗。請解決問題，然後重試一次安裝。如需詳細資訊，請參閱&lt;a href="#"&gt;記錄檔&lt;/a&gt;。</String>
+  <String Id="FailureRestartText">必須重新啟動電腦，才能完成軟體的復原。</String>
+  <String Id="FailureRestartButton">重新啟動(&amp;R)</String>
+  <String Id="FailureCloseButton">關閉(&amp;C)</String>
+  <String Id="FailureNotSupportedCurrentOperatingSystem">此作業系統不支援 [PRODUCT_NAME]。如需詳細資訊，請參閱 [LINK_PREREQ_PAGE]。</String>
+  <String Id="FailureNotSupportedX86OperatingSystem">x86 作業系統不支援 [PRODUCT_NAME]。請使用對應的 x86 安裝程式來安裝。</String>
+  <String Id="FilesInUseHeader">使用中的檔案</String>
+  <String Id="FilesInUseLabel">以下應用程式正在使用需要進行更新的檔案:</String>
+  <String Id="FilesInUseCloseRadioButton">關閉應用程式並嘗試重新啟動(&amp;A)</String>
+  <String Id="FilesInUseDontCloseRadioButton">不關閉應用程式，需要重新啟動(&amp;D)</String>
+  <String Id="FilesInUseOkButton">確定(&amp;O)</String>
+  <String Id="FilesInUseCancelButton">取消(&amp;C)</String>
+  <String Id="WelcomeHeaderMessage"></String>
   <String Id="WelcomeDescription"></String>
-  <String Id="LearnMoreTitle">Learn more about .NET Core</String>
-  <String Id="SuccessInstallLocation">The following was installed at [DOTNETHOME]</String>
+  <String Id="LearnMoreTitle">深入了解 .NET Core</String>
+  <String Id="SuccessInstallLocation">下列項目已安裝在 [DOTNETHOME]</String>
   <String Id="SuccessInstallProductName"> - [BUNDLEMONIKER] </String>
-  <String Id="ResourcesHeader">Resources</String>
-  <String Id="DocumentationLink">&lt;A HREF=&quot;https://aka.ms/dotnet-docs&quot;&gt;Documentation&lt;/A&gt;</String>
-  <String Id="RelaseNotesLink">&lt;A HREF=&quot;https://aka.ms/20-p2-rel-notes&quot;&gt;Release Notes&lt;/A&gt;</String>
-  <String Id="TutorialLink">&lt;A HREF=&quot;https://aka.ms/dotnet-tutorials&quot;&gt;Tutorials&lt;/A&gt;</String>
-  <String Id="TelemetryLink">&lt;A HREF=&quot;https://aka.ms/dotnet-cli-telemetry&quot;&gt;.NET Core Telemetry&lt;/A&gt;</String>
-  <String Id="PrivacyStatementLink">&lt;A HREF=&quot;https://aka.ms/dev-privacy&quot;&gt;Privacy Statement&lt;/A&gt;</String>
-  <String Id="EulaLink">&lt;A HREF=&quot;https://go.microsoft.com/fwlink/?LinkId=329770&quot;&gt;.NET Library EULA&lt;/A&gt;</String>
+  <String Id="ResourcesHeader">資源</String>
+  <String Id="DocumentationLink">&lt;A HREF="https://aka.ms/dotnet-docs"&gt;文件&lt;/A&gt;</String>
+  <String Id="RelaseNotesLink">&lt;A HREF="https://aka.ms/20-p2-rel-notes"&gt;版本資訊&lt;/A&gt;</String>
+  <String Id="TutorialLink">&lt;A HREF="https://aka.ms/dotnet-tutorials"&gt;教學課程&lt;/A&gt;</String>
+  <String Id="TelemetryLink">&lt;A HREF="https://aka.ms/dotnet-cli-telemetry"&gt;.NET Core 遙測&lt;/A&gt;</String>
+  <String Id="PrivacyStatementLink">&lt;A HREF="https://aka.ms/dev-privacy"&gt;隱私權聲明&lt;/A&gt;</String>
+  <String Id="EulaLink">&lt;A HREF="https://go.microsoft.com/fwlink/?LinkId=329770"&gt;.NET 程式庫 EULA&lt;/A&gt;</String>
   
 </WixLocalization>

--- a/src/pkg/projects/windowsdesktop/sfx/theme/1029/bundle.wxl
+++ b/src/pkg/projects/windowsdesktop/sfx/theme/1029/bundle.wxl
@@ -1,74 +1,74 @@
 <?xml version="1.0" encoding="utf-8"?>
 <WixLocalization Culture="en-us" Language="1033" xmlns="http://schemas.microsoft.com/wix/2006/localization">
-  <String Id="Caption">[WixBundleName] Installer</String>
+  <String Id="Caption">Instalační program pro [WixBundleName]</String>
   <String Id="Title">[BUNDLEMONIKER]</String>
-  <String Id="Motto">You just need a shell, a text editor and 10 minutes of your time.
+  <String Id="Motto">Potřebujete jenom prostředí, textový editor a 10 minut času.
 
-Ready? Set? Let's go!</String>
-  <String Id="ConfirmCancelMessage">Are you sure you want to cancel?</String>
-  <String Id="ExecuteUpgradeRelatedBundleMessage">Previous version</String>
-  <String Id="HelpHeader">Setup Help</String>
-  <String Id="HelpText">/install | /repair | /uninstall | /layout [directory] - installs, repairs, uninstalls or
-   creates a complete local copy of the bundle in directory. Install is the default.
+Jste připraveni? Dejme se tedy do toho!</String>
+  <String Id="ConfirmCancelMessage">Opravdu chcete akci zrušit?</String>
+  <String Id="ExecuteUpgradeRelatedBundleMessage">Předchozí verze</String>
+  <String Id="HelpHeader">Nápověda k instalaci</String>
+  <String Id="HelpText">/install | /repair | /uninstall | /layout [adresář] – Nainstaluje, opraví, odinstaluje nebo
+   vytvoří úplnou místní kopii svazku v adresáři. Výchozí možností je instalace.
 
-/passive | /quiet -  displays minimal UI with no prompts or displays no UI and
-   no prompts. By default UI and all prompts are displayed.
+/passive | /quiet –  Zobrazí minimální uživatelské rozhraní bez výzev nebo nezobrazí žádné uživatelské rozhraní a
+   žádné výzvy. Výchozí možností je zobrazení uživatelského rozhraní a všech výzev.
 
-/norestart   - suppress any attempts to restart. By default UI will prompt before restart.
-/log log.txt - logs to a specific file. By default a log file is created in %TEMP%.</String>
-  <String Id="HelpCloseButton">&amp;Close</String>
-  <String Id="InstallAcceptCheckbox">I &amp;agree to the license terms and conditions</String>
-  <String Id="InstallOptionsButton">&amp;Options</String>
-  <String Id="InstallInstallButton">&amp;Install</String>
-  <String Id="InstallCloseButton">&amp;Close</String>
-  <String Id="OptionsHeader">Setup Options</String>
-  <String Id="OptionsLocationLabel">Install location:</String>
-  <String Id="OptionsBrowseButton">&amp;Browse</String>
+/norestart   – potlačí všechny pokusy o restartování. Ve výchozím nastavení uživatelské rozhraní před restartováním zobrazí výzvu.
+/log log.txt – Uloží protokol do konkrétního souboru. Ve výchozím nastavení bude soubor protokolu vytvořen v adresáři %TEMP%.</String>
+  <String Id="HelpCloseButton">&amp;Zavřít</String>
+  <String Id="InstallAcceptCheckbox">Souhl&amp;asím s licenčními podmínkami.</String>
+  <String Id="InstallOptionsButton">M&amp;ožnosti</String>
+  <String Id="InstallInstallButton">&amp;Instalovat</String>
+  <String Id="InstallCloseButton">&amp;Zavřít</String>
+  <String Id="OptionsHeader">Možnosti instalace</String>
+  <String Id="OptionsLocationLabel">Umístění instalace:</String>
+  <String Id="OptionsBrowseButton">&amp;Procházet</String>
   <String Id="OptionsOkButton">&amp;OK</String>
-  <String Id="OptionsCancelButton">&amp;Cancel</String>
-  <String Id="ProgressHeader">Setup Progress</String>
-  <String Id="ProgressLabel">Processing:</String>
-  <String Id="OverallProgressPackageText">Initializing...</String>
-  <String Id="ProgressCancelButton">&amp;Cancel</String>
-  <String Id="ModifyHeader">Modify Setup</String>
-  <String Id="ModifyRepairButton">&amp;Repair</String>
-  <String Id="ModifyUninstallButton">&amp;Uninstall</String>
-  <String Id="ModifyCloseButton">&amp;Close</String>
-  <String Id="SuccessRepairHeader">Repair Successfully Completed</String>
-  <String Id="SuccessUninstallHeader">Uninstall Successfully Completed</String>
-  <String Id="SuccessInstallHeader">Installation was successful</String>
-  <String Id="SuccessHeader">Setup Successful</String>
-  <String Id="SuccessLaunchButton">&amp;Launch</String>
-  <String Id="SuccessRestartText">You must restart your computer before you can use the software.</String>
-  <String Id="SuccessRestartButton">&amp;Restart</String>
-  <String Id="SuccessCloseButton">&amp;Close</String>
-  <String Id="FailureHeader">Setup Failed</String>
-  <String Id="FailureInstallHeader">Setup Failed</String>
-  <String Id="FailureUninstallHeader">Uninstall Failed</String>
-  <String Id="FailureRepairHeader">Repair Failed</String>
-  <String Id="FailureHyperlinkLogText">One or more issues caused the setup to fail. Please fix the issues and then retry setup. For more information see the &lt;a href="#"&gt;log file&lt;/a&gt;.</String>
-  <String Id="FailureRestartText">You must restart your computer to complete the rollback of the software.</String>
-  <String Id="FailureRestartButton">&amp;Restart</String>
-  <String Id="FailureCloseButton">&amp;Close</String>
-  <String Id="FailureNotSupportedCurrentOperatingSystem">The [PRODUCT_NAME] is not supported on this operating system. For more information, see [LINK_PREREQ_PAGE].</String>
-  <String Id="FailureNotSupportedX86OperatingSystem">The [PRODUCT_NAME] isn't supported on x86 operating systems. Please install using the corresponding x86 installer.</String>
-  <String Id="FilesInUseHeader">Files In Use</String>
-  <String Id="FilesInUseLabel">The following applications are using files that need to be updated:</String>
-  <String Id="FilesInUseCloseRadioButton">Close the &amp;applications and attempt to restart them.</String>
-  <String Id="FilesInUseDontCloseRadioButton">&amp;Do not close applications. A reboot will be required.</String>
+  <String Id="OptionsCancelButton">&amp;Storno</String>
+  <String Id="ProgressHeader">Průběh instalace</String>
+  <String Id="ProgressLabel">Zpracování:</String>
+  <String Id="OverallProgressPackageText">Inicializuje se...</String>
+  <String Id="ProgressCancelButton">&amp;Storno</String>
+  <String Id="ModifyHeader">Změnit instalaci</String>
+  <String Id="ModifyRepairButton">Op&amp;ravit</String>
+  <String Id="ModifyUninstallButton">O&amp;dinstalovat</String>
+  <String Id="ModifyCloseButton">&amp;Zavřít</String>
+  <String Id="SuccessRepairHeader">Oprava se úspěšně dokončila.</String>
+  <String Id="SuccessUninstallHeader">Odinstalace se úspěšně dokončila.</String>
+  <String Id="SuccessInstallHeader">Instalace proběhla úspěšně.</String>
+  <String Id="SuccessHeader">Instalace byla úspěšná.</String>
+  <String Id="SuccessLaunchButton">&amp;Spustit</String>
+  <String Id="SuccessRestartText">Před použitím tohoto softwaru musíte restartovat počítač.</String>
+  <String Id="SuccessRestartButton">&amp;Restartovat</String>
+  <String Id="SuccessCloseButton">&amp;Zavřít</String>
+  <String Id="FailureHeader">Instalace se nepovedla.</String>
+  <String Id="FailureInstallHeader">Instalace se nepovedla.</String>
+  <String Id="FailureUninstallHeader">Odinstalace se nepovedla.</String>
+  <String Id="FailureRepairHeader">Oprava se nepovedla.</String>
+  <String Id="FailureHyperlinkLogText">Instalace se nepovedla kvůli jednomu nebo více problémům. Opravte prosím tyto problémy a zkuste software nainstalovat znovu. Další informace najdete v &lt;a href="#"&gt;souboru protokolu&lt;/a&gt;.</String>
+  <String Id="FailureRestartText">Pro dokončení vrácení změn tohoto softwaru je potřeba restartovat počítač.</String>
+  <String Id="FailureRestartButton">&amp;Restartovat</String>
+  <String Id="FailureCloseButton">&amp;Zavřít</String>
+  <String Id="FailureNotSupportedCurrentOperatingSystem">[PRODUCT_NAME] se tomto operačním systému nepodporuje. Další informace: [LINK_PREREQ_PAGE]</String>
+  <String Id="FailureNotSupportedX86OperatingSystem">[PRODUCT_NAME] se v operačních systémech pro platformu x86 nepodporuje. Použijte prosím k instalaci odpovídající instalační program pro platformu x86.</String>
+  <String Id="FilesInUseHeader">Používané soubory</String>
+  <String Id="FilesInUseLabel">Následující aplikace používají soubory, které je potřeba aktualizovat:</String>
+  <String Id="FilesInUseCloseRadioButton">Zavřete &amp;aplikace a zkuste je restartovat.</String>
+  <String Id="FilesInUseDontCloseRadioButton">A&amp;plikace nezavírejte. Bude potřeba provést restart.</String>
   <String Id="FilesInUseOkButton">&amp;OK</String>
-  <String Id="FilesInUseCancelButton">&amp;Cancel</String>
-  <String Id="WelcomeHeaderMessage">Windows Desktop Runtime</String>
+  <String Id="FilesInUseCancelButton">&amp;Zrušit</String>
+  <String Id="WelcomeHeaderMessage"></String>
   <String Id="WelcomeDescription"></String>
-  <String Id="LearnMoreTitle">Learn more about .NET Core</String>
-  <String Id="SuccessInstallLocation">The following was installed at [DOTNETHOME]</String>
+  <String Id="LearnMoreTitle">Další informace o .NET Core</String>
+  <String Id="SuccessInstallLocation">Do [DOTNETHOME] se nainstalovaly následující položky.</String>
   <String Id="SuccessInstallProductName"> - [BUNDLEMONIKER] </String>
-  <String Id="ResourcesHeader">Resources</String>
-  <String Id="DocumentationLink">&lt;A HREF=&quot;https://aka.ms/dotnet-docs&quot;&gt;Documentation&lt;/A&gt;</String>
-  <String Id="RelaseNotesLink">&lt;A HREF=&quot;https://aka.ms/20-p2-rel-notes&quot;&gt;Release Notes&lt;/A&gt;</String>
-  <String Id="TutorialLink">&lt;A HREF=&quot;https://aka.ms/dotnet-tutorials&quot;&gt;Tutorials&lt;/A&gt;</String>
-  <String Id="TelemetryLink">&lt;A HREF=&quot;https://aka.ms/dotnet-cli-telemetry&quot;&gt;.NET Core Telemetry&lt;/A&gt;</String>
-  <String Id="PrivacyStatementLink">&lt;A HREF=&quot;https://aka.ms/dev-privacy&quot;&gt;Privacy Statement&lt;/A&gt;</String>
-  <String Id="EulaLink">&lt;A HREF=&quot;https://go.microsoft.com/fwlink/?LinkId=329770&quot;&gt;.NET Library EULA&lt;/A&gt;</String>
+  <String Id="ResourcesHeader">Prostředky</String>
+  <String Id="DocumentationLink">&lt;A HREF="https://aka.ms/dotnet-docs"&gt;Dokumentace&lt;/A&gt;</String>
+  <String Id="RelaseNotesLink">&lt;A HREF="https://aka.ms/20-p2-rel-notes"&gt;Zpráva k vydání verze&lt;/A&gt;</String>
+  <String Id="TutorialLink">&lt;A HREF="https://aka.ms/dotnet-tutorials"&gt;Kurzy&lt;/A&gt;</String>
+  <String Id="TelemetryLink">&lt;A HREF="https://aka.ms/dotnet-cli-telemetry"&gt;Telemetrie pro platformu .NET Core&lt;/A&gt;</String>
+  <String Id="PrivacyStatementLink">&lt;A HREF="https://aka.ms/dev-privacy"&gt;Prohlášení o zásadách ochrany osobních údajů&lt;/A&gt;</String>
+  <String Id="EulaLink">&lt;A HREF="https://go.microsoft.com/fwlink/?LinkId=329770"&gt;Smlouva EULA ke knihovně .NET&lt;/A&gt;</String>
   
 </WixLocalization>

--- a/src/pkg/projects/windowsdesktop/sfx/theme/1031/bundle.wxl
+++ b/src/pkg/projects/windowsdesktop/sfx/theme/1031/bundle.wxl
@@ -1,74 +1,74 @@
 <?xml version="1.0" encoding="utf-8"?>
 <WixLocalization Culture="en-us" Language="1033" xmlns="http://schemas.microsoft.com/wix/2006/localization">
-  <String Id="Caption">[WixBundleName] Installer</String>
+  <String Id="Caption">[WixBundleName]-Installer</String>
   <String Id="Title">[BUNDLEMONIKER]</String>
-  <String Id="Motto">You just need a shell, a text editor and 10 minutes of your time.
+  <String Id="Motto">Sie benötigen nur eine Shell, einen Text-Editor und 10 Minuten Zeit.
 
-Ready? Set? Let's go!</String>
-  <String Id="ConfirmCancelMessage">Are you sure you want to cancel?</String>
-  <String Id="ExecuteUpgradeRelatedBundleMessage">Previous version</String>
-  <String Id="HelpHeader">Setup Help</String>
-  <String Id="HelpText">/install | /repair | /uninstall | /layout [directory] - installs, repairs, uninstalls or
-   creates a complete local copy of the bundle in directory. Install is the default.
+Bereit? Los geht's!</String>
+  <String Id="ConfirmCancelMessage">Möchten Sie den Vorgang wirklich abbrechen?</String>
+  <String Id="ExecuteUpgradeRelatedBundleMessage">Vorherige Version</String>
+  <String Id="HelpHeader">Hilfe zum Setup</String>
+  <String Id="HelpText">/install | /repair | /uninstall | /layout [Verzeichnis] - installiert, repariert, deinstalliert oder
+   erstellt eine vollständige lokale Kopie des Bundles im Verzeichnis. Installieren ist die Standardeinstellung.
 
-/passive | /quiet -  displays minimal UI with no prompts or displays no UI and
-   no prompts. By default UI and all prompts are displayed.
+/passive | /quiet -  zeigt eine minimale Benutzeroberfläche ohne Eingabeaufforderungen oder keine
+   Benutzeroberfläche und keine Eingabeaufforderungen an. Standardmäßig werden die Benutzeroberfläche und alle Eingabeaufforderungen angezeigt.
 
-/norestart   - suppress any attempts to restart. By default UI will prompt before restart.
-/log log.txt - logs to a specific file. By default a log file is created in %TEMP%.</String>
-  <String Id="HelpCloseButton">&amp;Close</String>
-  <String Id="InstallAcceptCheckbox">I &amp;agree to the license terms and conditions</String>
-  <String Id="InstallOptionsButton">&amp;Options</String>
-  <String Id="InstallInstallButton">&amp;Install</String>
-  <String Id="InstallCloseButton">&amp;Close</String>
-  <String Id="OptionsHeader">Setup Options</String>
-  <String Id="OptionsLocationLabel">Install location:</String>
-  <String Id="OptionsBrowseButton">&amp;Browse</String>
+/norestart   - Unterdrückt alle Neustartversuche. Standardmäßig fordert die Benutzeroberfläche zum Bestätigen eines Neustarts auf.
+/log log.txt - Erstellt das Protokoll in einer bestimmten Datei. Standardmäßig wird die Protokolldatei in %TEMP% erstellt.</String>
+  <String Id="HelpCloseButton">S&amp;chließen</String>
+  <String Id="InstallAcceptCheckbox">Ich &amp;stimme den Lizenzbedingungen zu.</String>
+  <String Id="InstallOptionsButton">&amp;Optionen</String>
+  <String Id="InstallInstallButton">&amp;Installieren</String>
+  <String Id="InstallCloseButton">S&amp;chließen</String>
+  <String Id="OptionsHeader">Setupoptionen</String>
+  <String Id="OptionsLocationLabel">Installationspfad:</String>
+  <String Id="OptionsBrowseButton">&amp;Durchsuchen</String>
   <String Id="OptionsOkButton">&amp;OK</String>
-  <String Id="OptionsCancelButton">&amp;Cancel</String>
-  <String Id="ProgressHeader">Setup Progress</String>
-  <String Id="ProgressLabel">Processing:</String>
-  <String Id="OverallProgressPackageText">Initializing...</String>
-  <String Id="ProgressCancelButton">&amp;Cancel</String>
-  <String Id="ModifyHeader">Modify Setup</String>
-  <String Id="ModifyRepairButton">&amp;Repair</String>
-  <String Id="ModifyUninstallButton">&amp;Uninstall</String>
-  <String Id="ModifyCloseButton">&amp;Close</String>
-  <String Id="SuccessRepairHeader">Repair Successfully Completed</String>
-  <String Id="SuccessUninstallHeader">Uninstall Successfully Completed</String>
-  <String Id="SuccessInstallHeader">Installation was successful</String>
-  <String Id="SuccessHeader">Setup Successful</String>
-  <String Id="SuccessLaunchButton">&amp;Launch</String>
-  <String Id="SuccessRestartText">You must restart your computer before you can use the software.</String>
-  <String Id="SuccessRestartButton">&amp;Restart</String>
-  <String Id="SuccessCloseButton">&amp;Close</String>
-  <String Id="FailureHeader">Setup Failed</String>
-  <String Id="FailureInstallHeader">Setup Failed</String>
-  <String Id="FailureUninstallHeader">Uninstall Failed</String>
-  <String Id="FailureRepairHeader">Repair Failed</String>
-  <String Id="FailureHyperlinkLogText">One or more issues caused the setup to fail. Please fix the issues and then retry setup. For more information see the &lt;a href="#"&gt;log file&lt;/a&gt;.</String>
-  <String Id="FailureRestartText">You must restart your computer to complete the rollback of the software.</String>
-  <String Id="FailureRestartButton">&amp;Restart</String>
-  <String Id="FailureCloseButton">&amp;Close</String>
-  <String Id="FailureNotSupportedCurrentOperatingSystem">The [PRODUCT_NAME] is not supported on this operating system. For more information, see [LINK_PREREQ_PAGE].</String>
-  <String Id="FailureNotSupportedX86OperatingSystem">The [PRODUCT_NAME] isn't supported on x86 operating systems. Please install using the corresponding x86 installer.</String>
-  <String Id="FilesInUseHeader">Files In Use</String>
-  <String Id="FilesInUseLabel">The following applications are using files that need to be updated:</String>
-  <String Id="FilesInUseCloseRadioButton">Close the &amp;applications and attempt to restart them.</String>
-  <String Id="FilesInUseDontCloseRadioButton">&amp;Do not close applications. A reboot will be required.</String>
+  <String Id="OptionsCancelButton">&amp;Abbrechen</String>
+  <String Id="ProgressHeader">Setupstatus</String>
+  <String Id="ProgressLabel">Wird verarbeitet:</String>
+  <String Id="OverallProgressPackageText">Initialisierung...</String>
+  <String Id="ProgressCancelButton">&amp;Abbrechen</String>
+  <String Id="ModifyHeader">Setup ändern</String>
+  <String Id="ModifyRepairButton">&amp;Reparieren</String>
+  <String Id="ModifyUninstallButton">&amp;Deinstallieren</String>
+  <String Id="ModifyCloseButton">S&amp;chließen</String>
+  <String Id="SuccessRepairHeader">Die Reparatur wurde erfolgreich abgeschlossen.</String>
+  <String Id="SuccessUninstallHeader">Die Deinstallation wurde erfolgreich abgeschlossen.</String>
+  <String Id="SuccessInstallHeader">Die Installation war erfolgreich.</String>
+  <String Id="SuccessHeader">Setup wurde erfolgreich abgeschlossen</String>
+  <String Id="SuccessLaunchButton">&amp;Starten</String>
+  <String Id="SuccessRestartText">Sie müssen den Computer neu starten, bevor Sie die Software verwenden können.</String>
+  <String Id="SuccessRestartButton">&amp;Neu starten</String>
+  <String Id="SuccessCloseButton">S&amp;chließen</String>
+  <String Id="FailureHeader">Setupfehler</String>
+  <String Id="FailureInstallHeader">Setupfehler</String>
+  <String Id="FailureUninstallHeader">Deinstallationsfehler</String>
+  <String Id="FailureRepairHeader">Reparaturfehler</String>
+  <String Id="FailureHyperlinkLogText">Setup ist aufgrund eines oder mehrerer Probleme fehlgeschlagen. Beheben Sie die Probleme, und führen Sie das Setup erneut aus. Weitere Informationen finden Sie in der &lt;a href="#"&gt;Protokolldatei&lt;/a&gt;.</String>
+  <String Id="FailureRestartText">Sie müssen den Computer neu starten, um das Zurücksetzen der Software abzuschließen.</String>
+  <String Id="FailureRestartButton">&amp;Neu starten</String>
+  <String Id="FailureCloseButton">&amp;Schließen</String>
+  <String Id="FailureNotSupportedCurrentOperatingSystem">[PRODUCT_NAME] wird auf diesem Betriebssystem nicht unterstützt. Weitere Informationen finden Sie unter [LINK_PREREQ_PAGE].</String>
+  <String Id="FailureNotSupportedX86OperatingSystem">[PRODUCT_NAME] wird auf x86-Betriebssystemen nicht unterstützt. Installieren Sie das entsprechende x86-Installationsprogramm.</String>
+  <String Id="FilesInUseHeader">Verwendete Dateien</String>
+  <String Id="FilesInUseLabel">Die folgenden Anwendungen verwenden Dateien, die aktualisiert werden müssen:</String>
+  <String Id="FilesInUseCloseRadioButton">Schließen Sie die &amp;Anwendungen, und versuchen Sie sie erneut zu starten.</String>
+  <String Id="FilesInUseDontCloseRadioButton">&amp;Anwendungen nicht schließen. Ein Neustart ist erforderlich.</String>
   <String Id="FilesInUseOkButton">&amp;OK</String>
-  <String Id="FilesInUseCancelButton">&amp;Cancel</String>
-  <String Id="WelcomeHeaderMessage">Windows Desktop Runtime</String>
+  <String Id="FilesInUseCancelButton">&amp;Abbrechen</String>
+  <String Id="WelcomeHeaderMessage"></String>
   <String Id="WelcomeDescription"></String>
-  <String Id="LearnMoreTitle">Learn more about .NET Core</String>
-  <String Id="SuccessInstallLocation">The following was installed at [DOTNETHOME]</String>
+  <String Id="LearnMoreTitle">Weitere Informationen zu .NET Core</String>
+  <String Id="SuccessInstallLocation">Folgendes wurde unter [DOTNETHOME] installiert.</String>
   <String Id="SuccessInstallProductName"> - [BUNDLEMONIKER] </String>
-  <String Id="ResourcesHeader">Resources</String>
-  <String Id="DocumentationLink">&lt;A HREF=&quot;https://aka.ms/dotnet-docs&quot;&gt;Documentation&lt;/A&gt;</String>
-  <String Id="RelaseNotesLink">&lt;A HREF=&quot;https://aka.ms/20-p2-rel-notes&quot;&gt;Release Notes&lt;/A&gt;</String>
-  <String Id="TutorialLink">&lt;A HREF=&quot;https://aka.ms/dotnet-tutorials&quot;&gt;Tutorials&lt;/A&gt;</String>
-  <String Id="TelemetryLink">&lt;A HREF=&quot;https://aka.ms/dotnet-cli-telemetry&quot;&gt;.NET Core Telemetry&lt;/A&gt;</String>
-  <String Id="PrivacyStatementLink">&lt;A HREF=&quot;https://aka.ms/dev-privacy&quot;&gt;Privacy Statement&lt;/A&gt;</String>
-  <String Id="EulaLink">&lt;A HREF=&quot;https://go.microsoft.com/fwlink/?LinkId=329770&quot;&gt;.NET Library EULA&lt;/A&gt;</String>
+  <String Id="ResourcesHeader">Ressourcen</String>
+  <String Id="DocumentationLink">&lt;A HREF="https://aka.ms/dotnet-docs"&gt;Dokumentation&lt;/A&gt;</String>
+  <String Id="RelaseNotesLink">&lt;A HREF="https://aka.ms/20-p2-rel-notes"&gt;Versionshinweise&lt;/A&gt;</String>
+  <String Id="TutorialLink">&lt;A HREF="https://aka.ms/dotnet-tutorials"&gt;Tutorials&lt;/A&gt;</String>
+  <String Id="TelemetryLink">&lt;A HREF="https://aka.ms/dotnet-cli-telemetry"&gt;.NET Core-Telemetrie&lt;/A&gt;</String>
+  <String Id="PrivacyStatementLink">&lt;A HREF="https://aka.ms/dev-privacy"&gt;Datenschutzerklärung&lt;/A&gt;</String>
+  <String Id="EulaLink">&lt;A HREF="https://go.microsoft.com/fwlink/?LinkId=329770"&gt;Lizenzbedingungen für die .NET-Bibliothek&lt;/A&gt;</String>
   
 </WixLocalization>

--- a/src/pkg/projects/windowsdesktop/sfx/theme/1033/bundle.wxl
+++ b/src/pkg/projects/windowsdesktop/sfx/theme/1033/bundle.wxl
@@ -58,7 +58,7 @@ Ready? Set? Let's go!</String>
   <String Id="FilesInUseDontCloseRadioButton">&amp;Do not close applications. A reboot will be required.</String>
   <String Id="FilesInUseOkButton">&amp;OK</String>
   <String Id="FilesInUseCancelButton">&amp;Cancel</String>
-  <String Id="WelcomeHeaderMessage">Windows Desktop Runtime</String>
+  <String Id="WelcomeHeaderMessage"></String>
   <String Id="WelcomeDescription"></String>
   <String Id="LearnMoreTitle">Learn more about .NET Core</String>
   <String Id="SuccessInstallLocation">The following was installed at [DOTNETHOME]</String>

--- a/src/pkg/projects/windowsdesktop/sfx/theme/1036/bundle.wxl
+++ b/src/pkg/projects/windowsdesktop/sfx/theme/1036/bundle.wxl
@@ -1,74 +1,74 @@
 <?xml version="1.0" encoding="utf-8"?>
 <WixLocalization Culture="en-us" Language="1033" xmlns="http://schemas.microsoft.com/wix/2006/localization">
-  <String Id="Caption">[WixBundleName] Installer</String>
+  <String Id="Caption">Programme d'installation de [WixBundleName]</String>
   <String Id="Title">[BUNDLEMONIKER]</String>
-  <String Id="Motto">You just need a shell, a text editor and 10 minutes of your time.
+  <String Id="Motto">Vous avez juste besoin d'un interpréteur de commandes, d'un éditeur de texte et de 10 minutes.
 
-Ready? Set? Let's go!</String>
-  <String Id="ConfirmCancelMessage">Are you sure you want to cancel?</String>
-  <String Id="ExecuteUpgradeRelatedBundleMessage">Previous version</String>
-  <String Id="HelpHeader">Setup Help</String>
-  <String Id="HelpText">/install | /repair | /uninstall | /layout [directory] - installs, repairs, uninstalls or
-   creates a complete local copy of the bundle in directory. Install is the default.
+À vos marques ? Prêt ? Partez !</String>
+  <String Id="ConfirmCancelMessage">Voulez-vous vraiment annuler ?</String>
+  <String Id="ExecuteUpgradeRelatedBundleMessage">Version précédente</String>
+  <String Id="HelpHeader">Aide à l'installation</String>
+  <String Id="HelpText">/install | /repair | /uninstall | /layout [répertoire] - installe, répare, désinstalle ou
+   crée une copie locale complète du bundle dans le répertoire. Install est l'option par défaut.
 
-/passive | /quiet -  displays minimal UI with no prompts or displays no UI and
-   no prompts. By default UI and all prompts are displayed.
+/passive | /quiet -  affiche une interface utilisateur minimale, sans invite, ou n'affiche 
+   ni interface utilisateur, ni invite. Par défaut, l'interface utilisateur et toutes les invites sont affichées.
 
-/norestart   - suppress any attempts to restart. By default UI will prompt before restart.
-/log log.txt - logs to a specific file. By default a log file is created in %TEMP%.</String>
-  <String Id="HelpCloseButton">&amp;Close</String>
-  <String Id="InstallAcceptCheckbox">I &amp;agree to the license terms and conditions</String>
+/norestart   - supprime toutes les tentatives de redémarrage. Par défaut, l'interface utilisateur affiche une invite avant le redémarrage.
+/log log.txt - enregistre les informations dans un fichier spécifique. Par défaut, un fichier journal est créé dans %TEMP%.</String>
+  <String Id="HelpCloseButton">&amp;Fermer</String>
+  <String Id="InstallAcceptCheckbox">J'&amp;accepte les conditions générales de la licence</String>
   <String Id="InstallOptionsButton">&amp;Options</String>
-  <String Id="InstallInstallButton">&amp;Install</String>
-  <String Id="InstallCloseButton">&amp;Close</String>
-  <String Id="OptionsHeader">Setup Options</String>
-  <String Id="OptionsLocationLabel">Install location:</String>
-  <String Id="OptionsBrowseButton">&amp;Browse</String>
+  <String Id="InstallInstallButton">&amp;Installer</String>
+  <String Id="InstallCloseButton">&amp;Fermer</String>
+  <String Id="OptionsHeader">Options d'installation</String>
+  <String Id="OptionsLocationLabel">Emplacement de l'installation :</String>
+  <String Id="OptionsBrowseButton">&amp;Parcourir</String>
   <String Id="OptionsOkButton">&amp;OK</String>
-  <String Id="OptionsCancelButton">&amp;Cancel</String>
-  <String Id="ProgressHeader">Setup Progress</String>
-  <String Id="ProgressLabel">Processing:</String>
-  <String Id="OverallProgressPackageText">Initializing...</String>
-  <String Id="ProgressCancelButton">&amp;Cancel</String>
-  <String Id="ModifyHeader">Modify Setup</String>
-  <String Id="ModifyRepairButton">&amp;Repair</String>
-  <String Id="ModifyUninstallButton">&amp;Uninstall</String>
-  <String Id="ModifyCloseButton">&amp;Close</String>
-  <String Id="SuccessRepairHeader">Repair Successfully Completed</String>
-  <String Id="SuccessUninstallHeader">Uninstall Successfully Completed</String>
-  <String Id="SuccessInstallHeader">Installation was successful</String>
-  <String Id="SuccessHeader">Setup Successful</String>
-  <String Id="SuccessLaunchButton">&amp;Launch</String>
-  <String Id="SuccessRestartText">You must restart your computer before you can use the software.</String>
-  <String Id="SuccessRestartButton">&amp;Restart</String>
-  <String Id="SuccessCloseButton">&amp;Close</String>
-  <String Id="FailureHeader">Setup Failed</String>
-  <String Id="FailureInstallHeader">Setup Failed</String>
-  <String Id="FailureUninstallHeader">Uninstall Failed</String>
-  <String Id="FailureRepairHeader">Repair Failed</String>
-  <String Id="FailureHyperlinkLogText">One or more issues caused the setup to fail. Please fix the issues and then retry setup. For more information see the &lt;a href="#"&gt;log file&lt;/a&gt;.</String>
-  <String Id="FailureRestartText">You must restart your computer to complete the rollback of the software.</String>
-  <String Id="FailureRestartButton">&amp;Restart</String>
-  <String Id="FailureCloseButton">&amp;Close</String>
-  <String Id="FailureNotSupportedCurrentOperatingSystem">The [PRODUCT_NAME] is not supported on this operating system. For more information, see [LINK_PREREQ_PAGE].</String>
-  <String Id="FailureNotSupportedX86OperatingSystem">The [PRODUCT_NAME] isn't supported on x86 operating systems. Please install using the corresponding x86 installer.</String>
-  <String Id="FilesInUseHeader">Files In Use</String>
-  <String Id="FilesInUseLabel">The following applications are using files that need to be updated:</String>
-  <String Id="FilesInUseCloseRadioButton">Close the &amp;applications and attempt to restart them.</String>
-  <String Id="FilesInUseDontCloseRadioButton">&amp;Do not close applications. A reboot will be required.</String>
+  <String Id="OptionsCancelButton">&amp;Annuler</String>
+  <String Id="ProgressHeader">Progression de l'installation</String>
+  <String Id="ProgressLabel">En cours :</String>
+  <String Id="OverallProgressPackageText">Initialisation...</String>
+  <String Id="ProgressCancelButton">&amp;Annuler</String>
+  <String Id="ModifyHeader">Modifier l'installation</String>
+  <String Id="ModifyRepairButton">&amp;Réparer</String>
+  <String Id="ModifyUninstallButton">&amp;Désinstaller</String>
+  <String Id="ModifyCloseButton">&amp;Fermer</String>
+  <String Id="SuccessRepairHeader">Réparation terminée avec succès</String>
+  <String Id="SuccessUninstallHeader">Désinstallation terminée avec succès</String>
+  <String Id="SuccessInstallHeader">Installation réussie</String>
+  <String Id="SuccessHeader">Installation/désinstallation réussie</String>
+  <String Id="SuccessLaunchButton">&amp;Démarrer</String>
+  <String Id="SuccessRestartText">Vous devez redémarrer votre ordinateur avant de pouvoir utiliser le logiciel.</String>
+  <String Id="SuccessRestartButton">&amp;Redémarrer</String>
+  <String Id="SuccessCloseButton">&amp;Fermer</String>
+  <String Id="FailureHeader">Échec de l'installation</String>
+  <String Id="FailureInstallHeader">Échec de l'installation</String>
+  <String Id="FailureUninstallHeader">Échec de la désinstallation</String>
+  <String Id="FailureRepairHeader">Échec de la réparation</String>
+  <String Id="FailureHyperlinkLogText">Un ou plusieurs problèmes sont à l'origine de l'échec de l'installation. Corrigez ces problèmes, puis recommencez l'installation. Pour plus d'informations, voir le &lt;a href="#"&gt;fichier journal&lt;/a&gt;.</String>
+  <String Id="FailureRestartText">Vous devez redémarrer votre ordinateur pour terminer l'opération de restauration du logiciel.</String>
+  <String Id="FailureRestartButton">&amp;Redémarrer</String>
+  <String Id="FailureCloseButton">&amp;Fermer</String>
+  <String Id="FailureNotSupportedCurrentOperatingSystem">[PRODUCT_NAME] n'est pas pris en charge sur ce système d'exploitation. Pour plus d'informations, consultez [LINK_PREREQ_PAGE].</String>
+  <String Id="FailureNotSupportedX86OperatingSystem">[PRODUCT_NAME] n'est pas pris en charge sur les systèmes d'exploitation x86. Effectuez l'installation à l'aide du programme d'installation x86 correspondant.</String>
+  <String Id="FilesInUseHeader">Fichiers en cours d'utilisation</String>
+  <String Id="FilesInUseLabel">Les applications suivantes utilisent des fichiers nécessitant une mise à jour :</String>
+  <String Id="FilesInUseCloseRadioButton">&amp;Fermez les applications, puis essayez de les redémarrer.</String>
+  <String Id="FilesInUseDontCloseRadioButton">&amp;Ne pas fermer les applications. Un redémarrage sera nécessaire.</String>
   <String Id="FilesInUseOkButton">&amp;OK</String>
-  <String Id="FilesInUseCancelButton">&amp;Cancel</String>
-  <String Id="WelcomeHeaderMessage">Windows Desktop Runtime</String>
+  <String Id="FilesInUseCancelButton">&amp;Annuler</String>
+  <String Id="WelcomeHeaderMessage"></String>
   <String Id="WelcomeDescription"></String>
-  <String Id="LearnMoreTitle">Learn more about .NET Core</String>
-  <String Id="SuccessInstallLocation">The following was installed at [DOTNETHOME]</String>
+  <String Id="LearnMoreTitle">En savoir plus sur .NET Core</String>
+  <String Id="SuccessInstallLocation">L'élément suivant a été installé sur [DOTNETHOME]</String>
   <String Id="SuccessInstallProductName"> - [BUNDLEMONIKER] </String>
-  <String Id="ResourcesHeader">Resources</String>
-  <String Id="DocumentationLink">&lt;A HREF=&quot;https://aka.ms/dotnet-docs&quot;&gt;Documentation&lt;/A&gt;</String>
-  <String Id="RelaseNotesLink">&lt;A HREF=&quot;https://aka.ms/20-p2-rel-notes&quot;&gt;Release Notes&lt;/A&gt;</String>
-  <String Id="TutorialLink">&lt;A HREF=&quot;https://aka.ms/dotnet-tutorials&quot;&gt;Tutorials&lt;/A&gt;</String>
-  <String Id="TelemetryLink">&lt;A HREF=&quot;https://aka.ms/dotnet-cli-telemetry&quot;&gt;.NET Core Telemetry&lt;/A&gt;</String>
-  <String Id="PrivacyStatementLink">&lt;A HREF=&quot;https://aka.ms/dev-privacy&quot;&gt;Privacy Statement&lt;/A&gt;</String>
-  <String Id="EulaLink">&lt;A HREF=&quot;https://go.microsoft.com/fwlink/?LinkId=329770&quot;&gt;.NET Library EULA&lt;/A&gt;</String>
+  <String Id="ResourcesHeader">Ressources</String>
+  <String Id="DocumentationLink">&lt;A HREF="https://aka.ms/dotnet-docs"&gt;Documentation&lt;/A&gt;</String>
+  <String Id="RelaseNotesLink">&lt;A HREF="https://aka.ms/20-p2-rel-notes"&gt;Notes de publication&lt;/A&gt;</String>
+  <String Id="TutorialLink">&lt;A HREF="https://aka.ms/dotnet-tutorials"&gt;Tutoriels&lt;/A&gt;</String>
+  <String Id="TelemetryLink">&lt;A HREF="https://aka.ms/dotnet-cli-telemetry"&gt;Télémétrie .NET Core&lt;/A&gt;</String>
+  <String Id="PrivacyStatementLink">&lt;A HREF="https://aka.ms/dev-privacy"&gt;Déclaration de confidentialité&lt;/A&gt;</String>
+  <String Id="EulaLink">&lt;A HREF="https://go.microsoft.com/fwlink/?LinkId=329770"&gt;CLUF de la bibliothèque .NET&lt;/A&gt;</String>
   
 </WixLocalization>

--- a/src/pkg/projects/windowsdesktop/sfx/theme/1040/bundle.wxl
+++ b/src/pkg/projects/windowsdesktop/sfx/theme/1040/bundle.wxl
@@ -1,74 +1,74 @@
 <?xml version="1.0" encoding="utf-8"?>
 <WixLocalization Culture="en-us" Language="1033" xmlns="http://schemas.microsoft.com/wix/2006/localization">
-  <String Id="Caption">[WixBundleName] Installer</String>
+  <String Id="Caption">Programma di installazione di [WixBundleName]</String>
   <String Id="Title">[BUNDLEMONIKER]</String>
-  <String Id="Motto">You just need a shell, a text editor and 10 minutes of your time.
+  <String Id="Motto">Bastano solo una shell, un editor di testo e 10 minuti di tempo.
 
-Ready? Set? Let's go!</String>
-  <String Id="ConfirmCancelMessage">Are you sure you want to cancel?</String>
-  <String Id="ExecuteUpgradeRelatedBundleMessage">Previous version</String>
-  <String Id="HelpHeader">Setup Help</String>
-  <String Id="HelpText">/install | /repair | /uninstall | /layout [directory] - installs, repairs, uninstalls or
-   creates a complete local copy of the bundle in directory. Install is the default.
+Pronti per iniziare?</String>
+  <String Id="ConfirmCancelMessage">Annullare?</String>
+  <String Id="ExecuteUpgradeRelatedBundleMessage">Versione precedente</String>
+  <String Id="HelpHeader">Guida alla configurazione</String>
+  <String Id="HelpText">/install | /repair | /uninstall | /layout [directory] - installa, ripara, disinstalla o
+   crea una copia locale completa del bundle nella directory. L'opzione predefinita è install.
 
-/passive | /quiet -  displays minimal UI with no prompts or displays no UI and
-   no prompts. By default UI and all prompts are displayed.
+/passive | /quiet -  visualizza un'interfaccia utente minima senza prompt oppure non visualizza alcuna interfaccia utente
+   né prompt. Per impostazione predefinita, viene visualizzata l'intera interfaccia utente e tutti i prompt.
 
-/norestart   - suppress any attempts to restart. By default UI will prompt before restart.
-/log log.txt - logs to a specific file. By default a log file is created in %TEMP%.</String>
-  <String Id="HelpCloseButton">&amp;Close</String>
-  <String Id="InstallAcceptCheckbox">I &amp;agree to the license terms and conditions</String>
-  <String Id="InstallOptionsButton">&amp;Options</String>
-  <String Id="InstallInstallButton">&amp;Install</String>
-  <String Id="InstallCloseButton">&amp;Close</String>
-  <String Id="OptionsHeader">Setup Options</String>
-  <String Id="OptionsLocationLabel">Install location:</String>
-  <String Id="OptionsBrowseButton">&amp;Browse</String>
+/norestart   - annulla qualsiasi tentativo di riavvio. Per impostazione predefinita, l'interfaccia utente visualizza una richiesta prima del riavvio.
+/log log.txt - registra il log in un file specifico. Per impostazione predefinita, viene creato un file di log in %TEMP%.</String>
+  <String Id="HelpCloseButton">&amp;Chiudi</String>
+  <String Id="InstallAcceptCheckbox">&amp;Accetto i termini e le condizioni di licenza</String>
+  <String Id="InstallOptionsButton">&amp;Opzioni</String>
+  <String Id="InstallInstallButton">&amp;Installa</String>
+  <String Id="InstallCloseButton">&amp;Chiudi</String>
+  <String Id="OptionsHeader">Opzioni di installazione</String>
+  <String Id="OptionsLocationLabel">Percorso di installazione:</String>
+  <String Id="OptionsBrowseButton">&amp;Sfoglia</String>
   <String Id="OptionsOkButton">&amp;OK</String>
-  <String Id="OptionsCancelButton">&amp;Cancel</String>
-  <String Id="ProgressHeader">Setup Progress</String>
-  <String Id="ProgressLabel">Processing:</String>
-  <String Id="OverallProgressPackageText">Initializing...</String>
-  <String Id="ProgressCancelButton">&amp;Cancel</String>
-  <String Id="ModifyHeader">Modify Setup</String>
-  <String Id="ModifyRepairButton">&amp;Repair</String>
-  <String Id="ModifyUninstallButton">&amp;Uninstall</String>
-  <String Id="ModifyCloseButton">&amp;Close</String>
-  <String Id="SuccessRepairHeader">Repair Successfully Completed</String>
-  <String Id="SuccessUninstallHeader">Uninstall Successfully Completed</String>
-  <String Id="SuccessInstallHeader">Installation was successful</String>
-  <String Id="SuccessHeader">Setup Successful</String>
-  <String Id="SuccessLaunchButton">&amp;Launch</String>
-  <String Id="SuccessRestartText">You must restart your computer before you can use the software.</String>
-  <String Id="SuccessRestartButton">&amp;Restart</String>
-  <String Id="SuccessCloseButton">&amp;Close</String>
-  <String Id="FailureHeader">Setup Failed</String>
-  <String Id="FailureInstallHeader">Setup Failed</String>
-  <String Id="FailureUninstallHeader">Uninstall Failed</String>
-  <String Id="FailureRepairHeader">Repair Failed</String>
-  <String Id="FailureHyperlinkLogText">One or more issues caused the setup to fail. Please fix the issues and then retry setup. For more information see the &lt;a href="#"&gt;log file&lt;/a&gt;.</String>
-  <String Id="FailureRestartText">You must restart your computer to complete the rollback of the software.</String>
-  <String Id="FailureRestartButton">&amp;Restart</String>
-  <String Id="FailureCloseButton">&amp;Close</String>
-  <String Id="FailureNotSupportedCurrentOperatingSystem">The [PRODUCT_NAME] is not supported on this operating system. For more information, see [LINK_PREREQ_PAGE].</String>
-  <String Id="FailureNotSupportedX86OperatingSystem">The [PRODUCT_NAME] isn't supported on x86 operating systems. Please install using the corresponding x86 installer.</String>
-  <String Id="FilesInUseHeader">Files In Use</String>
-  <String Id="FilesInUseLabel">The following applications are using files that need to be updated:</String>
-  <String Id="FilesInUseCloseRadioButton">Close the &amp;applications and attempt to restart them.</String>
-  <String Id="FilesInUseDontCloseRadioButton">&amp;Do not close applications. A reboot will be required.</String>
+  <String Id="OptionsCancelButton">&amp;Annulla</String>
+  <String Id="ProgressHeader">Stato installazione</String>
+  <String Id="ProgressLabel">Elaborazione di:</String>
+  <String Id="OverallProgressPackageText">Inizializzazione in corso...</String>
+  <String Id="ProgressCancelButton">&amp;Annulla</String>
+  <String Id="ModifyHeader">Modifica installazione</String>
+  <String Id="ModifyRepairButton">&amp;Ripristina</String>
+  <String Id="ModifyUninstallButton">&amp;Disinstalla</String>
+  <String Id="ModifyCloseButton">&amp;Chiudi</String>
+  <String Id="SuccessRepairHeader">La riparazione è stata completata</String>
+  <String Id="SuccessUninstallHeader">La disinstallazione è stata completata</String>
+  <String Id="SuccessInstallHeader">L'installazione è riuscita</String>
+  <String Id="SuccessHeader">L'installazione è stata completata</String>
+  <String Id="SuccessLaunchButton">&amp;Avvia</String>
+  <String Id="SuccessRestartText">Per poter usare il software, è necessario riavviare il computer.</String>
+  <String Id="SuccessRestartButton">&amp;Riavvia</String>
+  <String Id="SuccessCloseButton">&amp;Chiudi</String>
+  <String Id="FailureHeader">L'installazione non è riuscita</String>
+  <String Id="FailureInstallHeader">L'installazione non è riuscita</String>
+  <String Id="FailureUninstallHeader">La disinstallazione non è riuscita</String>
+  <String Id="FailureRepairHeader">La riparazione non è riuscita</String>
+  <String Id="FailureHyperlinkLogText">L'installazione non è riuscita a causa di uno o più problemi. Risolvere i problemi e ripetere l'installazione. Per altre informazioni, vedere il &lt;a href="#"&gt;file di log&lt;/a&gt;.</String>
+  <String Id="FailureRestartText">Per completare il rollback del software, è necessario riavviare il computer.</String>
+  <String Id="FailureRestartButton">&amp;Riavvia</String>
+  <String Id="FailureCloseButton">&amp;Chiudi</String>
+  <String Id="FailureNotSupportedCurrentOperatingSystem">[PRODUCT_NAME] non è supportato in questo sistema operativo. Per altre informazioni, vedere [LINK_PREREQ_PAGE].</String>
+  <String Id="FailureNotSupportedX86OperatingSystem">[PRODUCT_NAME] non è supportato in sistemi operativi x86. Eseguire l'installazione usando il programma di installazione x86 corrispondente.</String>
+  <String Id="FilesInUseHeader">File in uso</String>
+  <String Id="FilesInUseLabel">Le applicazioni seguenti usano file che necessitano di aggiornamento:</String>
+  <String Id="FilesInUseCloseRadioButton">Chiudere le &amp;applicazioni e provare a riavviarle.</String>
+  <String Id="FilesInUseDontCloseRadioButton">&amp;Non chiudere le applicazioni; sarà necessario riavviare il sistema</String>
   <String Id="FilesInUseOkButton">&amp;OK</String>
-  <String Id="FilesInUseCancelButton">&amp;Cancel</String>
-  <String Id="WelcomeHeaderMessage">Windows Desktop Runtime</String>
+  <String Id="FilesInUseCancelButton">&amp;Annulla</String>
+  <String Id="WelcomeHeaderMessage"></String>
   <String Id="WelcomeDescription"></String>
-  <String Id="LearnMoreTitle">Learn more about .NET Core</String>
-  <String Id="SuccessInstallLocation">The following was installed at [DOTNETHOME]</String>
+  <String Id="LearnMoreTitle">Altre informazioni su .NET Core</String>
+  <String Id="SuccessInstallLocation">I componenti seguenti sono stati installati in [DOTNETHOME]</String>
   <String Id="SuccessInstallProductName"> - [BUNDLEMONIKER] </String>
-  <String Id="ResourcesHeader">Resources</String>
-  <String Id="DocumentationLink">&lt;A HREF=&quot;https://aka.ms/dotnet-docs&quot;&gt;Documentation&lt;/A&gt;</String>
-  <String Id="RelaseNotesLink">&lt;A HREF=&quot;https://aka.ms/20-p2-rel-notes&quot;&gt;Release Notes&lt;/A&gt;</String>
-  <String Id="TutorialLink">&lt;A HREF=&quot;https://aka.ms/dotnet-tutorials&quot;&gt;Tutorials&lt;/A&gt;</String>
-  <String Id="TelemetryLink">&lt;A HREF=&quot;https://aka.ms/dotnet-cli-telemetry&quot;&gt;.NET Core Telemetry&lt;/A&gt;</String>
-  <String Id="PrivacyStatementLink">&lt;A HREF=&quot;https://aka.ms/dev-privacy&quot;&gt;Privacy Statement&lt;/A&gt;</String>
-  <String Id="EulaLink">&lt;A HREF=&quot;https://go.microsoft.com/fwlink/?LinkId=329770&quot;&gt;.NET Library EULA&lt;/A&gt;</String>
+  <String Id="ResourcesHeader">Risorse</String>
+  <String Id="DocumentationLink">&lt;A HREF="https://aka.ms/dotnet-docs"&gt;Documentazione&lt;/A&gt;</String>
+  <String Id="RelaseNotesLink">&lt;A HREF="https://aka.ms/20-p2-rel-notes"&gt;Note sulla versione&lt;/A&gt;</String>
+  <String Id="TutorialLink">&lt;A HREF="https://aka.ms/dotnet-tutorials"&gt;Esercitazioni&lt;/A&gt;</String>
+  <String Id="TelemetryLink">&lt;A HREF="https://aka.ms/dotnet-cli-telemetry"&gt;Telemetria di .NET Core&lt;/A&gt;</String>
+  <String Id="PrivacyStatementLink">&lt;A HREF="https://aka.ms/dev-privacy"&gt;Informativa sulla privacy&lt;/A&gt;</String>
+  <String Id="EulaLink">&lt;A HREF="https://go.microsoft.com/fwlink/?LinkId=329770"&gt;Condizioni di licenza della libreria .NET&lt;/A&gt;</String>
   
 </WixLocalization>

--- a/src/pkg/projects/windowsdesktop/sfx/theme/1041/bundle.wxl
+++ b/src/pkg/projects/windowsdesktop/sfx/theme/1041/bundle.wxl
@@ -1,74 +1,75 @@
 <?xml version="1.0" encoding="utf-8"?>
 <WixLocalization Culture="en-us" Language="1033" xmlns="http://schemas.microsoft.com/wix/2006/localization">
-  <String Id="Caption">[WixBundleName] Installer</String>
+  <String Id="Caption">[WixBundleName] インストーラー</String>
   <String Id="Title">[BUNDLEMONIKER]</String>
-  <String Id="Motto">You just need a shell, a text editor and 10 minutes of your time.
+  <String Id="Motto">必要なのは、シェル、テキスト エディター、それに時間が 10 分のみです。
 
-Ready? Set? Let's go!</String>
-  <String Id="ConfirmCancelMessage">Are you sure you want to cancel?</String>
-  <String Id="ExecuteUpgradeRelatedBundleMessage">Previous version</String>
-  <String Id="HelpHeader">Setup Help</String>
-  <String Id="HelpText">/install | /repair | /uninstall | /layout [directory] - installs, repairs, uninstalls or
-   creates a complete local copy of the bundle in directory. Install is the default.
+では、始めましょう。</String>
+  <String Id="ConfirmCancelMessage">取り消しますか?</String>
+  <String Id="ExecuteUpgradeRelatedBundleMessage">以前のバージョン</String>
+  <String Id="HelpHeader">セットアップのヘルプ</String>
+  <String Id="HelpText">/install | /repair | /uninstall | /layout [directory] - バンドルの完全なローカル コピーに対する
+  ディレクトリへのインストール、修復、ディレクトリからのアンインストール、またはディレクトリ内への
+  作成を行います。既定の設定はインストールです。
 
-/passive | /quiet -  displays minimal UI with no prompts or displays no UI and
-   no prompts. By default UI and all prompts are displayed.
+/passive | /quiet -  最小限の UI だけを表示しプロンプトは表示しない、または UI もプロンプトも
+   表示しません。既定では UI とすべてのプロンプトが表示されます。
 
-/norestart   - suppress any attempts to restart. By default UI will prompt before restart.
-/log log.txt - logs to a specific file. By default a log file is created in %TEMP%.</String>
-  <String Id="HelpCloseButton">&amp;Close</String>
-  <String Id="InstallAcceptCheckbox">I &amp;agree to the license terms and conditions</String>
-  <String Id="InstallOptionsButton">&amp;Options</String>
-  <String Id="InstallInstallButton">&amp;Install</String>
-  <String Id="InstallCloseButton">&amp;Close</String>
-  <String Id="OptionsHeader">Setup Options</String>
-  <String Id="OptionsLocationLabel">Install location:</String>
-  <String Id="OptionsBrowseButton">&amp;Browse</String>
-  <String Id="OptionsOkButton">&amp;OK</String>
-  <String Id="OptionsCancelButton">&amp;Cancel</String>
-  <String Id="ProgressHeader">Setup Progress</String>
-  <String Id="ProgressLabel">Processing:</String>
-  <String Id="OverallProgressPackageText">Initializing...</String>
-  <String Id="ProgressCancelButton">&amp;Cancel</String>
-  <String Id="ModifyHeader">Modify Setup</String>
-  <String Id="ModifyRepairButton">&amp;Repair</String>
-  <String Id="ModifyUninstallButton">&amp;Uninstall</String>
-  <String Id="ModifyCloseButton">&amp;Close</String>
-  <String Id="SuccessRepairHeader">Repair Successfully Completed</String>
-  <String Id="SuccessUninstallHeader">Uninstall Successfully Completed</String>
-  <String Id="SuccessInstallHeader">Installation was successful</String>
-  <String Id="SuccessHeader">Setup Successful</String>
-  <String Id="SuccessLaunchButton">&amp;Launch</String>
-  <String Id="SuccessRestartText">You must restart your computer before you can use the software.</String>
-  <String Id="SuccessRestartButton">&amp;Restart</String>
-  <String Id="SuccessCloseButton">&amp;Close</String>
-  <String Id="FailureHeader">Setup Failed</String>
-  <String Id="FailureInstallHeader">Setup Failed</String>
-  <String Id="FailureUninstallHeader">Uninstall Failed</String>
-  <String Id="FailureRepairHeader">Repair Failed</String>
-  <String Id="FailureHyperlinkLogText">One or more issues caused the setup to fail. Please fix the issues and then retry setup. For more information see the &lt;a href="#"&gt;log file&lt;/a&gt;.</String>
-  <String Id="FailureRestartText">You must restart your computer to complete the rollback of the software.</String>
-  <String Id="FailureRestartButton">&amp;Restart</String>
-  <String Id="FailureCloseButton">&amp;Close</String>
-  <String Id="FailureNotSupportedCurrentOperatingSystem">The [PRODUCT_NAME] is not supported on this operating system. For more information, see [LINK_PREREQ_PAGE].</String>
-  <String Id="FailureNotSupportedX86OperatingSystem">The [PRODUCT_NAME] isn't supported on x86 operating systems. Please install using the corresponding x86 installer.</String>
-  <String Id="FilesInUseHeader">Files In Use</String>
-  <String Id="FilesInUseLabel">The following applications are using files that need to be updated:</String>
-  <String Id="FilesInUseCloseRadioButton">Close the &amp;applications and attempt to restart them.</String>
-  <String Id="FilesInUseDontCloseRadioButton">&amp;Do not close applications. A reboot will be required.</String>
-  <String Id="FilesInUseOkButton">&amp;OK</String>
-  <String Id="FilesInUseCancelButton">&amp;Cancel</String>
-  <String Id="WelcomeHeaderMessage">Windows Desktop Runtime</String>
+/norestart   - 再起動を抑制します。既定では再起動前に確認メッセージが表示されます。
+/log log.txt - 特定のファイルに記録します。ログ ファイルは既定では %TEMP% に作成されます。</String>
+  <String Id="HelpCloseButton">閉じる(&amp;C)</String>
+  <String Id="InstallAcceptCheckbox">ライセンス条項および使用条件に同意する(&amp;A)</String>
+  <String Id="InstallOptionsButton">オプション(&amp;O)</String>
+  <String Id="InstallInstallButton">インストール(&amp;I)</String>
+  <String Id="InstallCloseButton">閉じる(&amp;C)</String>
+  <String Id="OptionsHeader">セットアップ オプション</String>
+  <String Id="OptionsLocationLabel">インストール場所:</String>
+  <String Id="OptionsBrowseButton">参照(&amp;B)</String>
+  <String Id="OptionsOkButton">OK(&amp;O)</String>
+  <String Id="OptionsCancelButton">キャンセル(&amp;C)</String>
+  <String Id="ProgressHeader">セットアップの進行状況</String>
+  <String Id="ProgressLabel">処理中:</String>
+  <String Id="OverallProgressPackageText">初期化しています...</String>
+  <String Id="ProgressCancelButton">キャンセル(&amp;C)</String>
+  <String Id="ModifyHeader">セットアップの変更</String>
+  <String Id="ModifyRepairButton">修復(&amp;R)</String>
+  <String Id="ModifyUninstallButton">アンインストール(&amp;U)</String>
+  <String Id="ModifyCloseButton">閉じる(&amp;C)</String>
+  <String Id="SuccessRepairHeader">修復が正常に完了しました</String>
+  <String Id="SuccessUninstallHeader">アンインストールが正常に完了しました</String>
+  <String Id="SuccessInstallHeader">インストールが正常に終了しました</String>
+  <String Id="SuccessHeader">セットアップ完了</String>
+  <String Id="SuccessLaunchButton">起動(&amp;L)</String>
+  <String Id="SuccessRestartText">ソフトウェアを使用する前にコンピューターを再起動する必要があります。</String>
+  <String Id="SuccessRestartButton">再起動(&amp;R)</String>
+  <String Id="SuccessCloseButton">閉じる(&amp;C)</String>
+  <String Id="FailureHeader">セットアップ失敗</String>
+  <String Id="FailureInstallHeader">セットアップに失敗しました</String>
+  <String Id="FailureUninstallHeader">アンインストールに失敗しました</String>
+  <String Id="FailureRepairHeader">修復に失敗しました</String>
+  <String Id="FailureHyperlinkLogText">1 つまたは複数の問題により、セットアップが失敗しました。問題を解決してからセットアップを再試行してください。詳細については、&lt;a href="#"&gt;ログ ファイル&lt;/a&gt;を参照してください。</String>
+  <String Id="FailureRestartText">ソフトウェアのロールバックを完了するには、コンピューターを再起動する必要があります。</String>
+  <String Id="FailureRestartButton">再起動(&amp;R)</String>
+  <String Id="FailureCloseButton">閉じる(&amp;C)</String>
+  <String Id="FailureNotSupportedCurrentOperatingSystem">[PRODUCT_NAME] は、このオペレーティング システムではサポートされていません。詳細については、[LINK_PREREQ_PAGE] を参照してください。</String>
+  <String Id="FailureNotSupportedX86OperatingSystem">x86 オペレーティング システムでは、[PRODUCT_NAME] はサポートされていません。対応する x86 インストーラーを使用してインストールしてください。</String>
+  <String Id="FilesInUseHeader">ファイルが使用中</String>
+  <String Id="FilesInUseLabel">次のアプリケーションは、更新の必要があるファイルを使用しています:</String>
+  <String Id="FilesInUseCloseRadioButton">アプリケーションを閉じて再起動を試みる。(&amp;A)</String>
+  <String Id="FilesInUseDontCloseRadioButton">アプリケーションを終了させない (コンピューターの再起動が必要になります)(&amp;D)</String>
+  <String Id="FilesInUseOkButton">OK(&amp;O)</String>
+  <String Id="FilesInUseCancelButton">キャンセル(&amp;C)</String>
+  <String Id="WelcomeHeaderMessage"></String>
   <String Id="WelcomeDescription"></String>
-  <String Id="LearnMoreTitle">Learn more about .NET Core</String>
-  <String Id="SuccessInstallLocation">The following was installed at [DOTNETHOME]</String>
+  <String Id="LearnMoreTitle">.Net Core の詳細</String>
+  <String Id="SuccessInstallLocation">[DOTNETHOME] に以下がインストールされました</String>
   <String Id="SuccessInstallProductName"> - [BUNDLEMONIKER] </String>
-  <String Id="ResourcesHeader">Resources</String>
-  <String Id="DocumentationLink">&lt;A HREF=&quot;https://aka.ms/dotnet-docs&quot;&gt;Documentation&lt;/A&gt;</String>
-  <String Id="RelaseNotesLink">&lt;A HREF=&quot;https://aka.ms/20-p2-rel-notes&quot;&gt;Release Notes&lt;/A&gt;</String>
-  <String Id="TutorialLink">&lt;A HREF=&quot;https://aka.ms/dotnet-tutorials&quot;&gt;Tutorials&lt;/A&gt;</String>
-  <String Id="TelemetryLink">&lt;A HREF=&quot;https://aka.ms/dotnet-cli-telemetry&quot;&gt;.NET Core Telemetry&lt;/A&gt;</String>
-  <String Id="PrivacyStatementLink">&lt;A HREF=&quot;https://aka.ms/dev-privacy&quot;&gt;Privacy Statement&lt;/A&gt;</String>
-  <String Id="EulaLink">&lt;A HREF=&quot;https://go.microsoft.com/fwlink/?LinkId=329770&quot;&gt;.NET Library EULA&lt;/A&gt;</String>
+  <String Id="ResourcesHeader">リソース</String>
+  <String Id="DocumentationLink">&lt;A HREF="https://aka.ms/dotnet-docs"&gt;ドキュメント&lt;/A&gt;</String>
+  <String Id="RelaseNotesLink">&lt;A HREF="https://aka.ms/20-p2-rel-notes"&gt;リリース ノート&lt;/A&gt;</String>
+  <String Id="TutorialLink">&lt;A HREF="https://aka.ms/dotnet-tutorials"&gt;チュートリアル&lt;/A&gt;</String>
+  <String Id="TelemetryLink">&lt;A HREF="https://aka.ms/dotnet-cli-telemetry"&gt;.NET Core テレメトリ&lt;/A&gt;</String>
+  <String Id="PrivacyStatementLink">&lt;A HREF="https://aka.ms/dev-privacy"&gt;プライバシーに関する声明&lt;/A&gt;</String>
+  <String Id="EulaLink">&lt;A HREF="https://go.microsoft.com/fwlink/?LinkId=329770"&gt;.NET ライブラリのライセンス条項&lt;/A&gt;</String>
   
 </WixLocalization>

--- a/src/pkg/projects/windowsdesktop/sfx/theme/1042/bundle.wxl
+++ b/src/pkg/projects/windowsdesktop/sfx/theme/1042/bundle.wxl
@@ -1,74 +1,74 @@
 <?xml version="1.0" encoding="utf-8"?>
 <WixLocalization Culture="en-us" Language="1033" xmlns="http://schemas.microsoft.com/wix/2006/localization">
-  <String Id="Caption">[WixBundleName] Installer</String>
+  <String Id="Caption">[WixBundleName] 설치 관리자</String>
   <String Id="Title">[BUNDLEMONIKER]</String>
-  <String Id="Motto">You just need a shell, a text editor and 10 minutes of your time.
+  <String Id="Motto">셸, 텍스트 편집기, 10분의 시간만 있으면 됩니다.
 
-Ready? Set? Let's go!</String>
-  <String Id="ConfirmCancelMessage">Are you sure you want to cancel?</String>
-  <String Id="ExecuteUpgradeRelatedBundleMessage">Previous version</String>
-  <String Id="HelpHeader">Setup Help</String>
-  <String Id="HelpText">/install | /repair | /uninstall | /layout [directory] - installs, repairs, uninstalls or
-   creates a complete local copy of the bundle in directory. Install is the default.
+준비되셨나요? 시작합니다!</String>
+  <String Id="ConfirmCancelMessage">취소하시겠습니까?</String>
+  <String Id="ExecuteUpgradeRelatedBundleMessage">이전 버전</String>
+  <String Id="HelpHeader">설치 도움말</String>
+  <String Id="HelpText">/install | /repair | /uninstall | /layout [directory] - 디렉터리에 번들의 전체 로컬 복사본을 설치, 복구, 제거 또는
+   작성합니다. 설치가 기본값입니다.
 
-/passive | /quiet -  displays minimal UI with no prompts or displays no UI and
-   no prompts. By default UI and all prompts are displayed.
+/passive | /quiet -  프롬프트 없이 최소 UI를 표시하거나 UI 및
+   프롬프트를 표시하지 않습니다. 기본적으로 UI와 모든 프롬프트가 표시됩니다.
 
-/norestart   - suppress any attempts to restart. By default UI will prompt before restart.
-/log log.txt - logs to a specific file. By default a log file is created in %TEMP%.</String>
-  <String Id="HelpCloseButton">&amp;Close</String>
-  <String Id="InstallAcceptCheckbox">I &amp;agree to the license terms and conditions</String>
-  <String Id="InstallOptionsButton">&amp;Options</String>
-  <String Id="InstallInstallButton">&amp;Install</String>
-  <String Id="InstallCloseButton">&amp;Close</String>
-  <String Id="OptionsHeader">Setup Options</String>
-  <String Id="OptionsLocationLabel">Install location:</String>
-  <String Id="OptionsBrowseButton">&amp;Browse</String>
-  <String Id="OptionsOkButton">&amp;OK</String>
-  <String Id="OptionsCancelButton">&amp;Cancel</String>
-  <String Id="ProgressHeader">Setup Progress</String>
-  <String Id="ProgressLabel">Processing:</String>
-  <String Id="OverallProgressPackageText">Initializing...</String>
-  <String Id="ProgressCancelButton">&amp;Cancel</String>
-  <String Id="ModifyHeader">Modify Setup</String>
-  <String Id="ModifyRepairButton">&amp;Repair</String>
-  <String Id="ModifyUninstallButton">&amp;Uninstall</String>
-  <String Id="ModifyCloseButton">&amp;Close</String>
-  <String Id="SuccessRepairHeader">Repair Successfully Completed</String>
-  <String Id="SuccessUninstallHeader">Uninstall Successfully Completed</String>
-  <String Id="SuccessInstallHeader">Installation was successful</String>
-  <String Id="SuccessHeader">Setup Successful</String>
-  <String Id="SuccessLaunchButton">&amp;Launch</String>
-  <String Id="SuccessRestartText">You must restart your computer before you can use the software.</String>
-  <String Id="SuccessRestartButton">&amp;Restart</String>
-  <String Id="SuccessCloseButton">&amp;Close</String>
-  <String Id="FailureHeader">Setup Failed</String>
-  <String Id="FailureInstallHeader">Setup Failed</String>
-  <String Id="FailureUninstallHeader">Uninstall Failed</String>
-  <String Id="FailureRepairHeader">Repair Failed</String>
-  <String Id="FailureHyperlinkLogText">One or more issues caused the setup to fail. Please fix the issues and then retry setup. For more information see the &lt;a href="#"&gt;log file&lt;/a&gt;.</String>
-  <String Id="FailureRestartText">You must restart your computer to complete the rollback of the software.</String>
-  <String Id="FailureRestartButton">&amp;Restart</String>
-  <String Id="FailureCloseButton">&amp;Close</String>
-  <String Id="FailureNotSupportedCurrentOperatingSystem">The [PRODUCT_NAME] is not supported on this operating system. For more information, see [LINK_PREREQ_PAGE].</String>
-  <String Id="FailureNotSupportedX86OperatingSystem">The [PRODUCT_NAME] isn't supported on x86 operating systems. Please install using the corresponding x86 installer.</String>
-  <String Id="FilesInUseHeader">Files In Use</String>
-  <String Id="FilesInUseLabel">The following applications are using files that need to be updated:</String>
-  <String Id="FilesInUseCloseRadioButton">Close the &amp;applications and attempt to restart them.</String>
-  <String Id="FilesInUseDontCloseRadioButton">&amp;Do not close applications. A reboot will be required.</String>
-  <String Id="FilesInUseOkButton">&amp;OK</String>
-  <String Id="FilesInUseCancelButton">&amp;Cancel</String>
-  <String Id="WelcomeHeaderMessage">Windows Desktop Runtime</String>
+/norestart   - 다시 시작하지 않게 합니다. 기본적으로 UI에서는 다시 시작하기 전에 묻는 메시지를 표시합니다.
+/log log.txt - 특정 파일에 기록합니다. 기본적으로 로그 파일은 %TEMP%에 만들어집니다.</String>
+  <String Id="HelpCloseButton">닫기(&amp;C)</String>
+  <String Id="InstallAcceptCheckbox">동의함(&amp;A)</String>
+  <String Id="InstallOptionsButton">옵션(&amp;O)</String>
+  <String Id="InstallInstallButton">설치(&amp;I)</String>
+  <String Id="InstallCloseButton">닫기(&amp;C)</String>
+  <String Id="OptionsHeader">설치 옵션</String>
+  <String Id="OptionsLocationLabel">설치 위치:</String>
+  <String Id="OptionsBrowseButton">찾아보기(&amp;B)</String>
+  <String Id="OptionsOkButton">확인(&amp;O)</String>
+  <String Id="OptionsCancelButton">취소(&amp;C)</String>
+  <String Id="ProgressHeader">설치 진행률</String>
+  <String Id="ProgressLabel">처리 중:</String>
+  <String Id="OverallProgressPackageText">초기화 중...</String>
+  <String Id="ProgressCancelButton">취소(&amp;C)</String>
+  <String Id="ModifyHeader">설치 수정</String>
+  <String Id="ModifyRepairButton">복구(&amp;R)</String>
+  <String Id="ModifyUninstallButton">제거(&amp;U)</String>
+  <String Id="ModifyCloseButton">닫기(&amp;C)</String>
+  <String Id="SuccessRepairHeader">복구 완료됨</String>
+  <String Id="SuccessUninstallHeader">제거 완료됨</String>
+  <String Id="SuccessInstallHeader">설치가 완료되었습니다.</String>
+  <String Id="SuccessHeader">설치 완료</String>
+  <String Id="SuccessLaunchButton">시작(&amp;L)</String>
+  <String Id="SuccessRestartText">소프트웨어를 사용하려면 먼저 컴퓨터를 다시 시작해야 합니다.</String>
+  <String Id="SuccessRestartButton">다시 시작(&amp;R)</String>
+  <String Id="SuccessCloseButton">닫기(&amp;C)</String>
+  <String Id="FailureHeader">설치 실패</String>
+  <String Id="FailureInstallHeader">설치 실패</String>
+  <String Id="FailureUninstallHeader">제거 실패</String>
+  <String Id="FailureRepairHeader">복구 실패</String>
+  <String Id="FailureHyperlinkLogText">하나 이상의 문제가 발생하여 설치하지 못했습니다. 문제를 해결한 다음 설치를 다시 시도하십시오. 자세한 내용은 &lt;a href="#"&gt;로그 파일&lt;/a&gt;을 참조하십시오.</String>
+  <String Id="FailureRestartText">소프트웨어 롤백을 완료하려면 컴퓨터를 다시 시작해야 합니다.</String>
+  <String Id="FailureRestartButton">다시 시작(&amp;R)</String>
+  <String Id="FailureCloseButton">닫기(&amp;C)</String>
+  <String Id="FailureNotSupportedCurrentOperatingSystem">이 운영 체제에서는 [PRODUCT_NAME]이(가) 지원되지 않습니다. 자세한 내용은 [LINK_PREREQ_PAGE]을(를) 참조하세요.</String>
+  <String Id="FailureNotSupportedX86OperatingSystem">x86 운영 체제에서는 [PRODUCT_NAME]이(가) 지원되지 않습니다. 해당 x86 설치 관리자를 사용하여 설치하세요.</String>
+  <String Id="FilesInUseHeader">사용 중인 파일</String>
+  <String Id="FilesInUseLabel">다음의 응용 프로그램이 업데이트해야 할 파일을 사용 중입니다.</String>
+  <String Id="FilesInUseCloseRadioButton">응용 프로그램을 닫고 다시 시작합니다(&amp;A).</String>
+  <String Id="FilesInUseDontCloseRadioButton">애플리케이션을 닫지 않습니다(&amp;D). 다시 부팅해야 합니다.</String>
+  <String Id="FilesInUseOkButton">확인(&amp;O)</String>
+  <String Id="FilesInUseCancelButton">취소(&amp;C)</String>
+  <String Id="WelcomeHeaderMessage"></String>
   <String Id="WelcomeDescription"></String>
-  <String Id="LearnMoreTitle">Learn more about .NET Core</String>
-  <String Id="SuccessInstallLocation">The following was installed at [DOTNETHOME]</String>
+  <String Id="LearnMoreTitle">.NET Core에 대한 자세한 정보</String>
+  <String Id="SuccessInstallLocation">다음이 [DOTNETHOME]에 설치되었습니다.</String>
   <String Id="SuccessInstallProductName"> - [BUNDLEMONIKER] </String>
-  <String Id="ResourcesHeader">Resources</String>
-  <String Id="DocumentationLink">&lt;A HREF=&quot;https://aka.ms/dotnet-docs&quot;&gt;Documentation&lt;/A&gt;</String>
-  <String Id="RelaseNotesLink">&lt;A HREF=&quot;https://aka.ms/20-p2-rel-notes&quot;&gt;Release Notes&lt;/A&gt;</String>
-  <String Id="TutorialLink">&lt;A HREF=&quot;https://aka.ms/dotnet-tutorials&quot;&gt;Tutorials&lt;/A&gt;</String>
-  <String Id="TelemetryLink">&lt;A HREF=&quot;https://aka.ms/dotnet-cli-telemetry&quot;&gt;.NET Core Telemetry&lt;/A&gt;</String>
-  <String Id="PrivacyStatementLink">&lt;A HREF=&quot;https://aka.ms/dev-privacy&quot;&gt;Privacy Statement&lt;/A&gt;</String>
-  <String Id="EulaLink">&lt;A HREF=&quot;https://go.microsoft.com/fwlink/?LinkId=329770&quot;&gt;.NET Library EULA&lt;/A&gt;</String>
+  <String Id="ResourcesHeader">리소스</String>
+  <String Id="DocumentationLink">&lt;A HREF="https://aka.ms/dotnet-docs"&gt;설명서&lt;/A&gt;</String>
+  <String Id="RelaseNotesLink">&lt;A HREF="https://aka.ms/20-p2-rel-notes"&gt;릴리스 정보&lt;/A&gt;</String>
+  <String Id="TutorialLink">&lt;A HREF="https://aka.ms/dotnet-tutorials"&gt;자습서&lt;/A&gt;</String>
+  <String Id="TelemetryLink">&lt;A HREF="https://aka.ms/dotnet-cli-telemetry"&gt;.NET Core 원격 분석&lt;/A&gt;</String>
+  <String Id="PrivacyStatementLink">&lt;A HREF="https://aka.ms/dev-privacy"&gt;개인정보처리방침&lt;/A&gt;</String>
+  <String Id="EulaLink">&lt;A HREF="https://go.microsoft.com/fwlink/?LinkId=329770"&gt;.NET Library EULA&lt;/A&gt;</String>
   
 </WixLocalization>

--- a/src/pkg/projects/windowsdesktop/sfx/theme/1045/bundle.wxl
+++ b/src/pkg/projects/windowsdesktop/sfx/theme/1045/bundle.wxl
@@ -1,74 +1,74 @@
 <?xml version="1.0" encoding="utf-8"?>
 <WixLocalization Culture="en-us" Language="1033" xmlns="http://schemas.microsoft.com/wix/2006/localization">
-  <String Id="Caption">[WixBundleName] Installer</String>
+  <String Id="Caption">Instalator pakietu [WixBundleName]</String>
   <String Id="Title">[BUNDLEMONIKER]</String>
-  <String Id="Motto">You just need a shell, a text editor and 10 minutes of your time.
+  <String Id="Motto">Potrzebujemy tylko powłoki, edytora tekstu i 10 minut czasu.
 
-Ready? Set? Let's go!</String>
-  <String Id="ConfirmCancelMessage">Are you sure you want to cancel?</String>
-  <String Id="ExecuteUpgradeRelatedBundleMessage">Previous version</String>
-  <String Id="HelpHeader">Setup Help</String>
-  <String Id="HelpText">/install | /repair | /uninstall | /layout [directory] - installs, repairs, uninstalls or
-   creates a complete local copy of the bundle in directory. Install is the default.
+Wszystko gotowe? Zaczynamy!</String>
+  <String Id="ConfirmCancelMessage">Czy na pewno chcesz anulować?</String>
+  <String Id="ExecuteUpgradeRelatedBundleMessage">Poprzednia wersja</String>
+  <String Id="HelpHeader">Pomoc dotycząca instalacji</String>
+  <String Id="HelpText">/install | /repair | /uninstall | /layout [katalog] - Instaluje, naprawia, odinstalowuje
+   lub tworzy pełną lokalną kopię pakietu w katalogu. Domyślnie jest używany przełącznik install.
 
-/passive | /quiet -  displays minimal UI with no prompts or displays no UI and
-   no prompts. By default UI and all prompts are displayed.
+/passive | /quiet -  Wyświetla ograniczony interfejs użytkownika bez monitów albo nie wyświetla ani interfejsu użytkownika,
+   ani monitów. Domyślnie jest wyświetlany interfejs użytkownika oraz wszystkie monity.
 
-/norestart   - suppress any attempts to restart. By default UI will prompt before restart.
-/log log.txt - logs to a specific file. By default a log file is created in %TEMP%.</String>
-  <String Id="HelpCloseButton">&amp;Close</String>
-  <String Id="InstallAcceptCheckbox">I &amp;agree to the license terms and conditions</String>
-  <String Id="InstallOptionsButton">&amp;Options</String>
-  <String Id="InstallInstallButton">&amp;Install</String>
-  <String Id="InstallCloseButton">&amp;Close</String>
-  <String Id="OptionsHeader">Setup Options</String>
-  <String Id="OptionsLocationLabel">Install location:</String>
-  <String Id="OptionsBrowseButton">&amp;Browse</String>
+/norestart   - Pomija próby ponownego uruchomienia. Domyślnie interfejs użytkownika wyświetla monit przed ponownym uruchomieniem.
+/log log.txt - Tworzy dziennik w określonym pliku. Domyślnie plik dziennika jest tworzony w katalogu %TEMP%.</String>
+  <String Id="HelpCloseButton">&amp;Zamknij</String>
+  <String Id="InstallAcceptCheckbox">&amp;Zgadzam się z postanowieniami licencyjnymi</String>
+  <String Id="InstallOptionsButton">&amp;Opcje</String>
+  <String Id="InstallInstallButton">&amp;Zainstaluj</String>
+  <String Id="InstallCloseButton">&amp;Zamknij</String>
+  <String Id="OptionsHeader">Opcje instalacji</String>
+  <String Id="OptionsLocationLabel">Lokalizacja instalacji:</String>
+  <String Id="OptionsBrowseButton">&amp;Przeglądaj</String>
   <String Id="OptionsOkButton">&amp;OK</String>
-  <String Id="OptionsCancelButton">&amp;Cancel</String>
-  <String Id="ProgressHeader">Setup Progress</String>
-  <String Id="ProgressLabel">Processing:</String>
-  <String Id="OverallProgressPackageText">Initializing...</String>
-  <String Id="ProgressCancelButton">&amp;Cancel</String>
-  <String Id="ModifyHeader">Modify Setup</String>
-  <String Id="ModifyRepairButton">&amp;Repair</String>
-  <String Id="ModifyUninstallButton">&amp;Uninstall</String>
-  <String Id="ModifyCloseButton">&amp;Close</String>
-  <String Id="SuccessRepairHeader">Repair Successfully Completed</String>
-  <String Id="SuccessUninstallHeader">Uninstall Successfully Completed</String>
-  <String Id="SuccessInstallHeader">Installation was successful</String>
-  <String Id="SuccessHeader">Setup Successful</String>
-  <String Id="SuccessLaunchButton">&amp;Launch</String>
-  <String Id="SuccessRestartText">You must restart your computer before you can use the software.</String>
-  <String Id="SuccessRestartButton">&amp;Restart</String>
-  <String Id="SuccessCloseButton">&amp;Close</String>
-  <String Id="FailureHeader">Setup Failed</String>
-  <String Id="FailureInstallHeader">Setup Failed</String>
-  <String Id="FailureUninstallHeader">Uninstall Failed</String>
-  <String Id="FailureRepairHeader">Repair Failed</String>
-  <String Id="FailureHyperlinkLogText">One or more issues caused the setup to fail. Please fix the issues and then retry setup. For more information see the &lt;a href="#"&gt;log file&lt;/a&gt;.</String>
-  <String Id="FailureRestartText">You must restart your computer to complete the rollback of the software.</String>
-  <String Id="FailureRestartButton">&amp;Restart</String>
-  <String Id="FailureCloseButton">&amp;Close</String>
-  <String Id="FailureNotSupportedCurrentOperatingSystem">The [PRODUCT_NAME] is not supported on this operating system. For more information, see [LINK_PREREQ_PAGE].</String>
-  <String Id="FailureNotSupportedX86OperatingSystem">The [PRODUCT_NAME] isn't supported on x86 operating systems. Please install using the corresponding x86 installer.</String>
-  <String Id="FilesInUseHeader">Files In Use</String>
-  <String Id="FilesInUseLabel">The following applications are using files that need to be updated:</String>
-  <String Id="FilesInUseCloseRadioButton">Close the &amp;applications and attempt to restart them.</String>
-  <String Id="FilesInUseDontCloseRadioButton">&amp;Do not close applications. A reboot will be required.</String>
+  <String Id="OptionsCancelButton">&amp;Anuluj</String>
+  <String Id="ProgressHeader">Postęp instalacji</String>
+  <String Id="ProgressLabel">Przetwarzanie:</String>
+  <String Id="OverallProgressPackageText">Trwa inicjowanie...</String>
+  <String Id="ProgressCancelButton">&amp;Anuluj</String>
+  <String Id="ModifyHeader">Modyfikuj instalację</String>
+  <String Id="ModifyRepairButton">&amp;Napraw</String>
+  <String Id="ModifyUninstallButton">&amp;Odinstaluj</String>
+  <String Id="ModifyCloseButton">&amp;Zamknij</String>
+  <String Id="SuccessRepairHeader">Pomyślnie ukończono naprawę</String>
+  <String Id="SuccessUninstallHeader">Pomyślnie ukończono dezinstalację</String>
+  <String Id="SuccessInstallHeader">Instalacja przebiegła pomyślnie</String>
+  <String Id="SuccessHeader">Pomyślnie ukończono instalację</String>
+  <String Id="SuccessLaunchButton">&amp;Uruchom</String>
+  <String Id="SuccessRestartText">Aby móc korzystać z oprogramowania, musisz uruchomić ponownie komputer.</String>
+  <String Id="SuccessRestartButton">&amp;Uruchom ponownie</String>
+  <String Id="SuccessCloseButton">&amp;Zamknij</String>
+  <String Id="FailureHeader">Instalacja nie powiodła się</String>
+  <String Id="FailureInstallHeader">Instalacja nie powiodła się</String>
+  <String Id="FailureUninstallHeader">Dezinstalacja nie powiodła się</String>
+  <String Id="FailureRepairHeader">Naprawa nie powiodła się</String>
+  <String Id="FailureHyperlinkLogText">Co najmniej jeden problem spowodował niepowodzenie instalacji. Rozwiąż problemy, a następnie ponów próbę instalacji. Aby uzyskać więcej informacji, zobacz &lt;a href="#"&gt;plik dziennika&lt;/a&gt;.</String>
+  <String Id="FailureRestartText">Aby ukończyć wycofywanie oprogramowania, musisz uruchomić ponownie komputer.</String>
+  <String Id="FailureRestartButton">&amp;Uruchom ponownie</String>
+  <String Id="FailureCloseButton">&amp;Zamknij</String>
+  <String Id="FailureNotSupportedCurrentOperatingSystem">Produkt [PRODUCT_NAME] nie jest obsługiwany w tym systemie operacyjnym. Aby uzyskać więcej informacji, zobacz [LINK_PREREQ_PAGE].</String>
+  <String Id="FailureNotSupportedX86OperatingSystem">Produkt [PRODUCT_NAME] nie jest obsługiwany w systemach operacyjnych x86. Przeprowadź instalację przy użyciu odpowiedniego instalatora x86.</String>
+  <String Id="FilesInUseHeader">Pliki w użyciu</String>
+  <String Id="FilesInUseLabel">Następujące aplikacje korzystają z plików, które muszą zostać zaktualizowane:</String>
+  <String Id="FilesInUseCloseRadioButton">Zamknij &amp;aplikacje i spróbuj je ponownie uruchomić.</String>
+  <String Id="FilesInUseDontCloseRadioButton">&amp;Nie zamykaj aplikacji. Będzie konieczne ponowne uruchomienie.</String>
   <String Id="FilesInUseOkButton">&amp;OK</String>
-  <String Id="FilesInUseCancelButton">&amp;Cancel</String>
-  <String Id="WelcomeHeaderMessage">Windows Desktop Runtime</String>
+  <String Id="FilesInUseCancelButton">&amp;Anuluj</String>
+  <String Id="WelcomeHeaderMessage"></String>
   <String Id="WelcomeDescription"></String>
-  <String Id="LearnMoreTitle">Learn more about .NET Core</String>
-  <String Id="SuccessInstallLocation">The following was installed at [DOTNETHOME]</String>
+  <String Id="LearnMoreTitle">Dowiedz się więcej o platformie .NET Core</String>
+  <String Id="SuccessInstallLocation">Następujące elementy zainstalowano w [DOTNETHOME]</String>
   <String Id="SuccessInstallProductName"> - [BUNDLEMONIKER] </String>
-  <String Id="ResourcesHeader">Resources</String>
-  <String Id="DocumentationLink">&lt;A HREF=&quot;https://aka.ms/dotnet-docs&quot;&gt;Documentation&lt;/A&gt;</String>
-  <String Id="RelaseNotesLink">&lt;A HREF=&quot;https://aka.ms/20-p2-rel-notes&quot;&gt;Release Notes&lt;/A&gt;</String>
-  <String Id="TutorialLink">&lt;A HREF=&quot;https://aka.ms/dotnet-tutorials&quot;&gt;Tutorials&lt;/A&gt;</String>
-  <String Id="TelemetryLink">&lt;A HREF=&quot;https://aka.ms/dotnet-cli-telemetry&quot;&gt;.NET Core Telemetry&lt;/A&gt;</String>
-  <String Id="PrivacyStatementLink">&lt;A HREF=&quot;https://aka.ms/dev-privacy&quot;&gt;Privacy Statement&lt;/A&gt;</String>
-  <String Id="EulaLink">&lt;A HREF=&quot;https://go.microsoft.com/fwlink/?LinkId=329770&quot;&gt;.NET Library EULA&lt;/A&gt;</String>
+  <String Id="ResourcesHeader">Zasoby</String>
+  <String Id="DocumentationLink">&lt;A HREF="https://aka.ms/dotnet-docs"&gt;Dokumentacja&lt;/A&gt;</String>
+  <String Id="RelaseNotesLink">&lt;A HREF="https://aka.ms/20-p2-rel-notes"&gt;Informacje o wersji&lt;/A&gt;</String>
+  <String Id="TutorialLink">&lt;A HREF="https://aka.ms/dotnet-tutorials"&gt;Samouczki&lt;/A&gt;</String>
+  <String Id="TelemetryLink">&lt;A HREF="https://aka.ms/dotnet-cli-telemetry"&gt;Telemetria programu .NET Core&lt;/A&gt;</String>
+  <String Id="PrivacyStatementLink">&lt;A HREF="https://aka.ms/dev-privacy"&gt;Zasady zachowania poufności informacji&lt;/A&gt;</String>
+  <String Id="EulaLink">&lt;A HREF="https://go.microsoft.com/fwlink/?LinkId=329770"&gt;Umowa licencyjna użytkownika oprogramowania biblioteki .NET&lt;/A&gt;</String>
   
 </WixLocalization>

--- a/src/pkg/projects/windowsdesktop/sfx/theme/1046/bundle.wxl
+++ b/src/pkg/projects/windowsdesktop/sfx/theme/1046/bundle.wxl
@@ -1,74 +1,74 @@
 <?xml version="1.0" encoding="utf-8"?>
 <WixLocalization Culture="en-us" Language="1033" xmlns="http://schemas.microsoft.com/wix/2006/localization">
-  <String Id="Caption">[WixBundleName] Installer</String>
+  <String Id="Caption">Instalador do [WixBundleName]</String>
   <String Id="Title">[BUNDLEMONIKER]</String>
-  <String Id="Motto">You just need a shell, a text editor and 10 minutes of your time.
+  <String Id="Motto">Você só precisa de um shell, um editor de texto e 10 minutos de seu tempo.
 
-Ready? Set? Let's go!</String>
-  <String Id="ConfirmCancelMessage">Are you sure you want to cancel?</String>
-  <String Id="ExecuteUpgradeRelatedBundleMessage">Previous version</String>
-  <String Id="HelpHeader">Setup Help</String>
-  <String Id="HelpText">/install | /repair | /uninstall | /layout [directory] - installs, repairs, uninstalls or
-   creates a complete local copy of the bundle in directory. Install is the default.
+Preparado? Tudo definido? Vamos nessa!</String>
+  <String Id="ConfirmCancelMessage">Tem certeza de que deseja cancelar?</String>
+  <String Id="ExecuteUpgradeRelatedBundleMessage">Versão anterior</String>
+  <String Id="HelpHeader">Ajuda de Instalação</String>
+  <String Id="HelpText">/install | /repair | /uninstall | /layout [diretório] - instala, repara, desinstala ou
+   cria uma cópia local completa do pacote no diretório. Install é o padrão
 
-/passive | /quiet -  displays minimal UI with no prompts or displays no UI and
-   no prompts. By default UI and all prompts are displayed.
+/passive | /quiet -  exibe a interface do usuário mínima sem nenhum prompt ou não exibe nenhuma interface do usuário e
+   nenhum prompt. Por padrão, a interface do usuário e todos os prompts são exibidos.
 
-/norestart   - suppress any attempts to restart. By default UI will prompt before restart.
-/log log.txt - logs to a specific file. By default a log file is created in %TEMP%.</String>
-  <String Id="HelpCloseButton">&amp;Close</String>
-  <String Id="InstallAcceptCheckbox">I &amp;agree to the license terms and conditions</String>
-  <String Id="InstallOptionsButton">&amp;Options</String>
-  <String Id="InstallInstallButton">&amp;Install</String>
-  <String Id="InstallCloseButton">&amp;Close</String>
-  <String Id="OptionsHeader">Setup Options</String>
-  <String Id="OptionsLocationLabel">Install location:</String>
-  <String Id="OptionsBrowseButton">&amp;Browse</String>
+/norestart   - suprime qualquer tentativa de reiniciar. Por padrão, a interface do usuário perguntará antes de reiniciar.
+/log log.txt - registra em um arquivo específico. Por padrão, um arquivo de log é criado em %TEMP%.</String>
+  <String Id="HelpCloseButton">&amp;Fechar</String>
+  <String Id="InstallAcceptCheckbox">&amp;Concordo com os termos e condições da licença</String>
+  <String Id="InstallOptionsButton">&amp;Opções</String>
+  <String Id="InstallInstallButton">&amp;Instalar</String>
+  <String Id="InstallCloseButton">&amp;Fechar</String>
+  <String Id="OptionsHeader">Opções de Instalação</String>
+  <String Id="OptionsLocationLabel">Local de instalação:</String>
+  <String Id="OptionsBrowseButton">&amp;Navegar</String>
   <String Id="OptionsOkButton">&amp;OK</String>
-  <String Id="OptionsCancelButton">&amp;Cancel</String>
-  <String Id="ProgressHeader">Setup Progress</String>
-  <String Id="ProgressLabel">Processing:</String>
-  <String Id="OverallProgressPackageText">Initializing...</String>
-  <String Id="ProgressCancelButton">&amp;Cancel</String>
-  <String Id="ModifyHeader">Modify Setup</String>
-  <String Id="ModifyRepairButton">&amp;Repair</String>
-  <String Id="ModifyUninstallButton">&amp;Uninstall</String>
-  <String Id="ModifyCloseButton">&amp;Close</String>
-  <String Id="SuccessRepairHeader">Repair Successfully Completed</String>
-  <String Id="SuccessUninstallHeader">Uninstall Successfully Completed</String>
-  <String Id="SuccessInstallHeader">Installation was successful</String>
-  <String Id="SuccessHeader">Setup Successful</String>
-  <String Id="SuccessLaunchButton">&amp;Launch</String>
-  <String Id="SuccessRestartText">You must restart your computer before you can use the software.</String>
-  <String Id="SuccessRestartButton">&amp;Restart</String>
-  <String Id="SuccessCloseButton">&amp;Close</String>
-  <String Id="FailureHeader">Setup Failed</String>
-  <String Id="FailureInstallHeader">Setup Failed</String>
-  <String Id="FailureUninstallHeader">Uninstall Failed</String>
-  <String Id="FailureRepairHeader">Repair Failed</String>
-  <String Id="FailureHyperlinkLogText">One or more issues caused the setup to fail. Please fix the issues and then retry setup. For more information see the &lt;a href="#"&gt;log file&lt;/a&gt;.</String>
-  <String Id="FailureRestartText">You must restart your computer to complete the rollback of the software.</String>
-  <String Id="FailureRestartButton">&amp;Restart</String>
-  <String Id="FailureCloseButton">&amp;Close</String>
-  <String Id="FailureNotSupportedCurrentOperatingSystem">The [PRODUCT_NAME] is not supported on this operating system. For more information, see [LINK_PREREQ_PAGE].</String>
-  <String Id="FailureNotSupportedX86OperatingSystem">The [PRODUCT_NAME] isn't supported on x86 operating systems. Please install using the corresponding x86 installer.</String>
-  <String Id="FilesInUseHeader">Files In Use</String>
-  <String Id="FilesInUseLabel">The following applications are using files that need to be updated:</String>
-  <String Id="FilesInUseCloseRadioButton">Close the &amp;applications and attempt to restart them.</String>
-  <String Id="FilesInUseDontCloseRadioButton">&amp;Do not close applications. A reboot will be required.</String>
+  <String Id="OptionsCancelButton">&amp;Cancelar</String>
+  <String Id="ProgressHeader">Progresso da Instalação</String>
+  <String Id="ProgressLabel">Processando:</String>
+  <String Id="OverallProgressPackageText">Inicializando...</String>
+  <String Id="ProgressCancelButton">&amp;Cancelar</String>
+  <String Id="ModifyHeader">Modificar Instalação</String>
+  <String Id="ModifyRepairButton">&amp;Reparar</String>
+  <String Id="ModifyUninstallButton">&amp;Desinstalar</String>
+  <String Id="ModifyCloseButton">&amp;Fechar</String>
+  <String Id="SuccessRepairHeader">Reparação Concluída com Êxito</String>
+  <String Id="SuccessUninstallHeader">Desinstalação Concluída com Êxito</String>
+  <String Id="SuccessInstallHeader">A instalação foi bem-sucedida</String>
+  <String Id="SuccessHeader">Instalação com Êxito</String>
+  <String Id="SuccessLaunchButton">&amp;Iniciar</String>
+  <String Id="SuccessRestartText">Você deve reiniciar seu computador antes de usar o software.</String>
+  <String Id="SuccessRestartButton">&amp;Reiniciar</String>
+  <String Id="SuccessCloseButton">&amp;Fechar</String>
+  <String Id="FailureHeader">Falha na Instalação</String>
+  <String Id="FailureInstallHeader">Falha na Instalação</String>
+  <String Id="FailureUninstallHeader">Falha na Desinstalação</String>
+  <String Id="FailureRepairHeader">Falha na Reparação</String>
+  <String Id="FailureHyperlinkLogText">Um ou mais problemas causaram falha na instalação. Corrija-os e tente instalar novamente. Para obter mais informações, consulte o &lt;a href="#"&gt;arquivo de log&lt;/a&gt;.</String>
+  <String Id="FailureRestartText">Você deve reiniciar seu computador para concluir a reversão do software.</String>
+  <String Id="FailureRestartButton">&amp;Reiniciar</String>
+  <String Id="FailureCloseButton">&amp;Fechar</String>
+  <String Id="FailureNotSupportedCurrentOperatingSystem">Não há suporte para o [PRODUCT_NAME] neste sistema operacional. Para obter mais informações, confira [LINK_PREREQ_PAGE].</String>
+  <String Id="FailureNotSupportedX86OperatingSystem">O [PRODUCT_NAME] não tem suporte em sistemas operacionais x86. Instale usando o instalador x86 correspondente.</String>
+  <String Id="FilesInUseHeader">Arquivos em Uso</String>
+  <String Id="FilesInUseLabel">Os aplicativos a seguir estão usando arquivos que precisam ser atualizados:</String>
+  <String Id="FilesInUseCloseRadioButton">Feche os &amp;aplicativos e tente reiniciá-los.</String>
+  <String Id="FilesInUseDontCloseRadioButton">&amp;Não feche os aplicativos. Será necessária uma reinicialização.</String>
   <String Id="FilesInUseOkButton">&amp;OK</String>
-  <String Id="FilesInUseCancelButton">&amp;Cancel</String>
-  <String Id="WelcomeHeaderMessage">Windows Desktop Runtime</String>
+  <String Id="FilesInUseCancelButton">&amp;Cancelar</String>
+  <String Id="WelcomeHeaderMessage"></String>
   <String Id="WelcomeDescription"></String>
-  <String Id="LearnMoreTitle">Learn more about .NET Core</String>
-  <String Id="SuccessInstallLocation">The following was installed at [DOTNETHOME]</String>
+  <String Id="LearnMoreTitle">Saiba mais sobre o .NET Core</String>
+  <String Id="SuccessInstallLocation">O seguinte foi instalado em [DOTNETHOME]</String>
   <String Id="SuccessInstallProductName"> - [BUNDLEMONIKER] </String>
-  <String Id="ResourcesHeader">Resources</String>
-  <String Id="DocumentationLink">&lt;A HREF=&quot;https://aka.ms/dotnet-docs&quot;&gt;Documentation&lt;/A&gt;</String>
-  <String Id="RelaseNotesLink">&lt;A HREF=&quot;https://aka.ms/20-p2-rel-notes&quot;&gt;Release Notes&lt;/A&gt;</String>
-  <String Id="TutorialLink">&lt;A HREF=&quot;https://aka.ms/dotnet-tutorials&quot;&gt;Tutorials&lt;/A&gt;</String>
-  <String Id="TelemetryLink">&lt;A HREF=&quot;https://aka.ms/dotnet-cli-telemetry&quot;&gt;.NET Core Telemetry&lt;/A&gt;</String>
-  <String Id="PrivacyStatementLink">&lt;A HREF=&quot;https://aka.ms/dev-privacy&quot;&gt;Privacy Statement&lt;/A&gt;</String>
-  <String Id="EulaLink">&lt;A HREF=&quot;https://go.microsoft.com/fwlink/?LinkId=329770&quot;&gt;.NET Library EULA&lt;/A&gt;</String>
+  <String Id="ResourcesHeader">Recursos</String>
+  <String Id="DocumentationLink">&lt;A HREF="https://aka.ms/dotnet-docs"&gt;Documentação&lt;/A&gt;</String>
+  <String Id="RelaseNotesLink">&lt;A HREF="https://aka.ms/20-p2-rel-notes"&gt;Notas sobre a Versão&lt;/A&gt;</String>
+  <String Id="TutorialLink">&lt;A HREF="https://aka.ms/dotnet-tutorials"&gt;Tutoriais&lt;/A&gt;</String>
+  <String Id="TelemetryLink">&lt;A HREF="https://aka.ms/dotnet-cli-telemetry"&gt;Telemetria do .NET Core&lt;/A&gt;</String>
+  <String Id="PrivacyStatementLink">&lt;A HREF="https://aka.ms/dev-privacy"&gt;Política de Privacidade&lt;/A&gt;</String>
+  <String Id="EulaLink">&lt;A HREF="https://go.microsoft.com/fwlink/?LinkId=329770"&gt;Termos de licença da Biblioteca do .NET&lt;/A&gt;</String>
   
 </WixLocalization>

--- a/src/pkg/projects/windowsdesktop/sfx/theme/1049/bundle.wxl
+++ b/src/pkg/projects/windowsdesktop/sfx/theme/1049/bundle.wxl
@@ -1,74 +1,74 @@
 <?xml version="1.0" encoding="utf-8"?>
 <WixLocalization Culture="en-us" Language="1033" xmlns="http://schemas.microsoft.com/wix/2006/localization">
-  <String Id="Caption">[WixBundleName] Installer</String>
+  <String Id="Caption">Установщик [WixBundleName]</String>
   <String Id="Title">[BUNDLEMONIKER]</String>
-  <String Id="Motto">You just need a shell, a text editor and 10 minutes of your time.
+  <String Id="Motto">Вам требуется только оболочка, текстовый редактор и 10 минут времени.
 
-Ready? Set? Let's go!</String>
-  <String Id="ConfirmCancelMessage">Are you sure you want to cancel?</String>
-  <String Id="ExecuteUpgradeRelatedBundleMessage">Previous version</String>
-  <String Id="HelpHeader">Setup Help</String>
-  <String Id="HelpText">/install | /repair | /uninstall | /layout [directory] - installs, repairs, uninstalls or
-   creates a complete local copy of the bundle in directory. Install is the default.
+Готовы? Тогда начинаем!</String>
+  <String Id="ConfirmCancelMessage">Вы действительно хотите отменить?</String>
+  <String Id="ExecuteUpgradeRelatedBundleMessage">Предыдущая версия</String>
+  <String Id="HelpHeader">Справка по установке</String>
+  <String Id="HelpText">/install | /repair | /uninstall | /layout [каталог] — установка, восстановление, удаление или
+ создание полной локальной копии пакета в каталоге. По умолчанию — установка.
 
-/passive | /quiet -  displays minimal UI with no prompts or displays no UI and
-   no prompts. By default UI and all prompts are displayed.
+/passive | /quiet — отображение минимального пользовательского интерфейса без запросов или работа без пользовательского интерфейса и
+ без запросов. По умолчанию отображаются пользовательский интерфейс и все запросы.
 
-/norestart   - suppress any attempts to restart. By default UI will prompt before restart.
-/log log.txt - logs to a specific file. By default a log file is created in %TEMP%.</String>
-  <String Id="HelpCloseButton">&amp;Close</String>
-  <String Id="InstallAcceptCheckbox">I &amp;agree to the license terms and conditions</String>
-  <String Id="InstallOptionsButton">&amp;Options</String>
-  <String Id="InstallInstallButton">&amp;Install</String>
-  <String Id="InstallCloseButton">&amp;Close</String>
-  <String Id="OptionsHeader">Setup Options</String>
-  <String Id="OptionsLocationLabel">Install location:</String>
-  <String Id="OptionsBrowseButton">&amp;Browse</String>
-  <String Id="OptionsOkButton">&amp;OK</String>
-  <String Id="OptionsCancelButton">&amp;Cancel</String>
-  <String Id="ProgressHeader">Setup Progress</String>
-  <String Id="ProgressLabel">Processing:</String>
-  <String Id="OverallProgressPackageText">Initializing...</String>
-  <String Id="ProgressCancelButton">&amp;Cancel</String>
-  <String Id="ModifyHeader">Modify Setup</String>
-  <String Id="ModifyRepairButton">&amp;Repair</String>
-  <String Id="ModifyUninstallButton">&amp;Uninstall</String>
-  <String Id="ModifyCloseButton">&amp;Close</String>
-  <String Id="SuccessRepairHeader">Repair Successfully Completed</String>
-  <String Id="SuccessUninstallHeader">Uninstall Successfully Completed</String>
-  <String Id="SuccessInstallHeader">Installation was successful</String>
-  <String Id="SuccessHeader">Setup Successful</String>
-  <String Id="SuccessLaunchButton">&amp;Launch</String>
-  <String Id="SuccessRestartText">You must restart your computer before you can use the software.</String>
-  <String Id="SuccessRestartButton">&amp;Restart</String>
-  <String Id="SuccessCloseButton">&amp;Close</String>
-  <String Id="FailureHeader">Setup Failed</String>
-  <String Id="FailureInstallHeader">Setup Failed</String>
-  <String Id="FailureUninstallHeader">Uninstall Failed</String>
-  <String Id="FailureRepairHeader">Repair Failed</String>
-  <String Id="FailureHyperlinkLogText">One or more issues caused the setup to fail. Please fix the issues and then retry setup. For more information see the &lt;a href="#"&gt;log file&lt;/a&gt;.</String>
-  <String Id="FailureRestartText">You must restart your computer to complete the rollback of the software.</String>
-  <String Id="FailureRestartButton">&amp;Restart</String>
-  <String Id="FailureCloseButton">&amp;Close</String>
-  <String Id="FailureNotSupportedCurrentOperatingSystem">The [PRODUCT_NAME] is not supported on this operating system. For more information, see [LINK_PREREQ_PAGE].</String>
-  <String Id="FailureNotSupportedX86OperatingSystem">The [PRODUCT_NAME] isn't supported on x86 operating systems. Please install using the corresponding x86 installer.</String>
-  <String Id="FilesInUseHeader">Files In Use</String>
-  <String Id="FilesInUseLabel">The following applications are using files that need to be updated:</String>
-  <String Id="FilesInUseCloseRadioButton">Close the &amp;applications and attempt to restart them.</String>
-  <String Id="FilesInUseDontCloseRadioButton">&amp;Do not close applications. A reboot will be required.</String>
-  <String Id="FilesInUseOkButton">&amp;OK</String>
-  <String Id="FilesInUseCancelButton">&amp;Cancel</String>
-  <String Id="WelcomeHeaderMessage">Windows Desktop Runtime</String>
+/norestart — отключение всех попыток перезагрузки. По умолчанию в пользовательском интерфейсе перед перезагрузкой отображается запрос.
+/log log.txt — запись журнала в указанный файл. По умолчанию файл журнала создается в папке %TEMP%.</String>
+  <String Id="HelpCloseButton">&amp;Закрыть</String>
+  <String Id="InstallAcceptCheckbox">Я &amp;принимаю условия лицензии</String>
+  <String Id="InstallOptionsButton">&amp;Параметры</String>
+  <String Id="InstallInstallButton">&amp;Установить</String>
+  <String Id="InstallCloseButton">&amp;Закрыть</String>
+  <String Id="OptionsHeader">Параметры установки</String>
+  <String Id="OptionsLocationLabel">Расположение установки:</String>
+  <String Id="OptionsBrowseButton">&amp;Обзор</String>
+  <String Id="OptionsOkButton">&amp;ОК</String>
+  <String Id="OptionsCancelButton">Отм&amp;ена</String>
+  <String Id="ProgressHeader">Ход установки</String>
+  <String Id="ProgressLabel">Обработка:</String>
+  <String Id="OverallProgressPackageText">Идет инициализация...</String>
+  <String Id="ProgressCancelButton">Отм&amp;ена</String>
+  <String Id="ModifyHeader">Изменение установки</String>
+  <String Id="ModifyRepairButton">&amp;Исправить</String>
+  <String Id="ModifyUninstallButton">&amp;Удалить</String>
+  <String Id="ModifyCloseButton">&amp;Закрыть</String>
+  <String Id="SuccessRepairHeader">Восстановление успешно завершено</String>
+  <String Id="SuccessUninstallHeader">Удаление успешно завершено</String>
+  <String Id="SuccessInstallHeader">Установка успешно завершена</String>
+  <String Id="SuccessHeader">Установка успешно завершена</String>
+  <String Id="SuccessLaunchButton">&amp;Запустить</String>
+  <String Id="SuccessRestartText">Перед использованием программного обеспечения необходимо перезапустить компьютер.</String>
+  <String Id="SuccessRestartButton">&amp;Перезапустить</String>
+  <String Id="SuccessCloseButton">&amp;Закрыть</String>
+  <String Id="FailureHeader">Настройка не завершена</String>
+  <String Id="FailureInstallHeader">Сбой установки</String>
+  <String Id="FailureUninstallHeader">Сбой удаления</String>
+  <String Id="FailureRepairHeader">Сбой восстановления</String>
+  <String Id="FailureHyperlinkLogText">Одна или несколько проблем вызывали сбой программы установки. Исправьте эти проблемы и попробуйте повторить установку. Дополнительные сведения см. в &lt;a href="#"&gt;файле журнала&lt;/a&gt;.</String>
+  <String Id="FailureRestartText">Необходимо перезагрузить компьютер, чтобы завершить откат программного обеспечения.</String>
+  <String Id="FailureRestartButton">&amp;Перезапустить</String>
+  <String Id="FailureCloseButton">З&amp;акрыть</String>
+  <String Id="FailureNotSupportedCurrentOperatingSystem">Продукт [PRODUCT_NAME] не поддерживается в этой операционной системе. Дополнительные сведения: [LINK_PREREQ_PAGE].</String>
+  <String Id="FailureNotSupportedX86OperatingSystem">Продукт [PRODUCT_NAME] не поддерживается в операционных системах x86. Установите с помощью соответствующего установщика x86.</String>
+  <String Id="FilesInUseHeader">Используемые файлы</String>
+  <String Id="FilesInUseLabel">Следующие приложения используют файлы, которые следует обновить:</String>
+  <String Id="FilesInUseCloseRadioButton">Закрыть &amp;приложения и попытаться перезапустить их.</String>
+  <String Id="FilesInUseDontCloseRadioButton">&amp;Не закрывать приложения. Потребуется перезагрузка.</String>
+  <String Id="FilesInUseOkButton">О&amp;К</String>
+  <String Id="FilesInUseCancelButton">&amp;Отмена</String>
+  <String Id="WelcomeHeaderMessage"></String>
   <String Id="WelcomeDescription"></String>
-  <String Id="LearnMoreTitle">Learn more about .NET Core</String>
-  <String Id="SuccessInstallLocation">The following was installed at [DOTNETHOME]</String>
+  <String Id="LearnMoreTitle">Дополнительные сведения о .NET Core</String>
+  <String Id="SuccessInstallLocation">Следующее было установлено в [DOTNETHOME]</String>
   <String Id="SuccessInstallProductName"> - [BUNDLEMONIKER] </String>
-  <String Id="ResourcesHeader">Resources</String>
-  <String Id="DocumentationLink">&lt;A HREF=&quot;https://aka.ms/dotnet-docs&quot;&gt;Documentation&lt;/A&gt;</String>
-  <String Id="RelaseNotesLink">&lt;A HREF=&quot;https://aka.ms/20-p2-rel-notes&quot;&gt;Release Notes&lt;/A&gt;</String>
-  <String Id="TutorialLink">&lt;A HREF=&quot;https://aka.ms/dotnet-tutorials&quot;&gt;Tutorials&lt;/A&gt;</String>
-  <String Id="TelemetryLink">&lt;A HREF=&quot;https://aka.ms/dotnet-cli-telemetry&quot;&gt;.NET Core Telemetry&lt;/A&gt;</String>
-  <String Id="PrivacyStatementLink">&lt;A HREF=&quot;https://aka.ms/dev-privacy&quot;&gt;Privacy Statement&lt;/A&gt;</String>
-  <String Id="EulaLink">&lt;A HREF=&quot;https://go.microsoft.com/fwlink/?LinkId=329770&quot;&gt;.NET Library EULA&lt;/A&gt;</String>
+  <String Id="ResourcesHeader">Ресурсы</String>
+  <String Id="DocumentationLink">&lt;A HREF="https://aka.ms/dotnet-docs"&gt;Документация&lt;/A&gt;</String>
+  <String Id="RelaseNotesLink">&lt;A HREF="https://aka.ms/20-p2-rel-notes"&gt;Заметки о выпуске&lt;/A&gt;</String>
+  <String Id="TutorialLink">&lt;A HREF="https://aka.ms/dotnet-tutorials"&gt;Руководства&lt;/A&gt;</String>
+  <String Id="TelemetryLink">&lt;A HREF="https://aka.ms/dotnet-cli-telemetry"&gt;Телеметрия .NET Core&lt;/A&gt;</String>
+  <String Id="PrivacyStatementLink">&lt;A HREF="https://aka.ms/dev-privacy"&gt;Заявление о конфиденциальности&lt;/A&gt;</String>
+  <String Id="EulaLink">&lt;A HREF="https://go.microsoft.com/fwlink/?LinkId=329770"&gt;Лицензионное соглашение для библиотеки .NET&lt;/A&gt;</String>
   
 </WixLocalization>

--- a/src/pkg/projects/windowsdesktop/sfx/theme/1055/bundle.wxl
+++ b/src/pkg/projects/windowsdesktop/sfx/theme/1055/bundle.wxl
@@ -1,74 +1,74 @@
 <?xml version="1.0" encoding="utf-8"?>
 <WixLocalization Culture="en-us" Language="1033" xmlns="http://schemas.microsoft.com/wix/2006/localization">
-  <String Id="Caption">[WixBundleName] Installer</String>
+  <String Id="Caption">[WixBundleName] Yükleyicisi</String>
   <String Id="Title">[BUNDLEMONIKER]</String>
-  <String Id="Motto">You just need a shell, a text editor and 10 minutes of your time.
+  <String Id="Motto">Yalnızca bir kabuğa, bir metin düzenleyicisine ve 10 dakikalık bir zamana ihtiyacınız var.
 
-Ready? Set? Let's go!</String>
-  <String Id="ConfirmCancelMessage">Are you sure you want to cancel?</String>
-  <String Id="ExecuteUpgradeRelatedBundleMessage">Previous version</String>
-  <String Id="HelpHeader">Setup Help</String>
-  <String Id="HelpText">/install | /repair | /uninstall | /layout [directory] - installs, repairs, uninstalls or
-   creates a complete local copy of the bundle in directory. Install is the default.
+Hazır mısınız? Haydi başlayalım!</String>
+  <String Id="ConfirmCancelMessage">İptal etmek istediğinizden emin misiniz?</String>
+  <String Id="ExecuteUpgradeRelatedBundleMessage">Önceki sürüm</String>
+  <String Id="HelpHeader">Kurulum Yardımı</String>
+  <String Id="HelpText">/install | /repair | /uninstall | /layout [dizin] - yükler, onarır, kaldırır ya da
+   dizindeki paketin tam bir yerel kopyasını oluşturur. Varsayılan install değeridir.
 
-/passive | /quiet -  displays minimal UI with no prompts or displays no UI and
-   no prompts. By default UI and all prompts are displayed.
+/passive | /quiet -  en az düzeyde istemsiz UI gösterir ya da hiç UI göstermez ve
+   istem yoktur. Varsayılan olarak UI ve tüm istemler görüntülenir.
 
-/norestart   - suppress any attempts to restart. By default UI will prompt before restart.
-/log log.txt - logs to a specific file. By default a log file is created in %TEMP%.</String>
-  <String Id="HelpCloseButton">&amp;Close</String>
-  <String Id="InstallAcceptCheckbox">I &amp;agree to the license terms and conditions</String>
-  <String Id="InstallOptionsButton">&amp;Options</String>
-  <String Id="InstallInstallButton">&amp;Install</String>
-  <String Id="InstallCloseButton">&amp;Close</String>
-  <String Id="OptionsHeader">Setup Options</String>
-  <String Id="OptionsLocationLabel">Install location:</String>
-  <String Id="OptionsBrowseButton">&amp;Browse</String>
-  <String Id="OptionsOkButton">&amp;OK</String>
-  <String Id="OptionsCancelButton">&amp;Cancel</String>
-  <String Id="ProgressHeader">Setup Progress</String>
-  <String Id="ProgressLabel">Processing:</String>
-  <String Id="OverallProgressPackageText">Initializing...</String>
-  <String Id="ProgressCancelButton">&amp;Cancel</String>
-  <String Id="ModifyHeader">Modify Setup</String>
-  <String Id="ModifyRepairButton">&amp;Repair</String>
-  <String Id="ModifyUninstallButton">&amp;Uninstall</String>
-  <String Id="ModifyCloseButton">&amp;Close</String>
-  <String Id="SuccessRepairHeader">Repair Successfully Completed</String>
-  <String Id="SuccessUninstallHeader">Uninstall Successfully Completed</String>
-  <String Id="SuccessInstallHeader">Installation was successful</String>
-  <String Id="SuccessHeader">Setup Successful</String>
-  <String Id="SuccessLaunchButton">&amp;Launch</String>
-  <String Id="SuccessRestartText">You must restart your computer before you can use the software.</String>
-  <String Id="SuccessRestartButton">&amp;Restart</String>
-  <String Id="SuccessCloseButton">&amp;Close</String>
-  <String Id="FailureHeader">Setup Failed</String>
-  <String Id="FailureInstallHeader">Setup Failed</String>
-  <String Id="FailureUninstallHeader">Uninstall Failed</String>
-  <String Id="FailureRepairHeader">Repair Failed</String>
-  <String Id="FailureHyperlinkLogText">One or more issues caused the setup to fail. Please fix the issues and then retry setup. For more information see the &lt;a href="#"&gt;log file&lt;/a&gt;.</String>
-  <String Id="FailureRestartText">You must restart your computer to complete the rollback of the software.</String>
-  <String Id="FailureRestartButton">&amp;Restart</String>
-  <String Id="FailureCloseButton">&amp;Close</String>
-  <String Id="FailureNotSupportedCurrentOperatingSystem">The [PRODUCT_NAME] is not supported on this operating system. For more information, see [LINK_PREREQ_PAGE].</String>
-  <String Id="FailureNotSupportedX86OperatingSystem">The [PRODUCT_NAME] isn't supported on x86 operating systems. Please install using the corresponding x86 installer.</String>
-  <String Id="FilesInUseHeader">Files In Use</String>
-  <String Id="FilesInUseLabel">The following applications are using files that need to be updated:</String>
-  <String Id="FilesInUseCloseRadioButton">Close the &amp;applications and attempt to restart them.</String>
-  <String Id="FilesInUseDontCloseRadioButton">&amp;Do not close applications. A reboot will be required.</String>
-  <String Id="FilesInUseOkButton">&amp;OK</String>
-  <String Id="FilesInUseCancelButton">&amp;Cancel</String>
-  <String Id="WelcomeHeaderMessage">Windows Desktop Runtime</String>
+/norestart   - yeniden başlama denemelerini engeller. Varsayılan olarak UI yeniden başlatılmadan önce sorar.
+/log log.txt - belirli bir günlük dosyası tutar. Varsayılan olarak %TEMP% içinde bir günlük dosyası oluşturulur.</String>
+  <String Id="HelpCloseButton">&amp;Kapat</String>
+  <String Id="InstallAcceptCheckbox">Lisans &amp;hüküm ve koşullarını kabul ediyorum</String>
+  <String Id="InstallOptionsButton">&amp;Seçenekler</String>
+  <String Id="InstallInstallButton">&amp;Yükle</String>
+  <String Id="InstallCloseButton">&amp;Kapat</String>
+  <String Id="OptionsHeader">Kurulum Seçenekleri</String>
+  <String Id="OptionsLocationLabel">Yükleme konumu:</String>
+  <String Id="OptionsBrowseButton">&amp;Gözat</String>
+  <String Id="OptionsOkButton">&amp;Tamam</String>
+  <String Id="OptionsCancelButton">İ&amp;ptal</String>
+  <String Id="ProgressHeader">Kurulum İlerleme Durumu</String>
+  <String Id="ProgressLabel">İşleniyor:</String>
+  <String Id="OverallProgressPackageText">Başlatılıyor...</String>
+  <String Id="ProgressCancelButton">İ&amp;ptal</String>
+  <String Id="ModifyHeader">Kurulumu Değiştir</String>
+  <String Id="ModifyRepairButton">&amp;Onar</String>
+  <String Id="ModifyUninstallButton">K&amp;aldır</String>
+  <String Id="ModifyCloseButton">&amp;Kapat</String>
+  <String Id="SuccessRepairHeader">Onarım Başarıyla Tamamlandı</String>
+  <String Id="SuccessUninstallHeader">Kaldırma Başarıyla Tamamlandı</String>
+  <String Id="SuccessInstallHeader">Yükleme başarılı oldu</String>
+  <String Id="SuccessHeader">Kurulum Başarılı</String>
+  <String Id="SuccessLaunchButton">&amp;Başlat</String>
+  <String Id="SuccessRestartText">Yazılımı kullanabilmek için bilgisayarınızı yeniden başlatmanız gerekiyor.</String>
+  <String Id="SuccessRestartButton">Yeniden &amp;Başlat</String>
+  <String Id="SuccessCloseButton">&amp;Kapat</String>
+  <String Id="FailureHeader">Kurulum Başarısız</String>
+  <String Id="FailureInstallHeader">Kurulum Başarısız</String>
+  <String Id="FailureUninstallHeader">Yükleme Başarısız</String>
+  <String Id="FailureRepairHeader">Onarım Başarısız</String>
+  <String Id="FailureHyperlinkLogText">En az bir sorun nedeniyle kurulum başarısız oldu. Lütfen bu sorunları düzeltin ve kurulumu yeniden deneyin. Daha fazla bilgi için &lt;a href="#"&gt;günlük dosyasına&lt;/a&gt; bakın.</String>
+  <String Id="FailureRestartText">Yazılımın geri alınmasını tamamlamak için bilgisayarınızı yeniden başlatmanız gerekiyor.</String>
+  <String Id="FailureRestartButton">Yeniden &amp;Başlat</String>
+  <String Id="FailureCloseButton">&amp;Kapat</String>
+  <String Id="FailureNotSupportedCurrentOperatingSystem">[PRODUCT_NAME] bu işletim sisteminde desteklenmiyor. Daha fazla bilgi için bkz. [LINK_PREREQ_PAGE].</String>
+  <String Id="FailureNotSupportedX86OperatingSystem">[PRODUCT_NAME], x86 işletim sistemlerinde desteklenmiyor. Lütfen karşılık gelen x86 yükleyicisini kullanarak yükleyin.</String>
+  <String Id="FilesInUseHeader">Kullanımda Olan Dosyalar</String>
+  <String Id="FilesInUseLabel">Şu uygulamalar güncelleştirilmesi gereken dosyaları kullanıyor:</String>
+  <String Id="FilesInUseCloseRadioButton">&amp;Uygulamaları kapatın ve yeniden başlatmayı deneyin.</String>
+  <String Id="FilesInUseDontCloseRadioButton">&amp;Uygulamaları kapatmayın. Sistemi yeniden başlatmanız gerekir.</String>
+  <String Id="FilesInUseOkButton">&amp;Tamam</String>
+  <String Id="FilesInUseCancelButton">&amp;İptal</String>
+  <String Id="WelcomeHeaderMessage"></String>
   <String Id="WelcomeDescription"></String>
-  <String Id="LearnMoreTitle">Learn more about .NET Core</String>
-  <String Id="SuccessInstallLocation">The following was installed at [DOTNETHOME]</String>
+  <String Id="LearnMoreTitle">.NET Core hakkında daha fazla bilgi edinin</String>
+  <String Id="SuccessInstallLocation">Aşağıdakiler [DOTNETHOME] konumunda yüklendi</String>
   <String Id="SuccessInstallProductName"> - [BUNDLEMONIKER] </String>
-  <String Id="ResourcesHeader">Resources</String>
-  <String Id="DocumentationLink">&lt;A HREF=&quot;https://aka.ms/dotnet-docs&quot;&gt;Documentation&lt;/A&gt;</String>
-  <String Id="RelaseNotesLink">&lt;A HREF=&quot;https://aka.ms/20-p2-rel-notes&quot;&gt;Release Notes&lt;/A&gt;</String>
-  <String Id="TutorialLink">&lt;A HREF=&quot;https://aka.ms/dotnet-tutorials&quot;&gt;Tutorials&lt;/A&gt;</String>
-  <String Id="TelemetryLink">&lt;A HREF=&quot;https://aka.ms/dotnet-cli-telemetry&quot;&gt;.NET Core Telemetry&lt;/A&gt;</String>
-  <String Id="PrivacyStatementLink">&lt;A HREF=&quot;https://aka.ms/dev-privacy&quot;&gt;Privacy Statement&lt;/A&gt;</String>
-  <String Id="EulaLink">&lt;A HREF=&quot;https://go.microsoft.com/fwlink/?LinkId=329770&quot;&gt;.NET Library EULA&lt;/A&gt;</String>
+  <String Id="ResourcesHeader">Kaynaklar</String>
+  <String Id="DocumentationLink">&lt;A HREF="https://aka.ms/dotnet-docs"&gt;Belgeler&lt;/A&gt;</String>
+  <String Id="RelaseNotesLink">&lt;A HREF="https://aka.ms/20-p2-rel-notes"&gt;Sürüm Notları&lt;/A&gt;</String>
+  <String Id="TutorialLink">&lt;A HREF="https://aka.ms/dotnet-tutorials"&gt;Öğreticiler&lt;/A&gt;</String>
+  <String Id="TelemetryLink">&lt;A HREF="https://aka.ms/dotnet-cli-telemetry"&gt;.NET Core Telemetrisi&lt;/A&gt;</String>
+  <String Id="PrivacyStatementLink">&lt;A HREF="https://aka.ms/dev-privacy"&gt;Gizlilik Bildirimi&lt;/A&gt;</String>
+  <String Id="EulaLink">&lt;A HREF="https://go.microsoft.com/fwlink/?LinkId=329770"&gt;.NET Kitaplığı EULA&lt;/A&gt;</String>
   
 </WixLocalization>

--- a/src/pkg/projects/windowsdesktop/sfx/theme/2052/bundle.wxl
+++ b/src/pkg/projects/windowsdesktop/sfx/theme/2052/bundle.wxl
@@ -1,74 +1,74 @@
 <?xml version="1.0" encoding="utf-8"?>
 <WixLocalization Culture="en-us" Language="1033" xmlns="http://schemas.microsoft.com/wix/2006/localization">
-  <String Id="Caption">[WixBundleName] Installer</String>
+  <String Id="Caption">[WixBundleName] 安装程序</String>
   <String Id="Title">[BUNDLEMONIKER]</String>
-  <String Id="Motto">You just need a shell, a text editor and 10 minutes of your time.
+  <String Id="Motto">你只需要一个 shell、一个文本编辑器，还需花 10 分钟即可。.
 
-Ready? Set? Let's go!</String>
-  <String Id="ConfirmCancelMessage">Are you sure you want to cancel?</String>
-  <String Id="ExecuteUpgradeRelatedBundleMessage">Previous version</String>
-  <String Id="HelpHeader">Setup Help</String>
-  <String Id="HelpText">/install | /repair | /uninstall | /layout [directory] - installs, repairs, uninstalls or
-   creates a complete local copy of the bundle in directory. Install is the default.
+准备好了吗? 要设置? 让我们开始吧!</String>
+  <String Id="ConfirmCancelMessage">是否确实要取消?</String>
+  <String Id="ExecuteUpgradeRelatedBundleMessage">上一版本</String>
+  <String Id="HelpHeader">安装程序帮助</String>
+  <String Id="HelpText">/install | /repair | /uninstall | /layout [目录] - 安装、修复、卸载
+   目录中的安装包或创建其完整本地副本。Install 为默认选择。
 
-/passive | /quiet -  displays minimal UI with no prompts or displays no UI and
-   no prompts. By default UI and all prompts are displayed.
+/passive | /quiet -  显示最少的 UI 且无提示，或不显示 UI 且
+   无提示。默认显示 UI 及全部提示。
 
-/norestart   - suppress any attempts to restart. By default UI will prompt before restart.
-/log log.txt - logs to a specific file. By default a log file is created in %TEMP%.</String>
-  <String Id="HelpCloseButton">&amp;Close</String>
-  <String Id="InstallAcceptCheckbox">I &amp;agree to the license terms and conditions</String>
-  <String Id="InstallOptionsButton">&amp;Options</String>
-  <String Id="InstallInstallButton">&amp;Install</String>
-  <String Id="InstallCloseButton">&amp;Close</String>
-  <String Id="OptionsHeader">Setup Options</String>
-  <String Id="OptionsLocationLabel">Install location:</String>
-  <String Id="OptionsBrowseButton">&amp;Browse</String>
-  <String Id="OptionsOkButton">&amp;OK</String>
-  <String Id="OptionsCancelButton">&amp;Cancel</String>
-  <String Id="ProgressHeader">Setup Progress</String>
-  <String Id="ProgressLabel">Processing:</String>
-  <String Id="OverallProgressPackageText">Initializing...</String>
-  <String Id="ProgressCancelButton">&amp;Cancel</String>
-  <String Id="ModifyHeader">Modify Setup</String>
-  <String Id="ModifyRepairButton">&amp;Repair</String>
-  <String Id="ModifyUninstallButton">&amp;Uninstall</String>
-  <String Id="ModifyCloseButton">&amp;Close</String>
-  <String Id="SuccessRepairHeader">Repair Successfully Completed</String>
-  <String Id="SuccessUninstallHeader">Uninstall Successfully Completed</String>
-  <String Id="SuccessInstallHeader">Installation was successful</String>
-  <String Id="SuccessHeader">Setup Successful</String>
-  <String Id="SuccessLaunchButton">&amp;Launch</String>
-  <String Id="SuccessRestartText">You must restart your computer before you can use the software.</String>
-  <String Id="SuccessRestartButton">&amp;Restart</String>
-  <String Id="SuccessCloseButton">&amp;Close</String>
-  <String Id="FailureHeader">Setup Failed</String>
-  <String Id="FailureInstallHeader">Setup Failed</String>
-  <String Id="FailureUninstallHeader">Uninstall Failed</String>
-  <String Id="FailureRepairHeader">Repair Failed</String>
-  <String Id="FailureHyperlinkLogText">One or more issues caused the setup to fail. Please fix the issues and then retry setup. For more information see the &lt;a href="#"&gt;log file&lt;/a&gt;.</String>
-  <String Id="FailureRestartText">You must restart your computer to complete the rollback of the software.</String>
-  <String Id="FailureRestartButton">&amp;Restart</String>
-  <String Id="FailureCloseButton">&amp;Close</String>
-  <String Id="FailureNotSupportedCurrentOperatingSystem">The [PRODUCT_NAME] is not supported on this operating system. For more information, see [LINK_PREREQ_PAGE].</String>
-  <String Id="FailureNotSupportedX86OperatingSystem">The [PRODUCT_NAME] isn't supported on x86 operating systems. Please install using the corresponding x86 installer.</String>
-  <String Id="FilesInUseHeader">Files In Use</String>
-  <String Id="FilesInUseLabel">The following applications are using files that need to be updated:</String>
-  <String Id="FilesInUseCloseRadioButton">Close the &amp;applications and attempt to restart them.</String>
-  <String Id="FilesInUseDontCloseRadioButton">&amp;Do not close applications. A reboot will be required.</String>
-  <String Id="FilesInUseOkButton">&amp;OK</String>
-  <String Id="FilesInUseCancelButton">&amp;Cancel</String>
-  <String Id="WelcomeHeaderMessage">Windows Desktop Runtime</String>
+/norestart   - 禁止任何重新启动。默认在重新启动前显示提示 UI。
+/log log.txt - 向特定文件写入日志。默认在 %TEMP% 中创建日志文件。</String>
+  <String Id="HelpCloseButton">关闭(&amp;C)</String>
+  <String Id="InstallAcceptCheckbox">我同意许可条款和条件(&amp;A)</String>
+  <String Id="InstallOptionsButton">选项(&amp;O)</String>
+  <String Id="InstallInstallButton">安装(&amp;I)</String>
+  <String Id="InstallCloseButton">关闭(&amp;C)</String>
+  <String Id="OptionsHeader">安装选项</String>
+  <String Id="OptionsLocationLabel">安装位置:</String>
+  <String Id="OptionsBrowseButton">浏览(&amp;B)</String>
+  <String Id="OptionsOkButton">确定(&amp;O)</String>
+  <String Id="OptionsCancelButton">取消(&amp;C)</String>
+  <String Id="ProgressHeader">安装进度</String>
+  <String Id="ProgressLabel">正在处理:</String>
+  <String Id="OverallProgressPackageText">正在初始化…</String>
+  <String Id="ProgressCancelButton">取消(&amp;C)</String>
+  <String Id="ModifyHeader">修改安装程序</String>
+  <String Id="ModifyRepairButton">修复(&amp;R)</String>
+  <String Id="ModifyUninstallButton">卸载(&amp;U)</String>
+  <String Id="ModifyCloseButton">关闭(&amp;C)</String>
+  <String Id="SuccessRepairHeader">成功完成了修复</String>
+  <String Id="SuccessUninstallHeader">成功完成了卸载</String>
+  <String Id="SuccessInstallHeader">安装成功</String>
+  <String Id="SuccessHeader">设置成功</String>
+  <String Id="SuccessLaunchButton">启动(&amp;L)</String>
+  <String Id="SuccessRestartText">在使用此软件之前，您必须重新启动计算机。</String>
+  <String Id="SuccessRestartButton">重新启动(&amp;R)</String>
+  <String Id="SuccessCloseButton">关闭(&amp;C)</String>
+  <String Id="FailureHeader">设置失败</String>
+  <String Id="FailureInstallHeader">安装失败</String>
+  <String Id="FailureUninstallHeader">卸载失败</String>
+  <String Id="FailureRepairHeader">修复失败</String>
+  <String Id="FailureHyperlinkLogText">一个或多个问题导致了安装失败。请修复这些问题，然后重试安装。有关详细信息，请参阅&lt;a href="#"&gt;日志文件&lt;/a&gt;。</String>
+  <String Id="FailureRestartText">必须重新启动计算机才能完成软件回退。</String>
+  <String Id="FailureRestartButton">重新启动(&amp;R)</String>
+  <String Id="FailureCloseButton">关闭(&amp;C)</String>
+  <String Id="FailureNotSupportedCurrentOperatingSystem">此操作系统不支持 [PRODUCT_NAME]。有关详细信息，请参阅[LINK_PREREQ_PAGE]。</String>
+  <String Id="FailureNotSupportedX86OperatingSystem">x86 操作系统不支持该 [PRODUCT_NAME]。请使用相应的 x86 安装程序进行安装。</String>
+  <String Id="FilesInUseHeader">文件正在使用</String>
+  <String Id="FilesInUseLabel">以下应用程序正在使用的文件需要更新:</String>
+  <String Id="FilesInUseCloseRadioButton">关闭应用程序并尝试重启(&amp;A)。</String>
+  <String Id="FilesInUseDontCloseRadioButton">不关闭应用程序(&amp;D)。需要重启。</String>
+  <String Id="FilesInUseOkButton">确定(&amp;O)</String>
+  <String Id="FilesInUseCancelButton">取消(&amp;C)</String>
+  <String Id="WelcomeHeaderMessage"></String>
   <String Id="WelcomeDescription"></String>
-  <String Id="LearnMoreTitle">Learn more about .NET Core</String>
-  <String Id="SuccessInstallLocation">The following was installed at [DOTNETHOME]</String>
+  <String Id="LearnMoreTitle">了解有关 .NET Core 的详细信息</String>
+  <String Id="SuccessInstallLocation">以下项已安装到 [DOTNETHOME]</String>
   <String Id="SuccessInstallProductName"> - [BUNDLEMONIKER] </String>
-  <String Id="ResourcesHeader">Resources</String>
-  <String Id="DocumentationLink">&lt;A HREF=&quot;https://aka.ms/dotnet-docs&quot;&gt;Documentation&lt;/A&gt;</String>
-  <String Id="RelaseNotesLink">&lt;A HREF=&quot;https://aka.ms/20-p2-rel-notes&quot;&gt;Release Notes&lt;/A&gt;</String>
-  <String Id="TutorialLink">&lt;A HREF=&quot;https://aka.ms/dotnet-tutorials&quot;&gt;Tutorials&lt;/A&gt;</String>
-  <String Id="TelemetryLink">&lt;A HREF=&quot;https://aka.ms/dotnet-cli-telemetry&quot;&gt;.NET Core Telemetry&lt;/A&gt;</String>
-  <String Id="PrivacyStatementLink">&lt;A HREF=&quot;https://aka.ms/dev-privacy&quot;&gt;Privacy Statement&lt;/A&gt;</String>
-  <String Id="EulaLink">&lt;A HREF=&quot;https://go.microsoft.com/fwlink/?LinkId=329770&quot;&gt;.NET Library EULA&lt;/A&gt;</String>
+  <String Id="ResourcesHeader">资源</String>
+  <String Id="DocumentationLink">&lt;A HREF="https://aka.ms/dotnet-docs"&gt;文档&lt;/A&gt;</String>
+  <String Id="RelaseNotesLink">&lt;A HREF="https://aka.ms/20-p2-rel-notes"&gt;发行说明&lt;/A&gt;</String>
+  <String Id="TutorialLink">&lt;A HREF="https://aka.ms/dotnet-tutorials"&gt;教程&lt;/A&gt;</String>
+  <String Id="TelemetryLink">&lt;A HREF="https://aka.ms/dotnet-cli-telemetry"&gt;.NET Core 遥测&lt;/A&gt;</String>
+  <String Id="PrivacyStatementLink">&lt;A HREF="https://aka.ms/dev-privacy"&gt;隐私声明&lt;/A&gt;</String>
+  <String Id="EulaLink">&lt;A HREF="https://go.microsoft.com/fwlink/?LinkId=329770"&gt;.NET 库 EULA&lt;/A&gt;</String>
   
 </WixLocalization>

--- a/src/pkg/projects/windowsdesktop/sfx/theme/3082/bundle.wxl
+++ b/src/pkg/projects/windowsdesktop/sfx/theme/3082/bundle.wxl
@@ -1,74 +1,74 @@
 <?xml version="1.0" encoding="utf-8"?>
 <WixLocalization Culture="en-us" Language="1033" xmlns="http://schemas.microsoft.com/wix/2006/localization">
-  <String Id="Caption">[WixBundleName] Installer</String>
+  <String Id="Caption">Instalador de [WixBundleName]</String>
   <String Id="Title">[BUNDLEMONIKER]</String>
-  <String Id="Motto">You just need a shell, a text editor and 10 minutes of your time.
+  <String Id="Motto">Solo necesita un shell, un editor de texto y 10 minutos.
 
-Ready? Set? Let's go!</String>
-  <String Id="ConfirmCancelMessage">Are you sure you want to cancel?</String>
-  <String Id="ExecuteUpgradeRelatedBundleMessage">Previous version</String>
-  <String Id="HelpHeader">Setup Help</String>
-  <String Id="HelpText">/install | /repair | /uninstall | /layout [directory] - installs, repairs, uninstalls or
-   creates a complete local copy of the bundle in directory. Install is the default.
+¿Preparados? ¿Listos? ¡Ya!</String>
+  <String Id="ConfirmCancelMessage">¿Está seguro de que desea cancelar?</String>
+  <String Id="ExecuteUpgradeRelatedBundleMessage">Versión anterior</String>
+  <String Id="HelpHeader">Ayuda de configuración</String>
+  <String Id="HelpText">/install | /repair | /uninstall | /layout [directory] - instala, repara, desinstala o
+   crea una copia local completa del paquete en el directorio. Install es la opción predeterminada.
 
-/passive | /quiet -  displays minimal UI with no prompts or displays no UI and
-   no prompts. By default UI and all prompts are displayed.
+/passive | /quiet -  muestra una IU mínima sin peticiones, o bien no muestra la IU 
+  ni las peticiones. De forma predeterminada, se muestran la IU y todas las peticiones.
 
-/norestart   - suppress any attempts to restart. By default UI will prompt before restart.
-/log log.txt - logs to a specific file. By default a log file is created in %TEMP%.</String>
-  <String Id="HelpCloseButton">&amp;Close</String>
-  <String Id="InstallAcceptCheckbox">I &amp;agree to the license terms and conditions</String>
-  <String Id="InstallOptionsButton">&amp;Options</String>
-  <String Id="InstallInstallButton">&amp;Install</String>
-  <String Id="InstallCloseButton">&amp;Close</String>
-  <String Id="OptionsHeader">Setup Options</String>
-  <String Id="OptionsLocationLabel">Install location:</String>
-  <String Id="OptionsBrowseButton">&amp;Browse</String>
-  <String Id="OptionsOkButton">&amp;OK</String>
-  <String Id="OptionsCancelButton">&amp;Cancel</String>
-  <String Id="ProgressHeader">Setup Progress</String>
-  <String Id="ProgressLabel">Processing:</String>
-  <String Id="OverallProgressPackageText">Initializing...</String>
-  <String Id="ProgressCancelButton">&amp;Cancel</String>
-  <String Id="ModifyHeader">Modify Setup</String>
-  <String Id="ModifyRepairButton">&amp;Repair</String>
-  <String Id="ModifyUninstallButton">&amp;Uninstall</String>
-  <String Id="ModifyCloseButton">&amp;Close</String>
-  <String Id="SuccessRepairHeader">Repair Successfully Completed</String>
-  <String Id="SuccessUninstallHeader">Uninstall Successfully Completed</String>
-  <String Id="SuccessInstallHeader">Installation was successful</String>
-  <String Id="SuccessHeader">Setup Successful</String>
-  <String Id="SuccessLaunchButton">&amp;Launch</String>
-  <String Id="SuccessRestartText">You must restart your computer before you can use the software.</String>
-  <String Id="SuccessRestartButton">&amp;Restart</String>
-  <String Id="SuccessCloseButton">&amp;Close</String>
-  <String Id="FailureHeader">Setup Failed</String>
-  <String Id="FailureInstallHeader">Setup Failed</String>
-  <String Id="FailureUninstallHeader">Uninstall Failed</String>
-  <String Id="FailureRepairHeader">Repair Failed</String>
-  <String Id="FailureHyperlinkLogText">One or more issues caused the setup to fail. Please fix the issues and then retry setup. For more information see the &lt;a href="#"&gt;log file&lt;/a&gt;.</String>
-  <String Id="FailureRestartText">You must restart your computer to complete the rollback of the software.</String>
-  <String Id="FailureRestartButton">&amp;Restart</String>
-  <String Id="FailureCloseButton">&amp;Close</String>
-  <String Id="FailureNotSupportedCurrentOperatingSystem">The [PRODUCT_NAME] is not supported on this operating system. For more information, see [LINK_PREREQ_PAGE].</String>
-  <String Id="FailureNotSupportedX86OperatingSystem">The [PRODUCT_NAME] isn't supported on x86 operating systems. Please install using the corresponding x86 installer.</String>
-  <String Id="FilesInUseHeader">Files In Use</String>
-  <String Id="FilesInUseLabel">The following applications are using files that need to be updated:</String>
-  <String Id="FilesInUseCloseRadioButton">Close the &amp;applications and attempt to restart them.</String>
-  <String Id="FilesInUseDontCloseRadioButton">&amp;Do not close applications. A reboot will be required.</String>
-  <String Id="FilesInUseOkButton">&amp;OK</String>
-  <String Id="FilesInUseCancelButton">&amp;Cancel</String>
-  <String Id="WelcomeHeaderMessage">Windows Desktop Runtime</String>
+/norestart   - suprime los intentos de reiniciar. De forma predeterminada, la IU preguntará antes de reiniciar.
+/log log.txt - se registra en un archivo específico. De forma predeterminada, se crea un archivo de registro en %TEMP%.</String>
+  <String Id="HelpCloseButton">&amp;Cerrar</String>
+  <String Id="InstallAcceptCheckbox">&amp;Acepto los términos y condiciones de licencia</String>
+  <String Id="InstallOptionsButton">&amp;Opciones</String>
+  <String Id="InstallInstallButton">&amp;Instalar</String>
+  <String Id="InstallCloseButton">&amp;Cerrar</String>
+  <String Id="OptionsHeader">Opciones de instalación</String>
+  <String Id="OptionsLocationLabel">Ubicación de instalación:</String>
+  <String Id="OptionsBrowseButton">E&amp;xaminar</String>
+  <String Id="OptionsOkButton">&amp;Aceptar</String>
+  <String Id="OptionsCancelButton">&amp;Cancelar</String>
+  <String Id="ProgressHeader">Progreso de la instalación</String>
+  <String Id="ProgressLabel">Procesando:</String>
+  <String Id="OverallProgressPackageText">Inicializando...</String>
+  <String Id="ProgressCancelButton">&amp;Cancelar</String>
+  <String Id="ModifyHeader">Modificar instalación</String>
+  <String Id="ModifyRepairButton">&amp;Reparar</String>
+  <String Id="ModifyUninstallButton">&amp;Desinstalar</String>
+  <String Id="ModifyCloseButton">&amp;Cerrar</String>
+  <String Id="SuccessRepairHeader">La reparación se completó correctamente</String>
+  <String Id="SuccessUninstallHeader">La desinstalación se completó correctamente</String>
+  <String Id="SuccessInstallHeader">La instalación se realizó correctamente</String>
+  <String Id="SuccessHeader">La instalación o desinstalación se realizó correctamente</String>
+  <String Id="SuccessLaunchButton">&amp;Iniciar</String>
+  <String Id="SuccessRestartText">Debe reiniciar el equipo para poder usar el software.</String>
+  <String Id="SuccessRestartButton">&amp;Reiniciar</String>
+  <String Id="SuccessCloseButton">&amp;Cerrar</String>
+  <String Id="FailureHeader">Error de instalación</String>
+  <String Id="FailureInstallHeader">No se pudo instalar</String>
+  <String Id="FailureUninstallHeader">No se pudo desinstalar</String>
+  <String Id="FailureRepairHeader">No se pudo reparar</String>
+  <String Id="FailureHyperlinkLogText">Error de instalación debido a uno o varios problemas. Corrija los problemas e intente de nuevo la instalación. Para obtener más información, consulte el &lt;a href="#"&gt;archivo de registro&lt;/a&gt;.</String>
+  <String Id="FailureRestartText">Debe reiniciar el equipo para completar la reversión del software.</String>
+  <String Id="FailureRestartButton">&amp;Reiniciar</String>
+  <String Id="FailureCloseButton">&amp;Cerrar</String>
+  <String Id="FailureNotSupportedCurrentOperatingSystem">[PRODUCT_NAME] no se admite en este sistema operativo. Para obtener más información, consulte [LINK_PREREQ_PAGE].</String>
+  <String Id="FailureNotSupportedX86OperatingSystem">[PRODUCT_NAME] no es compatible con los sistemas operativos x86. Instálelo con el instalador x86 correspondiente.</String>
+  <String Id="FilesInUseHeader">Archivos en uso</String>
+  <String Id="FilesInUseLabel">Las siguientes aplicaciones usan archivos que se deben actualizar:</String>
+  <String Id="FilesInUseCloseRadioButton">Cerrar las &amp;aplicaciones e intentar reiniciarlas.</String>
+  <String Id="FilesInUseDontCloseRadioButton">&amp;No cerrar las aplicaciones. Será necesario un reinicio.</String>
+  <String Id="FilesInUseOkButton">&amp;Aceptar</String>
+  <String Id="FilesInUseCancelButton">&amp;Cancelar</String>
+  <String Id="WelcomeHeaderMessage"></String>
   <String Id="WelcomeDescription"></String>
-  <String Id="LearnMoreTitle">Learn more about .NET Core</String>
-  <String Id="SuccessInstallLocation">The following was installed at [DOTNETHOME]</String>
+  <String Id="LearnMoreTitle">Más información sobre .NET Core</String>
+  <String Id="SuccessInstallLocation">Lo siguiente se instaló en [DOTNETHOME]</String>
   <String Id="SuccessInstallProductName"> - [BUNDLEMONIKER] </String>
-  <String Id="ResourcesHeader">Resources</String>
-  <String Id="DocumentationLink">&lt;A HREF=&quot;https://aka.ms/dotnet-docs&quot;&gt;Documentation&lt;/A&gt;</String>
-  <String Id="RelaseNotesLink">&lt;A HREF=&quot;https://aka.ms/20-p2-rel-notes&quot;&gt;Release Notes&lt;/A&gt;</String>
-  <String Id="TutorialLink">&lt;A HREF=&quot;https://aka.ms/dotnet-tutorials&quot;&gt;Tutorials&lt;/A&gt;</String>
-  <String Id="TelemetryLink">&lt;A HREF=&quot;https://aka.ms/dotnet-cli-telemetry&quot;&gt;.NET Core Telemetry&lt;/A&gt;</String>
-  <String Id="PrivacyStatementLink">&lt;A HREF=&quot;https://aka.ms/dev-privacy&quot;&gt;Privacy Statement&lt;/A&gt;</String>
-  <String Id="EulaLink">&lt;A HREF=&quot;https://go.microsoft.com/fwlink/?LinkId=329770&quot;&gt;.NET Library EULA&lt;/A&gt;</String>
+  <String Id="ResourcesHeader">Recursos</String>
+  <String Id="DocumentationLink">&lt;A HREF="https://aka.ms/dotnet-docs"&gt;Documentación&lt;/A&gt;</String>
+  <String Id="RelaseNotesLink">&lt;A HREF="https://aka.ms/20-p2-rel-notes"&gt;Notas de la versión&lt;/A&gt;</String>
+  <String Id="TutorialLink">&lt;A HREF="https://aka.ms/dotnet-tutorials"&gt;Tutoriales&lt;/A&gt;</String>
+  <String Id="TelemetryLink">&lt;A HREF="https://aka.ms/dotnet-cli-telemetry"&gt;Telemetría de .NET Core&lt;/A&gt;</String>
+  <String Id="PrivacyStatementLink">&lt;A HREF="https://aka.ms/dev-privacy"&gt;Declaración de privacidad&lt;/A&gt;</String>
+  <String Id="EulaLink">&lt;A HREF="https://go.microsoft.com/fwlink/?LinkId=329770"&gt;CLUF de la biblioteca .NET&lt;/A&gt;</String>
   
 </WixLocalization>


### PR DESCRIPTION
Copy over branding from .NET Core Runtime bundle installer to Windows Desktop Runtime bundle installer, then remove the `WelcomeHeaderMessage` and `WelcomeDescription` strings that could be confusing in the WD context. The result is a WindowsDesktop bundle installer with no useful description, but with UI localization.

This should let us get the bundle installer ported to 3.0 for Preview 9. (Per https://github.com/dotnet/core-setup/issues/7530#issuecomment-522103307.)

Getting the bundle installer into 3.0 tracked by https://github.com/dotnet/core-setup/issues/6384.

/cc @vatsan-madhavan @merriemcgaw @dleeapho 