### PR TITLE
Make it more obvious what constitutes an invalid directory.

### DIFF
--- a/src/corehost/common/longfile.windows.cpp
+++ b/src/corehost/common/longfile.windows.cpp
@@ -127,9 +127,9 @@ bool LongFile::IsPathNotFullyQualified(const pal::string_t& path)
         return !IsDirectorySeparator(path[1]); // There is no valid way to specify a relative path with two initial slashes
     }
 
-    return !((path.length() >= 3)           //The only way to specify a fixed path that doesn't begin with two slashes is the drive, colon, slash format- "i.e. C:\"
-        && (path[1] == VolumeSeparatorChar)
-        && IsDirectorySeparator(path[2]));
+    return (path.length() < 3)           //The only way to specify a fixed path that doesn't begin with two slashes is the drive, colon, slash format- "i.e. C:\"
+        || (path[1] != VolumeSeparatorChar)
+        || !IsDirectorySeparator(path[2]);
 }
 
 bool LongFile::ContainsDirectorySeparator(const pal::string_t & path)


### PR DESCRIPTION
There is a line of code that returns with an exclamation mark operating on a series of boolean statements that would be better off negated individually.