### PR TITLE
[release/3.0] Keep SemVer v1 in 3.0 servicing builds

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -8,8 +8,8 @@
     <!-- Enable to remove prerelease label. -->
     <StabilizePackageVersion Condition="'$(StabilizePackageVersion)' == ''">false</StabilizePackageVersion>
     <DotNetFinalVersionKind Condition="'$(StabilizePackageVersion)' == 'true'">release</DotNetFinalVersionKind>
-    <!-- Disable SemVer v2 until after 3.0.0. -->
-    <SemanticVersioningV1 Condition="&#xA;      $(MajorVersion) &lt; 3 or&#xA;      '$(MajorVersion).$(MinorVersion).$(PatchVersion)' == '3.0.1'">true</SemanticVersioningV1>
+    <!-- Disable SemVer v2 in 3.0 servicing builds. -->
+    <SemanticVersioningV1>true</SemanticVersioningV1>
     <!-- Blob storage container that has the "Latest" channel to publish to. -->
     <ContainerName>dotnet</ContainerName>
     <ChecksumContainerName>$(ContainerName)</ChecksumContainerName>


### PR DESCRIPTION
#### Description

The original plan was to use SemVer v2 for 3.0.1+ servicing builds (https://github.com/dotnet/core-setup/pull/8331), however, without any strong reason to do so, the potential risk doesn't seem worthwhile. (https://github.com/dotnet/roslyn/issues/35793 came up in ask mode review.)

This allows future `PatchVersion` updates without requiring also updating the `SemanticVersioningV1` property's condition to match, reducing maintenance cost.

#### Customer Impact

None.

#### Regression?

No.

#### Risk

None. This removes a single manual step in the process to advance the patch version, with the same result.