### PR TITLE
Bundles: Align assemblies at a 4K boundary

### DIFF
--- a/src/managed/Microsoft.NET.HostModel/Bundle/Bundler.cs
+++ b/src/managed/Microsoft.NET.HostModel/Bundle/Bundler.cs
@@ -129,21 +129,6 @@ namespace Microsoft.NET.HostModel.Bundle
         }
 
         /// <summary>
-        /// Determine whether files of this type will be aligned
-        /// in the bundle.
-        /// <paramref name="type">
-        /// The FileType to examine
-        /// </paramref>
-        /// <returns>
-        /// Whether a file of this type will be aligned
-        /// </returns>
-        /// </summary>
-        public static bool NeedsAlignment(FileType type)
-        {
-            return type == FileType.IL || type == FileType.Ready2Run;
-        }
-
-        /// <summary>
         /// Generate a bundle, given the specification of embedded files
         /// </summary>
         /// <param name="fileSpecs">
@@ -175,7 +160,7 @@ namespace Microsoft.NET.HostModel.Bundle
                 throw new ArgumentException("Invalid input specification: Must specify the host binary");
             }
 
-            if(fileSpecs.GroupBy(file => file.BundleRelativePath).Where(g => g.Count() > 1).Any())
+            if (fileSpecs.GroupBy(file => file.BundleRelativePath).Where(g => g.Count() > 1).Any())
             {
                 throw new ArgumentException("Invalid input specification: Found multiple entries with the same BundleRelativePath");
             }
@@ -204,6 +189,7 @@ namespace Microsoft.NET.HostModel.Bundle
                 // TODO: Order file writes to minimize file size.
 
                 List<Tuple<FileSpec, FileType>> ailgnedFiles = new List<Tuple<FileSpec, FileType>>();
+                bool NeedsAlignment(FileType type) => type == FileType.IL || type == FileType.Ready2Run;
 
                 foreach (var fileSpec in fileSpecs)
                 {
@@ -217,7 +203,7 @@ namespace Microsoft.NET.HostModel.Bundle
                     {
                         FileType type = InferType(fileSpec.BundleRelativePath, file);
 
-                        if(NeedsAlignment(type))
+                        if (NeedsAlignment(type))
                         {
                             ailgnedFiles.Add(Tuple.Create(fileSpec, type));
                             continue;
@@ -282,7 +268,7 @@ namespace Microsoft.NET.HostModel.Bundle
             Array.Sort(sources, StringComparer.Ordinal);
 
             List<FileSpec> fileSpecs = new List<FileSpec>(sources.Length);
-            foreach(var file in sources)
+            foreach (var file in sources)
             {
                 fileSpecs.Add(new FileSpec(file, RelativePath(sourceDir, file)));
             }

--- a/src/managed/Microsoft.NET.HostModel/Bundle/Bundler.cs
+++ b/src/managed/Microsoft.NET.HostModel/Bundle/Bundler.cs
@@ -30,10 +30,11 @@ namespace Microsoft.NET.HostModel.Bundle
         /// <summary>
         /// Align embedded assemblies such that they can be loaded 
         /// directly from memory-mapped bundle.
-        /// TBD: Set the correct value of alignment while working on 
-        /// the runtime changes to load the embedded assemblies.
+        /// 
+        /// TBD: Determine if this is the minimum required alignment 
+        /// on all platforms and assembly types (and customize the padding accordingly).
         /// </summary>
-        const int AssemblyAlignment = 16;
+        public const int AssemblyAlignment = 4096;
 
         public static string Version => (Manifest.MajorVersion + "." + Manifest.MinorVersion);
 
@@ -57,10 +58,9 @@ namespace Microsoft.NET.HostModel.Bundle
         /// </summary>
         /// <returns>Returns the offset of the start 'file' within 'bundle'</returns>
 
-        long AddToBundle(Stream bundle, Stream file, FileType type = FileType.Extract)
+        long AddToBundle(Stream bundle, Stream file, bool shouldAlign)
         {
-            // Allign assemblies, since they are loaded directly from bundle
-            if (type == FileType.Assembly)
+            if (shouldAlign)
             {
                 long misalignment = (bundle.Position % AssemblyAlignment);
 
@@ -116,16 +116,31 @@ namespace Microsoft.NET.HostModel.Bundle
             {
                 PEReader peReader = new PEReader(file);
                 CorHeader corHeader = peReader.PEHeaders.CorHeader;
-                if ((corHeader != null) && ((corHeader.Flags & CorFlags.ILOnly) != 0))
+                if (corHeader != null)
                 {
-                    return FileType.Assembly;
+                    return ((corHeader.Flags & CorFlags.ILOnly) != 0) ? FileType.IL : FileType.Ready2Run;
                 }
             }
             catch (BadImageFormatException)
             {
             }
 
-            return FileType.Extract;
+            return FileType.Other;
+        }
+
+        /// <summary>
+        /// Determine whether files of this type will be aligned
+        /// in the bundle.
+        /// <paramref name="type">
+        /// The FileType to examine
+        /// </paramref>
+        /// <returns>
+        /// Whether a file of this type will be aligned
+        /// </returns>
+        /// </summary>
+        public static bool NeedsAlignment(FileType type)
+        {
+            return type == FileType.IL || type == FileType.Ready2Run;
         }
 
         /// <summary>
@@ -180,6 +195,16 @@ namespace Microsoft.NET.HostModel.Bundle
                 bundle.Position = bundle.Length;
 
                 // Write the files from the specification into the bundle
+                // Alignment: 
+                //   Assemblies are written aligned at "AssemblyAlignment" bytes to facilitate loading from bundle
+                //   Remaining files (native binaries and other files) are written without alignment.
+                //
+                // The unaligned files are written first, followed by the aligned files, 
+                // and finally the bundle manifest. 
+                // TODO: Order file writes to minimize file size.
+
+                List<Tuple<FileSpec, FileType>> ailgnedFiles = new List<Tuple<FileSpec, FileType>>();
+
                 foreach (var fileSpec in fileSpecs)
                 {
                     if (!ShouldEmbed(fileSpec.BundleRelativePath))
@@ -191,7 +216,27 @@ namespace Microsoft.NET.HostModel.Bundle
                     using (FileStream file = File.OpenRead(fileSpec.SourcePath))
                     {
                         FileType type = InferType(fileSpec.BundleRelativePath, file);
-                        long startOffset = AddToBundle(bundle, file, type);
+
+                        if(NeedsAlignment(type))
+                        {
+                            ailgnedFiles.Add(Tuple.Create(fileSpec, type));
+                            continue;
+                        }
+
+                        long startOffset = AddToBundle(bundle, file, shouldAlign:false);
+                        FileEntry entry = BundleManifest.AddEntry(type, fileSpec.BundleRelativePath, startOffset, file.Length);
+                        trace.Log($"Embed: {entry}");
+                    }
+                }
+
+                foreach (var tuple in ailgnedFiles)
+                {
+                    var fileSpec = tuple.Item1;
+                    var type = tuple.Item2;
+
+                    using (FileStream file = File.OpenRead(fileSpec.SourcePath))
+                    {
+                        long startOffset = AddToBundle(bundle, file, shouldAlign: true);
                         FileEntry entry = BundleManifest.AddEntry(type, fileSpec.BundleRelativePath, startOffset, file.Length);
                         trace.Log($"Embed: {entry}");
                     }

--- a/src/managed/Microsoft.NET.HostModel/Bundle/FileType.cs
+++ b/src/managed/Microsoft.NET.HostModel/Bundle/FileType.cs
@@ -9,21 +9,14 @@ namespace Microsoft.NET.HostModel.Bundle
     /// 
     /// The bundler differentiates a few kinds of files via the manifest,
     /// with respect to the way in which they'll be used by the runtime.
-    ///
-    /// - Runtime Configuration files: Processed directly from memory
-    /// - Assemblies: Loaded directly from memory.
-    ///               Currently, these are only pure-managed assemblies.
-    ///               Future versions should include R2R assemblies here.
-    /// - Other files: Files that will be extracted out to disk. 
-    ///                These include native binaries.
     /// </summary>
     public enum FileType : byte
     {
-        Assembly,           // IL Assemblies, which will be processed from bundle
-        Ready2Run,          // R2R assemblies, currently unused, spilled to disk.
-        DepsJson,           // Configuration file, processed from bundle
-        RuntimeConfigJson,  // Configuration file, processed from bundle
-        Extract             // Files spilled to disk by the host
+        IL,                // IL Assemblies
+        Ready2Run,         // R2R assemblies
+        DepsJson,          // .deps.json configuration file
+        RuntimeConfigJson, // .runtimeconfig.json configuration file
+        Other              // Other files, including native binaries
     };
 }
 

--- a/src/test/BundleTests/Microsoft.NET.HostModel.Bundle.Tests/BundlerConsistencyTests.cs
+++ b/src/test/BundleTests/Microsoft.NET.HostModel.Bundle.Tests/BundlerConsistencyTests.cs
@@ -144,6 +144,26 @@ namespace Microsoft.NET.HostModel.Tests
         }
 
         [Fact]
+        public void TestAssemblyAlignment()
+        {
+            var fixture = sharedTestState.TestFixture.Copy();
+
+            var hostName = BundleHelper.GetHostName(fixture);
+            var appName = Path.GetFileNameWithoutExtension(hostName);
+            string publishPath = BundleHelper.GetPublishPath(fixture);
+            var bundleDir = BundleHelper.GetBundleDir(fixture);
+
+            var bundler = new Bundler(hostName, bundleDir.FullName);
+            bundler.GenerateBundle(BundleHelper.GetPublishPath(fixture));
+
+            foreach(var fileEntry in bundler.BundleManifest.Files)
+            {
+                Assert.True(!Bundler.NeedsAlignment(fileEntry.Type) || 
+                            fileEntry.Offset % Bundler.AssemblyAlignment == 0);
+            }
+        }
+
+        [Fact]
         public void TestWithAdditionalContentAfterBundleMetadata()
         {
             var fixture = sharedTestState.TestFixture.Copy();

--- a/src/test/BundleTests/Microsoft.NET.HostModel.Bundle.Tests/BundlerConsistencyTests.cs
+++ b/src/test/BundleTests/Microsoft.NET.HostModel.Bundle.Tests/BundlerConsistencyTests.cs
@@ -156,11 +156,9 @@ namespace Microsoft.NET.HostModel.Tests
             var bundler = new Bundler(hostName, bundleDir.FullName);
             bundler.GenerateBundle(BundleHelper.GetPublishPath(fixture));
 
-            foreach(var fileEntry in bundler.BundleManifest.Files)
-            {
-                Assert.True(!Bundler.NeedsAlignment(fileEntry.Type) || 
-                            fileEntry.Offset % Bundler.AssemblyAlignment == 0);
-            }
+            bundler.BundleManifest.Files.ForEach(file => 
+                Assert.True((file.Type != FileType.IL && file.Type != FileType.Ready2Run) ||
+                            (file.Offset % Bundler.AssemblyAlignment == 0)));
         }
 
         [Fact]


### PR DESCRIPTION
Align assemblies at a 4K boundary to facilitate their load
directly from the (memory-mapped) bundle by the runtime.

Assemblies are written with 4K alignment to facilitate loading from bundle
Remaining files (native binaries and other files) are written without alignment.

The unaligned files are written first, followed by the aligned files,
and finally the bundle manifest.

Further work is required to order the files better in order to minimize bundle size.

Bundle size change due to this change:
Console self-contained win10-x64: Increased by 0.3 MB (67.95 -> 68.26)
WebAPI self-contained win10-x64: Increased by 0.5 MB (84.53 -> 85.10)

- Please add a description for changes you are making.
- If there is an issue related to this PR, please add a reference to it.
- If this PR should not run tests please add say skip_ci_please in this description replacing the underscores with spaces.