### PR TITLE
Generate cross-arch AppHost pack MSIs

### DIFF
--- a/eng/jobs/windows-build.yml
+++ b/eng/jobs/windows-build.yml
@@ -73,10 +73,6 @@ jobs:
           publishFeedCredentials: 'DevDiv - VS package feed'
         condition: and(
           succeeded(),
-          or(
-            eq(variables['TargetArchitecture'], 'x64'),
-            eq(variables['TargetArchitecture'], 'x86')
-          ),
           eq(variables['_BuildConfig'], 'Release'),
           ne(variables['DisableVSPublish'], 'true'))
 

--- a/src/pkg/packaging-tools/installer.targets
+++ b/src/pkg/packaging-tools/installer.targets
@@ -17,6 +17,7 @@
             GenerateDeb;
             GenerateRpm;
             GenerateMsi;
+            GenerateCrossArchMsi;
             GenerateExeBundle;
             GeneratePkg;
             GenerateCompressedArchive" />
@@ -24,6 +25,7 @@
   <Target Name="GenerateDeb" DependsOnTargets="TestDebuild;CreateDeb" Condition="'$(GenerateDeb)' == 'true'"/>
   <Target Name="GenerateRpm" DependsOnTargets="TestFPMTool;CreateRpm" Condition="'$(GenerateRpm)' == 'true'"/>
   <Target Name="GenerateMsi" DependsOnTargets="CreateWixInstaller" Condition="'$(GenerateMSI)' == 'true'"/>
+  <Target Name="GenerateCrossArchMsi" DependsOnTargets="CreateCrossArchWixInstaller" Condition="'$(GenerateCrossArchMsi)' == 'true'"/>
   <Target Name="GenerateExeBundle" DependsOnTargets="CreateWixInstaller" Condition="'$(GenerateExeBundle)' == 'true'"/>
   <Target Name="GeneratePkg" DependsOnTargets="CreatePkg" Condition="'$(GeneratePkg)' == 'true'"/>
   <Target Name="GenerateCompressedArchive" DependsOnTargets="CreateCompressedArchive" Condition="'$(GenerateCompressedArchive)' == 'true'"/>
@@ -161,6 +163,22 @@
       Text="GenerateExeBundle and GenerateMSI are both set, but only one can be created at a time." />
 
     <Message Text="$(MSBuildProjectName) -> $(OutInstallerFile)" Importance="high" />
+  </Target>
+
+  <!--
+    Create MSI installers that install the current architecture's assets into the proper location
+    for a different architecture's SDK to find.
+  -->
+  <Target Name="CreateCrossArchWixInstaller"
+          DependsOnTargets="GetInstallerProperties">
+    <MSBuild
+      Condition="'@(CrossArchMsiToBuild)' != ''"
+      Projects="$(MSBuildProjectFullPath)"
+      Targets="CreateWixInstaller"
+      Properties="
+        TargetArchitecture=%(CrossArchMsiToBuild.Identity);
+        CrossArchContentsArch=$(TargetArchitecture);
+        PackLayoutDir=$(PackLayoutDir)" />
   </Target>
 
   <Target Name="CreateCompressedArchive"

--- a/src/pkg/packaging-tools/packaging-tools.targets
+++ b/src/pkg/packaging-tools/packaging-tools.targets
@@ -18,12 +18,22 @@
   <Target Name="GetInstallerGenerationFlags">
     <!-- Filter the installer generation/build flags for the current build machine. -->
     <PropertyGroup>
-      <_supportsWixBasedInstallers>true</_supportsWixBasedInstallers>
-      <_supportsWixBasedInstallers Condition="'$(TargetArchitecture)' == 'arm' or '$(TargetArchitecture)' == 'arm64'">false</_supportsWixBasedInstallers>
-      <_supportsWixBasedInstallers Condition="'$(OSGroup)' != 'Windows_NT'">false</_supportsWixBasedInstallers>
+      <_osSupportsWixBasedInstallers>true</_osSupportsWixBasedInstallers>
+      <_osSupportsWixBasedInstallers Condition="'$(OSGroup)' != 'Windows_NT'">false</_osSupportsWixBasedInstallers>
 
-      <GenerateMSI Condition="'$(_supportsWixBasedInstallers)' != 'true'">false</GenerateMSI>
-      <GenerateExeBundle Condition="'$(_supportsWixBasedInstallers)' != 'true'">false</GenerateExeBundle>
+      <_osArchSupportsWixBasedInstallers>$(_osSupportsWixBasedInstallers)</_osArchSupportsWixBasedInstallers>
+      <_osArchSupportsWixBasedInstallers Condition="'$(TargetArchitecture)' == 'arm' or '$(TargetArchitecture)' == 'arm64'">false</_osArchSupportsWixBasedInstallers>
+
+      <!--
+        Save the project's GenerateMSI setting. It's possible the current arch of the current OS
+        doesn't support MSI generation, but we still want to create an MSI across architectures. For
+        example, we want to make an MSI that installs the arm apphost pack into the x64 SDK location
+        on an x64 machine.
+      -->
+      <GenerateCrossArchMsi Condition="'$(_osSupportsWixBasedInstallers)' == 'true'">$(GenerateMSI)</GenerateCrossArchMsi>
+
+      <GenerateMSI Condition="'$(_osArchSupportsWixBasedInstallers)' != 'true'">false</GenerateMSI>
+      <GenerateExeBundle Condition="'$(_osArchSupportsWixBasedInstallers)' != 'true'">false</GenerateExeBundle>
 
       <GeneratePkg Condition="'$(OSGroup)' != 'OSX'">false</GeneratePkg>
     </PropertyGroup>
@@ -60,6 +70,11 @@
       <InstallerPackageVersion>$(ProductionVersion)</InstallerPackageVersion>
     </PropertyGroup>
 
+    <!-- Distinguish the cross-arch installer filename. -->
+    <PropertyGroup Condition="'$(CrossArchContentsArch)' != ''">
+      <CrossArchContentsBuildPart>_$(CrossArchContentsArch)</CrossArchContentsBuildPart>
+    </PropertyGroup>
+
     <PropertyGroup Condition="'$(InstallerExtension)' == '.deb'">
       <InstallerPackageVersion Condition="'$(IncludePreReleaseLabelInPackageVersion)' == 'true'">$(ProductionVersion)~$(VersionSuffix)</InstallerPackageVersion>
     </PropertyGroup>
@@ -77,7 +92,7 @@
         >$(ProductVersion)-$(TargetArchitecture)</InstallerBuildPart>
 
       <!-- Location to place the installer, in artifacts. -->
-      <InstallerFileNameWithoutExtension>$(InstallerName)-$(InstallerBuildPart)</InstallerFileNameWithoutExtension>
+      <InstallerFileNameWithoutExtension>$(InstallerName)-$(InstallerBuildPart)$(CrossArchContentsBuildPart)</InstallerFileNameWithoutExtension>
       <InstallerFile Condition="'$(InstallerFile)' == ''">$(AssetOutputPath)$(InstallerFileNameWithoutExtension)$(InstallerExtension)</InstallerFile>
       <ExeBundleInstallerFile>$(AssetOutputPath)$(InstallerFileNameWithoutExtension).exe</ExeBundleInstallerFile>
       <ExeBundleInstallerEngineFile>$(AssetOutputPath)$(InstallerFileNameWithoutExtension)-engine.exe</ExeBundleInstallerEngineFile>
@@ -94,6 +109,10 @@
     <PropertyGroup>
       <SharedFrameworkArchiveSourceDir Condition="'$(SharedFrameworkArchiveSourceDir)' == ''">$(SharedFrameworkLayoutDir)</SharedFrameworkArchiveSourceDir>
     </PropertyGroup>
+
+    <ItemGroup>
+      <CrossArchMsiToBuild Include="@(CrossArchSdkMsiInstallerArch)" Exclude="$(TargetArchitecture)" />
+    </ItemGroup>
   </Target>
 
   <Target Name="GetSkipBuildProps">

--- a/src/pkg/packaging-tools/windows/bundle/bundle.wxs
+++ b/src/pkg/packaging-tools/windows/bundle/bundle.wxs
@@ -48,7 +48,7 @@
     <Variable Name="DOTNETHOME" Type="string" Value="[$(var.Program_Files)]dotnet" bal:Overridable="no" />
 
     <!-- Variables used solely for localization. -->
-    <Variable Name="BUNDLEMONIKER" Type="string" Value="$(var.ProductMoniker) ($(var.TargetArchitecture))" bal:Overridable="no" />
+    <Variable Name="BUNDLEMONIKER" Type="string" Value="$(var.ProductMoniker) ($(var.TargetArchitectureDescription))" bal:Overridable="no" />
     <Variable Name="PRODUCT_NAME" Type="string" Value="$(var.ProductName)" bal:Overridable="no" />
     <Variable Name="LINK_PREREQ_PAGE" Type="string" Value="https://go.microsoft.com/fwlink/?linkid=846817" bal:Overridable="no" />
 

--- a/src/pkg/packaging-tools/windows/variables.wxi
+++ b/src/pkg/packaging-tools/windows/variables.wxi
@@ -5,7 +5,7 @@
   <?define Dotnet_BuildVersion = "$(var.BuildVersion)" ?>
 
   <?define Manufacturer     =   "Microsoft Corporation" ?>
-  <?define ProductName      =   "$(var.ProductMoniker) ($(var.TargetArchitecture))" ?>
+  <?define ProductName      =   "$(var.ProductMoniker) ($(var.TargetArchitectureDescription))" ?>
   <?define ProductLanguage  =   "1033" ?>
   <?define ProductVersion   =   "$(var.Dotnet_ProductVersion)" ?>
   <?define LCID  = "$(var.ProductLanguage)"?>
@@ -23,7 +23,7 @@
     <?error Invalid Platform ($(var.Platform))?>
   <?endif?>
 
-  <?define DependencyKey   = "$(var.DependencyKeyName)_$(var.BuildVersion)_$(var.Platform)"?>
+  <?define DependencyKey   = "$(var.DependencyKeyName)_$(var.BuildVersion)_$(var.Platform)$(var.CrossArchContentsPlatformPart)"?>
   <?define DependencyKeyId = "$(var.DependencyKey)" ?>
 
 </Include>

--- a/src/pkg/packaging-tools/windows/wix.targets
+++ b/src/pkg/packaging-tools/windows/wix.targets
@@ -237,8 +237,11 @@
       <CandleVariables Include="ProductMoniker" Value="$(WixProductMoniker)" />
       <CandleVariables Include="BuildVersion" Value="$(MsiVersionString)" />
       <CandleVariables Include="NugetVersion" Value="$(ProductVersion)" />
-      <CandleVariables Include="TargetArchitecture" Value="$(TargetArchitecture)" />
+      <CandleVariables Include="TargetArchitectureDescription" Value="$(TargetArchitecture)$(CrossArchContentsBuildPart)" />
       <CandleVariables Include="UpgradeCode" Value="$(UpgradeCode)" />
+
+      <!-- If this is a cross-arch MSI, add target arch to the dependency key for uniqueness. -->
+      <CandleVariables Include="CrossArchContentsPlatformPart" Value="$(CrossArchContentsBuildPart.Replace('-', '_'))" />
     </ItemGroup>
 
     <PropertyGroup>
@@ -290,12 +293,17 @@
   </Target>
 
   <!--
-    Entry point for an MSBuild call: creates a NuGet package suitable for VS insertion.
+    Entry point for an MSBuild call: creates NuGet packages suitable for VS insertion.
   -->
   <Target Name="GenerateVSInsertionNupkg"
           DependsOnTargets="
             GetInstallerGenerationFlags;
-            EnsureMsiBuilt">
+            GenerateCurrentArchVSInsertionNupkg;
+            GenerateCrossArchVSInsertionNupkg" />
+
+  <Target Name="GenerateCurrentArchVSInsertionNupkg"
+          Condition="'$(GenerateMSI)' == 'true'"
+          DependsOnTargets="EnsureMsiBuilt">
     <!--
       Run the nupkg creation code with IsShipping=false to use prerelease versions: this package
       must not be stable to avoid mutation conflicts, even though the project itself may be shipping
@@ -305,12 +313,45 @@
       stabilization status.
     -->
     <MSBuild
-      Condition="'$(GenerateMSI)' == 'true'"
       Projects="$(MSBuildProjectFullPath)"
       Targets="GenerateVSInsertionNupkgCore"
       Properties="
         IsShipping=false;
         ComponentMsiFile=$(OutInstallerFile)" />
+  </Target>
+
+  <Target Name="GenerateCrossArchVSInsertionNupkg"
+          Condition="'$(GenerateCrossArchMsi)' == 'true'"
+          DependsOnTargets="
+            GetInstallerProperties;
+            EnsureCrossArchMsiBuilt;
+            GenerateCrossArchVSInsertionNupkgPerArch" />
+
+  <Target Name="GenerateCrossArchVSInsertionNupkgPerArch"
+          Condition="'@(CrossArchMsiToBuild)' != ''"
+          Inputs="%(CrossArchMsiToBuild.Identity)"
+          Outputs="batching-on-CrossArchMsiToBuild">
+    <!--
+      Get the cross-arch MSI to pack into an insertion package. Do this separately from the
+      GenerateVSInsertionNupkgCore call because IsShipping influences the file name.
+    -->
+    <MSBuild
+      Projects="$(MSBuildProjectFullPath)"
+      Targets="GetOutputWixInstallerFile"
+      Properties="
+        TargetArchitecture=%(CrossArchMsiToBuild.Identity);
+        CrossArchContentsArch=$(TargetArchitecture)">
+      <Output TaskParameter="TargetOutputs" PropertyName="CrossArchMsiFile" />
+    </MSBuild>
+
+    <MSBuild
+      Projects="$(MSBuildProjectFullPath)"
+      Targets="GenerateVSInsertionNupkgCore"
+      Properties="
+        TargetArchitecture=%(CrossArchMsiToBuild.Identity);
+        CrossArchContentsArch=$(TargetArchitecture);
+        IsShipping=false;
+        ComponentMsiFile=$(CrossArchMsiFile)" />
   </Target>
 
   <!--
@@ -322,13 +363,20 @@
     <MSBuild Projects="$(MSBuildProjectFullPath)" Targets="Build" />
   </Target>
 
+  <Target Name="EnsureCrossArchMsiBuilt"
+          Condition="
+            '$(GenerateCrossArchMsi)' == 'true' and
+            '@(CrossArchMsiToBuild)' != ''">
+    <MSBuild Projects="$(MSBuildProjectFullPath)" Targets="Build" />
+  </Target>
+
   <Target Name="GenerateVSInsertionNupkgCore"
           DependsOnTargets="
             AcquireNuGetExe;
             GetInstallerProperties;
             GetWixBuildConfiguration">
     <PropertyGroup>
-      <VSInsertionComponentName>$(VSInsertionCommonPrefix).$(VSInsertionProductName).$(VSInsertionShortComponentName).$(TargetArchitecture).$(ProductBandVersion)</VSInsertionComponentName>
+      <VSInsertionComponentName>$(VSInsertionCommonPrefix).$(VSInsertionProductName).$(VSInsertionShortComponentName).$(TargetArchitecture)$(CrossArchContentsBuildPart).$(ProductBandVersion)</VSInsertionComponentName>
       <VSInsertionComponentFriendlyName>$(ProductBandVersion) $(ProductBrandPrefix) $(VSInsertionShortComponentName)</VSInsertionComponentFriendlyName>
 
       <NupkgOutputFile>$(ArtifactsNonShippingPackagesDir)$(VSInsertionComponentName).$(ProductVersion).nupkg</NupkgOutputFile>

--- a/src/pkg/projects/netcoreapp/pkg/Microsoft.NETCore.App.Host.pkgproj
+++ b/src/pkg/projects/netcoreapp/pkg/Microsoft.NETCore.App.Host.pkgproj
@@ -18,4 +18,12 @@
     <HeatOutputFileElementToStabilize Include="native\comhost.dll" ReplacementId="comhosttemplatecomhostdll" />
   </ItemGroup>
 
+  <!--
+    See https://github.com/dotnet/core-setup/issues/7846. Cross-arch MSI installers are needed for
+    C++/CLI project system support.
+  -->
+  <ItemGroup>
+    <CrossArchSdkMsiInstallerArch Include="x64;x86" />
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
For https://github.com/dotnet/core-setup/issues/7846.

Creates and publishes cross target MSIs and VS insertion nupkgs.

New MSIs and nupkgs are:
  * Install to x64 SDK location: `x64_x86`, `x64_arm`, `x64_arm64`
  * Install to x86 SDK location: `x86_x64`, `x86_arm`, `x86_arm64`

Note that there are no new product binaries here, this is simply a new set of installers because for each install location, we need a new MSI.

Validation build ongoing as of writing: https://dev.azure.com/dnceng/internal/_build/results?buildId=360394

Porting to 3.1 after this goes in.

/cc @wli3 @nguerrera @livarcocc @johnbeisner @dleeapho