### PR TITLE
Revert "[master] Update dependencies from dotnet/corefx (#8266)"

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -6,6 +6,12 @@
   </fallbackPackageFolders>
   <packageSources>
     <clear />
+    <!--
+      'src/test/PrepareTestAssets/PrepareTestAssets.proj' generates a NuGet.config file using this
+      one as a template. The following line is a marker to insert the test restore sources.
+    -->
+    <!-- TEST_RESTORE_SOURCES_INSERTION_LINE -->
+
     <add key="dotnet-core" value="https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json" />
     <add key="dotnet-coreclr" value="https://dotnetfeed.blob.core.windows.net/dotnet-coreclr/index.json" />
     <add key="dotnet-windowsdesktop" value="https://dotnetfeed.blob.core.windows.net/dotnet-windowsdesktop/index.json" />

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -1,105 +1,105 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Dependencies>
   <ProductDependencies>
-    <Dependency Name="Microsoft.NETCore.Platforms" Version="5.0.0-alpha1.19469.5">
+    <Dependency Name="Microsoft.NETCore.Platforms" Version="5.0.0-alpha1.19462.7">
       <Uri>https://github.com/dotnet/corefx</Uri>
-      <Sha>5bc2806f33090e78b38fafe4d5b46d5a0a4c1f08</Sha>
+      <Sha>be3d4bad4576eecda116d3e9a368cd6959ecf5ce</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.Targets" Version="5.0.0-alpha1.19469.5">
+    <Dependency Name="Microsoft.NETCore.Targets" Version="5.0.0-alpha1.19462.7">
       <Uri>https://github.com/dotnet/corefx</Uri>
-      <Sha>5bc2806f33090e78b38fafe4d5b46d5a0a4c1f08</Sha>
+      <Sha>be3d4bad4576eecda116d3e9a368cd6959ecf5ce</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Private.CoreFx.NETCoreApp" Version="5.0.0-alpha1.19469.5">
+    <Dependency Name="Microsoft.Private.CoreFx.NETCoreApp" Version="5.0.0-alpha1.19462.7">
       <Uri>https://github.com/dotnet/corefx</Uri>
-      <Sha>5bc2806f33090e78b38fafe4d5b46d5a0a4c1f08</Sha>
+      <Sha>be3d4bad4576eecda116d3e9a368cd6959ecf5ce</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Win32.Registry" Version="5.0.0-alpha1.19469.5">
+    <Dependency Name="Microsoft.Win32.Registry" Version="5.0.0-alpha1.19462.7">
       <Uri>https://github.com/dotnet/corefx</Uri>
-      <Sha>5bc2806f33090e78b38fafe4d5b46d5a0a4c1f08</Sha>
+      <Sha>be3d4bad4576eecda116d3e9a368cd6959ecf5ce</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Win32.SystemEvents" Version="5.0.0-alpha1.19469.5">
+    <Dependency Name="Microsoft.Win32.SystemEvents" Version="5.0.0-alpha1.19462.7">
       <Uri>https://github.com/dotnet/corefx</Uri>
-      <Sha>5bc2806f33090e78b38fafe4d5b46d5a0a4c1f08</Sha>
+      <Sha>be3d4bad4576eecda116d3e9a368cd6959ecf5ce</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Windows.Compatibility" Version="5.0.0-alpha1.19469.5">
+    <Dependency Name="Microsoft.Windows.Compatibility" Version="5.0.0-alpha1.19462.7">
       <Uri>https://github.com/dotnet/corefx</Uri>
-      <Sha>5bc2806f33090e78b38fafe4d5b46d5a0a4c1f08</Sha>
+      <Sha>be3d4bad4576eecda116d3e9a368cd6959ecf5ce</Sha>
     </Dependency>
-    <Dependency Name="System.CodeDom" Version="5.0.0-alpha1.19469.5">
+    <Dependency Name="System.CodeDom" Version="5.0.0-alpha1.19462.7">
       <Uri>https://github.com/dotnet/corefx</Uri>
-      <Sha>5bc2806f33090e78b38fafe4d5b46d5a0a4c1f08</Sha>
+      <Sha>be3d4bad4576eecda116d3e9a368cd6959ecf5ce</Sha>
     </Dependency>
-    <Dependency Name="System.Configuration.ConfigurationManager" Version="5.0.0-alpha1.19469.5">
+    <Dependency Name="System.Configuration.ConfigurationManager" Version="5.0.0-alpha1.19462.7">
       <Uri>https://github.com/dotnet/corefx</Uri>
-      <Sha>5bc2806f33090e78b38fafe4d5b46d5a0a4c1f08</Sha>
+      <Sha>be3d4bad4576eecda116d3e9a368cd6959ecf5ce</Sha>
     </Dependency>
-    <Dependency Name="System.Diagnostics.EventLog" Version="5.0.0-alpha1.19469.5">
+    <Dependency Name="System.Diagnostics.EventLog" Version="5.0.0-alpha1.19462.7">
       <Uri>https://github.com/dotnet/corefx</Uri>
-      <Sha>5bc2806f33090e78b38fafe4d5b46d5a0a4c1f08</Sha>
+      <Sha>be3d4bad4576eecda116d3e9a368cd6959ecf5ce</Sha>
     </Dependency>
-    <Dependency Name="System.DirectoryServices" Version="5.0.0-alpha1.19469.5">
+    <Dependency Name="System.DirectoryServices" Version="5.0.0-alpha1.19462.7">
       <Uri>https://github.com/dotnet/corefx</Uri>
-      <Sha>5bc2806f33090e78b38fafe4d5b46d5a0a4c1f08</Sha>
+      <Sha>be3d4bad4576eecda116d3e9a368cd6959ecf5ce</Sha>
     </Dependency>
-    <Dependency Name="System.Drawing.Common" Version="5.0.0-alpha1.19469.5">
+    <Dependency Name="System.Drawing.Common" Version="5.0.0-alpha1.19462.7">
       <Uri>https://github.com/dotnet/corefx</Uri>
-      <Sha>5bc2806f33090e78b38fafe4d5b46d5a0a4c1f08</Sha>
+      <Sha>be3d4bad4576eecda116d3e9a368cd6959ecf5ce</Sha>
     </Dependency>
-    <Dependency Name="System.IO.FileSystem.AccessControl" Version="5.0.0-alpha1.19469.5">
+    <Dependency Name="System.IO.FileSystem.AccessControl" Version="5.0.0-alpha1.19462.7">
       <Uri>https://github.com/dotnet/corefx</Uri>
-      <Sha>5bc2806f33090e78b38fafe4d5b46d5a0a4c1f08</Sha>
+      <Sha>be3d4bad4576eecda116d3e9a368cd6959ecf5ce</Sha>
     </Dependency>
-    <Dependency Name="System.Resources.Extensions" Version="5.0.0-alpha1.19469.5">
+    <Dependency Name="System.Resources.Extensions" Version="5.0.0-alpha1.19462.7">
       <Uri>https://github.com/dotnet/corefx</Uri>
-      <Sha>5bc2806f33090e78b38fafe4d5b46d5a0a4c1f08</Sha>
+      <Sha>be3d4bad4576eecda116d3e9a368cd6959ecf5ce</Sha>
     </Dependency>
-    <Dependency Name="System.IO.Packaging" Version="5.0.0-alpha1.19469.5">
+    <Dependency Name="System.IO.Packaging" Version="5.0.0-alpha1.19462.7">
       <Uri>https://github.com/dotnet/corefx</Uri>
-      <Sha>5bc2806f33090e78b38fafe4d5b46d5a0a4c1f08</Sha>
+      <Sha>be3d4bad4576eecda116d3e9a368cd6959ecf5ce</Sha>
     </Dependency>
-    <Dependency Name="System.Security.AccessControl" Version="5.0.0-alpha1.19469.5">
+    <Dependency Name="System.Security.AccessControl" Version="5.0.0-alpha1.19462.7">
       <Uri>https://github.com/dotnet/corefx</Uri>
-      <Sha>5bc2806f33090e78b38fafe4d5b46d5a0a4c1f08</Sha>
+      <Sha>be3d4bad4576eecda116d3e9a368cd6959ecf5ce</Sha>
     </Dependency>
-    <Dependency Name="System.Security.Cryptography.Cng" Version="5.0.0-alpha1.19469.5">
+    <Dependency Name="System.Security.Cryptography.Cng" Version="5.0.0-alpha1.19462.7">
       <Uri>https://github.com/dotnet/corefx</Uri>
-      <Sha>5bc2806f33090e78b38fafe4d5b46d5a0a4c1f08</Sha>
+      <Sha>be3d4bad4576eecda116d3e9a368cd6959ecf5ce</Sha>
     </Dependency>
-    <Dependency Name="System.Security.Cryptography.Pkcs" Version="5.0.0-alpha1.19469.5">
+    <Dependency Name="System.Security.Cryptography.Pkcs" Version="5.0.0-alpha1.19462.7">
       <Uri>https://github.com/dotnet/corefx</Uri>
-      <Sha>5bc2806f33090e78b38fafe4d5b46d5a0a4c1f08</Sha>
+      <Sha>be3d4bad4576eecda116d3e9a368cd6959ecf5ce</Sha>
     </Dependency>
-    <Dependency Name="System.Security.Cryptography.ProtectedData" Version="5.0.0-alpha1.19469.5">
+    <Dependency Name="System.Security.Cryptography.ProtectedData" Version="5.0.0-alpha1.19462.7">
       <Uri>https://github.com/dotnet/corefx</Uri>
-      <Sha>5bc2806f33090e78b38fafe4d5b46d5a0a4c1f08</Sha>
+      <Sha>be3d4bad4576eecda116d3e9a368cd6959ecf5ce</Sha>
     </Dependency>
-    <Dependency Name="System.Security.Cryptography.Xml" Version="5.0.0-alpha1.19469.5">
+    <Dependency Name="System.Security.Cryptography.Xml" Version="5.0.0-alpha1.19462.7">
       <Uri>https://github.com/dotnet/corefx</Uri>
-      <Sha>5bc2806f33090e78b38fafe4d5b46d5a0a4c1f08</Sha>
+      <Sha>be3d4bad4576eecda116d3e9a368cd6959ecf5ce</Sha>
     </Dependency>
-    <Dependency Name="System.Security.Permissions" Version="5.0.0-alpha1.19469.5">
+    <Dependency Name="System.Security.Permissions" Version="5.0.0-alpha1.19462.7">
       <Uri>https://github.com/dotnet/corefx</Uri>
-      <Sha>5bc2806f33090e78b38fafe4d5b46d5a0a4c1f08</Sha>
+      <Sha>be3d4bad4576eecda116d3e9a368cd6959ecf5ce</Sha>
     </Dependency>
-    <Dependency Name="System.Security.Principal.Windows" Version="5.0.0-alpha1.19469.5">
+    <Dependency Name="System.Security.Principal.Windows" Version="5.0.0-alpha1.19462.7">
       <Uri>https://github.com/dotnet/corefx</Uri>
-      <Sha>5bc2806f33090e78b38fafe4d5b46d5a0a4c1f08</Sha>
+      <Sha>be3d4bad4576eecda116d3e9a368cd6959ecf5ce</Sha>
     </Dependency>
-    <Dependency Name="System.Text.Encodings.Web" Version="5.0.0-alpha1.19469.5">
+    <Dependency Name="System.Text.Encodings.Web" Version="5.0.0-alpha1.19462.7">
       <Uri>https://github.com/dotnet/corefx</Uri>
-      <Sha>5bc2806f33090e78b38fafe4d5b46d5a0a4c1f08</Sha>
+      <Sha>be3d4bad4576eecda116d3e9a368cd6959ecf5ce</Sha>
     </Dependency>
-    <Dependency Name="System.Text.Json" Version="5.0.0-alpha1.19469.5">
+    <Dependency Name="System.Text.Json" Version="5.0.0-alpha1.19462.7">
       <Uri>https://github.com/dotnet/corefx</Uri>
-      <Sha>5bc2806f33090e78b38fafe4d5b46d5a0a4c1f08</Sha>
+      <Sha>be3d4bad4576eecda116d3e9a368cd6959ecf5ce</Sha>
     </Dependency>
-    <Dependency Name="System.Threading.AccessControl" Version="5.0.0-alpha1.19469.5">
+    <Dependency Name="System.Threading.AccessControl" Version="5.0.0-alpha1.19462.7">
       <Uri>https://github.com/dotnet/corefx</Uri>
-      <Sha>5bc2806f33090e78b38fafe4d5b46d5a0a4c1f08</Sha>
+      <Sha>be3d4bad4576eecda116d3e9a368cd6959ecf5ce</Sha>
     </Dependency>
-    <Dependency Name="System.Windows.Extensions" Version="5.0.0-alpha1.19469.5">
+    <Dependency Name="System.Windows.Extensions" Version="5.0.0-alpha1.19462.7">
       <Uri>https://github.com/dotnet/corefx</Uri>
-      <Sha>5bc2806f33090e78b38fafe4d5b46d5a0a4c1f08</Sha>
+      <Sha>be3d4bad4576eecda116d3e9a368cd6959ecf5ce</Sha>
     </Dependency>
     <Dependency Name="NETStandard.Library" Version="2.2.0-prerelease.19462.3">
       <Uri>https://github.com/dotnet/standard</Uri>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -31,31 +31,31 @@
     <!-- sourcelink -->
     <MicrosoftSourceLinkVersion>1.0.0-beta2-19367-01</MicrosoftSourceLinkVersion>
     <!-- corefx -->
-    <MicrosoftNETCorePlatformsPackageVersion>5.0.0-alpha1.19469.5</MicrosoftNETCorePlatformsPackageVersion>
-    <MicrosoftNETCoreTargetsPackageVersion>5.0.0-alpha1.19469.5</MicrosoftNETCoreTargetsPackageVersion>
-    <MicrosoftPrivateCoreFxNETCoreAppPackageVersion>5.0.0-alpha1.19469.5</MicrosoftPrivateCoreFxNETCoreAppPackageVersion>
-    <MicrosoftWin32RegistryVersion>5.0.0-alpha1.19469.5</MicrosoftWin32RegistryVersion>
-    <MicrosoftWin32SystemEventsVersion>5.0.0-alpha1.19469.5</MicrosoftWin32SystemEventsVersion>
-    <MicrosoftWindowsCompatibilityPackageVersion>5.0.0-alpha1.19469.5</MicrosoftWindowsCompatibilityPackageVersion>
-    <SystemCodeDomVersion>5.0.0-alpha1.19469.5</SystemCodeDomVersion>
-    <SystemConfigurationConfigurationManagerVersion>5.0.0-alpha1.19469.5</SystemConfigurationConfigurationManagerVersion>
-    <SystemDiagnosticsEventLogVersion>5.0.0-alpha1.19469.5</SystemDiagnosticsEventLogVersion>
-    <SystemDirectoryServicesVersion>5.0.0-alpha1.19469.5</SystemDirectoryServicesVersion>
-    <SystemDrawingCommonVersion>5.0.0-alpha1.19469.5</SystemDrawingCommonVersion>
-    <SystemIOFileSystemAccessControlVersion>5.0.0-alpha1.19469.5</SystemIOFileSystemAccessControlVersion>
-    <SystemIOPackagingVersion>5.0.0-alpha1.19469.5</SystemIOPackagingVersion>
-    <SystemResourcesExtensionsPackageVersion>5.0.0-alpha1.19469.5</SystemResourcesExtensionsPackageVersion>
-    <SystemSecurityAccessControlVersion>5.0.0-alpha1.19469.5</SystemSecurityAccessControlVersion>
-    <SystemSecurityCryptographyCngVersion>5.0.0-alpha1.19469.5</SystemSecurityCryptographyCngVersion>
-    <SystemSecurityCryptographyPkcsVersion>5.0.0-alpha1.19469.5</SystemSecurityCryptographyPkcsVersion>
-    <SystemSecurityCryptographyProtectedDataVersion>5.0.0-alpha1.19469.5</SystemSecurityCryptographyProtectedDataVersion>
-    <SystemSecurityCryptographyXmlVersion>5.0.0-alpha1.19469.5</SystemSecurityCryptographyXmlVersion>
-    <SystemSecurityPermissionsVersion>5.0.0-alpha1.19469.5</SystemSecurityPermissionsVersion>
-    <SystemSecurityPrincipalWindowsVersion>5.0.0-alpha1.19469.5</SystemSecurityPrincipalWindowsVersion>
-    <SystemTextJsonVersion>5.0.0-alpha1.19469.5</SystemTextJsonVersion>
-    <SystemTextEncodingsWebVersion>5.0.0-alpha1.19469.5</SystemTextEncodingsWebVersion>
-    <SystemThreadingAccessControlVersion>5.0.0-alpha1.19469.5</SystemThreadingAccessControlVersion>
-    <SystemWindowsExtensionsPackageVersion>5.0.0-alpha1.19469.5</SystemWindowsExtensionsPackageVersion>
+    <MicrosoftNETCorePlatformsPackageVersion>5.0.0-alpha1.19462.7</MicrosoftNETCorePlatformsPackageVersion>
+    <MicrosoftNETCoreTargetsPackageVersion>5.0.0-alpha1.19462.7</MicrosoftNETCoreTargetsPackageVersion>
+    <MicrosoftPrivateCoreFxNETCoreAppPackageVersion>5.0.0-alpha1.19462.7</MicrosoftPrivateCoreFxNETCoreAppPackageVersion>
+    <MicrosoftWin32RegistryVersion>5.0.0-alpha1.19462.7</MicrosoftWin32RegistryVersion>
+    <MicrosoftWin32SystemEventsVersion>5.0.0-alpha1.19462.7</MicrosoftWin32SystemEventsVersion>
+    <MicrosoftWindowsCompatibilityPackageVersion>5.0.0-alpha1.19462.7</MicrosoftWindowsCompatibilityPackageVersion>
+    <SystemCodeDomVersion>5.0.0-alpha1.19462.7</SystemCodeDomVersion>
+    <SystemConfigurationConfigurationManagerVersion>5.0.0-alpha1.19462.7</SystemConfigurationConfigurationManagerVersion>
+    <SystemDiagnosticsEventLogVersion>5.0.0-alpha1.19462.7</SystemDiagnosticsEventLogVersion>
+    <SystemDirectoryServicesVersion>5.0.0-alpha1.19462.7</SystemDirectoryServicesVersion>
+    <SystemDrawingCommonVersion>5.0.0-alpha1.19462.7</SystemDrawingCommonVersion>
+    <SystemIOFileSystemAccessControlVersion>5.0.0-alpha1.19462.7</SystemIOFileSystemAccessControlVersion>
+    <SystemIOPackagingVersion>5.0.0-alpha1.19462.7</SystemIOPackagingVersion>
+    <SystemResourcesExtensionsPackageVersion>5.0.0-alpha1.19462.7</SystemResourcesExtensionsPackageVersion>
+    <SystemSecurityAccessControlVersion>5.0.0-alpha1.19462.7</SystemSecurityAccessControlVersion>
+    <SystemSecurityCryptographyCngVersion>5.0.0-alpha1.19462.7</SystemSecurityCryptographyCngVersion>
+    <SystemSecurityCryptographyPkcsVersion>5.0.0-alpha1.19462.7</SystemSecurityCryptographyPkcsVersion>
+    <SystemSecurityCryptographyProtectedDataVersion>5.0.0-alpha1.19462.7</SystemSecurityCryptographyProtectedDataVersion>
+    <SystemSecurityCryptographyXmlVersion>5.0.0-alpha1.19462.7</SystemSecurityCryptographyXmlVersion>
+    <SystemSecurityPermissionsVersion>5.0.0-alpha1.19462.7</SystemSecurityPermissionsVersion>
+    <SystemSecurityPrincipalWindowsVersion>5.0.0-alpha1.19462.7</SystemSecurityPrincipalWindowsVersion>
+    <SystemTextJsonVersion>5.0.0-alpha1.19462.7</SystemTextJsonVersion>
+    <SystemTextEncodingsWebVersion>5.0.0-alpha1.19462.7</SystemTextEncodingsWebVersion>
+    <SystemThreadingAccessControlVersion>5.0.0-alpha1.19462.7</SystemThreadingAccessControlVersion>
+    <SystemWindowsExtensionsPackageVersion>5.0.0-alpha1.19462.7</SystemWindowsExtensionsPackageVersion>
     <!-- standard -->
     <NETStandardLibraryPackageVersion>2.2.0-prerelease.19462.3</NETStandardLibraryPackageVersion>
     <!-- coreclr -->


### PR DESCRIPTION
This reverts https://github.com/dotnet/core-setup/pull/8266.

That PR removed `TEST_RESTORE_SOURCES_INSERTION_LINE`, which normally causes test restore to fail. It looks like it didn't fail in this case because an internal build published packages with the same versions due to a coincidental build number match. The green build allowed the PR to merge, but now it's breaking builds where this coincidence isn't occurring.