### PR TITLE
[release/3.0] Fix publish stage dependencies to unblock build

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -183,32 +183,32 @@ stages:
       #     bar: <Name of the Arcade variable that contains the ID of this channel in BAR>
       #     storage: <Name of the Latest channel to publish to in dotnetcli blob storage>
       dependsOnPublishStages:
-      - dependsOn: NetCore_Dev30_Publish_Validation
+      - dependsOn: NetCore_Dev30_Publish
         channel:
           name: .NET Core 3 Dev
           bar: PublicDevRelease_30_Channel_Id
           storage: release/3.0
-      - dependsOn: NetCore_Release30_Publish_Validation
+      - dependsOn: NetCore_Release30_Publish
         channel:
           name: .NET Core 3 Release
           bar: PublicRelease_30_Channel_Id
           storage: release/3.0-preview9
-      - dependsOn: NetCore_Dev31_Publish_Validation
+      - dependsOn: NetCore_Dev31_Publish
         channel:
           name: .NET Core 3.1 Dev
           bar: PublicDevRelease_31_Channel_Id
           storage: release/3.1
-      - dependsOn: NetCore_Release31_Publish_Validation
+      - dependsOn: NetCore_Release31_Publish
         channel:
           name: .NET Core 3.1 Release
           bar: PublicRelease_31_Channel_Id
           storage: release/3.1-preview1
-      - dependsOn: NetCore_Dev5_Publish_Validation
+      - dependsOn: NetCore_Dev5_Publish
         channel:
           name: .NET Core 5 Dev
           bar: NetCore_5_Dev_Channel_Id
           storage: master
-      - dependsOn: PVR_PublishValidation
+      - dependsOn: PVR_Publish
         channel:
           name: .NET Tools - Validation
           bar: PublicValidationRelease_30_Channel_Id


### PR DESCRIPTION
#### Description

Ports https://github.com/dotnet/core-setup/pull/8142 to `release/3.0`.

Arcade removed the `{channel}_Validation` stages from the template yaml with https://github.com/dotnet/arcade/pull/3888, which breaks the Core-Setup publish implementation which depends on those stages. This PR moves the Core-Setup publish stages to depend on the `{channel}` stages from Arcade.

Will be merged into 3.1 as well by branch merge automation.

#### Customer Impact

3.0/3.1 builds are currently failing, this will get past the first error.

#### Regression?

Not a Core-Setup regression: Arcade SDK breaking change.

#### Risk

None. This is a very well-understood change.

---

@JohnTortugo (can't add as GitHub reviewer because no write permissions. 🙁)