### PR TITLE
Copy PTB NETCoreApp loc fix to WindowsDesktop

### DIFF
--- a/src/pkg/projects/windowsdesktop/sfx/theme/1046/bundle.wxl
+++ b/src/pkg/projects/windowsdesktop/sfx/theme/1046/bundle.wxl
@@ -4,7 +4,7 @@
   <String Id="Title">[BUNDLEMONIKER]</String>
   <String Id="Motto">Você só precisa de um shell, um editor de texto e 10 minutos de seu tempo.
 
-Preparado? Tudo definido? Vamos nessa!</String>
+Tudo pronto? Então, vamos nessa!</String>
   <String Id="ConfirmCancelMessage">Tem certeza de que deseja cancelar?</String>
   <String Id="ExecuteUpgradeRelatedBundleMessage">Versão anterior</String>
   <String Id="HelpHeader">Ajuda de Instalação</String>


### PR DESCRIPTION
Copy the applicable subset of changes made to the .NET Core Runtime installer in pt-BR from https://github.com/dotnet/core-setup/pull/7965 to the Windows Desktop Runtime installer. This keeps the welcome messages consistent for when I port this to `release/3.0`.

(Planning to merge when CI is green to move on to the 3.0 port, which will include both of these PRs in one and go through ask mode.)

/cc @danyeh 