### PR TITLE
Stop the BAR publish job assigning channel early

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -166,6 +166,7 @@ stages:
     # Publish to Build Asset Registry in order to generate the ReleaseConfigs artifact.
     - template: /eng/common/templates/job/publish-build-assets.yml
       parameters:
+        publishUsingPipelines: true
         dependsOn: PrepareSignedArtifacts
         pool:
           name: NetCoreInternal-Pool


### PR DESCRIPTION
`publish-build-assets.yml` uploads the build to BAR, but it also assigns the build to a channel. This is supposed to happen later in the build, after publishing, in the "promote build" job. Setting `publishUsingPipelines: true` prevents `publish-build-assets.yml` from assigning the channel.

See https://github.com/dotnet/core-setup/pull/7797#discussion_r316465897.

/cc @JohnTortugo 