### PR TITLE
Try switching core-setup to use VS2019.

### DIFF
--- a/eng/jobs/windows-build.yml
+++ b/eng/jobs/windows-build.yml
@@ -14,10 +14,10 @@ jobs:
       # Use a hosted pool when possible.
       ${{ if eq(variables['System.TeamProject'], 'public') }}:
         name: NetCorePublic-Pool
-        queue: buildpool.windows.10.amd64.vs2017.open
+        queue: buildpool.windows.10.amd64.vs2019.open
       ${{ if ne(variables['System.TeamProject'], 'public') }}:
         name: NetCoreInternal-Pool
-        queue: buildpool.windows.10.amd64.vs2017
+        queue: buildpool.windows.10.amd64.vs2019
     strategy:
       matrix: 
         debug:


### PR DESCRIPTION
Validate that core-setup can build on the VS2019 queue.