### PR TITLE
[release/3.0] Increase bundle's button size: avoid loc clipping

### DIFF
--- a/src/pkg/projects/netcoreapp/sfx/bundle.thm
+++ b/src/pkg/projects/netcoreapp/sfx/bundle.thm
@@ -15,7 +15,7 @@
 
         <Text Name="HelpHeader" X="11" Y="80" Width="-11" Height="30" FontId="2" DisablePrefix="yes">#(loc.HelpHeader)</Text>
         <Text Name="HelpText" X="20" Y="115" Width="-11" Height="-35" FontId="3" DisablePrefix="yes">#(loc.HelpText)</Text>
-        <Button Name="HelpCancelButton" X="-11" Y="-11" Width="75" Height="23" TabStop="yes" FontId="0">#(loc.HelpCloseButton)</Button>
+        <Button Name="HelpCancelButton" X="-31" Y="-11" Width="95" Height="23" TabStop="yes" FontId="0">#(loc.HelpCloseButton)</Button>
         <Image Name="BackgroundImage" X="0" Y="0" Width="620" Height="418" ImageFile="bg.png" />
     </Page>
     <Page Name="Install">
@@ -29,8 +29,8 @@
         <Hypertext Name="WelcomeDocumentationLink" X="185" Y="238" Width="400" Height="22" FontId="3" TabStop="yes" HideWhenDisabled="yes" DisablePrefix="yes">#(loc.DocumentationLink)</Hypertext>
         <Hypertext Name="PrivacyStatementLink" X="185" Y="259" Width="400" Height="22" FontId="3" TabStop="yes" HideWhenDisabled="yes" DisablePrefix="yes">#(loc.PrivacyStatementLink)</Hypertext>
         <Hypertext Name="EulaLink" X="185" Y="281" Width="400" Height="22" FontId="3" TabStop="yes" HideWhenDisabled="yes" DisablePrefix="yes">#(loc.EulaLink)</Hypertext>
-        <Button Name="InstallButton" X="-91" Y="-11" Width="75" Height="23" TabStop="yes" FontId="0">#(loc.InstallInstallButton)</Button>
-        <Button Name="WelcomeCancelButton" X="-11" Y="-11" Width="75" Height="23" TabStop="yes" FontId="0">#(loc.InstallCloseButton)</Button>
+        <Button Name="InstallButton" X="-131" Y="-11" Width="95" Height="23" TabStop="yes" FontId="0">#(loc.InstallInstallButton)</Button>
+        <Button Name="WelcomeCancelButton" X="-31" Y="-11" Width="95" Height="23" TabStop="yes" FontId="0">#(loc.InstallCloseButton)</Button>
     </Page>
     <Page Name="Options">
         <Image X="0" Y="0" Width="620" Height="418" ImageFile="bg.png" />
@@ -53,8 +53,8 @@
         <Button Name="FilesInUseCloseRadioButton" X="300" Y="-65" Width="-11" Height="23" TabStop="yes" FontId="0" HideWhenDisabled="yes" HexStyle="0x000009">#(loc.FilesInUseCloseRadioButton)</Button>
         <Button Name="FilesInUseDontCloseRadioButton" X="300" Y="-45" Width="-11" Height="23" TabStop="yes" FontId="0" HideWhenDisabled="yes" HexStyle="0x000009">#(loc.FilesInUseDontCloseRadioButton)</Button>
 
-        <Button Name="FilesInUseOkButton" X="-91" Y="-11" Width="75" Height="23" TabStop="yes" FontId="0" HideWhenDisabled="yes">#(loc.FilesInUseOkButton)</Button>
-        <Button Name="FilesInUseCancelButton" X="-11" Y="-11" Width="75" Height="23" TabStop="yes" FontId="0">#(loc.FilesInUseCancelButton)</Button>
+        <Button Name="FilesInUseOkButton" X="-131" Y="-11" Width="95" Height="23" TabStop="yes" FontId="0" HideWhenDisabled="yes">#(loc.FilesInUseOkButton)</Button>
+        <Button Name="FilesInUseCancelButton" X="-31" Y="-11" Width="95" Height="23" TabStop="yes" FontId="0">#(loc.FilesInUseCancelButton)</Button>
         <Image Name="BackgroundImage" X="0" Y="0" Width="620" Height="418" ImageFile="bg.png" />
     </Page>
     <Page Name="Progress">
@@ -65,16 +65,16 @@
         <Text Name="ProgressLabel" X="11" Y="121" Width="70" Height="17" FontId="3" DisablePrefix="yes">#(loc.ProgressLabel)</Text>
         <Text Name="OverallProgressPackageText" X="85" Y="121" Width="-11" Height="17" FontId="3" DisablePrefix="yes">#(loc.OverallProgressPackageText)</Text>
         <Progressbar Name="OverallCalculatedProgressbar" X="11" Y="143" Width="-11" Height="15" />
-        <Button Name="ProgressCancelButton" X="-11" Y="-11" Width="75" Height="23" TabStop="yes" FontId="0">#(loc.ProgressCancelButton)</Button>
+        <Button Name="ProgressCancelButton" X="-31" Y="-11" Width="95" Height="23" TabStop="yes" FontId="0">#(loc.ProgressCancelButton)</Button>
     </Page>
     <Page Name="Modify">
         <Image Name="BackgroundImage" X="0" Y="0" Width="620" Height="418" ImageFile="bg.png" />
         <Text X="0" Y="0" Width="660" Height="75" FontId="1" />
 
         <Text Name="ModifyHeader" X="11" Y="80" Width="-11" Height="30" FontId="2" DisablePrefix="yes">#(loc.ModifyHeader)</Text>
-        <Button Name="RepairButton" X="-171" Y="-11" Width="75" Height="23" TabStop="yes" FontId="0" HideWhenDisabled="yes">#(loc.ModifyRepairButton)</Button>
-        <Button Name="UninstallButton" X="-91" Y="-11" Width="75" Height="23" TabStop="yes" FontId="0">#(loc.ModifyUninstallButton)</Button>
-        <Button Name="ModifyCancelButton" X="-11" Y="-11" Width="75" Height="23" TabStop="yes" FontId="0">#(loc.ModifyCloseButton)</Button>
+        <Button Name="RepairButton" X="-231" Y="-11" Width="95" Height="23" TabStop="yes" FontId="0" HideWhenDisabled="yes">#(loc.ModifyRepairButton)</Button>
+        <Button Name="UninstallButton" X="-131" Y="-11" Width="95" Height="23" TabStop="yes" FontId="0">#(loc.ModifyUninstallButton)</Button>
+        <Button Name="ModifyCancelButton" X="-31" Y="-11" Width="95" Height="23" TabStop="yes" FontId="0">#(loc.ModifyCloseButton)</Button>
     </Page>
     <Page Name="Success">
         <Image Name="BackgroundImage" X="0" Y="0" Width="620" Height="418" ImageFile="bg.png" />
@@ -84,7 +84,7 @@
         <Text Name="SuccessInstallHeader" X="160" Y="80" Width="400" Height="30" FontId="2" HideWhenDisabled="yes" DisablePrefix="yes">#(loc.SuccessInstallHeader)</Text>
         <Text Name="SuccessRepairHeader" X="160" Y="80" Width="-11" Height="30" FontId="2" HideWhenDisabled="yes" DisablePrefix="yes">#(loc.SuccessRepairHeader)</Text>
         <Text Name="SuccessUninstallHeader" X="160" Y="80" Width="-11" Height="30" FontId="2" HideWhenDisabled="yes" DisablePrefix="yes">#(loc.SuccessUninstallHeader)</Text>
-        <Button Name="LaunchButton" X="-91" Y="-11" Width="75" Height="23" TabStop="yes" FontId="0" HideWhenDisabled="yes">#(loc.SuccessLaunchButton)</Button>
+        <Button Name="LaunchButton" X="-131" Y="-11" Width="95" Height="23" TabStop="yes" FontId="0" HideWhenDisabled="yes">#(loc.SuccessLaunchButton)</Button>
         <Text Name="SuccessRestartText" X="-11" Y="-51" Width="400" Height="34" FontId="3" HideWhenDisabled="yes" DisablePrefix="yes">#(loc.SuccessRestartText)</Text>
         
          <Text Name="SuccessInstallLocation" X="160" Y="130" Width="400" Height="20" FontId="3" HideWhenDisabled="yes" DisablePrefix="yes">#(loc.SuccessInstallLocation)</Text>
@@ -95,8 +95,8 @@
          <Hypertext Name="TutorialLink" X="185" Y="280" Width="400" Height="22" FontId="3" TabStop="yes" HideWhenDisabled="yes" DisablePrefix="yes">#(loc.TutorialLink)</Hypertext>
          <Hypertext Name="TelemetryLink" X="185" Y="301" Width="400" Height="22" FontId="3" TabStop="yes" HideWhenDisabled="yes" DisablePrefix="yes">#(loc.TelemetryLink)</Hypertext>
         
-        <Button Name="SuccessRestartButton" X="-91" Y="-11" Width="75" Height="23" TabStop="yes" FontId="0" HideWhenDisabled="yes">#(loc.SuccessRestartButton)</Button>
-        <Button Name="SuccessCancelButton" X="-11" Y="-11" Width="75" Height="23" TabStop="yes" FontId="0">#(loc.SuccessCloseButton)</Button>
+        <Button Name="SuccessRestartButton" X="-131" Y="-11" Width="95" Height="23" TabStop="yes" FontId="0" HideWhenDisabled="yes">#(loc.SuccessRestartButton)</Button>
+        <Button Name="SuccessCancelButton" X="-31" Y="-11" Width="95" Height="23" TabStop="yes" FontId="0">#(loc.SuccessCloseButton)</Button>
     </Page>
     <Page Name="Failure">
         <Image Name="BackgroundImage" X="0" Y="0" Width="620" Height="418" ImageFile="bg.png" />
@@ -109,7 +109,7 @@
         <Hypertext Name="FailureLogFileLink" X="11" Y="121" Width="-11" Height="42" FontId="3" TabStop="yes" HideWhenDisabled="yes">#(loc.FailureHyperlinkLogText)</Hypertext>
         <Hypertext Name="FailureMessageText" X="22" Y="163" Width="-11" Height="51" FontId="3" TabStop="yes" HideWhenDisabled="yes" />
         <Text Name="FailureRestartText" X="-11" Y="-51" Width="400" Height="34" FontId="3" HideWhenDisabled="yes" DisablePrefix="yes">#(loc.FailureRestartText)</Text>
-        <Button Name="FailureRestartButton" X="-91" Y="-11" Width="75" Height="23" TabStop="yes" FontId="0" HideWhenDisabled="yes">#(loc.FailureRestartButton)</Button>
-        <Button Name="FailureCloseButton" X="-11" Y="-11" Width="75" Height="23" TabStop="yes" FontId="0">#(loc.FailureCloseButton)</Button>
+        <Button Name="FailureRestartButton" X="-131" Y="-11" Width="95" Height="23" TabStop="yes" FontId="0" HideWhenDisabled="yes">#(loc.FailureRestartButton)</Button>
+        <Button Name="FailureCloseButton" X="-31" Y="-11" Width="95" Height="23" TabStop="yes" FontId="0">#(loc.FailureCloseButton)</Button>
     </Page>
 </Theme>

--- a/src/pkg/projects/windowsdesktop/sfx/bundle.thm
+++ b/src/pkg/projects/windowsdesktop/sfx/bundle.thm
@@ -15,7 +15,7 @@
 
         <Text Name="HelpHeader" X="11" Y="80" Width="-11" Height="30" FontId="2" DisablePrefix="yes">#(loc.HelpHeader)</Text>
         <Text Name="HelpText" X="20" Y="115" Width="-11" Height="-35" FontId="3" DisablePrefix="yes">#(loc.HelpText)</Text>
-        <Button Name="HelpCancelButton" X="-11" Y="-11" Width="75" Height="23" TabStop="yes" FontId="0">#(loc.HelpCloseButton)</Button>
+        <Button Name="HelpCancelButton" X="-31" Y="-11" Width="95" Height="23" TabStop="yes" FontId="0">#(loc.HelpCloseButton)</Button>
         <Image Name="BackgroundImage" X="0" Y="0" Width="620" Height="418" ImageFile="bg.png" />
     </Page>
     <Page Name="Install">
@@ -29,8 +29,8 @@
         <Hypertext Name="WelcomeDocumentationLink" X="185" Y="238" Width="400" Height="22" FontId="3" TabStop="yes" HideWhenDisabled="yes" DisablePrefix="yes">#(loc.DocumentationLink)</Hypertext>
         <Hypertext Name="PrivacyStatementLink" X="185" Y="259" Width="400" Height="22" FontId="3" TabStop="yes" HideWhenDisabled="yes" DisablePrefix="yes">#(loc.PrivacyStatementLink)</Hypertext>
         <Hypertext Name="EulaLink" X="185" Y="281" Width="400" Height="22" FontId="3" TabStop="yes" HideWhenDisabled="yes" DisablePrefix="yes">#(loc.EulaLink)</Hypertext>
-        <Button Name="InstallButton" X="-91" Y="-11" Width="75" Height="23" TabStop="yes" FontId="0">#(loc.InstallInstallButton)</Button>
-        <Button Name="WelcomeCancelButton" X="-11" Y="-11" Width="75" Height="23" TabStop="yes" FontId="0">#(loc.InstallCloseButton)</Button>
+        <Button Name="InstallButton" X="-131" Y="-11" Width="95" Height="23" TabStop="yes" FontId="0">#(loc.InstallInstallButton)</Button>
+        <Button Name="WelcomeCancelButton" X="-31" Y="-11" Width="95" Height="23" TabStop="yes" FontId="0">#(loc.InstallCloseButton)</Button>
     </Page>
     <Page Name="Options">
         <Image X="0" Y="0" Width="620" Height="418" ImageFile="bg.png" />
@@ -53,8 +53,8 @@
         <Button Name="FilesInUseCloseRadioButton" X="300" Y="-65" Width="-11" Height="23" TabStop="yes" FontId="0" HideWhenDisabled="yes" HexStyle="0x000009">#(loc.FilesInUseCloseRadioButton)</Button>
         <Button Name="FilesInUseDontCloseRadioButton" X="300" Y="-45" Width="-11" Height="23" TabStop="yes" FontId="0" HideWhenDisabled="yes" HexStyle="0x000009">#(loc.FilesInUseDontCloseRadioButton)</Button>
 
-        <Button Name="FilesInUseOkButton" X="-91" Y="-11" Width="75" Height="23" TabStop="yes" FontId="0" HideWhenDisabled="yes">#(loc.FilesInUseOkButton)</Button>
-        <Button Name="FilesInUseCancelButton" X="-11" Y="-11" Width="75" Height="23" TabStop="yes" FontId="0">#(loc.FilesInUseCancelButton)</Button>
+        <Button Name="FilesInUseOkButton" X="-131" Y="-11" Width="95" Height="23" TabStop="yes" FontId="0" HideWhenDisabled="yes">#(loc.FilesInUseOkButton)</Button>
+        <Button Name="FilesInUseCancelButton" X="-31" Y="-11" Width="95" Height="23" TabStop="yes" FontId="0">#(loc.FilesInUseCancelButton)</Button>
         <Image Name="BackgroundImage" X="0" Y="0" Width="620" Height="418" ImageFile="bg.png" />
     </Page>
     <Page Name="Progress">
@@ -65,16 +65,16 @@
         <Text Name="ProgressLabel" X="11" Y="121" Width="70" Height="17" FontId="3" DisablePrefix="yes">#(loc.ProgressLabel)</Text>
         <Text Name="OverallProgressPackageText" X="85" Y="121" Width="-11" Height="17" FontId="3" DisablePrefix="yes">#(loc.OverallProgressPackageText)</Text>
         <Progressbar Name="OverallCalculatedProgressbar" X="11" Y="143" Width="-11" Height="15" />
-        <Button Name="ProgressCancelButton" X="-11" Y="-11" Width="75" Height="23" TabStop="yes" FontId="0">#(loc.ProgressCancelButton)</Button>
+        <Button Name="ProgressCancelButton" X="-31" Y="-11" Width="95" Height="23" TabStop="yes" FontId="0">#(loc.ProgressCancelButton)</Button>
     </Page>
     <Page Name="Modify">
         <Image Name="BackgroundImage" X="0" Y="0" Width="620" Height="418" ImageFile="bg.png" />
         <Text X="0" Y="0" Width="660" Height="75" FontId="1" />
 
         <Text Name="ModifyHeader" X="11" Y="80" Width="-11" Height="30" FontId="2" DisablePrefix="yes">#(loc.ModifyHeader)</Text>
-        <Button Name="RepairButton" X="-171" Y="-11" Width="75" Height="23" TabStop="yes" FontId="0" HideWhenDisabled="yes">#(loc.ModifyRepairButton)</Button>
-        <Button Name="UninstallButton" X="-91" Y="-11" Width="75" Height="23" TabStop="yes" FontId="0">#(loc.ModifyUninstallButton)</Button>
-        <Button Name="ModifyCancelButton" X="-11" Y="-11" Width="75" Height="23" TabStop="yes" FontId="0">#(loc.ModifyCloseButton)</Button>
+        <Button Name="RepairButton" X="-231" Y="-11" Width="95" Height="23" TabStop="yes" FontId="0" HideWhenDisabled="yes">#(loc.ModifyRepairButton)</Button>
+        <Button Name="UninstallButton" X="-131" Y="-11" Width="95" Height="23" TabStop="yes" FontId="0">#(loc.ModifyUninstallButton)</Button>
+        <Button Name="ModifyCancelButton" X="-31" Y="-11" Width="95" Height="23" TabStop="yes" FontId="0">#(loc.ModifyCloseButton)</Button>
     </Page>
     <Page Name="Success">
         <Image Name="BackgroundImage" X="0" Y="0" Width="620" Height="418" ImageFile="bg.png" />
@@ -84,7 +84,7 @@
         <Text Name="SuccessInstallHeader" X="160" Y="80" Width="400" Height="30" FontId="2" HideWhenDisabled="yes" DisablePrefix="yes">#(loc.SuccessInstallHeader)</Text>
         <Text Name="SuccessRepairHeader" X="160" Y="80" Width="-11" Height="30" FontId="2" HideWhenDisabled="yes" DisablePrefix="yes">#(loc.SuccessRepairHeader)</Text>
         <Text Name="SuccessUninstallHeader" X="160" Y="80" Width="-11" Height="30" FontId="2" HideWhenDisabled="yes" DisablePrefix="yes">#(loc.SuccessUninstallHeader)</Text>
-        <Button Name="LaunchButton" X="-91" Y="-11" Width="75" Height="23" TabStop="yes" FontId="0" HideWhenDisabled="yes">#(loc.SuccessLaunchButton)</Button>
+        <Button Name="LaunchButton" X="-131" Y="-11" Width="95" Height="23" TabStop="yes" FontId="0" HideWhenDisabled="yes">#(loc.SuccessLaunchButton)</Button>
         <Text Name="SuccessRestartText" X="-11" Y="-51" Width="400" Height="34" FontId="3" HideWhenDisabled="yes" DisablePrefix="yes">#(loc.SuccessRestartText)</Text>
         
          <Text Name="SuccessInstallLocation" X="160" Y="130" Width="400" Height="20" FontId="3" HideWhenDisabled="yes" DisablePrefix="yes">#(loc.SuccessInstallLocation)</Text>
@@ -95,8 +95,8 @@
          <Hypertext Name="TutorialLink" X="185" Y="280" Width="400" Height="22" FontId="3" TabStop="yes" HideWhenDisabled="yes" DisablePrefix="yes">#(loc.TutorialLink)</Hypertext>
          <Hypertext Name="TelemetryLink" X="185" Y="301" Width="400" Height="22" FontId="3" TabStop="yes" HideWhenDisabled="yes" DisablePrefix="yes">#(loc.TelemetryLink)</Hypertext>
         
-        <Button Name="SuccessRestartButton" X="-91" Y="-11" Width="75" Height="23" TabStop="yes" FontId="0" HideWhenDisabled="yes">#(loc.SuccessRestartButton)</Button>
-        <Button Name="SuccessCancelButton" X="-11" Y="-11" Width="75" Height="23" TabStop="yes" FontId="0">#(loc.SuccessCloseButton)</Button>
+        <Button Name="SuccessRestartButton" X="-131" Y="-11" Width="95" Height="23" TabStop="yes" FontId="0" HideWhenDisabled="yes">#(loc.SuccessRestartButton)</Button>
+        <Button Name="SuccessCancelButton" X="-31" Y="-11" Width="95" Height="23" TabStop="yes" FontId="0">#(loc.SuccessCloseButton)</Button>
     </Page>
     <Page Name="Failure">
         <Image Name="BackgroundImage" X="0" Y="0" Width="620" Height="418" ImageFile="bg.png" />
@@ -109,7 +109,7 @@
         <Hypertext Name="FailureLogFileLink" X="11" Y="121" Width="-11" Height="42" FontId="3" TabStop="yes" HideWhenDisabled="yes">#(loc.FailureHyperlinkLogText)</Hypertext>
         <Hypertext Name="FailureMessageText" X="22" Y="163" Width="-11" Height="51" FontId="3" TabStop="yes" HideWhenDisabled="yes" />
         <Text Name="FailureRestartText" X="-11" Y="-51" Width="400" Height="34" FontId="3" HideWhenDisabled="yes" DisablePrefix="yes">#(loc.FailureRestartText)</Text>
-        <Button Name="FailureRestartButton" X="-91" Y="-11" Width="75" Height="23" TabStop="yes" FontId="0" HideWhenDisabled="yes">#(loc.FailureRestartButton)</Button>
-        <Button Name="FailureCloseButton" X="-11" Y="-11" Width="75" Height="23" TabStop="yes" FontId="0">#(loc.FailureCloseButton)</Button>
+        <Button Name="FailureRestartButton" X="-131" Y="-11" Width="95" Height="23" TabStop="yes" FontId="0" HideWhenDisabled="yes">#(loc.FailureRestartButton)</Button>
+        <Button Name="FailureCloseButton" X="-31" Y="-11" Width="95" Height="23" TabStop="yes" FontId="0">#(loc.FailureCloseButton)</Button>
     </Page>
 </Theme>


### PR DESCRIPTION
Ports https://github.com/dotnet/core-setup/pull/7757 to `release/3.0`. For https://github.com/dotnet/core-setup/issues/6532 and https://github.com/dotnet/core-setup/issues/6679.

**This PR contains commits from https://github.com/dotnet/core-setup/pull/7764 because this PR strongly depends on the changes in https://github.com/dotnet/core-setup/pull/7764. Only the last commit (https://github.com/dotnet/core-setup/commit/8efb758ead76a3357a09334eb45394d566d57505) contains the changes for review + approval.** The plan is to merge https://github.com/dotnet/core-setup/pull/7764 first, then rebase this PR to remove the extra commits, then merge this PR.

#### Description

Fixes an issue where the Install and Uninstall buttons are too short for the Japanese text, causing clipping.

<details>
<summary>Screenshots (click me)</summary>

| | | |
| --- | --- | --- |
| Install (before) | <img alt="install_en" src="https://user-images.githubusercontent.com/12819531/63279812-4cf82500-c26f-11e9-889f-ce80967376b4.png"> | <img alt="install_jp" src="https://user-images.githubusercontent.com/12819531/63279813-4cf82500-c26f-11e9-8d29-4b7be75eda42.png"> |
| Install (fixed) | <img alt="install_en" src="https://user-images.githubusercontent.com/12819531/63278026-1a98f880-c26c-11e9-9fe3-71ec3c6ad20d.png"> | <img alt="install_jp" src="https://user-images.githubusercontent.com/12819531/63278029-1d93e900-c26c-11e9-9a9e-2e363edbc19f.png"> |
| Uninstall (before) | <img alt="uninstall_en" src="https://user-images.githubusercontent.com/12819531/63279815-4cf82500-c26f-11e9-8ef8-7313ebc5146d.png"> | <img alt="uninstall_jp" src="https://user-images.githubusercontent.com/12819531/63279816-4d90bb80-c26f-11e9-8e50-c7ab68bc35b6.png"> |
| Uninstall (fixed) | <img alt="uninstall_en" src="https://user-images.githubusercontent.com/12819531/63278037-1ff64300-c26c-11e9-98db-c1dca6c6543b.png"> | <img alt="uninstall_jp" src="https://user-images.githubusercontent.com/12819531/63278045-22f13380-c26c-11e9-9296-b55df6f8ecd8.png"> |

</details>

#### Customer Impact

Users with Japanese localization will be able to fully read the Install and Uninstall buttons.

#### Regression?

No. This issue has been present since localization was introduced.

#### Risk

Minimal. It's trivial to move and expand the buttons a little, and I posted screenshots for comparison of the affected buttons, including how it looks in English now. This fix is also the same as the fix taken in Core-SDK for the same issue.

/cc @dleeapho 