### PR TITLE
[release/3.0] Infrastructure fixes to allow stabilized builds for 3.0 GA

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -25,7 +25,12 @@
   <Target Name="GetProductVersions">
     <PropertyGroup>
       <IncludePreReleaseLabelInPackageVersion Condition="'$(DotNetFinalVersionKind)' != 'release'">true</IncludePreReleaseLabelInPackageVersion>
+      <IncludePreReleaseLabelInPackageVersion Condition="'$(SuppressFinalPackageVersion)' == 'true'">true</IncludePreReleaseLabelInPackageVersion>
+      <IncludePreReleaseLabelInPackageVersion Condition="'$(IsShipping)' != 'true'">true</IncludePreReleaseLabelInPackageVersion>
+
       <IncludeBuildNumberInPackageVersion Condition="'$(StabilizePackageVersion)' != 'true'">true</IncludeBuildNumberInPackageVersion>
+      <IncludeBuildNumberInPackageVersion Condition="'$(SuppressFinalPackageVersion)' == 'true'">true</IncludeBuildNumberInPackageVersion>
+      <IncludeBuildNumberInPackageVersion Condition="'$(IsShipping)' != 'true'">true</IncludeBuildNumberInPackageVersion>
 
       <ProductVersionSuffix Condition="'$(IncludePreReleaseLabelInPackageVersion)' == 'true'">-$(VersionSuffix)</ProductVersionSuffix>
       <ProductBandVersion Condition="'$(ProductBandVersion)' == ''">$(MajorVersion).$(MinorVersion)</ProductBandVersion>

--- a/publish/Directory.Build.props
+++ b/publish/Directory.Build.props
@@ -6,6 +6,12 @@
     <TargetFramework>$(NETCoreAppFramework)</TargetFramework>
   </PropertyGroup>
 
+  <!-- Set IsStableBuild to mimic https://github.com/dotnet/arcade/blob/694d59f090b743f894779d04a7ffe11cbaf352e7/src/Microsoft.DotNet.Arcade.Sdk/tools/Publish.proj#L30-L31 -->
+  <PropertyGroup>
+    <IsStableBuild>false</IsStableBuild>
+    <IsStableBuild Condition="'$(DotNetFinalVersionKind)' == 'release'">true</IsStableBuild>
+  </PropertyGroup>
+
   <PropertyGroup>
     <BaseUrl Condition="'$(BaseUrl)' == ''">https://dotnetcli.blob.core.windows.net/</BaseUrl>
 

--- a/publish/prepare-artifacts.proj
+++ b/publish/prepare-artifacts.proj
@@ -65,6 +65,7 @@
       ManifestBranch="$(BUILD_SOURCEBRANCH)"
       ManifestBuildId="$(BUILD_BUILDNUMBER)"
       ManifestCommit="$(BUILD_SOURCEVERSION)"
+      IsStableBuild="$(IsStableBuild)"
       AssetManifestPath="$(AssetManifestFile)"
       AssetsTemporaryDirectory="$(TempWorkingDir)" />
 
@@ -109,6 +110,7 @@
       ManifestBranch="$(BUILD_SOURCEBRANCH)"
       ManifestBuildId="$(BUILD_BUILDNUMBER)"
       ManifestCommit="$(BUILD_SOURCEVERSION)"
+      IsStableBuild="$(IsStableBuild)"
       PublishFlatContainer="true"
       AssetManifestPath="$(AssetManifestFile)"
       AssetsTemporaryDirectory="$(TempWorkingDir)" />

--- a/src/pkg/packaging-tools/packaging-tools.targets
+++ b/src/pkg/packaging-tools/packaging-tools.targets
@@ -234,6 +234,10 @@
     </RemoveDuplicates>
   </Target>
 
+  <Target Name="ReturnProductVersion"
+          DependsOnTargets="GetProductVersions"
+          Returns="$(ProductVersion)" />
+
   <!--
     By default, shared frameworks are generated based on the package. This can be overridden by the
     project, and in the future, the runtime pack is likely to be used to assemble the sfx.

--- a/src/pkg/packaging-tools/windows/wix.targets
+++ b/src/pkg/packaging-tools/windows/wix.targets
@@ -295,20 +295,35 @@
   <Target Name="GenerateVSInsertionNupkg"
           DependsOnTargets="
             GetInstallerGenerationFlags;
-            GenerateVSInsertionNupkgCore" />
+            EnsureMsiBuilt">
+    <!--
+      Run the nupkg creation code with IsShipping=false to use prerelease versions: this package
+      must not be stable to avoid mutation conflicts, even though the project itself may be shipping
+      and therefore stabilized.
+
+      Also pass in the path to the MSI file to pack up because its file name is based on
+      stabilization status.
+    -->
+    <MSBuild
+      Condition="'$(GenerateMSI)' == 'true'"
+      Projects="$(MSBuildProjectFullPath)"
+      Targets="GenerateVSInsertionNupkgCore"
+      Properties="
+        IsShipping=false;
+        ComponentMsiFile=$(OutInstallerFile)" />
+  </Target>
 
   <!--
     When using the CreateVSInsertionNupkg entry point target, we have to make sure this project's
     MSI was created first.
   -->
-  <Target Name="EnsureMsiBuilt">
+  <Target Name="EnsureMsiBuilt"
+          Condition="'$(GenerateMSI)' == 'true'">
     <MSBuild Projects="$(MSBuildProjectFullPath)" Targets="Build" />
   </Target>
 
   <Target Name="GenerateVSInsertionNupkgCore"
-          Condition="'$(GenerateMSI)' == 'true'"
           DependsOnTargets="
-            EnsureMsiBuilt;
             AcquireNuGetExe;
             GetInstallerProperties;
             GetWixBuildConfiguration">
@@ -321,7 +336,7 @@
       <ProjectUrlForVS>https://github.com/dotnet/core-setup</ProjectUrlForVS>
 
       <PackProperties />
-      <PackProperties>$(PackProperties)COMPONENT_MSI=$(OutInstallerFile);</PackProperties>
+      <PackProperties>$(PackProperties)COMPONENT_MSI=$(ComponentMsiFile);</PackProperties>
       <PackProperties>$(PackProperties)ARCH=$(MsiArch);</PackProperties>
       <PackProperties>$(PackProperties)COMPONENT_NAME=$(VSInsertionComponentName);</PackProperties>
       <PackProperties>$(PackProperties)FRIENDLY_NAME=$(VSInsertionComponentFriendlyName);</PackProperties>

--- a/src/pkg/projects/Directory.Build.targets
+++ b/src/pkg/projects/Directory.Build.targets
@@ -16,11 +16,34 @@
 
   <!--
     For any Dependency items with a VersionProp, set it to the property by that name given by the
-    version generation target.
+    version generation target. For any with a VersionFromProject, query the ProductVersion from that
+    project file and use it as the dependency's version.
   -->
   <Target Name="SetCustomPackageDependencyVersions"
           BeforeTargets="GetPackageDependencies"
           DependsOnTargets="GetProductVersions">
+    <!--
+      Generate a VersionProp name for each dependency with VersionFromProject. The batched MSBuild
+      task then generates the property, which is picked up by the VersionProp implementation.
+
+      Using PropertyName rather than ItemName on the MSBuild task avoids the difficulty in
+      reattaching the separate list of items back into the original Dependency items without any
+      reasonable Join operation available.
+    -->
+    <ItemGroup>
+      <Dependency
+        VersionProp="_VersionProp_$([System.String]::new('%(Dependency.Identity)').Replace('.', '_'))"
+        Condition="'%(Dependency.VersionFromProject)' != ''" />
+    </ItemGroup>
+
+    <MSBuild
+      Condition="'%(Dependency.VersionFromProject)' != ''"
+      Projects="%(Dependency.VersionFromProject)"
+      Targets="ReturnProductVersion">
+      <Output TaskParameter="TargetOutputs" PropertyName="%(Dependency.VersionProp)" />
+    </MSBuild>
+
+    <!-- Use batching to use the value of an arbitrary property as the version. -->
     <ItemGroup>
       <Dependency Version="$(%(Dependency.VersionProp))" Condition="'%(Dependency.VersionProp)' != ''" />
     </ItemGroup>

--- a/src/pkg/projects/netcoreapp/pkg/legacy/Directory.Build.props
+++ b/src/pkg/projects/netcoreapp/pkg/legacy/Directory.Build.props
@@ -5,7 +5,7 @@
     <PreventImplementationReference Condition="'$(PackageTargetRuntime)' != ''">true</PreventImplementationReference>
     <BuildTargetPath>build/$(NETCoreAppFramework)/</BuildTargetPath>
 
-    <IsShippingPackage>false</IsShippingPackage>
+    <IsShipping>false</IsShipping>
   </PropertyGroup>
 
   <!-- Identity / Reference package content -->
@@ -16,7 +16,7 @@
     <!-- references the host packages -->
     <Dependency
       Include="Microsoft.NETCore.DotNetHostPolicy"
-      VersionProp="HostPolicyVersion"
+      VersionFromProject="$(SourceDir)pkg\projects\Microsoft.NETCore.DotNetHostPolicy\Microsoft.NETCore.DotNetHostPolicy.pkgproj"
       TargetFramework="$(NETCoreAppFramework)" />
   </ItemGroup>
 

--- a/src/pkg/projects/netcoreapp/pkg/workaround/Microsoft.NETCore.App.pkgproj
+++ b/src/pkg/projects/netcoreapp/pkg/workaround/Microsoft.NETCore.App.pkgproj
@@ -16,7 +16,7 @@
 
     <BuildRuntimePackages>false</BuildRuntimePackages>
 
-    <IsShippingPackage>false</IsShippingPackage>
+    <IsShipping>false</IsShipping>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/pkg/projects/windowsdesktop/pkg/Microsoft.WindowsDesktop.App.pkgproj
+++ b/src/pkg/projects/windowsdesktop/pkg/Microsoft.WindowsDesktop.App.pkgproj
@@ -18,7 +18,7 @@
     -->
     <SkipValidatePackage>false</SkipValidatePackage>
 
-    <IsShippingPackage>false</IsShippingPackage>
+    <IsShipping>false</IsShipping>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/test/Assets/TestProjects/Directory.Build.props
+++ b/src/test/Assets/TestProjects/Directory.Build.props
@@ -4,6 +4,7 @@
   <ItemGroup>
     <RestoreTestFallbackSource Include="$(ArtifactsShippingPackagesDir)" />
     <RestoreTestFallbackSource Include="$(ArtifactsNonShippingPackagesDir)" />
+    <RestoreTestFallbackSource Include="$(TestStabilizedLegacyPackagesDir)" />
     <RestoreTestSource Include="$(RestoreSources)" />
     <RestoreTestSource Include="https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json" />
     <RestoreTestSource Include="https://api.nuget.org/v3/index.json" />

--- a/src/test/Directory.Build.props
+++ b/src/test/Directory.Build.props
@@ -4,6 +4,7 @@
   <PropertyGroup>
     <TestDir>$(ProjectDir)src\test\</TestDir>
     <TestAssetsDir>$(TestDir)Assets\</TestAssetsDir>
+    <TestStabilizedLegacyPackagesDir>$(ObjDir)TestStabilizedPackages\</TestStabilizedLegacyPackagesDir>
     <TestRestorePackagesPath>$(ObjDir)TestPackageCache\</TestRestorePackagesPath>
     <TestArchitectures>$(TargetArchitecture)</TestArchitectures>
   </PropertyGroup>

--- a/src/test/Directory.Build.targets
+++ b/src/test/Directory.Build.targets
@@ -54,6 +54,20 @@
     </PropertyGroup>
 
     <!--
+      Fetch the package version of Microsoft.NETCore.App. Use the runtime nupkg project because it
+      always ships.
+
+      Some test projects end in ".Tests", which Arcade detects and applies IsShipping=false. This
+      makes ProductVersion non-stable, so we can't rely on the test project's ProductVersion to be
+      the same as the package's version. Fetch this directly from the project to avoid guesswork.
+    -->
+    <MSBuild
+      Projects="$(SourceDir)pkg\projects\netcoreapp\pkg\Microsoft.NETCore.App.Runtime.pkgproj"
+      Targets="ReturnProductVersion">
+      <Output TaskParameter="TargetOutputs" PropertyName="NETCoreAppRuntimePackageVersion" />
+    </MSBuild>
+
+    <!--
       Set up properties used inside tests. Write them to a text file so that they can be found
       inside the VS Test Explorer context the same way as the XUnit runner will find them.
       See https://github.com/dotnet/arcade/issues/3077.
@@ -65,7 +79,7 @@
       <TestContextVariable Include="BUILDRID=$(OutputRid)" />
       <TestContextVariable Include="BUILD_ARCHITECTURE=$(TargetArchitecture)" />
       <TestContextVariable Include="BUILD_CONFIGURATION=$(ConfigurationGroup)" />
-      <TestContextVariable Include="MNA_VERSION=$(ProductVersion)" />
+      <TestContextVariable Include="MNA_VERSION=$(NETCoreAppRuntimePackageVersion)" />
       <TestContextVariable Include="MNA_TFM=$(NETCoreAppFramework)" />
       <TestContextVariable Include="DOTNET_SDK_PATH=$(DotNetRoot)" />
     </ItemGroup>

--- a/src/test/Directory.Build.targets
+++ b/src/test/Directory.Build.targets
@@ -37,6 +37,7 @@
   <Target Name="SetupTestContextVariables"
           DependsOnTargets="
             GetProductVersions;
+            GetNETCoreAppRuntimePackVersion;
             DetermineTestOutputDirectory"
           BeforeTargets="Build">
     <PropertyGroup>
@@ -88,6 +89,34 @@
       File="$(OutDir)TestContextVariables.txt"
       Overwrite="true"
       Lines="@(TestContextVariable)" />
+  </Target>
+
+  <!--
+    Fetch the package version of 'Microsoft.NETCore.App.Runtime.<rid>'. The runtime nupkg project
+    always ships, so it may or may not have a stable version depending on product lifecycle.
+
+    Some test projects end in ".Tests", which Arcade detects and applies IsShipping=false. This
+    makes ProductVersion non-stable, so we can't rely on the test project's ProductVersion to be the
+    same as the package's version. Fetch this directly from the project to avoid guesswork.
+  -->
+  <Target Name="GetNETCoreAppRuntimePackVersion">
+    <MSBuild
+      Projects="$(SourceDir)pkg\projects\netcoreapp\pkg\Microsoft.NETCore.App.Runtime.pkgproj"
+      Targets="ReturnProductVersion">
+      <Output TaskParameter="TargetOutputs" PropertyName="NETCoreAppRuntimePackVersion" />
+    </MSBuild>
+  </Target>
+
+  <!--
+    Fetch the package version of Microsoft.NETCore.App.Internal. The legacy App nupkg project
+    doesn't ship, so it never has a stable version.
+  -->
+  <Target Name="GetNETCoreAppInternalPackageVersion">
+    <MSBuild
+      Projects="$(SourceDir)pkg\projects\netcoreapp\pkg\legacy\Microsoft.NETCore.App.Internal.pkgproj"
+      Targets="ReturnProductVersion">
+      <Output TaskParameter="TargetOutputs" PropertyName="NETCoreAppInternalPackageVersion" />
+    </MSBuild>
   </Target>
 
   <Target Name="DetermineTestOutputDirectory">

--- a/src/test/PrepareTestAssets/PrepareTestAssets.proj
+++ b/src/test/PrepareTestAssets/PrepareTestAssets.proj
@@ -1,9 +1,17 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
+  <UsingTask TaskName="CopyNupkgAndChangeVersion" AssemblyFile="$(LocalBuildToolsTaskFile)" />
+
   <Target Name="PrepareTestAssets"
           DependsOnTargets="
-            GetProductVersions;
-            DetermineTestOutputDirectory">
+            GetNETCoreAppInternalPackageVersion;
+            GetNETCoreAppRuntimePackVersion;
+            CleanTestAssets;
+            PrepareStabilizedLegacyPackages;
+            RestoreTestAssetProjects" />
+
+  <Target Name="CleanTestAssets"
+          DependsOnTargets="DetermineTestOutputDirectory">
     <!--
       Ensure installers (and therefore shared framework projects) are built first. Include used
       transitive dependenices here in case Subset is defined.
@@ -23,16 +31,42 @@
     <ItemGroup>
       <DirsToClean Include="$(TestDir)\**\bin" />
       <DirsToClean Include="$(TestDir)\**\obj" />
+      <DirsToClean Include="$(TestStabilizedLegacyPackagesDir)" />
       <DirsToClean Include="$(TestRestorePackagesPath)" />
       <DirsToClean Include="$(TempFolderRoot)$(TargetArchitecture)" />
+    </ItemGroup>
 
+    <RemoveDir Directories="@(DirsToClean)" />
+
+    <!-- Directory must exist even if there are no nupkgs inside to use, or NuGet fails. -->
+    <MakeDir Directories="$(TestStabilizedLegacyPackagesDir)" />
+  </Target>
+
+  <Target Name="PrepareStabilizedLegacyPackages"
+          Condition="'$(NETCoreAppInternalPackageVersion)' != '$(NETCoreAppRuntimePackVersion)'">
+    <ItemGroup>
+      <NonShippingPackageToStabilizeFile Include="
+        $(ArtifactsNonShippingPackagesDir)Microsoft.*.nupkg;
+        $(ArtifactsNonShippingPackagesDir)runtime.*.nupkg;" />
+    </ItemGroup>
+
+    <!-- Workaround for NonShipping packages being unable to have stable versions, see https://github.com/dotnet/core-setup/issues/8112 -->
+    <Message Importance="High" Text="Generating stabilized legacy NETCoreApp packages..." />
+
+    <CopyNupkgAndChangeVersion
+      SourceFile="%(NonShippingPackageToStabilizeFile.Identity)"
+      TargetFile="$(TestStabilizedLegacyPackagesDir)@(NonShippingPackageToStabilizeFile -> '%(Filename)%(Extension)')"
+      OriginalVersion="$(NETCoreAppInternalPackageVersion)"
+      TargetVersion="$(NETCoreAppRuntimePackVersion)" />
+  </Target>
+
+  <Target Name="RestoreTestAssetProjects">
+    <ItemGroup>
       <TestAssetProjectToRestore Include="$(TestAssetsDir)**\*.csproj" />
 
       <AllTestRestoreSources Include="@(RestoreTestSource)"/>
       <AllTestRestoreSources Include="@(RestoreTestFallbackSource)"/>
     </ItemGroup>
-
-    <RemoveDir Directories="@(DirsToClean)" />
 
     <Message Importance="High" Text="Running NuGet Restore for test asset projects..." />
 
@@ -42,9 +76,10 @@
       Properties="
         ArtifactsShippingPackagesDir=$(ArtifactsShippingPackagesDir);
         ArtifactsNonShippingPackagesDir=$(ArtifactsNonShippingPackagesDir);
+        TestStabilizedLegacyPackagesDir=$(TestStabilizedLegacyPackagesDir);
         TestRestorePackagesPath=$(TestRestorePackagesPath);
         TestTargetRid=$(TestTargetRid);
-        MNAVersion=$(ProductVersion)" />
+        MNAVersion=$(NETCoreAppRuntimePackVersion)" />
   </Target>
 
 </Project>

--- a/tools-local/tasks/CopyNupkgAndChangeVersion.cs
+++ b/tools-local/tasks/CopyNupkgAndChangeVersion.cs
@@ -1,0 +1,149 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Build.Framework;
+using Newtonsoft.Json.Linq;
+using NuGet.Versioning;
+using System;
+using System.IO;
+using System.IO.Compression;
+using System.Linq;
+using System.Xml.Linq;
+
+namespace Microsoft.DotNet.Build.Tasks
+{
+    public class CopyNupkgAndChangeVersion : BuildTask
+    {
+        [Required]
+        public string SourceFile { get; set; }
+
+        [Required]
+        public string TargetFile { get; set; }
+
+        [Required]
+        public string OriginalVersion { get; set; }
+
+        [Required]
+        public string TargetVersion { get; set; }
+
+        public string[] DependencyPackageIdsToChange { get; set; }
+
+        public override bool Execute()
+        {
+            Directory.CreateDirectory(Path.GetDirectoryName(TargetFile));
+            File.Copy(SourceFile, TargetFile, true);
+
+            using (ZipArchive zip = ZipFile.Open(TargetFile, ZipArchiveMode.Update))
+            {
+                RewriteNuspec(zip);
+                RewriteRuntimeJson(zip);
+            }
+
+            return !Log.HasLoggedErrors;
+        }
+
+        private void RewriteNuspec(ZipArchive zip)
+        {
+            foreach (var nuspec in zip.Entries.Where(e => e.FullName.EndsWith(".nuspec")))
+            {
+                Rewrite(nuspec, s =>
+                {
+                    XDocument content = XDocument.Parse(s);
+
+                    RewriteNuspecPackageVersion(content);
+                    RewriteNuspecDependencyVersions(content);
+
+                    return content.ToString();
+                });
+            }
+        }
+
+        private void RewriteRuntimeJson(ZipArchive zip)
+        {
+            foreach (var runtimeJson in zip.Entries.Where(e => e.FullName == "runtime.json"))
+            {
+                Rewrite(runtimeJson, s =>
+                {
+                    JObject content = JObject.Parse(s);
+
+                    RewriteRuntimeJsonVersions(content);
+
+                    return content.ToString();
+                });
+            }
+        }
+
+        private void RewriteNuspecPackageVersion(XDocument content)
+        {
+            XElement versionElement = content
+                .Element(CreateQualifiedName(content, "package"))
+                .Element(CreateQualifiedName(content, "metadata"))
+                .Element(CreateQualifiedName(content, "version"));
+
+            if (versionElement.Value != OriginalVersion)
+            {
+                Log.LogError(
+                    $"Original version is '{versionElement.Value}', " +
+                    $"expected '{OriginalVersion}'");
+            }
+
+            versionElement.Value = TargetVersion;
+        }
+
+        private void RewriteNuspecDependencyVersions(XDocument content)
+        {
+            foreach (var dependency in content
+                .Descendants(CreateQualifiedName(content, "dependency"))
+                .Where(x =>
+                    x.Attribute("version").Value == OriginalVersion &&
+                    DependencyPackageIdsToChange?.Contains(x.Attribute("id").Value) == true))
+            {
+                dependency.Value = TargetVersion;
+            }
+        }
+
+        private void RewriteRuntimeJsonVersions(JObject content)
+        {
+            var versionProperties = content
+                .Descendants()
+                .OfType<JProperty>()
+                .Where(p =>
+                    p.Value is JValue v &&
+                    v.Type == JTokenType.String);
+
+            foreach (var p in versionProperties)
+            {
+                var range = VersionRange.Parse(p.Value.Value<string>());
+
+                if (range.MinVersion.OriginalVersion == OriginalVersion)
+                {
+                    var newRange = new VersionRange(
+                        NuGetVersion.Parse(TargetVersion),
+                        range.Float);
+
+                    p.Value = newRange.ToString();
+                }
+            }
+        }
+
+        private static XName CreateQualifiedName(XDocument doc, string name)
+        {
+            return doc.Root.GetDefaultNamespace().GetName(name);
+        }
+
+        private static void Rewrite(ZipArchiveEntry entry, Func<string, string> rewrite)
+        {
+            using (var stream = entry.Open())
+            using (var reader = new StreamReader(stream))
+            using (var writer = new StreamWriter(stream))
+            {
+                var content = rewrite(reader.ReadToEnd());
+
+                stream.Position = 0;
+                stream.SetLength(0);
+                writer.Write(content);
+            }
+        }
+    }
+}


### PR DESCRIPTION
#### Description

For:
* #8100. Fixes VS insertion packages, testing, and publishing.
* #8112. Fixes NonShipping packages to have an unstable version, an Arcade requirement because they are published to a static feed and can't be mutated.

Ports https://github.com/dotnet/core-setup/pull/8105 and https://github.com/dotnet/core-setup/pull/8155 to `release/3.0`. See those PRs for implementation notes.

#### Customer Impact

Allows 3.0 stable-versioned builds.

#### Regression?

No.

#### Risk

Minimal. Changes and workarounds are tightly focused and don't involve significant changes to the build or test infrastructure.