### PR TITLE
[release/3.0] Fix version info missing from native binaries

### DIFF
--- a/src/corehost/build.proj
+++ b/src/corehost/build.proj
@@ -1,13 +1,15 @@
 <Project>
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), Directory.Build.props))\Directory.Build.props" />
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), Directory.Build.targets))\Directory.Build.targets" />
+  <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
 
   <!--
-    Always disable sourcelink in this project so that Arcade doesn't complain about 'The target
-    "InitializeSourceControlInformationFromSourceControlManager" does not exist in the project.'.
+    Add basic project properties for NuGet restore, needed to import the SourceLink MSBuild tool
+    package's targets into the build.
   -->
-  <Import Project="$(RepositoryEngineeringDir)/DisableSourceControlManagement.targets"
-          Condition="'$(DisableSourceControlManagementTargetsImported)' != 'true'" />
+  <PropertyGroup>
+    <TargetFramework>$(NETCoreAppFramework)</TargetFramework>
+  </PropertyGroup>
+
+  <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
 
   <!-- Target that builds dotnet, hostfxr and hostpolicy with the same version as what NetCoreApp will be built for
        since the build produced artifacts should always version the same (even if they may not get used).
@@ -18,11 +20,6 @@
             GenerateNativeVersionFile;
             BuildCoreHostUnix;
             BuildCoreHostWindows" />
-
-  <PropertyGroup Condition="'$(OSGroup)' != 'Windows_NT'">
-    <GenerateVersionSourceFile>true</GenerateVersionSourceFile>
-    <NativeVersionSourceFile>$(ObjDir)version.cpp</NativeVersionSourceFile>
-  </PropertyGroup>
 
   <Target Name="BuildCoreHostUnix"
           Condition="'$(OSGroup)' != 'Windows_NT'"

--- a/src/corehost/build.sh
+++ b/src/corehost/build.sh
@@ -100,7 +100,7 @@ __configuration=Debug
 __linkPortable=0
 __cmake_defines=
 __baseIntermediateOutputPath="$RootRepo/artifacts/obj"
-__versionSourceFile="$__baseIntermediateOutputPath/version.cpp"
+__versionSourceFile="$__baseIntermediateOutputPath/_version.c"
 __cmake_bin_prefix=
 
 while [ "$1" != "" ]; do


### PR DESCRIPTION
#### Description

For https://github.com/dotnet/core-setup/issues/7635. Ports https://github.com/dotnet/core-setup/pull/7864 to `release/3.0`.

Adds the expected product version and Git info to native binaries.

#### Customer Impact

Without this, devs who inspect the native host binaries to figure out where they came from will instead see a message like `3,0,19,40809 @Commit: unknown` or `@(#)No version information produced`.

With this, the message contains the version and commit hash.

#### Regression?

Yes, this worked before the migration to the Arcade SDK.

#### Risk

Low. With `src/corehost/build.proj` now depending a little more on the Arcade SDK, there may be undetected changes, however the project is a thin wrapper around a shell script, so this seems unlikely.

@vitek-karas @elinor-fung 