### PR TITLE
Fix license headers in HostModel.ComHost code.

### DIFF
--- a/src/managed/Microsoft.NET.HostModel/ComHost/ClsidMap.cs
+++ b/src/managed/Microsoft.NET.HostModel/ComHost/ClsidMap.cs
@@ -1,5 +1,6 @@
-﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/managed/Microsoft.NET.HostModel/ComHost/ComHost.cs
+++ b/src/managed/Microsoft.NET.HostModel/ComHost/ComHost.cs
@@ -1,4 +1,8 @@
-﻿using System;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
 using System.IO;
 using System.Text;
 

--- a/src/managed/Microsoft.NET.HostModel/ComHost/ConflictingGuidException.cs
+++ b/src/managed/Microsoft.NET.HostModel/ComHost/ConflictingGuidException.cs
@@ -1,4 +1,8 @@
-﻿using System;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
 using System.Collections.Generic;
 using System.Text;
 

--- a/src/managed/Microsoft.NET.HostModel/ComHost/MissingGuidException.cs
+++ b/src/managed/Microsoft.NET.HostModel/ComHost/MissingGuidException.cs
@@ -1,4 +1,8 @@
-﻿using System;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
 using System.Collections.Generic;
 using System.Text;
 

--- a/src/managed/Microsoft.NET.HostModel/ComHost/RegFreeComManifest.cs
+++ b/src/managed/Microsoft.NET.HostModel/ComHost/RegFreeComManifest.cs
@@ -1,4 +1,8 @@
-﻿using System;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;

--- a/src/test/Microsoft.NET.HostModel.Tests/Microsoft.NET.HostModel.ComHost.Tests/ClsidMapTests.cs
+++ b/src/test/Microsoft.NET.HostModel.Tests/Microsoft.NET.HostModel.ComHost.Tests/ClsidMapTests.cs
@@ -1,4 +1,8 @@
-﻿using Microsoft.DotNet.CoreSetup.Test;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.DotNet.CoreSetup.Test;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using System;

--- a/src/test/Microsoft.NET.HostModel.Tests/Microsoft.NET.HostModel.ComHost.Tests/RegFreeComManifestTests.cs
+++ b/src/test/Microsoft.NET.HostModel.Tests/Microsoft.NET.HostModel.ComHost.Tests/RegFreeComManifestTests.cs
@@ -1,4 +1,8 @@
-﻿using Newtonsoft.Json;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using System;
 using System.Collections.Generic;

--- a/src/test/Microsoft.NET.HostModel.Tests/Microsoft.NET.HostModel.ComHost.Tests/TestDirectory.cs
+++ b/src/test/Microsoft.NET.HostModel.Tests/Microsoft.NET.HostModel.ComHost.Tests/TestDirectory.cs
@@ -1,4 +1,8 @@
-﻿using System;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
 using System.IO;
 using System.Runtime.CompilerServices;
 


### PR DESCRIPTION
I forgot to add the license headers in #8293. The PR adds the license headers to the new files.