### PR TITLE
Fix version info missing from native binaries

### DIFF
--- a/src/corehost/build.proj
+++ b/src/corehost/build.proj
@@ -1,13 +1,15 @@
 <Project>
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), Directory.Build.props))\Directory.Build.props" />
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), Directory.Build.targets))\Directory.Build.targets" />
+  <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
 
   <!--
-    Always disable sourcelink in this project so that Arcade doesn't complain about 'The target
-    "InitializeSourceControlInformationFromSourceControlManager" does not exist in the project.'.
+    Add basic project properties for NuGet restore, needed to import the SourceLink MSBuild tool
+    package's targets into the build.
   -->
-  <Import Project="$(RepositoryEngineeringDir)/DisableSourceControlManagement.targets"
-          Condition="'$(DisableSourceControlManagementTargetsImported)' != 'true'" />
+  <PropertyGroup>
+    <TargetFramework>$(NETCoreAppFramework)</TargetFramework>
+  </PropertyGroup>
+
+  <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
 
   <!-- Target that builds dotnet, hostfxr and hostpolicy with the same version as what NetCoreApp will be built for
        since the build produced artifacts should always version the same (even if they may not get used).
@@ -18,11 +20,6 @@
             GenerateNativeVersionFile;
             BuildCoreHostUnix;
             BuildCoreHostWindows" />
-
-  <PropertyGroup Condition="'$(OSGroup)' != 'Windows_NT'">
-    <GenerateVersionSourceFile>true</GenerateVersionSourceFile>
-    <NativeVersionSourceFile>$(ObjDir)version.cpp</NativeVersionSourceFile>
-  </PropertyGroup>
 
   <Target Name="BuildCoreHostUnix"
           Condition="'$(OSGroup)' != 'Windows_NT'"

--- a/src/corehost/build.sh
+++ b/src/corehost/build.sh
@@ -100,7 +100,7 @@ __configuration=Debug
 __linkPortable=0
 __cmake_defines=
 __baseIntermediateOutputPath="$RootRepo/artifacts/obj"
-__versionSourceFile="$__baseIntermediateOutputPath/version.cpp"
+__versionSourceFile="$__baseIntermediateOutputPath/_version.c"
 __cmake_bin_prefix=
 
 while [ "$1" != "" ]; do


### PR DESCRIPTION
For https://github.com/dotnet/core-setup/issues/7635. To be ported to 3.0: it's an infra regression.

Allow the SDK to restore SourceLink and find its MSBuild props and targets files. These are used to fetch Git information.

Use Arcade-generated `_version.c`. The new `_version.c` is identical to the old `version.cpp`. The host `build.sh` generated an empty `version.cpp` when it doesn't already exist at the specified path, which caused the "No version information" message to be included.
