### PR TITLE
Fix macOS pkg package IDs: include version

### DIFF
--- a/src/pkg/Directory.Build.targets
+++ b/src/pkg/Directory.Build.targets
@@ -31,6 +31,11 @@
       <TargetingPackBrandName>$(ProductBrandPrefix) Targeting Pack - $(ProductBrandSuffix)</TargetingPackBrandName>
       <AppHostPackBrandName>$(ProductBrandPrefix) AppHost Pack - $(ProductBrandSuffix)</AppHostPackBrandName>
       <SharedFrameworkBrandName>$(ProductBrandPrefix) Runtime - $(ProductBrandSuffix)</SharedFrameworkBrandName>
+
+      <SharedHostComponentId>com.microsoft.dotnet.sharedhost.component.osx.x64</SharedHostComponentId>
+      <HostFxrComponentId>com.microsoft.dotnet.hostfxr.$(HostResolverVersion).component.osx.x64</HostFxrComponentId>
+      <SharedFxComponentId>com.microsoft.dotnet.sharedframework.$(SharedFrameworkName).$(SharedFrameworkNugetVersion).component.osx.x64</SharedFxComponentId>
+      <SharedPackageId>com.microsoft.dotnet.$(SharedFrameworkName).$(SharedFrameworkNugetVersion).osx.x64</SharedPackageId>
     </PropertyGroup>
   </Target>
 

--- a/src/pkg/packaging/osx/package.props
+++ b/src/pkg/packaging/osx/package.props
@@ -2,9 +2,5 @@
 <Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <OSXScriptRoot>$(PackagingRoot)osx/</OSXScriptRoot>
-    <SharedHostComponentId>com.microsoft.dotnet.sharedhost.component.osx.x64</SharedHostComponentId>
-    <HostFxrComponentId>com.microsoft.dotnet.hostfxr.$(HostResolverVersion).component.osx.x64</HostFxrComponentId>
-    <SharedFxComponentId>com.microsoft.dotnet.sharedframework.$(SharedFrameworkName).$(SharedFrameworkNugetVersion).component.osx.x64</SharedFxComponentId>
-    <SharedPackageId>com.microsoft.dotnet.$(SharedFrameworkName).$(SharedFrameworkNugetVersion).osx.x64</SharedPackageId>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Fixes a regression introduced during the Arcade SDK migration. Some macOS pkg component IDs no longer have a version in their pkg ID, instead being something like `com.microsoft.dotnet.sharedframework.Microsoft.NETCore.App..component.osx.x64`. (Note the `..`.)

This bug may be causing some unintended upgrade behavior that's been observed when installing Preview 8 then Preview 9 using the SDK pkg installer.

The Arcade SDK migration moved a lot of version-related MSBuild properties out of static properties into target-defined properties due to how Arcade makes versions available. Somehow I missed these static component ID properties while making the change.

Confirmed this fixes the pkg ID on my Mac. To check, I used this:

```
pkgutil --expand artifacts/packages/Debug/Shipping/dotnet-runtime-5*.pkg expanded
cat expanded/*sharedframework*/PackageInfo
```