### PR TITLE
Set up auto-update for infrastructure packages

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -127,5 +127,21 @@
       <Uri>https://github.com/dotnet/arcade</Uri>
       <Sha>c7f03b2cf06bdfc64dad4140fd0d486127095cd8</Sha>
     </Dependency>
+    <Dependency Name="Microsoft.DotNet.Build.Tasks.Feed" Version="2.2.0-beta.19422.24">
+      <Uri>https://github.com/dotnet/arcade</Uri>
+      <Sha>c7f03b2cf06bdfc64dad4140fd0d486127095cd8</Sha>
+    </Dependency>
+    <Dependency Name="Microsoft.DotNet.Build.Tasks.Packaging" Version="1.0.0-beta.19422.24">
+      <Uri>https://github.com/dotnet/arcade</Uri>
+      <Sha>c7f03b2cf06bdfc64dad4140fd0d486127095cd8</Sha>
+    </Dependency>
+    <Dependency Name="Microsoft.DotNet.VersionTools.Tasks" Version="1.0.0-beta.19422.24">
+      <Uri>https://github.com/dotnet/arcade</Uri>
+      <Sha>c7f03b2cf06bdfc64dad4140fd0d486127095cd8</Sha>
+    </Dependency>
+    <Dependency Name="Microsoft.SourceLink" Version="1.0.0-beta2-19367-01">
+      <Uri>https://github.com/dotnet/sourcelink</Uri>
+      <Sha></Sha>
+    </Dependency>
   </ToolsetDependencies>
 </Dependencies>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -36,9 +36,11 @@
   <!--Package versions-->
   <PropertyGroup>
     <!-- arcade -->
-    <MicrosoftDotNetBuildTasksPackagingPackageVersion>1.0.0-beta.19308.1</MicrosoftDotNetBuildTasksPackagingPackageVersion>
-    <MicrosoftDotNetBuildTasksFeedPackageVersion>2.2.0-beta.19410.2</MicrosoftDotNetBuildTasksFeedPackageVersion>
-    <MicrosoftDotNetVersionToolsTasksPackageVersion>1.0.0-beta.19308.1</MicrosoftDotNetVersionToolsTasksPackageVersion>
+    <MicrosoftDotNetBuildTasksFeedPackageVersion>2.2.0-beta.19422.24</MicrosoftDotNetBuildTasksFeedPackageVersion>
+    <MicrosoftDotNetBuildTasksPackagingPackageVersion>1.0.0-beta.19422.24</MicrosoftDotNetBuildTasksPackagingPackageVersion>
+    <MicrosoftDotNetVersionToolsTasksPackageVersion>1.0.0-beta.19422.24</MicrosoftDotNetVersionToolsTasksPackageVersion>
+    <!-- sourcelink -->
+    <MicrosoftSourceLinkVersion>1.0.0-beta2-19367-01</MicrosoftSourceLinkVersion>
     <!-- corefx -->
     <MicrosoftNETCorePlatformsPackageVersion>5.0.0-alpha1.19409.9</MicrosoftNETCorePlatformsPackageVersion>
     <MicrosoftNETCoreTargetsPackageVersion>5.0.0-alpha1.19409.9</MicrosoftNETCoreTargetsPackageVersion>
@@ -85,8 +87,6 @@
     <NugetPackagingPackageVersion>4.9.4</NugetPackagingPackageVersion>
     <MicrosoftTargetingPackPrivateWinRTPackageVersion>1.0.5</MicrosoftTargetingPackPrivateWinRTPackageVersion>
     <MicrosoftDiaSymReaderNativePackageVersion>1.7.0</MicrosoftDiaSymReaderNativePackageVersion>
-    <!-- Infrastructure and test-only. -->
-    <MicrosoftSourceLinkVersion>1.0.0-beta2-18618-05</MicrosoftSourceLinkVersion>
   </PropertyGroup>
   <!--Package names-->
   <PropertyGroup>

--- a/eng/jobs/steps/upload-job-artifacts.yml
+++ b/eng/jobs/steps/upload-job-artifacts.yml
@@ -8,7 +8,9 @@ steps:
     displayName: Prepare job-specific Artifacts subdirectory
     inputs:
       SourceFolder: '$(Build.SourcesDirectory)/artifacts/packages/$(_BuildConfig)'
-      Contents: '**/*'
+      Contents: |
+        Shipping/**/*
+        NonShipping/**/*
       TargetFolder: '$(Build.StagingDirectory)/Artifacts/${{ parameters.name }}'
       CleanTargetFolder: true
     condition: and(succeeded(), eq(variables._BuildConfig, 'Release'))

--- a/src/test/Microsoft.DotNet.CoreSetup.Packaging.Tests/NuGetArtifactTester.cs
+++ b/src/test/Microsoft.DotNet.CoreSetup.Packaging.Tests/NuGetArtifactTester.cs
@@ -36,8 +36,8 @@ namespace Microsoft.DotNet.CoreSetup.Packaging.Tests
             id = id ?? project;
 
             string nuspecPath = Path.Combine(
-                dirs.BaseBinFolder,
-                project,
+                dirs.BaseArtifactsFolder,
+                "packages",
                 dirs.Configuration,
                 "specs",
                 $"{id}.nuspec");


### PR DESCRIPTION
Set up auto-update for infra packages, and update.

There is a minor breaking change I reacted to from the packaging tools: the generated NuGet spec files are now in `artifacts/packages/` rather than a per-project dir. https://github.com/dotnet/arcade/pull/3542