### PR TITLE
[release/3.0] Fix bundle installer signing

### DIFF
--- a/signing/SignBurnBundleFiles.proj
+++ b/signing/SignBurnBundleFiles.proj
@@ -4,7 +4,7 @@
   <Target Name="ReattachAllEnginesToBundles"
           BeforeTargets="RunArcadeSigning">
     <MSBuild
-      Projects="@(ProjectToBuild -> WithMetadataValue('SignPhase', 'Bundle'))"
+      Projects="@(ProjectToBuild -> WithMetadataValue('SignPhase', 'BundleInstallerFiles'))"
       Targets="ReattachEngineToBundle" />
   </Target>
 

--- a/signing/SignMsiFiles.proj
+++ b/signing/SignMsiFiles.proj
@@ -12,7 +12,7 @@
           DependsOnTargets="GetSharedFrameworkProjects"
           BeforeTargets="EnsureProjectsBuilt">
     <ItemGroup>
-      <StageProject Include="@(SharedFrameworkProjects)" />
+      <StageProject Include="@(SharedFrameworkProject)" />
     </ItemGroup>
   </Target>
 

--- a/src/pkg/packaging-tools/packaging-tools.targets
+++ b/src/pkg/packaging-tools/packaging-tools.targets
@@ -80,6 +80,7 @@
       <InstallerFileNameWithoutExtension>$(InstallerName)-$(InstallerBuildPart)</InstallerFileNameWithoutExtension>
       <InstallerFile Condition="'$(InstallerFile)' == ''">$(AssetOutputPath)$(InstallerFileNameWithoutExtension)$(InstallerExtension)</InstallerFile>
       <ExeBundleInstallerFile>$(AssetOutputPath)$(InstallerFileNameWithoutExtension).exe</ExeBundleInstallerFile>
+      <ExeBundleInstallerEngineFile>$(AssetOutputPath)$(InstallerFileNameWithoutExtension)-engine.exe</ExeBundleInstallerEngineFile>
       <CompressedArchiveFile>$(AssetOutputPath)$(InstallerFileNameWithoutExtension)$(CompressedFileExtension)</CompressedArchiveFile>
     </PropertyGroup>
 

--- a/src/pkg/packaging-tools/windows/wix.targets
+++ b/src/pkg/packaging-tools/windows/wix.targets
@@ -346,18 +346,22 @@
   </Target>
 
   <Target Name="ExtractEngineBundle"
-          DependsOnTargets="GetInstallerGenerationFlags">
+          DependsOnTargets="
+            GetInstallerGenerationFlags;
+            GetWixBuildConfiguration">
     <Exec
       Condition="'$(GenerateExeBundle)' == 'true'"
-      Command="insignia.exe -ib $(CombinedInstallerFile) -o $(CombinedInstallerEngine)"
+      Command="insignia.exe -ib $(OutInstallerFile) -o $(ExeBundleInstallerEngineFile)"
       WorkingDirectory="$(WixToolsDir)" />
   </Target>
 
   <Target Name="ReattachEngineToBundle"
-          DependsOnTargets="GetInstallerGenerationFlags">
+          DependsOnTargets="
+            GetInstallerGenerationFlags;
+            GetWixBuildConfiguration">
     <Exec
       Condition="'$(GenerateExeBundle)' == 'true'"
-      Command="insignia.exe -ab $(CombinedInstallerEngine) $(CombinedInstallerFile) -o $(CombinedInstallerFile)"
+      Command="insignia.exe -ab $(ExeBundleInstallerEngineFile) $(OutInstallerFile) -o $(OutInstallerFile)"
       WorkingDirectory="$(WixToolsDir)" />
   </Target>
 

--- a/src/pkg/projects/netcoreapp/sfx/Microsoft.NETCore.App.SharedFx.sfxproj
+++ b/src/pkg/projects/netcoreapp/sfx/Microsoft.NETCore.App.SharedFx.sfxproj
@@ -27,8 +27,6 @@
     <PkgProjectReference Include="..\..\Microsoft.NETCore.DotNetHost\Microsoft.NETCore.DotNetHost.pkgproj" />
     <PkgProjectReference Include="..\..\Microsoft.NETCore.DotNetHostPolicy\Microsoft.NETCore.DotNetHostPolicy.pkgproj" />
     <PkgProjectReference Include="..\..\Microsoft.NETCore.DotNetHostResolver\Microsoft.NETCore.DotNetHostResolver.pkgproj" />
-
-    <OrderProjectReference Include="$(RepoRoot)signing\SignMsiFiles.proj" />
   </ItemGroup>
 
   <!--

--- a/src/pkg/projects/windowsdesktop/sfx/Microsoft.WindowsDesktop.App.SharedFx.sfxproj
+++ b/src/pkg/projects/windowsdesktop/sfx/Microsoft.WindowsDesktop.App.SharedFx.sfxproj
@@ -8,8 +8,6 @@
 
   <ItemGroup>
     <PkgProjectReference Include="..\pkg\Microsoft.WindowsDesktop.App.pkgproj" />
-
-    <OrderProjectReference Include="$(RepoRoot)signing\SignMsiFiles.proj" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
#### Description

#7817. The bundle installers fail to install with `0x80070001 - Incorrect function`. The most likely direct cause of that error is the burn engine not being signed. There are several MSBuild authoring problems related to signing that this PR fixes: runtime MSIs are not signed due to a build order issue, and the burn bundle engine is not reattached to the bundle installer.

A validation real-signed build shows that this PR resolves the issue: https://github.com/dotnet/core-setup/issues/7817#issuecomment-524388499.

Clean cherry-pick of https://github.com/dotnet/core-setup/pull/7820 to `release/3.0`.

#### Customer Impact

The .NET Core Runtime and Windows Desktop Runtime bundle installers currently fail to install, with a cryptic error message.

#### Regression?

Yes, the .NET Core Runtime bundle installer in particular. The changes made to produce the Windows Desktop Runtime bundle inadvertently caused this problem for both bundle installers.

#### Risk

Low. The authoring errors are simple to correct.