### PR TITLE
[release/3.0] Categorize shipping/nonshipping NuGet packages

### DIFF
--- a/publish/Directory.Build.targets
+++ b/publish/Directory.Build.targets
@@ -23,7 +23,16 @@
         Include="$(DownloadDirectory)**\*.nupkg"
         Exclude="@(DownloadedSymbolNupkgFile)" />
 
-      <!-- RID-specific nupkg. These are published from every job. -->
+      <!-- Add files that are not affected by filtering. -->
+      <UploadToBlobStorageFile
+        Include="@(DownloadedArtifactFile)"
+        Exclude="@(DownloadedSymbolNupkgFile);@(DownloadedNupkgFile)" />
+
+      <!--
+        Filter out the RID-specific (Runtime) nupkgs and RID-agnostic nupkgs. RID-specific packages
+        are published from every job. RID-agnostic nupkgs are built with the same ID/version by
+        every job, so one specific job's outputs must be picked to sign and publish.
+      -->
       <RuntimeNupkgFile
         Include="
           $(DownloadDirectory)**\runtime.*.nupkg;
@@ -32,29 +41,34 @@
           $(DownloadDirectory)**\VS.Redist.Common.*.nupkg"
         Exclude="@(DownloadedSymbolNupkgFile)" />
 
-      <!--
-        RID-agnostic nupkg. These are built with the same ID/version by every job, so only one job's
-        results are picked for signing and publishing.
-      -->
       <RidAgnosticNupkgToPublishFile
         Include="$(DownloadDirectory)*\$(PublishRidAgnosticPackagesFromJobName)\**\*.nupkg"
         Exclude="@(RuntimeNupkgFile);@(DownloadedSymbolNupkgFile)" />
-      
-      <RidAgnosticNupkgToIgnoreFile
-        Include="@(DownloadedNupkgFile)"
-        Exclude="@(RidAgnosticNupkgToPublishFile);@(RuntimeNupkgFile)" />
-
-      <RidAgnosticSymbolNupkgToIgnoreFile
-        Include="@(RidAgnosticNupkgToIgnoreFile -> '%(RootDir)%(Directory)%(Filename).symbols.nupkg')" />
 
       <NupkgToPublishFile Include="@(RuntimeNupkgFile);@(RidAgnosticNupkgToPublishFile)" />
-      <SymbolNupkgToPublishFile Include="@(DownloadedSymbolNupkgFile)" Exclude="@(RidAgnosticSymbolNupkgToIgnoreFile)" />
 
-      <!-- Filter out duplicate nupkgs/symbols.nupkgs, but other artifacts are fine. -->
-      <UploadToBlobStorageFile
-        Include="@(DownloadedArtifactFile)"
-        Exclude="@(RidAgnosticNupkgToIgnoreFile);@(RidAgnosticSymbolNupkgToIgnoreFile)" />
+      <UploadToBlobStorageFile Include="@(NupkgToPublishFile)" />
+
+      <!--
+        Assuming all symbol packages ship and can be found by turning .nupkg => .symbols.nupkg, find
+        them. Don't check for missing symbol packages here: some nupkgs don't have them for valid
+        reasons, such as the VS insertion packages that transport MSIs. Symbol package validation
+        will check for symbol completeness with file-by-file granularity rather than looking for
+        missing symbols.nupkg files: https://github.com/dotnet/arcade/issues/2499.
+      -->
+      <PotentialSymbolNupkgToPublishFile
+        Include="@(NupkgToPublishFile->Replace('\NonShipping\', '\Shipping\')->Replace('.nupkg', '.symbols.nupkg'))" />
+
+      <SymbolNupkgToPublishFile
+        Include="@(PotentialSymbolNupkgToPublishFile)"
+        Condition="Exists('%(Identity)')" />
+
+      <UploadToBlobStorageFile Include="@(SymbolNupkgToPublishFile)" />
     </ItemGroup>
+
+    <Error
+      Condition="'@(SymbolNupkgToPublishFile)' == ''"
+      Text="No symbol packages found." />
   </Target>
 
   <Import Project="..\Directory.Build.targets" />

--- a/publish/prepare-artifacts.proj
+++ b/publish/prepare-artifacts.proj
@@ -41,9 +41,19 @@
     </PropertyGroup>
 
     <ItemGroup>
+      <!-- Split nupkgs into shipping/nonshipping for BAR categorization. -->
+      <ShippingNupkgToPublishFile
+        Include="@(NupkgToPublishFile)"
+        Condition="$([System.String]::new('%(Identity)').Contains('\Shipping\'))" />
+
+      <NonShippingNupkgToPublishFile
+        Include="@(NupkgToPublishFile)"
+        Exclude="@(ShippingNupkgToPublishFile)" />
+
       <ItemsToPush Remove="@(ItemsToPush)" />
 
-      <ItemsToPush Include="@(NupkgToPublishFile)" />
+      <ItemsToPush Include="@(ShippingNupkgToPublishFile)" />
+      <ItemsToPush Include="@(NonShippingNupkgToPublishFile)" ManifestArtifactData="NonShipping=true" />
       <ItemsToPush Include="@(SymbolNupkgToPublishFile)" />
     </ItemGroup>
 

--- a/src/pkg/packaging-tools/framework.sharedfx.props
+++ b/src/pkg/packaging-tools/framework.sharedfx.props
@@ -21,7 +21,7 @@
     <MicrosoftNETPlatformLibrary>do-not-consider-existing-platform</MicrosoftNETPlatformLibrary>
 
     <!-- Only Restore from our built packages -->
-    <RestoreSources>$(ArtifactsShippingPackagesDir)</RestoreSources>
+    <RestoreSources>$(ArtifactsShippingPackagesDir);$(ArtifactsNonShippingPackagesDir)</RestoreSources>
     <AddDotnetfeedProjectSource>false</AddDotnetfeedProjectSource>
     <RestoreAllBuildRids>false</RestoreAllBuildRids>
     <!-- Ensure only this repo's NuGet.config file is used. -->

--- a/src/pkg/projects/netcoreapp/pkg/legacy/Directory.Build.props
+++ b/src/pkg/projects/netcoreapp/pkg/legacy/Directory.Build.props
@@ -4,6 +4,8 @@
   <PropertyGroup>
     <PreventImplementationReference Condition="'$(PackageTargetRuntime)' != ''">true</PreventImplementationReference>
     <BuildTargetPath>build/$(NETCoreAppFramework)/</BuildTargetPath>
+
+    <IsShippingPackage>false</IsShippingPackage>
   </PropertyGroup>
 
   <!-- Identity / Reference package content -->

--- a/src/pkg/projects/netcoreapp/pkg/workaround/Microsoft.NETCore.App.pkgproj
+++ b/src/pkg/projects/netcoreapp/pkg/workaround/Microsoft.NETCore.App.pkgproj
@@ -15,6 +15,8 @@
     <ExcludeLineupReference>true</ExcludeLineupReference>
 
     <BuildRuntimePackages>false</BuildRuntimePackages>
+
+    <IsShippingPackage>false</IsShippingPackage>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/pkg/projects/windowsdesktop/pkg/Microsoft.WindowsDesktop.App.pkgproj
+++ b/src/pkg/projects/windowsdesktop/pkg/Microsoft.WindowsDesktop.App.pkgproj
@@ -17,6 +17,8 @@
       it in correctly. Being wrong means dependency failures at runtime.
     -->
     <SkipValidatePackage>false</SkipValidatePackage>
+
+    <IsShippingPackage>false</IsShippingPackage>
   </PropertyGroup>
 
   <!-- Temporarily ignore duplicate types until WPF updates. https://github.com/dotnet/core-setup/issues/6838 -->

--- a/src/test/Assets/TestProjects/Directory.Build.props
+++ b/src/test/Assets/TestProjects/Directory.Build.props
@@ -3,6 +3,7 @@
 
   <ItemGroup>
     <RestoreTestFallbackSource Include="$(ArtifactsShippingPackagesDir)" />
+    <RestoreTestFallbackSource Include="$(ArtifactsNonShippingPackagesDir)" />
     <RestoreTestSource Include="$(RestoreSources)" />
     <RestoreTestSource Include="https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json" />
     <RestoreTestSource Include="https://api.nuget.org/v3/index.json" />

--- a/src/test/PrepareTestAssets/PrepareTestAssets.proj
+++ b/src/test/PrepareTestAssets/PrepareTestAssets.proj
@@ -41,6 +41,7 @@
       Targets="Restore"
       Properties="
         ArtifactsShippingPackagesDir=$(ArtifactsShippingPackagesDir);
+        ArtifactsNonShippingPackagesDir=$(ArtifactsNonShippingPackagesDir);
         TestRestorePackagesPath=$(TestRestorePackagesPath);
         TestTargetRid=$(TestTargetRid);
         MNAVersion=$(ProductVersion)" />


### PR DESCRIPTION
Port https://github.com/dotnet/core-setup/pull/7776 to `release/3.0`.

#### Description

For https://github.com/dotnet/core-setup/issues/6893.

The past few releases have seen some manual intervention to get legacy packages off the NuGet gallery. Marking legacy packages NonShipping fixes this. The PR changes the asset category in BAR so release automation won't pick up assets that we don't want to publish.

#### Customer Impact

None, this affects internal infra.

#### Regression?

No.

#### Risk

Minimal, working in `master` official builds, only changes a flag in BAR for the affected assets.