### PR TITLE
Use NuGet.config, not RestoreSources

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -6,6 +6,12 @@
   </fallbackPackageFolders>
   <packageSources>
     <clear />
+    <!--
+      'src/test/PrepareTestAssets/PrepareTestAssets.proj' generates a NuGet.config file using this
+      one as a template. The following line is a marker to insert the test restore sources.
+    -->
+    <!-- TEST_RESTORE_SOURCES_INSERTION_LINE -->
+
     <add key="dotnet-core" value="https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json" />
     <add key="dotnet-coreclr" value="https://dotnetfeed.blob.core.windows.net/dotnet-coreclr/index.json" />
     <add key="dotnet-windowsdesktop" value="https://dotnetfeed.blob.core.windows.net/dotnet-windowsdesktop/index.json" />

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -19,17 +19,6 @@
     <NETCoreAppFrameworkVersion>$(MajorVersion).$(MinorVersion)</NETCoreAppFrameworkVersion>
     <NETCoreAppFramework>netcoreapp$(NETCoreAppFrameworkVersion)</NETCoreAppFramework>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(DotNetBuildOffline)' != 'true'">
-    <!-- list of nuget package sources passed to NuGet -->
-    <RestoreSources>
-      $(OverridePackageSource);
-      https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json;
-      https://dotnetfeed.blob.core.windows.net/dotnet-coreclr/index.json;
-      https://dotnetfeed.blob.core.windows.net/dotnet-windowsdesktop/index.json;
-      https://api.nuget.org/v3/index.json;
-      $(RestoreSources);
-    </RestoreSources>
-  </PropertyGroup>
   <PropertyGroup>
     <MicrosoftDotNetMaestroTasksVersion>1.0.0-beta.18619.4</MicrosoftDotNetMaestroTasksVersion>
   </PropertyGroup>

--- a/src/test/Assets/TestProjects/Directory.Build.props
+++ b/src/test/Assets/TestProjects/Directory.Build.props
@@ -1,17 +1,7 @@
 <Project>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), TestProjects.props))\TestProjects.props" />
 
-  <ItemGroup>
-    <RestoreTestFallbackSource Include="$(ArtifactsShippingPackagesDir)" />
-    <RestoreTestFallbackSource Include="$(ArtifactsNonShippingPackagesDir)" />
-    <RestoreTestFallbackSource Include="$(TestStabilizedLegacyPackagesDir)" />
-    <RestoreTestSource Include="$(RestoreSources)" />
-    <RestoreTestSource Include="https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json" />
-    <RestoreTestSource Include="https://api.nuget.org/v3/index.json" />
-  </ItemGroup>
-
   <PropertyGroup>
-    <RestoreSources>@(RestoreTestSource);@(RestoreTestFallbackSource)</RestoreSources>
     <RestorePackagesPath>$(TestRestorePackagesPath)</RestorePackagesPath>
     <RestoreNoCache>true</RestoreNoCache>
   </PropertyGroup>

--- a/src/test/Directory.Build.props
+++ b/src/test/Directory.Build.props
@@ -6,6 +6,7 @@
     <TestAssetsDir>$(TestDir)Assets\</TestAssetsDir>
     <TestStabilizedLegacyPackagesDir>$(ObjDir)TestStabilizedPackages\</TestStabilizedLegacyPackagesDir>
     <TestRestorePackagesPath>$(ObjDir)TestPackageCache\</TestRestorePackagesPath>
+    <TestRestoreNuGetConfigFile>$(ObjDir)TestNuGetConfig\NuGet.config</TestRestoreNuGetConfigFile>
     <TestArchitectures>$(TargetArchitecture)</TestArchitectures>
     <TestInfraTargetFramework>netcoreapp3.0</TestInfraTargetFramework>
   </PropertyGroup>

--- a/src/test/PrepareTestAssets/PrepareTestAssets.proj
+++ b/src/test/PrepareTestAssets/PrepareTestAssets.proj
@@ -7,6 +7,7 @@
             GetNETCoreAppInternalPackageVersion;
             GetNETCoreAppRuntimePackVersion;
             CleanTestAssets;
+            GenerateTestRestoreSourcesNuGetConfig;
             PrepareStabilizedLegacyPackages;
             RestoreTestAssetProjects" />
 
@@ -42,6 +43,29 @@
     <MakeDir Directories="$(TestStabilizedLegacyPackagesDir)" />
   </Target>
 
+  <Target Name="GenerateTestRestoreSourcesNuGetConfig">
+    <ItemGroup>
+      <RestoreTestSource Include="$(ArtifactsShippingPackagesDir)" Key="artifacts-shipping-packages" />
+      <RestoreTestSource Include="$(ArtifactsNonShippingPackagesDir)" Key="artifacts-nonshipping-packages" />
+      <RestoreTestSource Include="$(TestStabilizedLegacyPackagesDir)" Key="stabilized-legacy-packages" />
+    </ItemGroup>
+
+    <PropertyGroup>
+      <TemplateNuGetConfigFile>$(ProjectDir)NuGet.config</TemplateNuGetConfigFile>
+
+      <RestoreTestSourceConfigLines>@(RestoreTestSource -> '&lt;add key="%(Key)" value="%(Identity)" /&gt;', '%0A    ')</RestoreTestSourceConfigLines>
+
+      <TestRestoreNuGetConfigContent>$([System.IO.File]::ReadAllText('$(TemplateNuGetConfigFile)').Replace(
+        '&lt;!-- TEST_RESTORE_SOURCES_INSERTION_LINE --&gt;',
+        '$(RestoreTestSourceConfigLines)'))</TestRestoreNuGetConfigContent>
+    </PropertyGroup>
+
+    <WriteLinesToFile
+      File="$(TestRestoreNuGetConfigFile)"
+      Lines="$(TestRestoreNuGetConfigContent)"
+      Overwrite="true" />
+  </Target>
+
   <Target Name="PrepareStabilizedLegacyPackages"
           Condition="'$(NETCoreAppInternalPackageVersion)' != '$(NETCoreAppRuntimePackVersion)'">
     <ItemGroup>
@@ -74,9 +98,7 @@
       Projects="@(TestAssetProjectToRestore)"
       Targets="Restore"
       Properties="
-        ArtifactsShippingPackagesDir=$(ArtifactsShippingPackagesDir);
-        ArtifactsNonShippingPackagesDir=$(ArtifactsNonShippingPackagesDir);
-        TestStabilizedLegacyPackagesDir=$(TestStabilizedLegacyPackagesDir);
+        RestoreConfigFile=$(TestRestoreNuGetConfigFile);
         TestRestorePackagesPath=$(TestRestorePackagesPath);
         TestTargetRid=$(TestTargetRid);
         MNAVersion=$(NETCoreAppRuntimePackVersion)" />


### PR DESCRIPTION
For https://github.com/dotnet/core-setup/issues/8252. Needed for 3.0 GA readiness.

Example generated `C:\git\core-setup-arcade\artifacts\obj\TestNuGetConfig\NuGet.config`:

```xml
<configuration>
...
  <packageSources>
    <clear />
    <!--
      'src/test/PrepareTestAssets/PrepareTestAssets.proj' generates a NuGet.config file using this
      one as a template. The following line is a marker to insert the test restore sources.
    -->
    <add key="artifacts-shipping-packages" value="C:\git\core-setup-arcade\artifacts\packages\Debug\Shipping\" />
    <add key="artifacts-nonshipping-packages" value="C:\git\core-setup-arcade\artifacts\packages\Debug\NonShipping\" />
    <add key="stabilized-legacy-packages" value="C:\git\core-setup-arcade\artifacts\obj\TestStabilizedPackages\" />

    <add key="dotnet-core" value="https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json" />
    <add key="dotnet-coreclr" value="https://dotnetfeed.blob.core.windows.net/dotnet-coreclr/index.json" />
    <add key="dotnet-windowsdesktop" value="https://dotnetfeed.blob.core.windows.net/dotnet-windowsdesktop/index.json" />
    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
  </packageSources>
...
</configuration>
```