### PR TITLE
[release/3.0] Fix CoreFX PDBs not being included in symbol archive zip/tarball

### DIFF
--- a/src/pkg/packaging-tools/framework.dependency.targets
+++ b/src/pkg/packaging-tools/framework.dependency.targets
@@ -4,7 +4,12 @@
   -->
 
   <!-- Fetches all the file items from the packages that we want to redist -->
-  <Target Name="GetFilesFromPackages">
+  <Target Name="GetFilesFromPackages"
+          DependsOnTargets="
+            GetFilesFromPackageResolve;
+            GetSymbolFilesFromPackages" />
+
+  <Target Name="GetFilesFromPackageResolve">
     <ItemGroup>
       <!-- RID-specific: include all runtime files. -->
       <RidSpecificFilesToPackage Include="@(ReferenceCopyLocalPaths)">
@@ -45,6 +50,31 @@
       <FilesToPackage Include="$(IntermediateOutputPath)\$(FrameworkPackageName).versions.txt">
         <TargetPath></TargetPath>
       </FilesToPackage>
+    </ItemGroup>
+  </Target>
+
+  <Target Name="SetupFindSiblingSymbolFilesByName"
+          DependsOnTargets="GetFilesFromPackageResolve">
+    <ItemGroup>
+      <FindSiblingSymbolsForFile Include="@(RidSpecificFilesToPackage)" />
+    </ItemGroup>
+  </Target>
+
+  <!--
+    Include symbol files and mark them as such. Ensures they are redistributed correctly, and that
+    they can be filtered out when necessary.
+  -->
+  <Target Name="GetSymbolFilesFromPackages"
+          DependsOnTargets="
+            SetupFindSiblingSymbolFilesByName;
+            FindSiblingSymbolFilesByName">
+    <ItemGroup>
+      <!--
+        Discovered symbol files might already be in File, without IsSymbolFile set. Make sure we
+        keep the discovered one, which has IsSymbolFile=true.
+      -->
+      <FilesToPackage Remove="@(SiblingSymbolFile)" />
+      <FilesToPackage Include="@(SiblingSymbolFile)" />
     </ItemGroup>
   </Target>
 
@@ -456,6 +486,19 @@
     </ItemGroup>
   </Target>
 
+  <Target Name="GenerateRedistributeSymbolArchiveLayout"
+          DependsOnTargets="GetFilesToPackage">
+    <ItemGroup>
+      <RedistributeSymbolFile
+        Include="@(FilesToPackage)"
+        Condition="'%(FilesToPackage.IsSymbolFile)' == 'true'" />
+    </ItemGroup>
+
+    <Copy
+      SourceFiles="@(RedistributeSymbolFile)"
+      DestinationFolder="$(PackageSymbolsBinDir)$(MSBuildProjectName)\%(TargetPath)\" />
+  </Target>
+
   <Target Name="GetRuntimeFilesToPackage"
           BeforeTargets="GetFilesToPackage"
           DependsOnTargets="PrepareForCrossGen;GetCrossGenSymbolsFiles" />
@@ -486,7 +529,8 @@
             GetFilesToPackage;
             CrossGen;
             GenerateHashVersionsFile;
-            GenerateFileVersionProps"
+            GenerateFileVersionProps;
+            GenerateRedistributeSymbolArchiveLayout"
           Condition="'$(SkipBuild)' != 'true'" />
 
 </Project>

--- a/src/pkg/packaging-tools/framework.sharedfx.targets
+++ b/src/pkg/packaging-tools/framework.sharedfx.targets
@@ -162,17 +162,13 @@
     <Delete Files="@(ToDelete)" />
   </Target>
 
-  <!-- Preserve symbol files for compressed symbol archive. -->
+  <!-- Preserve symbol files for compressed symbol archive. Specific to NETCoreApp. -->
   <Target Name="CopySymbolsToPublishFolder"
           Condition="'$(SfxIdentity)' == 'Microsoft.NETCore.App'"
           AfterTargets="Publish">
     <PropertyGroup>
-      <!--
-        Microsoft.NETCore.App is the name of the shared framework, but the internal package is
-        the one doing the crossgen.
-      -->
-      <CrossgennedPackageId>Microsoft.NETCore.App.Internal</CrossgennedPackageId>
-      <CrossgennedPackageSymbolDir>$(PackageSymbolsBinDir)$(CrossgennedPackageId)/</CrossgennedPackageSymbolDir>
+      <!-- Get crossgen-generated and redist symbols from the depproj. -->
+      <CrossgennedPackageSymbolDir>$(PackageSymbolsBinDir)netcoreapp/</CrossgennedPackageSymbolDir>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/pkg/packaging-tools/packaging-tools.targets
+++ b/src/pkg/packaging-tools/packaging-tools.targets
@@ -176,6 +176,65 @@
   </Target>
 
   <!--
+    For each file in @(FindSiblingSymbolsForFile), finds symbol files in the same directory as the
+    file ("sibling") and puts them in @(SiblingSymbolFile). The inputs are not included in the
+    outputs, and the output paths are normalized. Symbol files are found by looking in the file's
+    directory for other files with the appropriate changed extensions.
+  -->
+  <Target Name="FindSiblingSymbolFilesByName">
+    <ItemGroup>
+      <!-- Normalize file paths up front (preserving metadata) for easier duplicate detection. -->
+      <FindSiblingSymbolsForFile NormalizedIdentity="$([MSBuild]::NormalizePath('%(Identity)'))" />
+      <FindSiblingSymbolsForFileNormalized
+        Include="@(FindSiblingSymbolsForFile -> '%(NormalizedIdentity)')"
+        RemoveMetadata="NormalizedIdentity" />
+
+      <FindSiblingSymbolsForFile Remove="@(FindSiblingSymbolsForFile)" />
+      <FindSiblingSymbolsForFile Include="@(FindSiblingSymbolsForFileNormalized)" />
+
+      <WindowsNativeFile
+        Include="@(FindSiblingSymbolsForFile)"
+        Condition="
+          '%(FindSiblingSymbolsForFile.Extension)' == '.dll' or
+          '%(FindSiblingSymbolsForFile.Extension)' == '.exe'" />
+
+      <!-- Don't include *.pdb for export libraries or headers -->
+      <WindowsSymbolFile
+        Include="@(FindSiblingSymbolsForFile -> '%(RootDir)%(Directory)%(Filename).pdb')"
+        Condition="
+          '%(FindSiblingSymbolsForFile.Extension)' != '.lib' and
+          '%(FindSiblingSymbolsForFile.Extension)' != '.h'" />
+
+      <!--
+        Crossgened files (on windows) have both a *.pdb and a *.ni.pdb symbol file. Include the
+        *.ni.pdb file as well if it exists.
+      -->
+      <WindowsSymbolFile
+        Include="@(FindSiblingSymbolsForFile -> '%(RootDir)%(Directory)%(Filename).ni.pdb')" />
+
+      <ExistingWindowsSymbolFile Include="@(WindowsSymbolFile)" Condition="Exists('%(Identity)')" />
+
+      <!-- Create list of potentially native non-Windows files, check for related symbol files. -->
+      <NonWindowsNativeFile
+        Include="@(FindSiblingSymbolsForFile)"
+        Exclude="@(WindowsNativeFile)" />
+      <NonWindowsSymbolFile
+        Include="@(NonWindowsNativeFile -> '%(Identity)$(SymbolFileExtension)')" />
+
+      <ExistingNonWindowsSymbolFile Include="@(NonWindowsSymbolFile)" Condition="Exists('%(Identity)')" />
+
+      <DiscoveredSymbolFile
+        Include="@(ExistingWindowsSymbolFile);@(ExistingNonWindowsSymbolFile)"
+        IsSymbolFile="true" />
+    </ItemGroup>
+
+    <!-- Remove any duplicates in symbol files found by the above searches. -->
+    <RemoveDuplicates Inputs="@(DiscoveredSymbolFile)">
+      <Output TaskParameter="Filtered" ItemName="SiblingSymbolFile"/>
+    </RemoveDuplicates>
+  </Target>
+
+  <!--
     By default, shared frameworks are generated based on the package. This can be overridden by the
     project, and in the future, the runtime pack is likely to be used to assemble the sfx.
   -->

--- a/src/pkg/projects/Directory.Build.props
+++ b/src/pkg/projects/Directory.Build.props
@@ -68,33 +68,6 @@
     <IncludeRuntimeJson>true</IncludeRuntimeJson>
   </PropertyGroup>
 
-  <Choose>
-    <When Condition="$(PackageTargetRid.StartsWith('win'))">
-      <PropertyGroup>
-        <ApplicationFileExtension>.exe</ApplicationFileExtension>
-        <LibraryFilePrefix></LibraryFilePrefix>
-        <LibraryFileExtension>.dll</LibraryFileExtension>
-        <SymbolFileExtension>.pdb</SymbolFileExtension>
-      </PropertyGroup>
-    </When>
-    <When Condition="$(PackageTargetRid.StartsWith('osx'))">
-      <PropertyGroup>
-        <ApplicationFileExtension></ApplicationFileExtension>
-        <LibraryFilePrefix>lib</LibraryFilePrefix>
-        <LibraryFileExtension>.dylib</LibraryFileExtension>
-        <SymbolFileExtension>.dwarf</SymbolFileExtension>
-      </PropertyGroup>
-    </When>
-    <Otherwise>
-      <PropertyGroup>
-        <ApplicationFileExtension></ApplicationFileExtension>
-        <LibraryFilePrefix>lib</LibraryFilePrefix>
-        <LibraryFileExtension>.so</LibraryFileExtension>
-        <SymbolFileExtension>.dbg</SymbolFileExtension>
-      </PropertyGroup>
-    </Otherwise>
-  </Choose>
-
   <Import Project="$(PackagingToolsDir)packaging-tools.props" />
 
   <PropertyGroup Condition="'$(MSBuildProjectExtension)' == '.depproj'">
@@ -127,9 +100,6 @@
           Include="$(PackageThirdPartyNoticesFile)" >
       <SkipPackageFileCheck>true</SkipPackageFileCheck>
     </File>
-
-    <AdditionalLibPackageExcludes Condition="'$(SymbolFileExtension)' != ''" Include="%2A%2A\%2A$(SymbolFileExtension)" />
-    <AdditionalSymbolPackageExcludes Condition="'$(LibraryFileExtension)' != ''" Include="%2A%2A\%2A.a;%2A%2A\%2A$(LibraryFileExtension)" />
   </ItemGroup>
 
   <PropertyGroup>
@@ -192,5 +162,37 @@
     <!-- When resolving assets to pack, use the target runtime (if any). -->
     <RuntimeIdentifier>$(PackageRID)</RuntimeIdentifier>
   </PropertyGroup>
+
+  <Choose>
+    <When Condition="$(RuntimeIdentifier.StartsWith('win'))">
+      <PropertyGroup>
+        <ApplicationFileExtension>.exe</ApplicationFileExtension>
+        <LibraryFilePrefix></LibraryFilePrefix>
+        <LibraryFileExtension>.dll</LibraryFileExtension>
+        <SymbolFileExtension>.pdb</SymbolFileExtension>
+      </PropertyGroup>
+    </When>
+    <When Condition="$(RuntimeIdentifier.StartsWith('osx'))">
+      <PropertyGroup>
+        <ApplicationFileExtension></ApplicationFileExtension>
+        <LibraryFilePrefix>lib</LibraryFilePrefix>
+        <LibraryFileExtension>.dylib</LibraryFileExtension>
+        <SymbolFileExtension>.dwarf</SymbolFileExtension>
+      </PropertyGroup>
+    </When>
+    <Otherwise>
+      <PropertyGroup>
+        <ApplicationFileExtension></ApplicationFileExtension>
+        <LibraryFilePrefix>lib</LibraryFilePrefix>
+        <LibraryFileExtension>.so</LibraryFileExtension>
+        <SymbolFileExtension>.dbg</SymbolFileExtension>
+      </PropertyGroup>
+    </Otherwise>
+  </Choose>
+
+  <ItemGroup>
+    <AdditionalLibPackageExcludes Condition="'$(SymbolFileExtension)' != ''" Include="%2A%2A\%2A$(SymbolFileExtension)" />
+    <AdditionalSymbolPackageExcludes Condition="'$(LibraryFileExtension)' != ''" Include="%2A%2A\%2A.a;%2A%2A\%2A$(LibraryFileExtension)" />
+  </ItemGroup>
 
 </Project>

--- a/src/pkg/projects/Directory.Build.targets
+++ b/src/pkg/projects/Directory.Build.targets
@@ -82,10 +82,20 @@
     </ItemGroup>
   </Target>
 
+  <Target Name="SetupFindSiblingSymbolFilesByNameForSymbolPackage">
+    <ItemGroup>
+      <FindSiblingSymbolsForFile Include="@(File)" />
+    </ItemGroup>
+  </Target>
+
   <!--
     Finds symbol files and injects them into the package build.
   -->
-  <Target Name="GetSymbolPackageFiles" BeforeTargets="GetPackageFiles">
+  <Target Name="GetSymbolPackageFiles"
+          BeforeTargets="GetPackageFiles"
+          DependsOnTargets="
+            SetupFindSiblingSymbolFilesByNameForSymbolPackage;
+            FindSiblingSymbolFilesByName">
     <ItemGroup Condition="'$(SymbolFileExtension)' != ''">
       <AdditionalLibPackageExcludes Include="%2A%2A\%2A$(SymbolFileExtension)" />
     </ItemGroup>
@@ -94,41 +104,12 @@
     </ItemGroup>
 
     <ItemGroup>
-      <!-- Normalize file paths up front (preserving metadata) for easier duplicate detection. -->
-      <File NormalizedIdentity="$([MSBuild]::NormalizePath('%(Identity)'))" />
-      <FileNormalized Include="@(File -> '%(NormalizedIdentity)')" RemoveMetadata="NormalizedIdentity" />
-      <File Remove="@(File)" />
-      <File Include="@(FileNormalized)" />
-
-      <WindowsNativeFile Include="@(File)"
-                         Condition="'%(File.Extension)' == '.dll' OR '%(File.Extension)' == '.exe'" />
-      <!-- Don't include *.pdb for export libraries or headers -->
-      <WindowsSymbolFile Include="@(File -> '%(RootDir)%(Directory)%(Filename).pdb')"
-                         Condition="'%(File.Extension)' != '.lib' AND '%(File.Extension)' != '.h'" />
-      <!-- Crossgened files (on windows) have both a *.pdb and a *.ni.pdb symbol file.  Include the *.ni.pdb file as well if it exists. -->
-      <WindowsSymbolFile Include="@(File -> '%(RootDir)%(Directory)%(Filename).ni.pdb')" />
-      <ExistingWindowsSymbolFile Include="@(WindowsSymbolFile)" Condition="Exists('%(Identity)')" />
-
-      <NonWindowsNativeFile Include="@(File)"
-                            Exclude="@(WindowsNativeFile)" />
-      <NonWindowsSymbolFile Include="@(NonWindowsNativeFile -> '%(Identity)$(SymbolFileExtension)')" />
-      <ExistingNonWindowsSymbolFile Include="@(NonWindowsSymbolFile)" Condition="Exists('%(Identity)')" />
-
-      <DiscoveredSymbolFile Include="@(ExistingWindowsSymbolFile);@(ExistingNonWindowsSymbolFile)" />
-    </ItemGroup>
-
-    <!-- Remove any duplicates in symbol files found by the above searches. -->
-    <RemoveDuplicates Inputs="@(DiscoveredSymbolFile)">
-      <Output TaskParameter="Filtered" ItemName="FilteredDiscoveredSymbolFile"/>
-    </RemoveDuplicates>
-
-    <ItemGroup>
       <!--
         Discovered symbol files might already be in File, without IsSymbolFile set. Make sure we
-        keep the discovered one and apply IsSymbolFile=true.
+        keep the discovered one, which has IsSymbolFile=true.
       -->
-      <File Remove="@(FilteredDiscoveredSymbolFile)" />
-      <File Include="@(FilteredDiscoveredSymbolFile)" IsSymbolFile="true" />
+      <File Remove="@(SiblingSymbolFile)" />
+      <File Include="@(SiblingSymbolFile)" />
     </ItemGroup>
 
     <PropertyGroup>
@@ -142,21 +123,6 @@
         <IsSymbolFile>true</IsSymbolFile>
       </File>
     </ItemGroup>
-  </Target>
-
-  <Target Name="PreserveSymbols"
-          AfterTargets="CreatePackage">
-    <PropertyGroup>
-      <_PackageSymbolsProjectDir>$(PackageSymbolsBinDir)$(MSBuildProjectName)/</_PackageSymbolsProjectDir>
-    </PropertyGroup>
-    <ItemGroup>
-      <_SymbolsFiles Include="%(File.Identity)" Condition="'%(File.Extension)' == '.pdb' OR '%(File.Extension)' == '$(SymbolFileExtension)'">
-        <DestinationFolder>$(_PackageSymbolsProjectDir)%(File.TargetPath)/</DestinationFolder>
-      </_SymbolsFiles>
-    </ItemGroup>
-    <MakeDir Directories="%(_SymbolsFiles.DestinationFolder)" />
-    <Copy SourceFiles="%(_SymbolsFiles.Identity)"
-          DestinationFolder="%(_SymbolsFiles.DestinationFolder)" />
   </Target>
 
   <!-- override GetPackageIdentity so that it doesn't attempt to gather


### PR DESCRIPTION
Fixes https://github.com/dotnet/core-setup/issues/7147.

#### Description

Ports https://github.com/dotnet/core-setup/pull/7959 to `release/3.0`.

Reworks some of the symbol redistribution infrastructure to be more maintainable and easier to verify. See https://github.com/dotnet/core-setup/pull/7959 for more info on these changes.

This PR ensures CoreFX symbols (shared framework .PDB files) and crossgen symbols (`.ni.pdb` for Windows and `.ni.{GUID}.map` files on others) make it into the symbol archive zip/tarball and symbol packages.

#### Customer Impact

The Core-Setup symbol packages were missing CoreFX PDBs for (at least) Preview 9. CoreFX symbol packages had them, but they were marked nonshipping so I had to manually publish them. This PR will redistribute the PDBs in the Core-Setup symbol packages and remove this hiccup from the release process for future 3.0 releases.

This PR also allows users of source-build to rely on Core-Setup's outputs to have the full set of managed symbols.

#### Regression?

Yes, this was an issue with the migration to the Arcade SDK.

#### Risk

Minimal, this is validated in `master`, and `release/3.0` hasn't diverged in this area.