### PR TITLE
Add single quotes to warnAsError:false to fix official build break during symbol publish

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -181,8 +181,9 @@ stages:
       enableSigningValidation: false
       # SourceLink validation doesn't work in dev builds: tries to pull from GitHub. https://github.com/dotnet/arcade/issues/3604
       enableSourceLinkValidation: false
-      # Allow symbol publish to emit expected warnings without failing the build.
-      symbolPublishingAdditionalParameters: -warnAsError:$false
+      # Allow symbol publish to emit expected warnings without failing the build. Include single
+      # quotes inside the string so that it passes through to MSBuild without script interference.
+      symbolPublishingAdditionalParameters: "'-warnAsError:$false'"
 
   - template: /eng/stages/custom-publish.yml
     parameters:


### PR DESCRIPTION
For example:
https://dev.azure.com/dnceng/internal/_build/results?buildId=314995&view=logs&s=a21ada51-e004-53d2-3ec7-8286e425df0d&j=ba74bb7f-eac9-54e1-9a19-7176689830db

```
MSBUILD : error MSB1008: Only one project can be specified.
Switch: False

For switch syntax, type "MSBuild -help"
##[error]Build failed.
```

I haven't debugged into why this happens, but adding single quotes fixes it locally. My suspicion is that at some point, PowerShell argument parsing tries to take it and it ends up passed to MSBuild in an unexpected way.

/cc @JohnTortugo @AaronRobinsonMSFT 