### PR TITLE
Add missing "--ci" option to Linux build

### DIFF
--- a/eng/jobs/steps/build-linux-package.yml
+++ b/eng/jobs/steps/build-linux-package.yml
@@ -12,6 +12,7 @@ steps:
       set -x
       df -h
       $(DockerRunMSBuild) ${{ parameters.image }} $(MSBuildScript) \
+        --ci \
         /root/coresetup/tools-local/tasks/core-setup.tasks.csproj \
         /t:Restore /t:Build /t:CreateHostMachineInfoFile \
         $(CommonMSBuildArgs) \


### PR DESCRIPTION
For internal build readiness.

This missing option caused the http cache not to be cleared at the right time. Clearing the http cache is a unfortunately necessary workaround to get authenticated NuGet restore to work, so this causes the internal build to fail if it tries to use an authenticated feed. More info at https://github.com/dotnet/arcade/issues/3868#issuecomment-533646445 what this is about and why the issue didn't repro on the first pass.

@JohnTortugo 