### PR TITLE
[release/3.0] Allow semver v2: we are past 3.0.0

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -9,7 +9,7 @@ pr:
 - master
 - release/3.*
 
-name: $(Date:yyyyMMdd)$(Rev:.rr)
+name: $(Date:yyyyMMdd)$(Rev:.r)
 
 variables:
   - name: TeamName

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -8,8 +8,6 @@
     <!-- Enable to remove prerelease label. -->
     <StabilizePackageVersion Condition="'$(StabilizePackageVersion)' == ''">false</StabilizePackageVersion>
     <DotNetFinalVersionKind Condition="'$(StabilizePackageVersion)' == 'true'">release</DotNetFinalVersionKind>
-    <!-- Disable SemVer v2 until after 3.0.0. -->
-    <SemanticVersioningV1 Condition="&#xA;      $(MajorVersion) &lt; 3 or&#xA;      '$(MajorVersion).$(MinorVersion).$(PatchVersion)' == '3.0.1'">true</SemanticVersioningV1>
     <!-- Blob storage container that has the "Latest" channel to publish to. -->
     <ContainerName>dotnet</ContainerName>
     <ChecksumContainerName>$(ContainerName)</ChecksumContainerName>


### PR DESCRIPTION
#### Description

Fixes infrastructure to continue to with the plan to use semver v2 for 3.0.1. (#6825)

#### Customer Impact

None.

#### Regression?

Yes, the infrastructure was in place to use semver v2 for 3.0.1 but there was a change in the stabilization PR that prevented this.

#### Risk

Minimal. The host supports this, other runtimes were already switched over for 3.0.0, and the .NET Core Runtime has switched in the 3.1+ branches.

---

In #6825, we planned to move to semver v2 after 3.0.0. https://github.com/dotnet/core-setup/pull/8313 changed the condition so that the move will happen after 3.0.1. @Anipik, what was the reason for this change, is there a reason not to use semver v2 for 3.0 servicing?

I believe we're safe to move to semver v2 even though Core-Setup has already built a 3.0.1-servicing-19475-04, because we haven't yet released it to the NuGet gallery. Maybe I'm wrong and we need to wait for 3.0.2. @sdmaclea @jeffschwMSFT let me know what you think.

/cc @dleeapho @leecow @mmitche 