### PR TITLE
Use IsShipping=false to keep VS insertion nupkgs unique

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -33,7 +33,12 @@
   <Target Name="GetProductVersions">
     <PropertyGroup>
       <IncludePreReleaseLabelInPackageVersion Condition="'$(DotNetFinalVersionKind)' != 'release'">true</IncludePreReleaseLabelInPackageVersion>
+      <IncludePreReleaseLabelInPackageVersion Condition="'$(SuppressFinalPackageVersion)' == 'true'">true</IncludePreReleaseLabelInPackageVersion>
+      <IncludePreReleaseLabelInPackageVersion Condition="'$(IsShipping)' != 'true'">true</IncludePreReleaseLabelInPackageVersion>
+
       <IncludeBuildNumberInPackageVersion Condition="'$(StabilizePackageVersion)' != 'true'">true</IncludeBuildNumberInPackageVersion>
+      <IncludeBuildNumberInPackageVersion Condition="'$(SuppressFinalPackageVersion)' == 'true'">true</IncludeBuildNumberInPackageVersion>
+      <IncludeBuildNumberInPackageVersion Condition="'$(IsShipping)' != 'true'">true</IncludeBuildNumberInPackageVersion>
 
       <ProductVersionSuffix Condition="'$(IncludePreReleaseLabelInPackageVersion)' == 'true'">-$(VersionSuffix)</ProductVersionSuffix>
       <ProductBandVersion Condition="'$(ProductBandVersion)' == ''">$(MajorVersion).$(MinorVersion)</ProductBandVersion>

--- a/publish/Directory.Build.props
+++ b/publish/Directory.Build.props
@@ -6,6 +6,12 @@
     <TargetFramework>$(NETCoreAppFramework)</TargetFramework>
   </PropertyGroup>
 
+  <!-- Set IsStableBuild to mimic https://github.com/dotnet/arcade/blob/694d59f090b743f894779d04a7ffe11cbaf352e7/src/Microsoft.DotNet.Arcade.Sdk/tools/Publish.proj#L30-L31 -->
+  <PropertyGroup>
+    <IsStableBuild>false</IsStableBuild>
+    <IsStableBuild Condition="'$(DotNetFinalVersionKind)' == 'release'">true</IsStableBuild>
+  </PropertyGroup>
+
   <PropertyGroup>
     <BaseUrl Condition="'$(BaseUrl)' == ''">https://dotnetcli.blob.core.windows.net/</BaseUrl>
 

--- a/publish/prepare-artifacts.proj
+++ b/publish/prepare-artifacts.proj
@@ -65,6 +65,7 @@
       ManifestBranch="$(BUILD_SOURCEBRANCH)"
       ManifestBuildId="$(BUILD_BUILDNUMBER)"
       ManifestCommit="$(BUILD_SOURCEVERSION)"
+      IsStableBuild="$(IsStableBuild)"
       AssetManifestPath="$(AssetManifestFile)"
       AssetsTemporaryDirectory="$(TempWorkingDir)" />
 
@@ -109,6 +110,7 @@
       ManifestBranch="$(BUILD_SOURCEBRANCH)"
       ManifestBuildId="$(BUILD_BUILDNUMBER)"
       ManifestCommit="$(BUILD_SOURCEVERSION)"
+      IsStableBuild="$(IsStableBuild)"
       PublishFlatContainer="true"
       AssetManifestPath="$(AssetManifestFile)"
       AssetsTemporaryDirectory="$(TempWorkingDir)" />

--- a/src/pkg/packaging-tools/packaging-tools.targets
+++ b/src/pkg/packaging-tools/packaging-tools.targets
@@ -200,6 +200,10 @@
     </RemoveDuplicates>
   </Target>
 
+  <Target Name="ReturnProductVersion"
+          DependsOnTargets="GetProductVersions"
+          Returns="$(ProductVersion)" />
+
   <!--
     By default, shared frameworks are generated based on the package. This can be overridden by the
     project, and in the future, the runtime pack is likely to be used to assemble the sfx.

--- a/src/pkg/packaging-tools/windows/wix.targets
+++ b/src/pkg/packaging-tools/windows/wix.targets
@@ -295,20 +295,35 @@
   <Target Name="GenerateVSInsertionNupkg"
           DependsOnTargets="
             GetInstallerGenerationFlags;
-            GenerateVSInsertionNupkgCore" />
+            EnsureMsiBuilt">
+    <!--
+      Run the nupkg creation code with IsShipping=false to use prerelease versions: this package
+      must not be stable to avoid mutation conflicts, even though the project itself may be shipping
+      and therefore stabilized.
+
+      Also pass in the path to the MSI file to pack up because its file name is based on
+      stabilization status.
+    -->
+    <MSBuild
+      Condition="'$(GenerateMSI)' == 'true'"
+      Projects="$(MSBuildProjectFullPath)"
+      Targets="GenerateVSInsertionNupkgCore"
+      Properties="
+        IsShipping=false;
+        ComponentMsiFile=$(OutInstallerFile)" />
+  </Target>
 
   <!--
     When using the CreateVSInsertionNupkg entry point target, we have to make sure this project's
     MSI was created first.
   -->
-  <Target Name="EnsureMsiBuilt">
+  <Target Name="EnsureMsiBuilt"
+          Condition="'$(GenerateMSI)' == 'true'">
     <MSBuild Projects="$(MSBuildProjectFullPath)" Targets="Build" />
   </Target>
 
   <Target Name="GenerateVSInsertionNupkgCore"
-          Condition="'$(GenerateMSI)' == 'true'"
           DependsOnTargets="
-            EnsureMsiBuilt;
             AcquireNuGetExe;
             GetInstallerProperties;
             GetWixBuildConfiguration">
@@ -321,7 +336,7 @@
       <ProjectUrlForVS>https://github.com/dotnet/core-setup</ProjectUrlForVS>
 
       <PackProperties />
-      <PackProperties>$(PackProperties)COMPONENT_MSI=$(OutInstallerFile);</PackProperties>
+      <PackProperties>$(PackProperties)COMPONENT_MSI=$(ComponentMsiFile);</PackProperties>
       <PackProperties>$(PackProperties)ARCH=$(MsiArch);</PackProperties>
       <PackProperties>$(PackProperties)COMPONENT_NAME=$(VSInsertionComponentName);</PackProperties>
       <PackProperties>$(PackProperties)FRIENDLY_NAME=$(VSInsertionComponentFriendlyName);</PackProperties>

--- a/src/test/Directory.Build.targets
+++ b/src/test/Directory.Build.targets
@@ -54,6 +54,20 @@
     </PropertyGroup>
 
     <!--
+      Fetch the package version of Microsoft.NETCore.App. Use the runtime nupkg project because it
+      always ships.
+
+      Some test projects end in ".Tests", which Arcade detects and applies IsShipping=false. This
+      makes ProductVersion non-stable, so we can't rely on the test project's ProductVersion to be
+      the same as the package's version. Fetch this directly from the project to avoid guesswork.
+    -->
+    <MSBuild
+      Projects="$(SourceDir)pkg\projects\netcoreapp\pkg\Microsoft.NETCore.App.Runtime.pkgproj"
+      Targets="ReturnProductVersion">
+      <Output TaskParameter="TargetOutputs" PropertyName="NETCoreAppRuntimePackageVersion" />
+    </MSBuild>
+
+    <!--
       Set up properties used inside tests. Write them to a text file so that they can be found
       inside the VS Test Explorer context the same way as the XUnit runner will find them.
       See https://github.com/dotnet/arcade/issues/3077.
@@ -65,7 +79,7 @@
       <TestContextVariable Include="BUILDRID=$(OutputRid)" />
       <TestContextVariable Include="BUILD_ARCHITECTURE=$(TargetArchitecture)" />
       <TestContextVariable Include="BUILD_CONFIGURATION=$(ConfigurationGroup)" />
-      <TestContextVariable Include="MNA_VERSION=$(ProductVersion)" />
+      <TestContextVariable Include="MNA_VERSION=$(NETCoreAppRuntimePackageVersion)" />
       <TestContextVariable Include="MNA_TFM=$(NETCoreAppFramework)" />
       <TestContextVariable Include="DOTNET_SDK_PATH=$(DotNetRoot)" />
     </ItemGroup>


### PR DESCRIPTION
For https://github.com/dotnet/core-setup/issues/8100.

In Arcade, NonShipping packages always have unstable (`-{prerelease}-{buildnum}`) versions. This is necessary to push VS insertion packages to the VS feed, because mutation is not allowed and we may need to build a stabilized build multiple times. Core-Setup infra structure didn't properly support this in two ways:
* The insertion package generation infra runs inside the pkgproj that also produces the MSI. This means they are both shipping, or both nonshipping. The MSI needs to be shipping and the VS insertion package needs to be nonshipping.
  * Solved by using an MSBuild task with shipping set to `false` for the insertion nupkg.
* `IsShipping` isn't supported in Core-Setup's `GetProductVersions` target.
  * Solved by adding it. Also support the related `SuppressFinalPackageVersion` property in case it's necessary in the future.
* `PushToAzureDevOpsArtifacts` is missing `IsStableBuild="$(IsStableBuild)"`, which is necessary to make the correct asset manifest.
  * Solved by adding it. It is missing from the [yaml stages publish doc](https://github.com/dotnet/arcade/blob/a82e129e6df744f26e920284ab098fb5c2c13418/Documentation/CorePackages/YamlStagesPublishing.md) but present in [Arcade's usage of the task](https://github.com/dotnet/arcade/blob/694d59f090b743f894779d04a7ffe11cbaf352e7/src/Microsoft.DotNet.Arcade.Sdk/tools/Publish.proj#L169).

(This PR is a cherry-pick of changes I'm making to a stabilization validation branch based on 3.0.)