### PR TITLE
Enable publishing for release channel

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -203,7 +203,7 @@ stages:
         channel:
           name: .NET Core 3 Release
           bar: PublicRelease_30_Channel_Id
-          storage: release/3.0
+          storage: release/3.0-preview9
       - dependsOn: NetCore_Dev5_PublishValidation
         channel:
           name: .NET Core 5 Dev

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -199,6 +199,11 @@ stages:
           name: .NET Core 3 Dev
           bar: PublicDevRelease_30_Channel_Id
           storage: release/3.0
+      - dependsOn: PublishValidation
+        channel:
+          name: .NET Core 3 Release
+          bar: PublicRelease_30_Channel_Id
+          storage: release/3.0
       - dependsOn: NetCore_Dev5_PublishValidation
         channel:
           name: .NET Core 5 Dev


### PR DESCRIPTION
#### Description

Preview9 builds are blocked because the custom publishing steps don't run for the release channel.

#### Customer Impact

No build