### PR TITLE
Exclude symbol files from platform manifest

### DIFF
--- a/src/pkg/packaging-tools/framework.dependency.targets
+++ b/src/pkg/packaging-tools/framework.dependency.targets
@@ -40,6 +40,15 @@
       </FilesToPackage>
     </ItemGroup>
 
+    <!-- Mark files with symbol file extensions as symbol files: allows filtering them out. -->
+    <ItemGroup>
+      <FilesToPackage
+        Condition="
+          '%(FilesToPackage.Extension)' == '.pdb' or
+          '%(FilesToPackage.Extension)' == '$(SymbolFileExtension)'"
+        IsSymbolFile="true" />
+    </ItemGroup>
+
     <!-- Add versions file with the hashes of the repos we consume -->
     <ItemGroup Condition="'$(FrameworkPackageName)' != ''">
       <FilesToPackage Include="$(IntermediateOutputPath)\$(FrameworkPackageName).versions.txt">
@@ -146,6 +155,13 @@
              Targets="GetFilesToPackage">
       <Output TaskParameter="TargetOutputs" ItemName="SharedFrameworkRuntimeFiles" />
     </MSBuild>
+
+    <!-- Don't include symbol files in platform manifest. -->
+    <ItemGroup>
+      <SharedFrameworkRuntimeFiles
+        Remove="@(SharedFrameworkRuntimeFiles)"
+        Condition="'%(SharedFrameworkRuntimeFiles.IsSymbolFile)' == 'true'" />
+    </ItemGroup>
 
     <!--
       Workaround: zero-versioned Microsoft.VisualBasic.dll in non-Windows CoreFX transport package.

--- a/src/pkg/projects/Directory.Build.props
+++ b/src/pkg/projects/Directory.Build.props
@@ -70,33 +70,6 @@
     <IncludeRuntimeJson>true</IncludeRuntimeJson>
   </PropertyGroup>
 
-  <Choose>
-    <When Condition="$(PackageTargetRid.StartsWith('win'))">
-      <PropertyGroup>
-        <ApplicationFileExtension>.exe</ApplicationFileExtension>
-        <LibraryFilePrefix></LibraryFilePrefix>
-        <LibraryFileExtension>.dll</LibraryFileExtension>
-        <SymbolFileExtension>.pdb</SymbolFileExtension>
-      </PropertyGroup>
-    </When>
-    <When Condition="$(PackageTargetRid.StartsWith('osx'))">
-      <PropertyGroup>
-        <ApplicationFileExtension></ApplicationFileExtension>
-        <LibraryFilePrefix>lib</LibraryFilePrefix>
-        <LibraryFileExtension>.dylib</LibraryFileExtension>
-        <SymbolFileExtension>.dwarf</SymbolFileExtension>
-      </PropertyGroup>
-    </When>
-    <Otherwise>
-      <PropertyGroup>
-        <ApplicationFileExtension></ApplicationFileExtension>
-        <LibraryFilePrefix>lib</LibraryFilePrefix>
-        <LibraryFileExtension>.so</LibraryFileExtension>
-        <SymbolFileExtension>.dbg</SymbolFileExtension>
-      </PropertyGroup>
-    </Otherwise>
-  </Choose>
-
   <Import Project="$(PackagingToolsDir)packaging-tools.props" />
 
   <PropertyGroup Condition="'$(MSBuildProjectExtension)' == '.depproj'">
@@ -129,9 +102,6 @@
           Include="$(PackageThirdPartyNoticesFile)" >
       <SkipPackageFileCheck>true</SkipPackageFileCheck>
     </File>
-
-    <AdditionalLibPackageExcludes Condition="'$(SymbolFileExtension)' != ''" Include="%2A%2A\%2A$(SymbolFileExtension)" />
-    <AdditionalSymbolPackageExcludes Condition="'$(LibraryFileExtension)' != ''" Include="%2A%2A\%2A.a;%2A%2A\%2A$(LibraryFileExtension)" />
   </ItemGroup>
 
   <PropertyGroup>
@@ -194,5 +164,37 @@
     <!-- When resolving assets to pack, use the target runtime (if any). -->
     <RuntimeIdentifier>$(PackageRID)</RuntimeIdentifier>
   </PropertyGroup>
+
+  <Choose>
+    <When Condition="$(RuntimeIdentifier.StartsWith('win'))">
+      <PropertyGroup>
+        <ApplicationFileExtension>.exe</ApplicationFileExtension>
+        <LibraryFilePrefix></LibraryFilePrefix>
+        <LibraryFileExtension>.dll</LibraryFileExtension>
+        <SymbolFileExtension>.pdb</SymbolFileExtension>
+      </PropertyGroup>
+    </When>
+    <When Condition="$(RuntimeIdentifier.StartsWith('osx'))">
+      <PropertyGroup>
+        <ApplicationFileExtension></ApplicationFileExtension>
+        <LibraryFilePrefix>lib</LibraryFilePrefix>
+        <LibraryFileExtension>.dylib</LibraryFileExtension>
+        <SymbolFileExtension>.dwarf</SymbolFileExtension>
+      </PropertyGroup>
+    </When>
+    <Otherwise>
+      <PropertyGroup>
+        <ApplicationFileExtension></ApplicationFileExtension>
+        <LibraryFilePrefix>lib</LibraryFilePrefix>
+        <LibraryFileExtension>.so</LibraryFileExtension>
+        <SymbolFileExtension>.dbg</SymbolFileExtension>
+      </PropertyGroup>
+    </Otherwise>
+  </Choose>
+
+  <ItemGroup>
+    <AdditionalLibPackageExcludes Condition="'$(SymbolFileExtension)' != ''" Include="%2A%2A\%2A$(SymbolFileExtension)" />
+    <AdditionalSymbolPackageExcludes Condition="'$(LibraryFileExtension)' != ''" Include="%2A%2A\%2A.a;%2A%2A\%2A$(LibraryFileExtension)" />
+  </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Fixes https://github.com/dotnet/core-setup/issues/7317.

Detects and marks symbol files that are detected by NuGet, then filters them out of the platform manifest.

Changes the way the symbol file extension is determined to use `RuntimeIdentifier` rather than `PackageTargetRid` so we can use it during this part of the build. (In general, Core-Setup should use `RuntimeIdentifier` when possible to reduce the number of properties that track the current RID. This is possible since the Arcade SDK migration--I moved a significant amount of code over to `RuntimeIdentifier` already to get that working.)

Diff: https://gist.github.com/dagood/f70e19ca135b541c450e0cb40608d031