### PR TITLE
[release/3.0] Fix macOS pkg IDs: include version to prevent unwanted in-place upgrade

### DIFF
--- a/src/pkg/Directory.Build.targets
+++ b/src/pkg/Directory.Build.targets
@@ -27,6 +27,11 @@
       <TargetingPackBrandName>$(ProductBrandPrefix) Targeting Pack - $(ProductBrandSuffix)</TargetingPackBrandName>
       <AppHostPackBrandName>$(ProductBrandPrefix) AppHost Pack - $(ProductBrandSuffix)</AppHostPackBrandName>
       <SharedFrameworkBrandName>$(ProductBrandPrefix) Runtime - $(ProductBrandSuffix)</SharedFrameworkBrandName>
+
+      <SharedHostComponentId>com.microsoft.dotnet.sharedhost.component.osx.x64</SharedHostComponentId>
+      <HostFxrComponentId>com.microsoft.dotnet.hostfxr.$(HostResolverVersion).component.osx.x64</HostFxrComponentId>
+      <SharedFxComponentId>com.microsoft.dotnet.sharedframework.$(SharedFrameworkName).$(SharedFrameworkNugetVersion).component.osx.x64</SharedFxComponentId>
+      <SharedPackageId>com.microsoft.dotnet.$(SharedFrameworkName).$(SharedFrameworkNugetVersion).osx.x64</SharedPackageId>
     </PropertyGroup>
   </Target>
 

--- a/src/pkg/packaging/osx/package.props
+++ b/src/pkg/packaging/osx/package.props
@@ -2,9 +2,5 @@
 <Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <OSXScriptRoot>$(PackagingRoot)osx/</OSXScriptRoot>
-    <SharedHostComponentId>com.microsoft.dotnet.sharedhost.component.osx.x64</SharedHostComponentId>
-    <HostFxrComponentId>com.microsoft.dotnet.hostfxr.$(HostResolverVersion).component.osx.x64</HostFxrComponentId>
-    <SharedFxComponentId>com.microsoft.dotnet.sharedframework.$(SharedFrameworkName).$(SharedFrameworkNugetVersion).component.osx.x64</SharedFxComponentId>
-    <SharedPackageId>com.microsoft.dotnet.$(SharedFrameworkName).$(SharedFrameworkNugetVersion).osx.x64</SharedPackageId>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
#### Description

Ports https://github.com/dotnet/core-setup/pull/7974 to `release/3.0`.

Fixes a regression introduced during the Arcade SDK migration. Some macOS pkg component IDs no longer have a version in their pkg ID, instead being something like `com.microsoft.dotnet.sharedframework.Microsoft.NETCore.App..component.osx.x64`. (Note the `..`. There should be a version there that gives every build a unique ID.)

The Arcade SDK migration moved a lot of version-related MSBuild properties out of static properties into target-defined properties due to how Arcade makes versions available. Somehow I missed these static component ID properties while making the change.

Confirmed this fixes the pkg ID on my Mac. To check, I used this:

```
pkgutil --expand artifacts/packages/Debug/Shipping/dotnet-runtime-5*.pkg expanded
cat expanded/*sharedframework*/PackageInfo
```

#### Customer Impact

This bug causes unintended upgrade behavior when installing Preview 8 then Preview 9 using the SDK pkg installer or the Runtime pkg installer. VS for Mac uses this installer: this bug was initially encountered during validation when upgrading VS for Mac from a version that uses Preview 8 to a version that uses Preview 9. The upgrade caused the Preview 8 Runtime to be removed from the machine unexpectedly.

At surface level, this looks like the upgrade-in-place behavior we have on Windows. However, the upgrade behavior here doesn't have product band boundaries, so it would cause bad removals. For example, it would remove a 3.0 Runtime if you install a 5.0 Runtime pkg.

For a workaround, in the Windows case, you can run an MSI directly to get a specific Runtime back on your machine, but there is no such easy workaround for Mac, as the upgrade behavior applies to the innermost pkg.

With a few dev builds with different simulated versions, I confirmed the bad in-place upgrade behavior described above on my Mac, and that this PR fixes the installer to do correct side-by-side installs.

#### Regression?

Yes, this "upgrade in place" behavior was not present before Preview 8.

#### Risk

Minimal. This returns to the normal behavior. The bad `[...]Microsoft.NETCore.App..component.osx.x64` package ID that is installed on people's machines doesn't interfere with the fix.