### PR TITLE
Enable signing validation with exclusions

### DIFF
--- a/eng/SignCheckExclusionsFile.txt
+++ b/eng/SignCheckExclusionsFile.txt
@@ -1,0 +1,12 @@
+;; Exclusions for SignCheck. Corresponds to info in Signing.props.
+;; Format: https://github.com/dotnet/arcade/blob/397316e195639450b6c76bfeb9823b40bee72d6d/src/SignCheck/Microsoft.SignCheck/Verification/Exclusion.cs#L23-L35
+;;
+;; This issue tracks a way to implement exclusions via Signing.props and avoid this extra file: https://github.com/dotnet/arcade/issues/2888
+
+;; The apphost and comhost are template files, modified by the SDK to produce the executable for FDE
+;; and FDD apps. If they are signed, the file that the SDK produces has an invalid signature and
+;; can't be signed again. More info at https://github.com/dotnet/core-setup/pull/7549.
+*apphost.exe;;Template, https://github.com/dotnet/core-setup/pull/7549
+*comhost.dll;;Template, https://github.com/dotnet/core-setup/pull/7549
+*apphosttemplateapphostexe.exe;;Template, https://github.com/dotnet/core-setup/pull/7549
+*comhosttemplatecomhostdll.dll;;Template, https://github.com/dotnet/core-setup/pull/7549

--- a/eng/stages/publish.yml
+++ b/eng/stages/publish.yml
@@ -24,8 +24,6 @@ stages:
       - PublishBlob_${{ dependency.dependsOn }}
     # Symbol validation is not ready yet. https://github.com/dotnet/arcade/issues/2871
     enableSymbolValidation: false
-    # Doesn't work yet, not fully configured. https://github.com/dotnet/core-setup/issues/5254
-    enableSigningValidation: false
     # SourceLink validation doesn't work in dev builds: tries to pull from GitHub. https://github.com/dotnet/arcade/issues/3604
     enableSourceLinkValidation: false
     # Allow symbol publish to emit expected warnings without failing the build. Include single


### PR DESCRIPTION
For https://github.com/dotnet/core-setup/issues/5254. This validates that our nupkgs, MSIs, and bundle installer EXEs are signed and contain signed files.

A few missing pieces:
* Check that the burn bundle engine is signed. https://github.com/dotnet/core-setup/issues/7848
* Ensure that apphost/comhost are *not* signed. https://github.com/dotnet/core-setup/issues/7849
* (Less important.) Switch to generating the exclusion text file via `Signing.props` rather than checking in a separate txt file: https://github.com/dotnet/arcade/issues/2888.
* (Less important.) Have the job upload a binlog for diagnosability: https://github.com/dotnet/arcade/issues/3687.

Validation build: [325387](https://dev.azure.com/dnceng/internal/_build/results?buildId=325387&view=logs&s=3df7d716-4c9c-5c26-9f45-11f62216640d&j=b11b921d-8982-5bb3-754b-b114d42fd804)