### PR TITLE
Remove the runtime property AppDomainCompatSwitch as it's not used

### DIFF
--- a/src/corehost/cli/hostpolicy/coreclr.cpp
+++ b/src/corehost/cli/hostpolicy/coreclr.cpp
@@ -195,7 +195,6 @@ namespace
         _X("TRUSTED_PLATFORM_ASSEMBLIES"),
         _X("NATIVE_DLL_SEARCH_DIRECTORIES"),
         _X("PLATFORM_RESOURCE_ROOTS"),
-        _X("AppDomainCompatSwitch"),
         _X("APP_CONTEXT_BASE_DIRECTORY"),
         _X("APP_CONTEXT_DEPS_FILES"),
         _X("FX_DEPS_FILE"),

--- a/src/corehost/cli/hostpolicy/coreclr.h
+++ b/src/corehost/cli/hostpolicy/coreclr.h
@@ -58,7 +58,6 @@ enum class common_property
     TrustedPlatformAssemblies,
     NativeDllSearchDirectories,
     PlatformResourceRoots,
-    AppDomainCompatSwitch,
     AppContextBaseDirectory,
     AppContextDepsFiles,
     FxDepsFile,

--- a/src/corehost/cli/hostpolicy/hostpolicy_context.cpp
+++ b/src/corehost/cli/hostpolicy/hostpolicy_context.cpp
@@ -140,7 +140,6 @@ int hostpolicy_context_t::initialize(hostpolicy_init_t &hostpolicy_init, const a
     coreclr_properties.add(common_property::TrustedPlatformAssemblies, probe_paths.tpa.c_str());
     coreclr_properties.add(common_property::NativeDllSearchDirectories, probe_paths.native.c_str());
     coreclr_properties.add(common_property::PlatformResourceRoots, probe_paths.resources.c_str());
-    coreclr_properties.add(common_property::AppDomainCompatSwitch, _X("UseLatestBehaviorWhenTFMNotSpecified"));
     coreclr_properties.add(common_property::AppContextBaseDirectory, app_base.c_str());
     coreclr_properties.add(common_property::AppContextDepsFiles, app_context_deps_str.c_str());
     coreclr_properties.add(common_property::FxDepsFile, fx_deps_str.c_str());


### PR DESCRIPTION
The usage of this has been removed several years ago in https://github.com/dotnet/coreclr/pull/5708. The new runtime behavior is always the one we were explicitly selecting with the property value anyway.