### PR TITLE
Fix NonShipping packages to always be unstable

### DIFF
--- a/src/pkg/projects/Directory.Build.targets
+++ b/src/pkg/projects/Directory.Build.targets
@@ -16,11 +16,34 @@
 
   <!--
     For any Dependency items with a VersionProp, set it to the property by that name given by the
-    version generation target.
+    version generation target. For any with a VersionFromProject, query the ProductVersion from that
+    project file and use it as the dependency's version.
   -->
   <Target Name="SetCustomPackageDependencyVersions"
           BeforeTargets="GetPackageDependencies"
           DependsOnTargets="GetProductVersions">
+    <!--
+      Generate a VersionProp name for each dependency with VersionFromProject. The batched MSBuild
+      task then generates the property, which is picked up by the VersionProp implementation.
+
+      Using PropertyName rather than ItemName on the MSBuild task avoids the difficulty in
+      reattaching the separate list of items back into the original Dependency items without any
+      reasonable Join operation available.
+    -->
+    <ItemGroup>
+      <Dependency
+        VersionProp="_VersionProp_$([System.String]::new('%(Dependency.Identity)').Replace('.', '_'))"
+        Condition="'%(Dependency.VersionFromProject)' != ''" />
+    </ItemGroup>
+
+    <MSBuild
+      Condition="'%(Dependency.VersionFromProject)' != ''"
+      Projects="%(Dependency.VersionFromProject)"
+      Targets="ReturnProductVersion">
+      <Output TaskParameter="TargetOutputs" PropertyName="%(Dependency.VersionProp)" />
+    </MSBuild>
+
+    <!-- Use batching to use the value of an arbitrary property as the version. -->
     <ItemGroup>
       <Dependency Version="$(%(Dependency.VersionProp))" Condition="'%(Dependency.VersionProp)' != ''" />
     </ItemGroup>

--- a/src/pkg/projects/netcoreapp/pkg/legacy/Directory.Build.props
+++ b/src/pkg/projects/netcoreapp/pkg/legacy/Directory.Build.props
@@ -5,7 +5,7 @@
     <PreventImplementationReference Condition="'$(PackageTargetRuntime)' != ''">true</PreventImplementationReference>
     <BuildTargetPath>build/$(NETCoreAppFramework)/</BuildTargetPath>
 
-    <IsShippingPackage>false</IsShippingPackage>
+    <IsShipping>false</IsShipping>
   </PropertyGroup>
 
   <!-- Identity / Reference package content -->
@@ -16,7 +16,7 @@
     <!-- references the host packages -->
     <Dependency
       Include="Microsoft.NETCore.DotNetHostPolicy"
-      VersionProp="HostPolicyVersion"
+      VersionFromProject="$(SourceDir)pkg\projects\Microsoft.NETCore.DotNetHostPolicy\Microsoft.NETCore.DotNetHostPolicy.pkgproj"
       TargetFramework="$(NETCoreAppFramework)" />
   </ItemGroup>
 

--- a/src/pkg/projects/netcoreapp/pkg/workaround/Microsoft.NETCore.App.pkgproj
+++ b/src/pkg/projects/netcoreapp/pkg/workaround/Microsoft.NETCore.App.pkgproj
@@ -16,7 +16,7 @@
 
     <BuildRuntimePackages>false</BuildRuntimePackages>
 
-    <IsShippingPackage>false</IsShippingPackage>
+    <IsShipping>false</IsShipping>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/pkg/projects/windowsdesktop/pkg/Microsoft.WindowsDesktop.App.pkgproj
+++ b/src/pkg/projects/windowsdesktop/pkg/Microsoft.WindowsDesktop.App.pkgproj
@@ -18,7 +18,7 @@
     -->
     <SkipValidatePackage>false</SkipValidatePackage>
 
-    <IsShippingPackage>false</IsShippingPackage>
+    <IsShipping>false</IsShipping>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/test/Assets/TestProjects/Directory.Build.props
+++ b/src/test/Assets/TestProjects/Directory.Build.props
@@ -4,6 +4,7 @@
   <ItemGroup>
     <RestoreTestFallbackSource Include="$(ArtifactsShippingPackagesDir)" />
     <RestoreTestFallbackSource Include="$(ArtifactsNonShippingPackagesDir)" />
+    <RestoreTestFallbackSource Include="$(TestStabilizedLegacyPackagesDir)" />
     <RestoreTestSource Include="$(RestoreSources)" />
     <RestoreTestSource Include="https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json" />
     <RestoreTestSource Include="https://api.nuget.org/v3/index.json" />

--- a/src/test/Directory.Build.props
+++ b/src/test/Directory.Build.props
@@ -4,6 +4,7 @@
   <PropertyGroup>
     <TestDir>$(ProjectDir)src\test\</TestDir>
     <TestAssetsDir>$(TestDir)Assets\</TestAssetsDir>
+    <TestStabilizedLegacyPackagesDir>$(ObjDir)TestStabilizedPackages\</TestStabilizedLegacyPackagesDir>
     <TestRestorePackagesPath>$(ObjDir)TestPackageCache\</TestRestorePackagesPath>
     <TestArchitectures>$(TargetArchitecture)</TestArchitectures>
     <TestInfraTargetFramework>netcoreapp3.0</TestInfraTargetFramework>

--- a/src/test/Directory.Build.targets
+++ b/src/test/Directory.Build.targets
@@ -93,7 +93,7 @@
 
   <!--
     Fetch the package version of 'Microsoft.NETCore.App.Runtime.<rid>'. The runtime nupkg project
-    always ships, and may have a stable version.
+    always ships, so it may or may not have a stable version depending on product lifecycle.
 
     Some test projects end in ".Tests", which Arcade detects and applies IsShipping=false. This
     makes ProductVersion non-stable, so we can't rely on the test project's ProductVersion to be the
@@ -109,7 +109,7 @@
 
   <!--
     Fetch the package version of Microsoft.NETCore.App.Internal. The legacy App nupkg project
-    doesn't ship, so it may or may not have a stable version.
+    doesn't ship, so it never has a stable version.
   -->
   <Target Name="GetNETCoreAppInternalPackageVersion">
     <MSBuild

--- a/src/test/Directory.Build.targets
+++ b/src/test/Directory.Build.targets
@@ -37,6 +37,7 @@
   <Target Name="SetupTestContextVariables"
           DependsOnTargets="
             GetProductVersions;
+            GetNETCoreAppRuntimePackVersion;
             DetermineTestOutputDirectory"
           BeforeTargets="Build">
     <PropertyGroup>
@@ -88,6 +89,34 @@
       File="$(OutDir)TestContextVariables.txt"
       Overwrite="true"
       Lines="@(TestContextVariable)" />
+  </Target>
+
+  <!--
+    Fetch the package version of 'Microsoft.NETCore.App.Runtime.<rid>'. The runtime nupkg project
+    always ships, and may have a stable version.
+
+    Some test projects end in ".Tests", which Arcade detects and applies IsShipping=false. This
+    makes ProductVersion non-stable, so we can't rely on the test project's ProductVersion to be the
+    same as the package's version. Fetch this directly from the project to avoid guesswork.
+  -->
+  <Target Name="GetNETCoreAppRuntimePackVersion">
+    <MSBuild
+      Projects="$(SourceDir)pkg\projects\netcoreapp\pkg\Microsoft.NETCore.App.Runtime.pkgproj"
+      Targets="ReturnProductVersion">
+      <Output TaskParameter="TargetOutputs" PropertyName="NETCoreAppRuntimePackVersion" />
+    </MSBuild>
+  </Target>
+
+  <!--
+    Fetch the package version of Microsoft.NETCore.App.Internal. The legacy App nupkg project
+    doesn't ship, so it may or may not have a stable version.
+  -->
+  <Target Name="GetNETCoreAppInternalPackageVersion">
+    <MSBuild
+      Projects="$(SourceDir)pkg\projects\netcoreapp\pkg\legacy\Microsoft.NETCore.App.Internal.pkgproj"
+      Targets="ReturnProductVersion">
+      <Output TaskParameter="TargetOutputs" PropertyName="NETCoreAppInternalPackageVersion" />
+    </MSBuild>
   </Target>
 
   <Target Name="DetermineTestOutputDirectory">

--- a/src/test/PrepareTestAssets/PrepareTestAssets.proj
+++ b/src/test/PrepareTestAssets/PrepareTestAssets.proj
@@ -1,9 +1,17 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
+  <UsingTask TaskName="CopyNupkgAndChangeVersion" AssemblyFile="$(LocalBuildToolsTaskFile)" />
+
   <Target Name="PrepareTestAssets"
           DependsOnTargets="
-            GetProductVersions;
-            DetermineTestOutputDirectory">
+            GetNETCoreAppInternalPackageVersion;
+            GetNETCoreAppRuntimePackVersion;
+            CleanTestAssets;
+            PrepareStabilizedLegacyPackages;
+            RestoreTestAssetProjects" />
+
+  <Target Name="CleanTestAssets"
+          DependsOnTargets="DetermineTestOutputDirectory">
     <!--
       Ensure installers (and therefore shared framework projects) are built first. Include used
       transitive dependenices here in case Subset is defined.
@@ -23,16 +31,42 @@
     <ItemGroup>
       <DirsToClean Include="$(TestDir)\**\bin" />
       <DirsToClean Include="$(TestDir)\**\obj" />
+      <DirsToClean Include="$(TestStabilizedLegacyPackagesDir)" />
       <DirsToClean Include="$(TestRestorePackagesPath)" />
       <DirsToClean Include="$(TempFolderRoot)$(TargetArchitecture)" />
+    </ItemGroup>
 
+    <RemoveDir Directories="@(DirsToClean)" />
+
+    <!-- Directory must exist even if there are no nupkgs inside to use, or NuGet fails. -->
+    <MakeDir Directories="$(TestStabilizedLegacyPackagesDir)" />
+  </Target>
+
+  <Target Name="PrepareStabilizedLegacyPackages"
+          Condition="'$(NETCoreAppInternalPackageVersion)' != '$(NETCoreAppRuntimePackVersion)'">
+    <ItemGroup>
+      <NonShippingPackageToStabilizeFile Include="
+        $(ArtifactsNonShippingPackagesDir)Microsoft.*.nupkg;
+        $(ArtifactsNonShippingPackagesDir)runtime.*.nupkg;" />
+    </ItemGroup>
+
+    <!-- Workaround for NonShipping packages being unable to have stable versions, see https://github.com/dotnet/core-setup/issues/8112 -->
+    <Message Importance="High" Text="Generating stabilized legacy NETCoreApp packages..." />
+
+    <CopyNupkgAndChangeVersion
+      SourceFile="%(NonShippingPackageToStabilizeFile.Identity)"
+      TargetFile="$(TestStabilizedLegacyPackagesDir)@(NonShippingPackageToStabilizeFile -> '%(Filename)%(Extension)')"
+      OriginalVersion="$(NETCoreAppInternalPackageVersion)"
+      TargetVersion="$(NETCoreAppRuntimePackVersion)" />
+  </Target>
+
+  <Target Name="RestoreTestAssetProjects">
+    <ItemGroup>
       <TestAssetProjectToRestore Include="$(TestAssetsDir)**\*.csproj" />
 
       <AllTestRestoreSources Include="@(RestoreTestSource)"/>
       <AllTestRestoreSources Include="@(RestoreTestFallbackSource)"/>
     </ItemGroup>
-
-    <RemoveDir Directories="@(DirsToClean)" />
 
     <Message Importance="High" Text="Running NuGet Restore for test asset projects..." />
 
@@ -42,9 +76,10 @@
       Properties="
         ArtifactsShippingPackagesDir=$(ArtifactsShippingPackagesDir);
         ArtifactsNonShippingPackagesDir=$(ArtifactsNonShippingPackagesDir);
+        TestStabilizedLegacyPackagesDir=$(TestStabilizedLegacyPackagesDir);
         TestRestorePackagesPath=$(TestRestorePackagesPath);
         TestTargetRid=$(TestTargetRid);
-        MNAVersion=$(ProductVersion)" />
+        MNAVersion=$(NETCoreAppRuntimePackVersion)" />
   </Target>
 
 </Project>

--- a/tools-local/tasks/CopyNupkgAndChangeVersion.cs
+++ b/tools-local/tasks/CopyNupkgAndChangeVersion.cs
@@ -1,0 +1,123 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Build.Framework;
+using Newtonsoft.Json.Linq;
+using NuGet.Versioning;
+using System;
+using System.IO;
+using System.IO.Compression;
+using System.Linq;
+using System.Xml.Linq;
+
+namespace Microsoft.DotNet.Build.Tasks
+{
+    public class CopyNupkgAndChangeVersion : BuildTask
+    {
+        [Required]
+        public string SourceFile { get; set; }
+
+        [Required]
+        public string TargetFile { get; set; }
+
+        [Required]
+        public string OriginalVersion { get; set; }
+
+        [Required]
+        public string TargetVersion { get; set; }
+
+        public string[] DependencyPackageIdsToChange { get; set; }
+
+        public override bool Execute()
+        {
+            Directory.CreateDirectory(Path.GetDirectoryName(TargetFile));
+            File.Copy(SourceFile, TargetFile, true);
+
+            using (ZipArchive zip = ZipFile.Open(TargetFile, ZipArchiveMode.Update))
+            {
+                foreach (var nuspec in zip.Entries.Where(e => e.FullName.EndsWith(".nuspec")))
+                {
+                    Rewrite(nuspec, s =>
+                    {
+                        XDocument content = XDocument.Parse(s);
+
+                        XNamespace rootNamespace = content.Root.GetDefaultNamespace();
+                        XName GetQualifiedName(string name) => rootNamespace.GetName(name);
+
+                        var versionElement = content
+                            .Element(GetQualifiedName("package"))
+                            .Element(GetQualifiedName("metadata"))
+                            .Element(GetQualifiedName("version"));
+
+                        if (versionElement.Value != OriginalVersion)
+                        {
+                            Log.LogError(
+                                $"Original version is '{versionElement.Value}', " +
+                                $"expected '{OriginalVersion}'");
+                        }
+
+                        versionElement.Value = TargetVersion;
+
+                        foreach (var dependency in content
+                            .Descendants(GetQualifiedName("dependency"))
+                            .Where(x =>
+                                x.Attribute("version").Value == OriginalVersion &&
+                                DependencyPackageIdsToChange?.Contains(x.Attribute("id").Value) == true))
+                        {
+                            dependency.Value = TargetVersion;
+                        }
+
+                        return content.ToString();
+                    });
+                }
+
+                foreach (var runtimeJson in zip.Entries.Where(e => e.FullName == "runtime.json"))
+                {
+                    Rewrite(runtimeJson, s =>
+                    {
+                        JObject content = JObject.Parse(s);
+                        var versionProperties = content
+                            .Descendants()
+                            .OfType<JProperty>()
+                            .Where(p =>
+                                p.Value is JValue v &&
+                                v.Type == JTokenType.String);
+
+                        foreach (var p in versionProperties)
+                        {
+                            var range = VersionRange.Parse(p.Value.Value<string>());
+
+                            if (range.MinVersion.OriginalVersion == OriginalVersion)
+                            {
+                                var newRange = new VersionRange(
+                                    NuGetVersion.Parse(TargetVersion),
+                                    range.Float);
+
+                                p.Value = newRange.ToString();
+                            }
+                        }
+
+                        return content.ToString();
+                    });
+                }
+            }
+
+            return !Log.HasLoggedErrors;
+        }
+
+        private void Rewrite(ZipArchiveEntry entry, Func<string, string> rewrite)
+        {
+            using (var stream = entry.Open())
+            using (var reader = new StreamReader(stream))
+            using (var writer = new StreamWriter(stream))
+            {
+                var content = rewrite(reader.ReadToEnd());
+
+                stream.Position = 0;
+                stream.SetLength(0);
+                writer.Write(content);
+            }
+        }
+    }
+}

--- a/tools-local/tasks/CopyNupkgAndChangeVersion.cs
+++ b/tools-local/tasks/CopyNupkgAndChangeVersion.cs
@@ -126,6 +126,7 @@ namespace Microsoft.DotNet.Build.Tasks
                 }
             }
         }
+
         private static XName CreateQualifiedName(XDocument doc, string name)
         {
             return doc.Root.GetDefaultNamespace().GetName(name);

--- a/tools-local/tasks/CopyNupkgAndChangeVersion.cs
+++ b/tools-local/tasks/CopyNupkgAndChangeVersion.cs
@@ -36,77 +36,102 @@ namespace Microsoft.DotNet.Build.Tasks
 
             using (ZipArchive zip = ZipFile.Open(TargetFile, ZipArchiveMode.Update))
             {
-                foreach (var nuspec in zip.Entries.Where(e => e.FullName.EndsWith(".nuspec")))
-                {
-                    Rewrite(nuspec, s =>
-                    {
-                        XDocument content = XDocument.Parse(s);
-
-                        XNamespace rootNamespace = content.Root.GetDefaultNamespace();
-                        XName GetQualifiedName(string name) => rootNamespace.GetName(name);
-
-                        var versionElement = content
-                            .Element(GetQualifiedName("package"))
-                            .Element(GetQualifiedName("metadata"))
-                            .Element(GetQualifiedName("version"));
-
-                        if (versionElement.Value != OriginalVersion)
-                        {
-                            Log.LogError(
-                                $"Original version is '{versionElement.Value}', " +
-                                $"expected '{OriginalVersion}'");
-                        }
-
-                        versionElement.Value = TargetVersion;
-
-                        foreach (var dependency in content
-                            .Descendants(GetQualifiedName("dependency"))
-                            .Where(x =>
-                                x.Attribute("version").Value == OriginalVersion &&
-                                DependencyPackageIdsToChange?.Contains(x.Attribute("id").Value) == true))
-                        {
-                            dependency.Value = TargetVersion;
-                        }
-
-                        return content.ToString();
-                    });
-                }
-
-                foreach (var runtimeJson in zip.Entries.Where(e => e.FullName == "runtime.json"))
-                {
-                    Rewrite(runtimeJson, s =>
-                    {
-                        JObject content = JObject.Parse(s);
-                        var versionProperties = content
-                            .Descendants()
-                            .OfType<JProperty>()
-                            .Where(p =>
-                                p.Value is JValue v &&
-                                v.Type == JTokenType.String);
-
-                        foreach (var p in versionProperties)
-                        {
-                            var range = VersionRange.Parse(p.Value.Value<string>());
-
-                            if (range.MinVersion.OriginalVersion == OriginalVersion)
-                            {
-                                var newRange = new VersionRange(
-                                    NuGetVersion.Parse(TargetVersion),
-                                    range.Float);
-
-                                p.Value = newRange.ToString();
-                            }
-                        }
-
-                        return content.ToString();
-                    });
-                }
+                RewriteNuspec(zip);
+                RewriteRuntimeJson(zip);
             }
 
             return !Log.HasLoggedErrors;
         }
 
-        private void Rewrite(ZipArchiveEntry entry, Func<string, string> rewrite)
+        private void RewriteNuspec(ZipArchive zip)
+        {
+            foreach (var nuspec in zip.Entries.Where(e => e.FullName.EndsWith(".nuspec")))
+            {
+                Rewrite(nuspec, s =>
+                {
+                    XDocument content = XDocument.Parse(s);
+
+                    RewriteNuspecPackageVersion(content);
+                    RewriteNuspecDependencyVersions(content);
+
+                    return content.ToString();
+                });
+            }
+        }
+
+        private void RewriteRuntimeJson(ZipArchive zip)
+        {
+            foreach (var runtimeJson in zip.Entries.Where(e => e.FullName == "runtime.json"))
+            {
+                Rewrite(runtimeJson, s =>
+                {
+                    JObject content = JObject.Parse(s);
+
+                    RewriteRuntimeJsonVersions(content);
+
+                    return content.ToString();
+                });
+            }
+        }
+
+        private void RewriteNuspecPackageVersion(XDocument content)
+        {
+            XElement versionElement = content
+                .Element(CreateQualifiedName(content, "package"))
+                .Element(CreateQualifiedName(content, "metadata"))
+                .Element(CreateQualifiedName(content, "version"));
+
+            if (versionElement.Value != OriginalVersion)
+            {
+                Log.LogError(
+                    $"Original version is '{versionElement.Value}', " +
+                    $"expected '{OriginalVersion}'");
+            }
+
+            versionElement.Value = TargetVersion;
+        }
+
+        private void RewriteNuspecDependencyVersions(XDocument content)
+        {
+            foreach (var dependency in content
+                .Descendants(CreateQualifiedName(content, "dependency"))
+                .Where(x =>
+                    x.Attribute("version").Value == OriginalVersion &&
+                    DependencyPackageIdsToChange?.Contains(x.Attribute("id").Value) == true))
+            {
+                dependency.Value = TargetVersion;
+            }
+        }
+
+        private void RewriteRuntimeJsonVersions(JObject content)
+        {
+            var versionProperties = content
+                .Descendants()
+                .OfType<JProperty>()
+                .Where(p =>
+                    p.Value is JValue v &&
+                    v.Type == JTokenType.String);
+
+            foreach (var p in versionProperties)
+            {
+                var range = VersionRange.Parse(p.Value.Value<string>());
+
+                if (range.MinVersion.OriginalVersion == OriginalVersion)
+                {
+                    var newRange = new VersionRange(
+                        NuGetVersion.Parse(TargetVersion),
+                        range.Float);
+
+                    p.Value = newRange.ToString();
+                }
+            }
+        }
+        private static XName CreateQualifiedName(XDocument doc, string name)
+        {
+            return doc.Root.GetDefaultNamespace().GetName(name);
+        }
+
+        private static void Rewrite(ZipArchiveEntry entry, Func<string, string> rewrite)
         {
             using (var stream = entry.Open())
             using (var reader = new StreamReader(stream))


### PR DESCRIPTION
For https://github.com/dotnet/core-setup/issues/8112.

Change `<IsShippingPackage>false</IsShippingPackage>` to `<IsShipping>false</IsShipping>`: this is what I did to get the nonshipping packages unstable before we get the Arcade fix change https://github.com/dotnet/arcade/pull/3909, and I don't know a reason to revert it.

Fix the `Microsoft.NETCore.App.Internal` dependency on `Microsoft.NETCore.DotNetHostPolicy` to be correct regardless of stable/nonstable versioning, by adding a `VersionFromProject` feature similar to `VersionProp`.

Add `PrepareStabilizedLegacyPackages` in `PrepareTestAssets.proj` that kicks in when shipping packages are stable. It uses a new task `CopyNupkgAndChangeVersion` to create a copy of the nonshipping packages in an intermediate directory that is fed into test restore. When the versions are the same, like here in `master`, the packages are left alone.

Test build (with 3.0 stabilization changes) ongoing: https://dev.azure.com/dnceng/internal/_build/results?buildId=348560

/cc @dleeapho 