### PR TITLE
[release/3.0] Set up auto-update for infrastructure packages

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -139,5 +139,21 @@
       <Uri>https://github.com/dotnet/arcade</Uri>
       <Sha>a7b5eb8de300b6a30bd797c4ecc8769f7028aeec</Sha>
     </Dependency>
+    <Dependency Name="Microsoft.DotNet.Build.Tasks.Feed" Version="2.2.0-beta.19422.24">
+      <Uri>https://github.com/dotnet/arcade</Uri>
+      <Sha>c7f03b2cf06bdfc64dad4140fd0d486127095cd8</Sha>
+    </Dependency>
+    <Dependency Name="Microsoft.DotNet.Build.Tasks.Packaging" Version="1.0.0-beta.19422.24">
+      <Uri>https://github.com/dotnet/arcade</Uri>
+      <Sha>c7f03b2cf06bdfc64dad4140fd0d486127095cd8</Sha>
+    </Dependency>
+    <Dependency Name="Microsoft.DotNet.VersionTools.Tasks" Version="1.0.0-beta.19422.24">
+      <Uri>https://github.com/dotnet/arcade</Uri>
+      <Sha>c7f03b2cf06bdfc64dad4140fd0d486127095cd8</Sha>
+    </Dependency>
+    <Dependency Name="Microsoft.SourceLink" Version="1.0.0-beta2-19367-01">
+      <Uri>https://github.com/dotnet/sourcelink</Uri>
+      <Sha></Sha>
+    </Dependency>
   </ToolsetDependencies>
 </Dependencies>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -35,9 +35,11 @@
   <!--Package versions-->
   <PropertyGroup>
     <!-- arcade -->
-    <MicrosoftDotNetBuildTasksPackagingPackageVersion>1.0.0-beta.19308.1</MicrosoftDotNetBuildTasksPackagingPackageVersion>
-    <MicrosoftDotNetBuildTasksFeedPackageVersion>2.2.0-beta.19410.2</MicrosoftDotNetBuildTasksFeedPackageVersion>
-    <MicrosoftDotNetVersionToolsTasksPackageVersion>1.0.0-beta.19308.1</MicrosoftDotNetVersionToolsTasksPackageVersion>
+    <MicrosoftDotNetBuildTasksFeedPackageVersion>2.2.0-beta.19422.24</MicrosoftDotNetBuildTasksFeedPackageVersion>
+    <MicrosoftDotNetBuildTasksPackagingPackageVersion>1.0.0-beta.19422.24</MicrosoftDotNetBuildTasksPackagingPackageVersion>
+    <MicrosoftDotNetVersionToolsTasksPackageVersion>1.0.0-beta.19422.24</MicrosoftDotNetVersionToolsTasksPackageVersion>
+    <!-- sourcelink -->
+    <MicrosoftSourceLinkVersion>1.0.0-beta2-19367-01</MicrosoftSourceLinkVersion>
     <!-- corefx -->
     <MicrosoftNETCorePlatformsPackageVersion>3.0.0-rc1.19420.10</MicrosoftNETCorePlatformsPackageVersion>
     <MicrosoftNETCoreTargetsPackageVersion>3.0.0-rc1.19420.10</MicrosoftNETCoreTargetsPackageVersion>
@@ -87,8 +89,6 @@
     <NugetPackagingPackageVersion>4.9.4</NugetPackagingPackageVersion>
     <MicrosoftTargetingPackPrivateWinRTPackageVersion>1.0.5</MicrosoftTargetingPackPrivateWinRTPackageVersion>
     <MicrosoftDiaSymReaderNativePackageVersion>1.7.0</MicrosoftDiaSymReaderNativePackageVersion>
-    <!-- Infrastructure and test-only. -->
-    <MicrosoftSourceLinkVersion>1.0.0-beta2-18618-05</MicrosoftSourceLinkVersion>
   </PropertyGroup>
   <!--Package names-->
   <PropertyGroup>

--- a/eng/jobs/steps/upload-job-artifacts.yml
+++ b/eng/jobs/steps/upload-job-artifacts.yml
@@ -8,7 +8,9 @@ steps:
     displayName: Prepare job-specific Artifacts subdirectory
     inputs:
       SourceFolder: '$(Build.SourcesDirectory)/artifacts/packages/$(_BuildConfig)'
-      Contents: '**/*'
+      Contents: |
+        Shipping/**/*
+        NonShipping/**/*
       TargetFolder: '$(Build.StagingDirectory)/Artifacts/${{ parameters.name }}'
       CleanTargetFolder: true
     condition: and(succeeded(), eq(variables._BuildConfig, 'Release'))

--- a/src/test/Microsoft.DotNet.CoreSetup.Packaging.Tests/NuGetArtifactTester.cs
+++ b/src/test/Microsoft.DotNet.CoreSetup.Packaging.Tests/NuGetArtifactTester.cs
@@ -36,8 +36,8 @@ namespace Microsoft.DotNet.CoreSetup.Packaging.Tests
             id = id ?? project;
 
             string nuspecPath = Path.Combine(
-                dirs.BaseBinFolder,
-                project,
+                dirs.BaseArtifactsFolder,
+                "packages",
                 dirs.Configuration,
                 "specs",
                 $"{id}.nuspec");


### PR DESCRIPTION
#### Description

For https://github.com/dotnet/core-setup/issues/7693.

Sets up auto-update infrastructure for the Arcade tooling packages, and resolves a small breaking change. Making updates automatic will give us early warning about future breaking changes, avoiding issues building up over time as servicing builds go on.

Ports https://github.com/dotnet/core-setup/pull/7824 to `release/3.0`.

#### Customer Impact

None.

#### Regression?

In a way: BuildTools updates were automatic, but these Arcade tooling package updates haven't been.

#### Risk

Minor, there could potentially be issues with the new packages that weren't caught by my validation run, but it's unlikely.