### PR TITLE
[release/3.0] Upgrade SDK toolset from 3.0 preview6 => GA 

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "tools": {
-    "dotnet": "3.0.100-preview6-012264"
+    "dotnet": "3.0.100"
   },
   "msbuild-sdks": {
     "Microsoft.DotNet.Arcade.Sdk": "1.0.0-beta.19461.7"

--- a/src/test/Assets/TestProjects/Directory.Build.targets
+++ b/src/test/Assets/TestProjects/Directory.Build.targets
@@ -6,7 +6,7 @@
     versions. Remove them before the SDK tries to download them.
   -->
   <Target Name="RemoveUpstackKnownFrameworkReferences"
-          BeforeTargets="ResolveFrameworkReferences">
+          BeforeTargets="ProcessFrameworkReferences">
     <ItemGroup>
       <KnownFrameworkReference Remove="Microsoft.AspNetCore.App" />
     </ItemGroup>


### PR DESCRIPTION
#### Description

Upgrades the SDK used to build Core-Setup from 3.0 preview 6 to GA.

Handle SDK target name change from ResolveFrameworkReferences to ProcessFrameworkReferences in https://github.com/dotnet/sdk/commit/a55022eb89ef3d0fcecbcb6b53883181928e7030.

#### Customer Impact

Unblocks Arcade auto-update PRs like https://github.com/dotnet/core-setup/pull/8317.

#### Regression?

No.

#### Risk

There may be undetected additional breaks that need followup PRs to fix.