### PR TITLE
Fix reference to renamed SDK target in test asset project restore

### DIFF
--- a/src/test/Assets/TestProjects/Directory.Build.targets
+++ b/src/test/Assets/TestProjects/Directory.Build.targets
@@ -6,7 +6,7 @@
     versions. Remove them before the SDK tries to download them.
   -->
   <Target Name="RemoveUpstackKnownFrameworkReferences"
-          BeforeTargets="ResolveFrameworkReferences">
+          BeforeTargets="ProcessFrameworkReferences">
     <ItemGroup>
       <KnownFrameworkReference Remove="Microsoft.AspNetCore.App" />
     </ItemGroup>


### PR DESCRIPTION
Brings hotfix https://github.com/dotnet/core-setup/pull/8330 back to `master`.

Handle SDK target name change from ResolveFrameworkReferences to ProcessFrameworkReferences in https://github.com/dotnet/sdk/commit/a55022eb89ef3d0fcecbcb6b53883181928e7030.

My guess as to why the `release/3.0` issue didn't repro in `master` and block the SDK upgrade (`master` already uses `3.0.100`) is that the 3.0 SDK only knows about a 3.0 ASP.NET Core runtime pack, not a 5.0 runtime pack, so it never tries to restore one in the first place when building a `netcoreapp5.0` test project. This fix will probably become required in `master` once we need to build using a 5.0 SDK.

(It is also good to keep the branches the same.)