### PR TITLE
Add license to project file

### DIFF
--- a/src/managed/Microsoft.DotNet.PlatformAbstractions/Microsoft.DotNet.PlatformAbstractions.csproj
+++ b/src/managed/Microsoft.DotNet.PlatformAbstractions/Microsoft.DotNet.PlatformAbstractions.csproj
@@ -6,6 +6,7 @@
     <TargetFrameworks>net45;netstandard1.3;netstandard2.0</TargetFrameworks>
     <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'" >netstandard1.3;netstandard2.0</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
I'm a total noob when it comes to dotnet. Feel free to reject.

I was running gitlab's built-in license management tool, and no license was found for this package. Upon reading the docs, this seems like the preferred method for NuGet packages moving forward. My assumption is that this will update NuGet and I will get the correct license information in the future. If this works, I'm happy to update other csproj files in other dotnet repos.

I believe this can be skip ci please