### PR TITLE
Fix source-build patch and "RestoreAllBuildRids=false" workaround argument

### DIFF
--- a/src/pkg/packaging-tools/framework.sharedfx.targets
+++ b/src/pkg/packaging-tools/framework.sharedfx.targets
@@ -18,9 +18,15 @@
     </PropertyGroup>
   </Target>
 
+  <!--
+    Set up the PackageReference based on the pkgproj output at the right point in the build process.
+    The BeforeTargets makes it try to run even when the project is excluded from a build from
+    source, so this has to be handled directly.
+  -->
   <Target Name="GetPackageReference"
           DependsOnTargets="GetProductVersions"
-          BeforeTargets="CollectPackageReferences">
+          BeforeTargets="CollectPackageReferences"
+          Condition="'$(DotNetBuildFromSource)' != 'true' or '$(ExcludeFromSourceBuild)' != 'true'">
     <PropertyGroup>
       <SfxVersion Condition="'$(SfxVersion)' == ''">$(ProductVersion)</SfxVersion>
       <SfxPackageIdentity Condition="'$(SfxPackageIdentity)' == ''">$(SfxIdentity)</SfxPackageIdentity>

--- a/src/pkg/projects/Directory.Build.props
+++ b/src/pkg/projects/Directory.Build.props
@@ -38,7 +38,13 @@
     -->
     <DisableRarCache>true</DisableRarCache>
 
-    <RestoreAllBuildRids>true</RestoreAllBuildRids>
+    <!-- During a build from source, only current-RID assets are available from upstream repos. -->
+    <RestoreAllBuildRids Condition="'$(RestoreAllBuildRids)' == '' and '$(DotNetBuildFromSource)' == 'true'">false</RestoreAllBuildRids>
+    <!--
+      Normally, it is necessary to restore all RIDs so that assets are available to inspect. For
+      example, the platform manifest includes data from all RIDs.
+    -->
+    <RestoreAllBuildRids Condition="'$(RestoreAllBuildRids)' == ''">true</RestoreAllBuildRids>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/pkg/projects/windowsdesktop/Directory.Build.props
+++ b/src/pkg/projects/windowsdesktop/Directory.Build.props
@@ -15,6 +15,12 @@
     <VSInsertionProductName>WindowsDesktop</VSInsertionProductName>
 
     <!--
+      Do not attempt to restore or build WindowsDesktop projects when building from source, because
+      WinForms and WPF do not participate.
+    -->
+    <ExcludeFromSourceBuild>true</ExcludeFromSourceBuild>
+
+    <!--
       Disable FileVersion check for WindowsDesktop. Files with no FileVersion, as of writing:
 
       runtimes\win-x86\native\PenImc_cor3.dll


### PR DESCRIPTION
For https://github.com/dotnet/core-setup/issues/7572.

* Incorporates source-build patch that was added to exclude WindowsDesktop from NuGet restore.
  * [0002-Try-ExcludeFromSourceBuild-in-windowsdesktop.patch](https://github.com/dotnet/source-build/blob/249b034a11bf0f0fcb6e264cb5c933265687777a/patches/core-setup/0002-Try-ExcludeFromSourceBuild-in-windowsdesktop.patch)
* Adds logic to determine RestoreAllBuildRids based on DotNetBuildFromSource, so that source-build doesn't have to pass in the `/p:RestoreAllBuildRids=false` override argument.

Tried it out with a simple build with `/p:DotNetBuildFromSource=true` on Linux, which works, and ends up with only `linux-x64` packages in `.packages`.

/cc @dseefeld 