### PR TITLE
[release/3.0] Stop the BAR publish job assigning channel early

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -166,6 +166,7 @@ stages:
     # Publish to Build Asset Registry in order to generate the ReleaseConfigs artifact.
     - template: /eng/common/templates/job/publish-build-assets.yml
       parameters:
+        publishUsingPipelines: true
         dependsOn: PrepareSignedArtifacts
         pool:
           name: NetCoreInternal-Pool


### PR DESCRIPTION
#### Description

For https://github.com/dotnet/core-setup/issues/7772.

`publish-build-assets.yml` uploads the build to BAR, but it also assigns the build to a channel. This is supposed to happen later in the build, after publishing, in the "promote build" job. Setting `publishUsingPipelines: true` prevents `publish-build-assets.yml` from assigning the channel.

I believe this missing parameter nullified the earlier fix I made to attempt to fix this ordering issue: https://github.com/dotnet/core-setup/pull/7807.

See https://github.com/dotnet/core-setup/pull/7797#discussion_r316465897.

#### Customer Impact

Without this, dependency flow is slower because auto-PR validation builds need to be retried.

#### Regression?

Yes, converting to yaml stages-based publishing changed the publish order.

#### Risk

Minimal, this change is straightforward and has been validated in a `release/3.0-preview9` build. (https://github.com/dotnet/core-setup/pull/7797)
