### PR TITLE
Remove WPF IgnoredDuplicateType exceptions: improve validation

### DIFF
--- a/src/pkg/projects/windowsdesktop/pkg/Microsoft.WindowsDesktop.App.pkgproj
+++ b/src/pkg/projects/windowsdesktop/pkg/Microsoft.WindowsDesktop.App.pkgproj
@@ -21,21 +21,6 @@
     <IsShippingPackage>false</IsShippingPackage>
   </PropertyGroup>
 
-  <!-- Temporarily ignore duplicate types until WPF updates. https://github.com/dotnet/core-setup/issues/6838 -->
-  <ItemGroup>
-    <IgnoredDuplicateType Include="
-      System.Xaml.Permissions.XamlAccessLevel;
-      System.Xaml.Permissions.XamlLoadPermission;
-      System.Security.Permissions.MediaPermissionAudio;
-      System.Security.Permissions.MediaPermissionVideo;
-      System.Security.Permissions.MediaPermissionImage;
-      System.Security.Permissions.MediaPermission;
-      System.Security.Permissions.MediaPermissionAttribute;
-      System.Security.Permissions.WebBrowserPermissionLevel;
-      System.Security.Permissions.WebBrowserPermission;
-      System.Security.Permissions.WebBrowserPermissionAttribute" />
-  </ItemGroup>
-
   <ItemGroup>
     <ExcludeFromDuplicateTypes Include="PresentationFramework.Aero" />
     <ExcludeFromDuplicateTypes Include="PresentationFramework.Aero2" />


### PR DESCRIPTION
For https://github.com/dotnet/core-setup/issues/6838.

These duplicate types were cleaned up in WPF a while ago, so we should remove the exception entries. If they become duplicates again, it is a mistake that we should catch in Core-Setup PR validation.

I'll port this to 3.0 as well for servicing stability.

@ojhad

/cc @MichaelSimons 