### PR TITLE
Fix bundle installer signing

### DIFF
--- a/signing/SignBurnBundleFiles.proj
+++ b/signing/SignBurnBundleFiles.proj
@@ -4,7 +4,7 @@
   <Target Name="ReattachAllEnginesToBundles"
           BeforeTargets="RunArcadeSigning">
     <MSBuild
-      Projects="@(ProjectToBuild -> WithMetadataValue('SignPhase', 'Bundle'))"
+      Projects="@(ProjectToBuild -> WithMetadataValue('SignPhase', 'BundleInstallerFiles'))"
       Targets="ReattachEngineToBundle" />
   </Target>
 

--- a/signing/SignMsiFiles.proj
+++ b/signing/SignMsiFiles.proj
@@ -12,7 +12,7 @@
           DependsOnTargets="GetSharedFrameworkProjects"
           BeforeTargets="EnsureProjectsBuilt">
     <ItemGroup>
-      <StageProject Include="@(SharedFrameworkProjects)" />
+      <StageProject Include="@(SharedFrameworkProject)" />
     </ItemGroup>
   </Target>
 

--- a/src/pkg/packaging-tools/packaging-tools.targets
+++ b/src/pkg/packaging-tools/packaging-tools.targets
@@ -80,6 +80,7 @@
       <InstallerFileNameWithoutExtension>$(InstallerName)-$(InstallerBuildPart)</InstallerFileNameWithoutExtension>
       <InstallerFile Condition="'$(InstallerFile)' == ''">$(AssetOutputPath)$(InstallerFileNameWithoutExtension)$(InstallerExtension)</InstallerFile>
       <ExeBundleInstallerFile>$(AssetOutputPath)$(InstallerFileNameWithoutExtension).exe</ExeBundleInstallerFile>
+      <ExeBundleInstallerEngineFile>$(AssetOutputPath)$(InstallerFileNameWithoutExtension)-engine.exe</ExeBundleInstallerEngineFile>
       <CompressedArchiveFile>$(AssetOutputPath)$(InstallerFileNameWithoutExtension)$(CompressedFileExtension)</CompressedArchiveFile>
     </PropertyGroup>
 

--- a/src/pkg/packaging-tools/windows/wix.targets
+++ b/src/pkg/packaging-tools/windows/wix.targets
@@ -346,18 +346,22 @@
   </Target>
 
   <Target Name="ExtractEngineBundle"
-          DependsOnTargets="GetInstallerGenerationFlags">
+          DependsOnTargets="
+            GetInstallerGenerationFlags;
+            GetWixBuildConfiguration">
     <Exec
       Condition="'$(GenerateExeBundle)' == 'true'"
-      Command="insignia.exe -ib $(CombinedInstallerFile) -o $(CombinedInstallerEngine)"
+      Command="insignia.exe -ib $(OutInstallerFile) -o $(ExeBundleInstallerEngineFile)"
       WorkingDirectory="$(WixToolsDir)" />
   </Target>
 
   <Target Name="ReattachEngineToBundle"
-          DependsOnTargets="GetInstallerGenerationFlags">
+          DependsOnTargets="
+            GetInstallerGenerationFlags;
+            GetWixBuildConfiguration">
     <Exec
       Condition="'$(GenerateExeBundle)' == 'true'"
-      Command="insignia.exe -ab $(CombinedInstallerEngine) $(CombinedInstallerFile) -o $(CombinedInstallerFile)"
+      Command="insignia.exe -ab $(ExeBundleInstallerEngineFile) $(OutInstallerFile) -o $(OutInstallerFile)"
       WorkingDirectory="$(WixToolsDir)" />
   </Target>
 

--- a/src/pkg/projects/netcoreapp/sfx/Microsoft.NETCore.App.SharedFx.sfxproj
+++ b/src/pkg/projects/netcoreapp/sfx/Microsoft.NETCore.App.SharedFx.sfxproj
@@ -27,8 +27,6 @@
     <PkgProjectReference Include="..\..\Microsoft.NETCore.DotNetHost\Microsoft.NETCore.DotNetHost.pkgproj" />
     <PkgProjectReference Include="..\..\Microsoft.NETCore.DotNetHostPolicy\Microsoft.NETCore.DotNetHostPolicy.pkgproj" />
     <PkgProjectReference Include="..\..\Microsoft.NETCore.DotNetHostResolver\Microsoft.NETCore.DotNetHostResolver.pkgproj" />
-
-    <OrderProjectReference Include="$(RepoRoot)signing\SignMsiFiles.proj" />
   </ItemGroup>
 
   <!--

--- a/src/pkg/projects/windowsdesktop/sfx/Microsoft.WindowsDesktop.App.SharedFx.sfxproj
+++ b/src/pkg/projects/windowsdesktop/sfx/Microsoft.WindowsDesktop.App.SharedFx.sfxproj
@@ -8,8 +8,6 @@
 
   <ItemGroup>
     <PkgProjectReference Include="..\pkg\Microsoft.WindowsDesktop.App.pkgproj" />
-
-    <OrderProjectReference Include="$(RepoRoot)signing\SignMsiFiles.proj" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
For https://github.com/dotnet/core-setup/issues/7817.

The runtime MSI files weren't signed, due to a typo in `SharedFrameworkProject` preventing the signing project from ensuring the correct build order.

Fix the bundle signing project's references to the bundle projects. No items were found, causing `ReattachEngineToBundle` to never run, and the signed bundle engine wasn't reattached.

Bundle engine extraction/attachment was assuming the old, static 'dotnet-runtime' properties rather than current per-project properties. Based on logs, this seems like it would break windowsdesktop-runtime engine signing (if it were otherwise working).

Worked in validation build: https://dev.azure.com/dnceng/internal/_build/results?buildId=322283

We'll need this in 3.0 p9 to produce valid .NET Core Runtime and WindowsDesktop bundles. (https://github.com/dotnet/core-setup/issues/7817 for background.)

/cc @mmitche 