### PR TITLE
Self contained component fx validation

### DIFF
--- a/src/corehost/cli/fxr/corehost_init.cpp
+++ b/src/corehost/cli/fxr/corehost_init.cpp
@@ -58,6 +58,11 @@ corehost_init_t::corehost_init_t(
         m_clr_values.push_back(kv.second);
     }
 
+    for (const auto& included_framework : get_app(fx_definitions).get_runtime_config().get_included_frameworks())
+    {
+        m_included_frameworks.emplace_back(included_framework);
+    }
+
     make_cstr_arr(m_fx_names, &m_fx_names_cstr);
     make_cstr_arr(m_fx_dirs, &m_fx_dirs_cstr);
     make_cstr_arr(m_fx_requested_versions, &m_fx_requested_versions_cstr);
@@ -130,12 +135,22 @@ const host_interface_t& corehost_init_t::get_host_init_data()
     return hi;
 }
 
-void corehost_init_t::get_found_fx_versions(std::unordered_map<pal::string_t, const fx_ver_t> &out_fx_versions)
+void corehost_init_t::get_found_fx_versions(std::unordered_map<pal::string_t, const fx_ver_t> &out_fx_versions) const
 {
     for (size_t i = 0; i < m_fx_names.size(); ++i)
     {
         fx_ver_t version;
         if (fx_ver_t::parse(m_fx_found_versions[i], &version))
+        {
             out_fx_versions.emplace(m_fx_names[i], version);
+        }
+    }
+}
+
+void corehost_init_t::get_included_frameworks(std::unordered_map<pal::string_t, const fx_ver_t>& out_included_frameworks) const
+{
+    for (const auto& included_framework : m_included_frameworks)
+    {
+        out_included_frameworks.emplace(included_framework.get_fx_name(), included_framework.get_fx_version_number());
     }
 }

--- a/src/corehost/cli/fxr/corehost_init.h
+++ b/src/corehost/cli/fxr/corehost_init.h
@@ -32,6 +32,7 @@ private:
     std::vector<const pal::char_t*> m_fx_requested_versions_cstr;
     std::vector<pal::string_t> m_fx_found_versions;
     std::vector<const pal::char_t*> m_fx_found_versions_cstr;
+    fx_reference_vector_t m_included_frameworks;
     const pal::string_t m_host_command;
     const pal::string_t m_host_info_host_path;
     const pal::string_t m_host_info_dotnet_root;
@@ -48,7 +49,8 @@ public:
 
     const host_interface_t& get_host_init_data();
 
-    void get_found_fx_versions(std::unordered_map<pal::string_t, const fx_ver_t> &out_fx_versions);
+    void get_found_fx_versions(std::unordered_map<pal::string_t, const fx_ver_t> &out_fx_versions) const;
+    void get_included_frameworks(std::unordered_map<pal::string_t, const fx_ver_t>& out_included_frameworks) const;
 };
 
 #endif // __COREHOST_INIT_H__

--- a/src/corehost/cli/fxr/host_context.cpp
+++ b/src/corehost/cli/fxr/host_context.cpp
@@ -55,7 +55,7 @@ int host_context_t::create(
     if (rc == StatusCode::Success)
     {
         std::unique_ptr<host_context_t> context_local(new host_context_t(host_context_type::initialized, hostpolicy_contract, hostpolicy_context_contract));
-        init.get_found_fx_versions(context_local->fx_versions_by_name);
+        context_local->initialize_frameworks(init);
         context = std::move(context_local);
     }
 
@@ -131,6 +131,12 @@ host_context_t::host_context_t(
     , hostpolicy_contract { hostpolicy_contract }
     , hostpolicy_context_contract { hostpolicy_context_contract }
 { }
+
+void host_context_t::initialize_frameworks(const corehost_init_t& init)
+{
+    init.get_found_fx_versions(fx_versions_by_name);
+    init.get_included_frameworks(included_fx_versions_by_name);
+}
 
 void host_context_t::close()
 {

--- a/src/corehost/cli/fxr/host_context.h
+++ b/src/corehost/cli/fxr/host_context.h
@@ -50,6 +50,10 @@ public:
     // Frameworks used for active context
     std::unordered_map<pal::string_t, const fx_ver_t> fx_versions_by_name;
 
+    // Included frameworks used for active context - in case this is a self-contained app
+    // this contains a list of frameworks which are part of the app - they are not framework dependencies/refernces.
+    std::unordered_map<pal::string_t, const fx_ver_t> included_fx_versions_by_name;
+
     // Config properties for secondary contexts
     std::unordered_map<pal::string_t, pal::string_t> config_properties;
 
@@ -57,6 +61,8 @@ public:
         host_context_type type,
         const hostpolicy_contract_t &hostpolicy_contract,
         const corehost_context_contract &hostpolicy_context_contract);
+
+    void initialize_frameworks(const corehost_init_t& init);
 
     void close();
 };

--- a/src/corehost/cli/runtime_config.cpp
+++ b/src/corehost/cli/runtime_config.cpp
@@ -180,7 +180,6 @@ bool runtime_config_t::parse_opts(const json_parser_t::value_t& opts)
     }
 
     // Step #3: read the "framework" and "frameworks" section
-    bool rc = true;
     const auto& framework = opts_obj.FindMember(_X("framework"));
     if (framework != opts_obj.MemberEnd())
     {

--- a/src/corehost/cli/runtime_config.cpp
+++ b/src/corehost/cli/runtime_config.cpp
@@ -201,7 +201,22 @@ bool runtime_config_t::parse_opts(const json_parser_t::value_t& opts)
         {
             m_is_framework_dependent = true;
 
-            rc = read_framework_array(iter->value);
+            rc = read_framework_array(iter->value, m_frameworks);
+        }
+    }
+
+    if (rc)
+    {
+        const auto& includedFrameworks = opts_obj.FindMember(_X("includedFrameworks"));
+        if (includedFrameworks != opts_obj.MemberEnd())
+        {
+            if (m_is_framework_dependent)
+            {
+                trace::error(_X("It's invalid to specify both `framework`/`frameworks` and `includedFrameworks` properties."));
+                return false;
+            }
+
+            rc = read_framework_array(includedFrameworks->value, m_included_frameworks, /*name_and_version_only*/ true);
         }
     }
 
@@ -226,7 +241,10 @@ namespace
 
 bool runtime_config_t::parse_framework(const json_parser_t::value_t& fx_obj, fx_reference_t& fx_out)
 {
-    apply_settings_to_fx_reference(m_default_settings, fx_out);
+    if (!name_and_version_only)
+    {
+        apply_settings_to_fx_reference(m_default_settings, fx_out);
+    }
 
     const auto& fx_name = fx_obj.FindMember(_X("name"));
     if (fx_name != fx_obj.MemberEnd())
@@ -241,10 +259,15 @@ bool runtime_config_t::parse_framework(const json_parser_t::value_t& fx_obj, fx_
 
         // Release version should prefer release versions, unless the rollForwardToPrerelease is set
         // in which case no preference should be applied.
-        if (!fx_out.get_fx_version_number().is_prerelease() && !m_roll_forward_to_prerelease)
+        if (!name_and_version_only && !fx_out.get_fx_version_number().is_prerelease() && !m_roll_forward_to_prerelease)
         {
             fx_out.set_prefer_release(true);
         }
+    }
+
+    if (name_and_version_only)
+    {
+        return true;
     }
 
     const auto& roll_forward = fx_obj.FindMember(_X("rollForward"));
@@ -330,14 +353,14 @@ bool runtime_config_t::ensure_dev_config_parsed()
     return true;
 }
 
-bool runtime_config_t::read_framework_array(const json_parser_t::value_t& frameworks_json)
+bool runtime_config_t::read_framework_array(const json_parser_t::value_t& frameworks_json, fx_reference_vector_t& frameworks, bool name_and_version_only)
 {
     bool rc = true;
 
     for (const auto& fx_json : frameworks_json.GetArray())
     {
         fx_reference_t fx_out;
-        rc = parse_framework(fx_json, fx_out);
+        rc = parse_framework(fx_json, fx_out, name_and_version_only);
         if (!rc)
         {
             break;
@@ -351,17 +374,17 @@ bool runtime_config_t::read_framework_array(const json_parser_t::value_t& framew
         }
 
         if (std::find_if(
-                m_frameworks.begin(),
-                m_frameworks.end(),
+                frameworks.begin(),
+                frameworks.end(),
                 [&](const fx_reference_t& item) { return fx_out.get_fx_name() == item.get_fx_name(); })
-            != m_frameworks.end())
+            != frameworks.end())
         {
             trace::verbose(_X("Framework %s already specified."), fx_out.get_fx_name().c_str());
             rc = false;
             break;
         }
 
-        m_frameworks.push_back(fx_out);
+        frameworks.push_back(fx_out);
     }
 
     return rc;

--- a/src/corehost/cli/runtime_config.cpp
+++ b/src/corehost/cli/runtime_config.cpp
@@ -239,7 +239,7 @@ namespace
     }
 }
 
-bool runtime_config_t::parse_framework(const json_parser_t::value_t& fx_obj, fx_reference_t& fx_out)
+bool runtime_config_t::parse_framework(const json_parser_t::value_t& fx_obj, fx_reference_t& fx_out, bool name_and_version_only)
 {
     if (!name_and_version_only)
     {
@@ -353,7 +353,7 @@ bool runtime_config_t::ensure_dev_config_parsed()
     return true;
 }
 
-bool runtime_config_t::read_framework_array(const json_parser_t::value_t& frameworks_json, fx_reference_vector_t& frameworks, bool name_and_version_only)
+bool runtime_config_t::read_framework_array(const json_parser_t::value_t& frameworks_json, fx_reference_vector_t& frameworks_out, bool name_and_version_only)
 {
     bool rc = true;
 
@@ -374,17 +374,17 @@ bool runtime_config_t::read_framework_array(const json_parser_t::value_t& framew
         }
 
         if (std::find_if(
-                frameworks.begin(),
-                frameworks.end(),
+                frameworks_out.begin(),
+                frameworks_out.end(),
                 [&](const fx_reference_t& item) { return fx_out.get_fx_name() == item.get_fx_name(); })
-            != frameworks.end())
+            != frameworks_out.end())
         {
             trace::verbose(_X("Framework %s already specified."), fx_out.get_fx_name().c_str());
             rc = false;
             break;
         }
 
-        frameworks.push_back(fx_out);
+        frameworks_out.push_back(fx_out);
     }
 
     return rc;

--- a/src/corehost/cli/runtime_config.h
+++ b/src/corehost/cli/runtime_config.h
@@ -77,7 +77,7 @@ private:
     bool m_roll_forward_to_prerelease;
 
     bool parse_framework(const json_parser_t::value_t& fx_obj, fx_reference_t& fx_out, bool name_and_version_only = false);
-    bool read_framework_array(const json_parser_t::value_t& frameworks, fx_reference_vector_t& frameworks, bool name_and_version_only = false);
+    bool read_framework_array(const json_parser_t::value_t& frameworks, fx_reference_vector_t& frameworks_out, bool name_and_version_only = false);
 
     bool mark_specified_setting(specified_setting setting);
 };

--- a/src/corehost/cli/runtime_config.h
+++ b/src/corehost/cli/runtime_config.h
@@ -39,6 +39,7 @@ public:
     bool parse_opts(const json_parser_t::value_t& opts);
     void combine_properties(std::unordered_map<pal::string_t, pal::string_t>& combined_properties) const;
     const fx_reference_vector_t& get_frameworks() const { return m_frameworks; }
+    const fx_reference_vector_t& get_included_frameworks() const { return m_included_frameworks; }
     void set_fx_version(pal::string_t version);
 
 private:
@@ -47,6 +48,7 @@ private:
 
     std::unordered_map<pal::string_t, pal::string_t> m_properties;
     fx_reference_vector_t m_frameworks;
+    fx_reference_vector_t m_included_frameworks;
     settings_t m_default_settings;   // the default settings (Steps #0 and #1)
     settings_t m_override_settings;  // the settings that can't be changed (Step #5)
     std::vector<std::string> m_prop_keys;
@@ -74,8 +76,8 @@ private:
     // If set to true, all versions (including pre-release) are considered even if starting from a release framework reference.
     bool m_roll_forward_to_prerelease;
 
-    bool parse_framework(const json_parser_t::value_t& fx_obj, fx_reference_t& fx_out);
-    bool read_framework_array(const json_parser_t::value_t& frameworks);
+    bool parse_framework(const json_parser_t::value_t& fx_obj, fx_reference_t& fx_out, bool name_and_version_only = false);
+    bool read_framework_array(const json_parser_t::value_t& frameworks, fx_reference_vector_t& frameworks, bool name_and_version_only = false);
 
     bool mark_specified_setting(specified_setting setting);
 };

--- a/src/test/HostActivation.Tests/FrameworkResolution/FrameworkResolutionBase.cs
+++ b/src/test/HostActivation.Tests/FrameworkResolution/FrameworkResolutionBase.cs
@@ -57,14 +57,42 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.FrameworkResolution
             }
         }
 
+        protected CommandResult RunSelfContainedTest(
+            TestApp app,
+            TestSettings settings)
+        {
+            if (settings.RuntimeConfigCustomizer != null)
+            {
+                settings.RuntimeConfigCustomizer(RuntimeConfig.Path(app.RuntimeConfigJson)).Save();
+            }
+
+            settings.WithCommandLine(app.AppDll);
+
+            Command command = Command.Create(app.AppExe, settings.CommandLine);
+
+            if (settings.WorkingDirectory != null)
+            {
+                command = command.WorkingDirectory(settings.WorkingDirectory);
+            }
+
+            CommandResult result = command
+                .EnableTracingAndCaptureOutputs()
+                .Environment(settings.Environment)
+                .Execute();
+
+            return result;
+        }
+
         public class SharedTestStateBase : IDisposable
         {
             private readonly string _builtDotnet;
+            private readonly RepoDirectoriesProvider _repoDirectories;
             private readonly string _baseDir;
 
             public SharedTestStateBase()
             {
                 _builtDotnet = Path.Combine(TestArtifact.TestArtifactsPath, "sharedFrameworkPublish");
+                _repoDirectories = new RepoDirectoriesProvider();
 
                 string baseDir = Path.Combine(TestArtifact.TestArtifactsPath, "frameworkResolution");
                 _baseDir = SharedFramework.CalculateUniqueTestDirectory(baseDir);
@@ -88,6 +116,46 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.FrameworkResolution
                 File.WriteAllText(Path.Combine(testAppDir, "FrameworkReferenceApp.runtimeconfig.json"), "{}");
 
                 return new TestApp(testAppDir);
+            }
+
+            public TestApp CreateSelfContainedAppWithMockHostPolicy()
+            {
+                string testAppDir = Path.Combine(_baseDir, "SelfContainedApp");
+                Directory.CreateDirectory(testAppDir);
+                TestApp testApp = new TestApp(testAppDir);
+
+                string hostFxrFileName = RuntimeInformationExtensions.GetSharedLibraryFileNameForCurrentPlatform("hostfxr");
+                string hostPolicyFileName = RuntimeInformationExtensions.GetSharedLibraryFileNameForCurrentPlatform("hostpolicy");
+                string mockHostPolicyFileName = RuntimeInformationExtensions.GetSharedLibraryFileNameForCurrentPlatform("mockhostpolicy");
+                string appHostFileName = RuntimeInformationExtensions.GetExeFileNameForCurrentPlatform("apphost");
+                string coreclrFileName = RuntimeInformationExtensions.GetSharedLibraryFileNameForCurrentPlatform("coreclr");
+                string mockCoreclrFileName = RuntimeInformationExtensions.GetSharedLibraryFileNameForCurrentPlatform("mockcoreclr");
+
+                string currentRid = _repoDirectories.TargetRID;
+                DotNetCli builtDotNetCli = new DotNetCli(_builtDotnet);
+
+                // ./hostfxr - the product version
+                File.Copy(builtDotNetCli.GreatestVersionHostFxrFilePath, Path.Combine(testAppDir, hostFxrFileName));
+
+                // ./hostpolicy - the mock
+                File.Copy(
+                    Path.Combine(_repoDirectories.Artifacts, "corehost_test", mockHostPolicyFileName),
+                    Path.Combine(testAppDir, hostPolicyFileName));
+
+                // ./SelfContainedApp.dll
+                File.WriteAllText(Path.Combine(testAppDir, "SelfContainedApp.dll"), string.Empty);
+
+                // ./SelfContainedApp.runtimeconfig.json
+                File.WriteAllText(Path.Combine(testAppDir, "SelfContainedApp.runtimeconfig.json"), "{}");
+
+                // ./SelfContainedApp.exe
+                string selfContainedAppExePath = Path.Combine(testAppDir, RuntimeInformationExtensions.GetExeFileNameForCurrentPlatform("SelfContainedApp"));
+                File.Copy(
+                    Path.Combine(_repoDirectories.HostArtifacts, appHostFileName),
+                    selfContainedAppExePath);
+                AppHostExtensions.BindAppHost(selfContainedAppExePath);
+
+                return testApp;
             }
 
             public void Dispose()

--- a/src/test/HostActivation.Tests/FrameworkResolution/FrameworkResolutionBase.cs
+++ b/src/test/HostActivation.Tests/FrameworkResolution/FrameworkResolutionBase.cs
@@ -128,10 +128,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.FrameworkResolution
                 string hostPolicyFileName = RuntimeInformationExtensions.GetSharedLibraryFileNameForCurrentPlatform("hostpolicy");
                 string mockHostPolicyFileName = RuntimeInformationExtensions.GetSharedLibraryFileNameForCurrentPlatform("mockhostpolicy");
                 string appHostFileName = RuntimeInformationExtensions.GetExeFileNameForCurrentPlatform("apphost");
-                string coreclrFileName = RuntimeInformationExtensions.GetSharedLibraryFileNameForCurrentPlatform("coreclr");
-                string mockCoreclrFileName = RuntimeInformationExtensions.GetSharedLibraryFileNameForCurrentPlatform("mockcoreclr");
 
-                string currentRid = _repoDirectories.TargetRID;
                 DotNetCli builtDotNetCli = new DotNetCli(_builtDotnet);
 
                 // ./hostfxr - the product version

--- a/src/test/HostActivation.Tests/FrameworkResolution/IncludedFrameworksSettings.cs
+++ b/src/test/HostActivation.Tests/FrameworkResolution/IncludedFrameworksSettings.cs
@@ -1,0 +1,54 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.DotNet.Cli.Build;
+using Microsoft.DotNet.Cli.Build.Framework;
+using Xunit;
+
+namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.FrameworkResolution
+{
+    public class IncludedFrameworksSettings :
+        FrameworkResolutionBase,
+        IClassFixture<IncludedFrameworksSettings.SharedTestState>
+    {
+        private SharedTestState SharedState { get; }
+
+        public IncludedFrameworksSettings(SharedTestState sharedState)
+        {
+            SharedState = sharedState;
+        }
+
+        // Verifies that the default is true
+        [Fact]
+        public void FrameworkAndIncludedFrameworksIsInvalid()
+        {
+            RunTest(
+                new TestSettings()
+                    .WithRuntimeConfigCustomizer(runtimeConfig => runtimeConfig
+                        .WithFramework(MicrosoftNETCoreApp, "5.1.2")
+                        .WithIncludedFramework(MicrosoftNETCoreApp, "5.1.2")))
+                .Should().Fail()
+                .And.HaveStdErrContaining("It's invalid to specify both `framework`/`frameworks` and `includedFrameworks` properties.");
+        }
+
+        private CommandResult RunTest(TestSettings testSettings) =>
+            RunTest(SharedState.DotNetWithFrameworks, SharedState.FrameworkReferenceApp, testSettings);
+
+        public class SharedTestState : SharedTestStateBase
+        {
+            public TestApp FrameworkReferenceApp { get; }
+
+            public DotNetCli DotNetWithFrameworks { get; }
+
+            public SharedTestState()
+            {
+                DotNetWithFrameworks = DotNet("WithOneFramework")
+                    .AddMicrosoftNETCoreAppFrameworkMockHostPolicy("5.1.2")
+                    .Build();
+
+                FrameworkReferenceApp = CreateFrameworkReferenceApp();
+            }
+        }
+    }
+}

--- a/src/test/HostActivation.Tests/FrameworkResolution/IncludedFrameworksSettings.cs
+++ b/src/test/HostActivation.Tests/FrameworkResolution/IncludedFrameworksSettings.cs
@@ -60,8 +60,8 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.FrameworkResolution
                 new TestSettings()
                     .WithRuntimeConfigCustomizer(runtimeConfig => runtimeConfig
                         .WithIncludedFramework(new RuntimeConfig.Framework(MicrosoftNETCoreApp, "5.1.2")
-                            .WithApplyPatches(false)    // Properties which are otherwise valid on frameworks are ignored
-                            .WithRollForward("invalid") // in case of included frameworks.
+                            .WithApplyPatches(false)    // Properties which are otherwise parsed on frameworks are ignored
+                            .WithRollForward("invalid") // in case of included frameworks. (so invalid values will be accepted)
                             .WithRollForwardOnNoCandidateFx(42))))
                 .Should().Pass()
                 .And.HaveStdOutContaining("mock is_framework_dependent: 0");

--- a/src/test/HostActivation.Tests/FrameworkResolution/IncludedFrameworksSettings.cs
+++ b/src/test/HostActivation.Tests/FrameworkResolution/IncludedFrameworksSettings.cs
@@ -23,7 +23,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.FrameworkResolution
         [Fact]
         public void FrameworkAndIncludedFrameworksIsInvalid()
         {
-            RunTest(
+            RunFrameworkDependentTest(
                 new TestSettings()
                     .WithRuntimeConfigCustomizer(runtimeConfig => runtimeConfig
                         .WithFramework(MicrosoftNETCoreApp, "5.1.2")
@@ -32,12 +32,27 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.FrameworkResolution
                 .And.HaveStdErrContaining("It's invalid to specify both `framework`/`frameworks` and `includedFrameworks` properties.");
         }
 
-        private CommandResult RunTest(TestSettings testSettings) =>
+        [Fact]
+        public void SelfContainedCanHaveIncludedFrameworks()
+        {
+            RunSelfContainedTest(
+                new TestSettings()
+                    .WithRuntimeConfigCustomizer(runtimeConfig => runtimeConfig
+                        .WithIncludedFramework(MicrosoftNETCoreApp, "5.1.2")))
+                .Should().Pass();
+        }
+
+        private CommandResult RunFrameworkDependentTest(TestSettings testSettings) =>
             RunTest(SharedState.DotNetWithFrameworks, SharedState.FrameworkReferenceApp, testSettings);
+
+        private CommandResult RunSelfContainedTest(TestSettings testSettings) =>
+            RunSelfContainedTest(SharedState.SelfContainedApp, testSettings);
 
         public class SharedTestState : SharedTestStateBase
         {
             public TestApp FrameworkReferenceApp { get; }
+
+            public TestApp SelfContainedApp { get; }
 
             public DotNetCli DotNetWithFrameworks { get; }
 
@@ -48,6 +63,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.FrameworkResolution
                     .Build();
 
                 FrameworkReferenceApp = CreateFrameworkReferenceApp();
+                SelfContainedApp = CreateSelfContainedAppWithMockHostPolicy();
             }
         }
     }

--- a/src/test/HostActivation.Tests/NativeHosting/HostContext.cs
+++ b/src/test/HostActivation.Tests/NativeHosting/HostContext.cs
@@ -2,10 +2,12 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using Microsoft.DotNet.Cli.Build;
 using Microsoft.DotNet.Cli.Build.Framework;
 using System;
 using System.IO;
 using System.Linq;
+using System.Runtime.InteropServices.ComTypes;
 using Xunit;
 
 namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.NativeHosting
@@ -291,72 +293,98 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.NativeHosting
         }
 
         [Theory]
-        [InlineData(Scenario.ConfigMultiple, false, Constants.MicrosoftNETCoreApp, "1.1.0", Constants.RollForwardSetting.LatestPatch, false)]
-        [InlineData(Scenario.ConfigMultiple, false, Constants.MicrosoftNETCoreApp, "1.1.0", Constants.RollForwardSetting.Minor, false)]
-        [InlineData(Scenario.ConfigMultiple, false, Constants.MicrosoftNETCoreApp, "1.1.0", Constants.RollForwardSetting.LatestMinor, false)]
-        [InlineData(Scenario.ConfigMultiple, false, Constants.MicrosoftNETCoreApp, "1.1.0", Constants.RollForwardSetting.Major, true)]
-        [InlineData(Scenario.ConfigMultiple, false, Constants.MicrosoftNETCoreApp, "1.1.0", Constants.RollForwardSetting.LatestMajor, true)]
-        [InlineData(Scenario.ConfigMultiple, false, Constants.MicrosoftNETCoreApp, "2.1.0", Constants.RollForwardSetting.LatestPatch, false)]
-        [InlineData(Scenario.ConfigMultiple, false, Constants.MicrosoftNETCoreApp, "2.1.0", Constants.RollForwardSetting.Minor, true)]
-        [InlineData(Scenario.ConfigMultiple, false, Constants.MicrosoftNETCoreApp, "2.1.0", Constants.RollForwardSetting.LatestMinor, true)]
-        [InlineData(Scenario.ConfigMultiple, false, Constants.MicrosoftNETCoreApp, "2.1.0", Constants.RollForwardSetting.Major, true)]
-        [InlineData(Scenario.ConfigMultiple, false, Constants.MicrosoftNETCoreApp, "2.1.0", Constants.RollForwardSetting.LatestMajor, true)]
-        [InlineData(Scenario.ConfigMultiple, false, Constants.MicrosoftNETCoreApp, "2.2.0", Constants.RollForwardSetting.Disable, true)]
-        [InlineData(Scenario.ConfigMultiple, false, Constants.MicrosoftNETCoreApp, "3.1.0", Constants.RollForwardSetting.LatestMinor, false)]
-        [InlineData(Scenario.ConfigMultiple, false, "UnknownFramework", "2.2.0", null, null)]
-        [InlineData(Scenario.Mixed, false, Constants.MicrosoftNETCoreApp, "1.1.0", Constants.RollForwardSetting.LatestPatch, false)]
-        [InlineData(Scenario.Mixed, false, Constants.MicrosoftNETCoreApp, "1.1.0", Constants.RollForwardSetting.Minor, false)]
-        [InlineData(Scenario.Mixed, false, Constants.MicrosoftNETCoreApp, "1.1.0", Constants.RollForwardSetting.LatestMinor, false)]
-        [InlineData(Scenario.Mixed, false, Constants.MicrosoftNETCoreApp, "1.1.0", Constants.RollForwardSetting.Major, true)]
-        [InlineData(Scenario.Mixed, false, Constants.MicrosoftNETCoreApp, "1.1.0", Constants.RollForwardSetting.LatestMajor, true)]
-        [InlineData(Scenario.Mixed, false, Constants.MicrosoftNETCoreApp, "2.1.0", Constants.RollForwardSetting.LatestPatch, false)]
-        [InlineData(Scenario.Mixed, false, Constants.MicrosoftNETCoreApp, "2.1.0", Constants.RollForwardSetting.Minor, true)]
-        [InlineData(Scenario.Mixed, false, Constants.MicrosoftNETCoreApp, "2.1.0", Constants.RollForwardSetting.LatestMinor, true)]
-        [InlineData(Scenario.Mixed, false, Constants.MicrosoftNETCoreApp, "2.1.0", Constants.RollForwardSetting.Major, true)]
-        [InlineData(Scenario.Mixed, false, Constants.MicrosoftNETCoreApp, "2.1.0", Constants.RollForwardSetting.LatestMajor, true)]
-        [InlineData(Scenario.Mixed, false, Constants.MicrosoftNETCoreApp, "2.2.0", Constants.RollForwardSetting.Disable, true)]
-        [InlineData(Scenario.Mixed, false, Constants.MicrosoftNETCoreApp, "3.1.0", Constants.RollForwardSetting.LatestMinor, false)]
-        [InlineData(Scenario.Mixed, false, "UnknownFramework", "2.2.0", null, null)]
-        [InlineData(Scenario.Mixed, true, Constants.MicrosoftNETCoreApp, "1.1.0", Constants.RollForwardSetting.LatestPatch, true)]
-        [InlineData(Scenario.Mixed, true, Constants.MicrosoftNETCoreApp, "1.1.0", Constants.RollForwardSetting.Minor, true)]
-        [InlineData(Scenario.Mixed, true, Constants.MicrosoftNETCoreApp, "1.1.0", Constants.RollForwardSetting.LatestMinor, true)]
-        [InlineData(Scenario.Mixed, true, Constants.MicrosoftNETCoreApp, "1.1.0", Constants.RollForwardSetting.Major, true)]
-        [InlineData(Scenario.Mixed, true, Constants.MicrosoftNETCoreApp, "1.1.0", Constants.RollForwardSetting.LatestMajor, true)]
-        [InlineData(Scenario.Mixed, true, Constants.MicrosoftNETCoreApp, "2.1.0", Constants.RollForwardSetting.LatestPatch, true)]
-        [InlineData(Scenario.Mixed, true, Constants.MicrosoftNETCoreApp, "2.1.0", Constants.RollForwardSetting.Minor, true)]
-        [InlineData(Scenario.Mixed, true, Constants.MicrosoftNETCoreApp, "2.1.0", Constants.RollForwardSetting.LatestMinor, true)]
-        [InlineData(Scenario.Mixed, true, Constants.MicrosoftNETCoreApp, "2.1.0", Constants.RollForwardSetting.Major, true)]
-        [InlineData(Scenario.Mixed, true, Constants.MicrosoftNETCoreApp, "2.1.0", Constants.RollForwardSetting.LatestMajor, true)]
-        [InlineData(Scenario.Mixed, true, Constants.MicrosoftNETCoreApp, "2.2.0", Constants.RollForwardSetting.Disable, true)]
-        [InlineData(Scenario.Mixed, true, Constants.MicrosoftNETCoreApp, "3.1.0", Constants.RollForwardSetting.LatestMinor, true)]
-        [InlineData(Scenario.Mixed, true, "UnknownFramework", "2.2.0", null, true)]
-        [InlineData(Scenario.NonContextMixed, false, Constants.MicrosoftNETCoreApp, "1.1.0", Constants.RollForwardSetting.LatestPatch, false)]
-        [InlineData(Scenario.NonContextMixed, false, Constants.MicrosoftNETCoreApp, "1.1.0", Constants.RollForwardSetting.Minor, false)]
-        [InlineData(Scenario.NonContextMixed, false, Constants.MicrosoftNETCoreApp, "1.1.0", Constants.RollForwardSetting.LatestMinor, false)]
-        [InlineData(Scenario.NonContextMixed, false, Constants.MicrosoftNETCoreApp, "1.1.0", Constants.RollForwardSetting.Major, true)]
-        [InlineData(Scenario.NonContextMixed, false, Constants.MicrosoftNETCoreApp, "1.1.0", Constants.RollForwardSetting.LatestMajor, true)]
-        [InlineData(Scenario.NonContextMixed, false, Constants.MicrosoftNETCoreApp, "2.1.0", Constants.RollForwardSetting.LatestPatch, false)]
-        [InlineData(Scenario.NonContextMixed, false, Constants.MicrosoftNETCoreApp, "2.1.0", Constants.RollForwardSetting.Minor, true)]
-        [InlineData(Scenario.NonContextMixed, false, Constants.MicrosoftNETCoreApp, "2.1.0", Constants.RollForwardSetting.LatestMinor, true)]
-        [InlineData(Scenario.NonContextMixed, false, Constants.MicrosoftNETCoreApp, "2.1.0", Constants.RollForwardSetting.Major, true)]
-        [InlineData(Scenario.NonContextMixed, false, Constants.MicrosoftNETCoreApp, "2.1.0", Constants.RollForwardSetting.LatestMajor, true)]
-        [InlineData(Scenario.NonContextMixed, false, Constants.MicrosoftNETCoreApp, "2.2.0", Constants.RollForwardSetting.Disable, true)]
-        [InlineData(Scenario.NonContextMixed, false, Constants.MicrosoftNETCoreApp, "3.1.0", Constants.RollForwardSetting.LatestMinor, false)]
-        [InlineData(Scenario.NonContextMixed, false, "UnknownFramework", "2.2.0", null, null)]
-        [InlineData(Scenario.NonContextMixed, true, Constants.MicrosoftNETCoreApp, "1.1.0", Constants.RollForwardSetting.LatestPatch, true)]
-        [InlineData(Scenario.NonContextMixed, true, Constants.MicrosoftNETCoreApp, "1.1.0", Constants.RollForwardSetting.Minor, true)]
-        [InlineData(Scenario.NonContextMixed, true, Constants.MicrosoftNETCoreApp, "1.1.0", Constants.RollForwardSetting.LatestMinor, true)]
-        [InlineData(Scenario.NonContextMixed, true, Constants.MicrosoftNETCoreApp, "1.1.0", Constants.RollForwardSetting.Major, true)]
-        [InlineData(Scenario.NonContextMixed, true, Constants.MicrosoftNETCoreApp, "1.1.0", Constants.RollForwardSetting.LatestMajor, true)]
-        [InlineData(Scenario.NonContextMixed, true, Constants.MicrosoftNETCoreApp, "2.1.0", Constants.RollForwardSetting.LatestPatch, true)]
-        [InlineData(Scenario.NonContextMixed, true, Constants.MicrosoftNETCoreApp, "2.1.0", Constants.RollForwardSetting.Minor, true)]
-        [InlineData(Scenario.NonContextMixed, true, Constants.MicrosoftNETCoreApp, "2.1.0", Constants.RollForwardSetting.LatestMinor, true)]
-        [InlineData(Scenario.NonContextMixed, true, Constants.MicrosoftNETCoreApp, "2.1.0", Constants.RollForwardSetting.Major, true)]
-        [InlineData(Scenario.NonContextMixed, true, Constants.MicrosoftNETCoreApp, "2.1.0", Constants.RollForwardSetting.LatestMajor, true)]
-        [InlineData(Scenario.NonContextMixed, true, Constants.MicrosoftNETCoreApp, "2.2.0", Constants.RollForwardSetting.Disable, true)]
-        [InlineData(Scenario.NonContextMixed, true, Constants.MicrosoftNETCoreApp, "3.1.0", Constants.RollForwardSetting.LatestMinor, true)]
-        [InlineData(Scenario.NonContextMixed, true, "UnknownFramework", "2.2.0", null, true)]
-        public void CompatibilityCheck_Frameworks(string scenario, bool selfContained, string frameworkName, string version, string rollForward, bool? isCompatibleVersion)
+        [InlineData(Scenario.ConfigMultiple, false, false, Constants.MicrosoftNETCoreApp, "1.1.0", Constants.RollForwardSetting.LatestPatch, false)]
+        [InlineData(Scenario.ConfigMultiple, false, false, Constants.MicrosoftNETCoreApp, "1.1.0", Constants.RollForwardSetting.Minor, false)]
+        [InlineData(Scenario.ConfigMultiple, false, false, Constants.MicrosoftNETCoreApp, "1.1.0", Constants.RollForwardSetting.LatestMinor, false)]
+        [InlineData(Scenario.ConfigMultiple, false, false, Constants.MicrosoftNETCoreApp, "1.1.0", Constants.RollForwardSetting.Major, true)]
+        [InlineData(Scenario.ConfigMultiple, false, false, Constants.MicrosoftNETCoreApp, "1.1.0", Constants.RollForwardSetting.LatestMajor, true)]
+        [InlineData(Scenario.ConfigMultiple, false, false, Constants.MicrosoftNETCoreApp, "2.1.0", Constants.RollForwardSetting.LatestPatch, false)]
+        [InlineData(Scenario.ConfigMultiple, false, false, Constants.MicrosoftNETCoreApp, "2.1.0", Constants.RollForwardSetting.Minor, true)]
+        [InlineData(Scenario.ConfigMultiple, false, false, Constants.MicrosoftNETCoreApp, "2.1.0", Constants.RollForwardSetting.LatestMinor, true)]
+        [InlineData(Scenario.ConfigMultiple, false, false, Constants.MicrosoftNETCoreApp, "2.1.0", Constants.RollForwardSetting.Major, true)]
+        [InlineData(Scenario.ConfigMultiple, false, false, Constants.MicrosoftNETCoreApp, "2.1.0", Constants.RollForwardSetting.LatestMajor, true)]
+        [InlineData(Scenario.ConfigMultiple, false, false, Constants.MicrosoftNETCoreApp, "2.2.0", Constants.RollForwardSetting.Disable, true)]
+        [InlineData(Scenario.ConfigMultiple, false, false, Constants.MicrosoftNETCoreApp, "3.1.0", Constants.RollForwardSetting.LatestMinor, false)]
+        [InlineData(Scenario.ConfigMultiple, false, false, "UnknownFramework", "2.2.0", null, null)]
+        [InlineData(Scenario.Mixed, false, false, Constants.MicrosoftNETCoreApp, "1.1.0", Constants.RollForwardSetting.LatestPatch, false)]
+        [InlineData(Scenario.Mixed, false, false, Constants.MicrosoftNETCoreApp, "1.1.0", Constants.RollForwardSetting.Minor, false)]
+        [InlineData(Scenario.Mixed, false, false, Constants.MicrosoftNETCoreApp, "1.1.0", Constants.RollForwardSetting.LatestMinor, false)]
+        [InlineData(Scenario.Mixed, false, false, Constants.MicrosoftNETCoreApp, "1.1.0", Constants.RollForwardSetting.Major, true)]
+        [InlineData(Scenario.Mixed, false, false, Constants.MicrosoftNETCoreApp, "1.1.0", Constants.RollForwardSetting.LatestMajor, true)]
+        [InlineData(Scenario.Mixed, false, false, Constants.MicrosoftNETCoreApp, "2.1.0", Constants.RollForwardSetting.LatestPatch, false)]
+        [InlineData(Scenario.Mixed, false, false, Constants.MicrosoftNETCoreApp, "2.1.0", Constants.RollForwardSetting.Minor, true)]
+        [InlineData(Scenario.Mixed, false, false, Constants.MicrosoftNETCoreApp, "2.1.0", Constants.RollForwardSetting.LatestMinor, true)]
+        [InlineData(Scenario.Mixed, false, false, Constants.MicrosoftNETCoreApp, "2.1.0", Constants.RollForwardSetting.Major, true)]
+        [InlineData(Scenario.Mixed, false, false, Constants.MicrosoftNETCoreApp, "2.1.0", Constants.RollForwardSetting.LatestMajor, true)]
+        [InlineData(Scenario.Mixed, false, false, Constants.MicrosoftNETCoreApp, "2.2.0", Constants.RollForwardSetting.Disable, true)]
+        [InlineData(Scenario.Mixed, false, false, Constants.MicrosoftNETCoreApp, "3.1.0", Constants.RollForwardSetting.LatestMinor, false)]
+        [InlineData(Scenario.Mixed, false, false, "UnknownFramework", "2.2.0", null, null)]
+        [InlineData(Scenario.Mixed, true, false, Constants.MicrosoftNETCoreApp, "1.1.0", Constants.RollForwardSetting.LatestPatch, true)]
+        [InlineData(Scenario.Mixed, true, false, Constants.MicrosoftNETCoreApp, "1.1.0", Constants.RollForwardSetting.Minor, true)]
+        [InlineData(Scenario.Mixed, true, false, Constants.MicrosoftNETCoreApp, "1.1.0", Constants.RollForwardSetting.LatestMinor, true)]
+        [InlineData(Scenario.Mixed, true, false, Constants.MicrosoftNETCoreApp, "1.1.0", Constants.RollForwardSetting.Major, true)]
+        [InlineData(Scenario.Mixed, true, false, Constants.MicrosoftNETCoreApp, "1.1.0", Constants.RollForwardSetting.LatestMajor, true)]
+        [InlineData(Scenario.Mixed, true, false, Constants.MicrosoftNETCoreApp, "2.1.0", Constants.RollForwardSetting.LatestPatch, true)]
+        [InlineData(Scenario.Mixed, true, false, Constants.MicrosoftNETCoreApp, "2.1.0", Constants.RollForwardSetting.Minor, true)]
+        [InlineData(Scenario.Mixed, true, false, Constants.MicrosoftNETCoreApp, "2.1.0", Constants.RollForwardSetting.LatestMinor, true)]
+        [InlineData(Scenario.Mixed, true, false, Constants.MicrosoftNETCoreApp, "2.1.0", Constants.RollForwardSetting.Major, true)]
+        [InlineData(Scenario.Mixed, true, false, Constants.MicrosoftNETCoreApp, "2.1.0", Constants.RollForwardSetting.LatestMajor, true)]
+        [InlineData(Scenario.Mixed, true, false, Constants.MicrosoftNETCoreApp, "2.2.0", Constants.RollForwardSetting.Disable, true)]
+        [InlineData(Scenario.Mixed, true, false, Constants.MicrosoftNETCoreApp, "3.1.0", Constants.RollForwardSetting.LatestMinor, true)]
+        [InlineData(Scenario.Mixed, true, false, "UnknownFramework", "2.2.0", null, true)]
+        [InlineData(Scenario.Mixed, true, true, Constants.MicrosoftNETCoreApp, "1.1.0", Constants.RollForwardSetting.LatestPatch, false)]
+        [InlineData(Scenario.Mixed, true, true, Constants.MicrosoftNETCoreApp, "1.1.0", Constants.RollForwardSetting.Minor, false)]
+        [InlineData(Scenario.Mixed, true, true, Constants.MicrosoftNETCoreApp, "1.1.0", Constants.RollForwardSetting.LatestMinor, false)]
+        [InlineData(Scenario.Mixed, true, true, Constants.MicrosoftNETCoreApp, "1.1.0", Constants.RollForwardSetting.Major, true)]
+        [InlineData(Scenario.Mixed, true, true, Constants.MicrosoftNETCoreApp, "1.1.0", Constants.RollForwardSetting.LatestMajor, true)]
+        [InlineData(Scenario.Mixed, true, true, Constants.MicrosoftNETCoreApp, "2.1.0", Constants.RollForwardSetting.LatestPatch, false)]
+        [InlineData(Scenario.Mixed, true, true, Constants.MicrosoftNETCoreApp, "2.1.0", Constants.RollForwardSetting.Minor, true)]
+        [InlineData(Scenario.Mixed, true, true, Constants.MicrosoftNETCoreApp, "2.1.0", Constants.RollForwardSetting.LatestMinor, true)]
+        [InlineData(Scenario.Mixed, true, true, Constants.MicrosoftNETCoreApp, "2.1.0", Constants.RollForwardSetting.Major, true)]
+        [InlineData(Scenario.Mixed, true, true, Constants.MicrosoftNETCoreApp, "2.1.0", Constants.RollForwardSetting.LatestMajor, true)]
+        [InlineData(Scenario.Mixed, true, true, Constants.MicrosoftNETCoreApp, "2.2.0", Constants.RollForwardSetting.Disable, true)]
+        [InlineData(Scenario.Mixed, true, true, Constants.MicrosoftNETCoreApp, "3.1.0", Constants.RollForwardSetting.LatestMinor, false)]
+        [InlineData(Scenario.Mixed, true, true, "UnknownFramework", "2.2.0", null, null)]
+        [InlineData(Scenario.NonContextMixed, false, false, Constants.MicrosoftNETCoreApp, "1.1.0", Constants.RollForwardSetting.LatestPatch, false)]
+        [InlineData(Scenario.NonContextMixed, false, false, Constants.MicrosoftNETCoreApp, "1.1.0", Constants.RollForwardSetting.Minor, false)]
+        [InlineData(Scenario.NonContextMixed, false, false, Constants.MicrosoftNETCoreApp, "1.1.0", Constants.RollForwardSetting.LatestMinor, false)]
+        [InlineData(Scenario.NonContextMixed, false, false, Constants.MicrosoftNETCoreApp, "1.1.0", Constants.RollForwardSetting.Major, true)]
+        [InlineData(Scenario.NonContextMixed, false, false, Constants.MicrosoftNETCoreApp, "1.1.0", Constants.RollForwardSetting.LatestMajor, true)]
+        [InlineData(Scenario.NonContextMixed, false, false, Constants.MicrosoftNETCoreApp, "2.1.0", Constants.RollForwardSetting.LatestPatch, false)]
+        [InlineData(Scenario.NonContextMixed, false, false, Constants.MicrosoftNETCoreApp, "2.1.0", Constants.RollForwardSetting.Minor, true)]
+        [InlineData(Scenario.NonContextMixed, false, false, Constants.MicrosoftNETCoreApp, "2.1.0", Constants.RollForwardSetting.LatestMinor, true)]
+        [InlineData(Scenario.NonContextMixed, false, false, Constants.MicrosoftNETCoreApp, "2.1.0", Constants.RollForwardSetting.Major, true)]
+        [InlineData(Scenario.NonContextMixed, false, false, Constants.MicrosoftNETCoreApp, "2.1.0", Constants.RollForwardSetting.LatestMajor, true)]
+        [InlineData(Scenario.NonContextMixed, false, false, Constants.MicrosoftNETCoreApp, "2.2.0", Constants.RollForwardSetting.Disable, true)]
+        [InlineData(Scenario.NonContextMixed, false, false, Constants.MicrosoftNETCoreApp, "3.1.0", Constants.RollForwardSetting.LatestMinor, false)]
+        [InlineData(Scenario.NonContextMixed, false, false, "UnknownFramework", "2.2.0", null, null)]
+        [InlineData(Scenario.NonContextMixed, true, false, Constants.MicrosoftNETCoreApp, "1.1.0", Constants.RollForwardSetting.LatestPatch, true)]
+        [InlineData(Scenario.NonContextMixed, true, false, Constants.MicrosoftNETCoreApp, "1.1.0", Constants.RollForwardSetting.Minor, true)]
+        [InlineData(Scenario.NonContextMixed, true, false, Constants.MicrosoftNETCoreApp, "1.1.0", Constants.RollForwardSetting.LatestMinor, true)]
+        [InlineData(Scenario.NonContextMixed, true, false, Constants.MicrosoftNETCoreApp, "1.1.0", Constants.RollForwardSetting.Major, true)]
+        [InlineData(Scenario.NonContextMixed, true, false, Constants.MicrosoftNETCoreApp, "1.1.0", Constants.RollForwardSetting.LatestMajor, true)]
+        [InlineData(Scenario.NonContextMixed, true, false, Constants.MicrosoftNETCoreApp, "2.1.0", Constants.RollForwardSetting.LatestPatch, true)]
+        [InlineData(Scenario.NonContextMixed, true, false, Constants.MicrosoftNETCoreApp, "2.1.0", Constants.RollForwardSetting.Minor, true)]
+        [InlineData(Scenario.NonContextMixed, true, false, Constants.MicrosoftNETCoreApp, "2.1.0", Constants.RollForwardSetting.LatestMinor, true)]
+        [InlineData(Scenario.NonContextMixed, true, false, Constants.MicrosoftNETCoreApp, "2.1.0", Constants.RollForwardSetting.Major, true)]
+        [InlineData(Scenario.NonContextMixed, true, false, Constants.MicrosoftNETCoreApp, "2.1.0", Constants.RollForwardSetting.LatestMajor, true)]
+        [InlineData(Scenario.NonContextMixed, true, false, Constants.MicrosoftNETCoreApp, "2.2.0", Constants.RollForwardSetting.Disable, true)]
+        [InlineData(Scenario.NonContextMixed, true, false, Constants.MicrosoftNETCoreApp, "3.1.0", Constants.RollForwardSetting.LatestMinor, true)]
+        [InlineData(Scenario.NonContextMixed, true, false, "UnknownFramework", "2.2.0", null, true)]
+        [InlineData(Scenario.NonContextMixed, true, true, Constants.MicrosoftNETCoreApp, "1.1.0", Constants.RollForwardSetting.LatestPatch, false)]
+        [InlineData(Scenario.NonContextMixed, true, true, Constants.MicrosoftNETCoreApp, "1.1.0", Constants.RollForwardSetting.Minor, false)]
+        [InlineData(Scenario.NonContextMixed, true, true, Constants.MicrosoftNETCoreApp, "1.1.0", Constants.RollForwardSetting.LatestMinor, false)]
+        [InlineData(Scenario.NonContextMixed, true, true, Constants.MicrosoftNETCoreApp, "1.1.0", Constants.RollForwardSetting.Major, true)]
+        [InlineData(Scenario.NonContextMixed, true, true, Constants.MicrosoftNETCoreApp, "1.1.0", Constants.RollForwardSetting.LatestMajor, true)]
+        [InlineData(Scenario.NonContextMixed, true, true, Constants.MicrosoftNETCoreApp, "2.1.0", Constants.RollForwardSetting.LatestPatch, false)]
+        [InlineData(Scenario.NonContextMixed, true, true, Constants.MicrosoftNETCoreApp, "2.1.0", Constants.RollForwardSetting.Minor, true)]
+        [InlineData(Scenario.NonContextMixed, true, true, Constants.MicrosoftNETCoreApp, "2.1.0", Constants.RollForwardSetting.LatestMinor, true)]
+        [InlineData(Scenario.NonContextMixed, true, true, Constants.MicrosoftNETCoreApp, "2.1.0", Constants.RollForwardSetting.Major, true)]
+        [InlineData(Scenario.NonContextMixed, true, true, Constants.MicrosoftNETCoreApp, "2.1.0", Constants.RollForwardSetting.LatestMajor, true)]
+        [InlineData(Scenario.NonContextMixed, true, true, Constants.MicrosoftNETCoreApp, "2.2.0", Constants.RollForwardSetting.Disable, true)]
+        [InlineData(Scenario.NonContextMixed, true, true, Constants.MicrosoftNETCoreApp, "3.1.0", Constants.RollForwardSetting.LatestMinor, false)]
+        [InlineData(Scenario.NonContextMixed, true, true, "UnknownFramework", "2.2.0", null, null)]
+        public void CompatibilityCheck_Frameworks(string scenario, bool selfContained, bool useIncludedFrameworks, string frameworkName, string version, string rollForward, bool? isCompatibleVersion)
         {
             if (scenario != Scenario.ConfigMultiple && scenario != Scenario.Mixed && scenario != Scenario.NonContextMixed)
                 throw new Exception($"Unexpected scenario: {scenario}");
@@ -368,13 +396,14 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.NativeHosting
                 .Save();
 
             string appOrConfigPath = scenario == Scenario.ConfigMultiple ? sharedState.RuntimeConfigPath : 
-                (selfContained ? sharedState.SelfContainedAppPath : sharedState.AppPath);
+                (selfContained ? (useIncludedFrameworks ? sharedState.SelfContainedWithIncludedFrameworksAppPath : sharedState.SelfContainedAppPath) : sharedState.AppPath);
+
             string[] args =
             {
                 HostContextArg,
                 scenario,
                 CheckProperties.None,
-                selfContained ? sharedState.SelfContainedHostFxrPath : sharedState.HostFxrPath,
+                selfContained ? (useIncludedFrameworks ? sharedState.SelfContainedWithIncludedFrameworksHostFxrPath : sharedState.SelfContainedHostFxrPath) : sharedState.HostFxrPath,
                 appOrConfigPath,
                 frameworkCompatConfig
             };
@@ -661,6 +690,10 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.NativeHosting
             public string SelfContainedConfigPath { get; }
             public string SelfContainedHostFxrPath { get; }
 
+            public string SelfContainedWithIncludedFrameworksAppPath { get; }
+            public string SelfContainedWithIncludedFrameworksConfigPath { get; }
+            public string SelfContainedWithIncludedFrameworksHostFxrPath { get; }
+
             public string AppPath_MultiProperty { get; }
             public string RuntimeConfigPath_MultiProperty { get; }
 
@@ -711,21 +744,17 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.NativeHosting
                     .WithProperty(AppMultiPropertyName, AppMultiPropertyValue)
                     .Save();
 
-                string selfContainedDir = Path.Combine(BaseDirectory, "selfContained");
-                Directory.CreateDirectory(selfContainedDir);
-                SelfContainedAppPath = Path.Combine(selfContainedDir, "SelfContained.dll");
-                File.WriteAllText(SelfContainedAppPath, string.Empty);
-                var toCopy = Directory.GetFiles(dotNet.GreatestVersionSharedFxPath)
-                    .Concat(Directory.GetFiles(dotNet.GreatestVersionHostFxrPath));
-                foreach (string file in toCopy)
-                {
-                    File.Copy(file, Path.Combine(selfContainedDir, Path.GetFileName(file)));
-                }
+                CreateSelfContainedApp(dotNet, "SelfContained", out string selfContainedAppPath, out string selfContainedHostFxrPath, out string selfContainedConfigPath);
+                SelfContainedAppPath = selfContainedAppPath;
+                SelfContainedHostFxrPath = selfContainedHostFxrPath;
+                SelfContainedConfigPath = selfContainedConfigPath;
 
-                SelfContainedHostFxrPath = Path.Combine(selfContainedDir, Path.GetFileName(dotNet.GreatestVersionHostFxrFilePath));
-                SelfContainedConfigPath = Path.Combine(selfContainedDir, "SelfContained.runtimeconfig.json");
-                RuntimeConfig.FromFile(SelfContainedConfigPath)
-                    .WithProperty(AppPropertyName, AppPropertyValue)
+                CreateSelfContainedApp(dotNet, "SelfContainedWithIncludedFrameworks", out selfContainedAppPath, out selfContainedHostFxrPath, out selfContainedConfigPath);
+                SelfContainedWithIncludedFrameworksAppPath = selfContainedAppPath;
+                SelfContainedWithIncludedFrameworksHostFxrPath = selfContainedHostFxrPath;
+                SelfContainedWithIncludedFrameworksConfigPath = selfContainedConfigPath;
+                RuntimeConfig.FromFile(SelfContainedWithIncludedFrameworksConfigPath)
+                    .WithIncludedFramework(Constants.MicrosoftNETCoreApp, NetCoreAppVersion)
                     .Save();
 
                 string configDir = Path.Combine(BaseDirectory, "config");
@@ -749,6 +778,26 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.NativeHosting
                 RuntimeConfig.FromFile(SecondaryRuntimeConfigPath)
                     .WithFramework(new RuntimeConfig.Framework(Constants.MicrosoftNETCoreApp, NetCoreAppVersion))
                     .WithProperty(SecondaryConfigPropertyName, SecondaryConfigPropertyValue)
+                    .Save();
+            }
+
+            public void CreateSelfContainedApp(DotNetCli dotNet, string name, out string appPath, out string hostFxrPath, out string configPath)
+            {
+                string selfContainedDir = Path.Combine(BaseDirectory, name);
+                Directory.CreateDirectory(selfContainedDir);
+                appPath = Path.Combine(selfContainedDir, name + ".dll");
+                File.WriteAllText(appPath, string.Empty);
+                var toCopy = Directory.GetFiles(dotNet.GreatestVersionSharedFxPath)
+                    .Concat(Directory.GetFiles(dotNet.GreatestVersionHostFxrPath));
+                foreach (string file in toCopy)
+                {
+                    File.Copy(file, Path.Combine(selfContainedDir, Path.GetFileName(file)));
+                }
+
+                hostFxrPath = Path.Combine(selfContainedDir, Path.GetFileName(dotNet.GreatestVersionHostFxrFilePath));
+                configPath = Path.Combine(selfContainedDir, name + ".runtimeconfig.json");
+                RuntimeConfig.FromFile(configPath)
+                    .WithProperty(AppPropertyName, AppPropertyValue)
                     .Save();
             }
         }

--- a/src/test/HostActivation.Tests/RuntimeConfig.cs
+++ b/src/test/HostActivation.Tests/RuntimeConfig.cs
@@ -141,6 +141,15 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
                         }
                     }
 
+                    var includedFrameworks = runtimeOptions["includedFrameworks"];
+                    if (includedFrameworks != null)
+                    {
+                        foreach (JObject includedFramework in includedFrameworks)
+                        {
+                            runtimeConfig.WithFramework(Framework.FromJson(includedFramework));
+                        }
+                    }
+
                     var configProperties = runtimeOptions["configProperties"] as JObject;
                     if (configProperties != null)
                     {

--- a/src/test/HostActivation.Tests/RuntimeConfig.cs
+++ b/src/test/HostActivation.Tests/RuntimeConfig.cs
@@ -8,7 +8,6 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Runtime.InteropServices.ComTypes;
 
 namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
 {

--- a/src/test/HostActivation.Tests/RuntimeConfig.cs
+++ b/src/test/HostActivation.Tests/RuntimeConfig.cs
@@ -8,6 +8,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Runtime.InteropServices.ComTypes;
 
 namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
 {
@@ -48,11 +49,17 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
 
             internal JObject ToJson()
             {
-                JObject frameworkReference =
-                    new JObject(
-                        new JProperty("name", Name),
-                        new JProperty("version", Version)
-                        );
+                JObject frameworkReference = new JObject();
+
+                if (Name != null)
+                {
+                    frameworkReference.Add("name", Name);
+                }
+
+                if (Version != null)
+                {
+                    frameworkReference.Add("version", Version);
+                }
 
                 if (RollForward != null)
                 {

--- a/src/test/HostActivation.Tests/RuntimeConfig.cs
+++ b/src/test/HostActivation.Tests/RuntimeConfig.cs
@@ -94,6 +94,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
         private bool? _applyPatches;
         private readonly string _path;
         private readonly List<Framework> _frameworks = new List<Framework>();
+        private readonly List<Framework> _includedFrameworks = new List<Framework>();
         private readonly List<Tuple<string, string>> _properties = new List<Tuple<string, string>>();
 
         /// <summary>
@@ -183,6 +184,17 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
             return this;
         }
 
+        public RuntimeConfig WithIncludedFramework(Framework framework)
+        {
+            _includedFrameworks.Add(framework);
+            return this;
+        }
+
+        public RuntimeConfig WithIncludedFramework(string name, string version)
+        {
+            return WithIncludedFramework(new Framework(name, version));
+        }
+
         public RuntimeConfig WithRollForward(string value)
         {
             _rollForward = value;
@@ -215,6 +227,13 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
                 runtimeOptions.Add(
                     "frameworks",
                     new JArray(_frameworks.Select(f => f.ToJson()).ToArray()));
+            }
+
+            if (_includedFrameworks.Any())
+            {
+                runtimeOptions.Add(
+                    "includedFrameworks",
+                    new JArray(_includedFrameworks.Select(f => f.ToJson()).ToArray()));
             }
 
             if (_rollForward != null)

--- a/src/test/TestUtils/TestUtils.csproj
+++ b/src/test/TestUtils/TestUtils.csproj
@@ -8,6 +8,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\managed\Microsoft.NET.HostModel\Microsoft.NET.HostModel.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="4.19.4" />
     <PackageReference Include="System.Runtime.Serialization.Primitives" Version="4.1.1" />
     <PackageReference Include="xunit" Version="2.2.0" />


### PR DESCRIPTION
When the native hosting APIs are used to load a managed component into a process which is running a .NET Core app, the hosting layer should validate that the new component framework requirements are met by the frameworks loaded into the process already. This is to allow the new component to communicate with the app (same FX types), but also to overcome the fact that we don't want to load frameworks twice ever.

In order to validate the framework references declared by the new component, the host must know what frameworks are loaded into the process. For framework dependent apps this works fine as the host knows which frameworks it resolved during the app startup. But for self-contained apps, the host doesn't know as everything looks like an app to it.

Related change dotnet/sdk#3697 modifies the build of a self-contained app to add `includedFrameworks` property into `.runtimeconfig.json` (in place of the `frameworks` property which is used for framework dependent apps). This property stores the list of frameworks the app was built with.

This change consumes the new property and implements framework validation for native hosting of managed components even in self-contained apps. The new property is parsed using the same code as `frameworks`, just validation is slightly different (`includedFrameworks` doesn't support/recognize properties like `rollForward`). The values are then propagated from the config into the global store.

Validation is performed every time the included framework information is available. This means there's no explicit version check in the hosting layer. (Unlike the SDK which only produces the new property for 3.1 and above). As such it will maintain backward compatibility (3.0 apps will not have the property, and thus FX validation will be skipped). It also means that if somebody adds the new property even to 3.0 apps, it will be picked up and used - potentially allowing a workaround for issues caused by FX validation skipping in 3.0.

Testing changes:
* Parser validation for the new property
* Refactor helpers to create self-contained apps as this is now needed from more places
* Modify the existing tests to validate the new behavior

#7732 - this is the master (5.0) version of it. The plan is to port this to 3.1 if the SDK change will be approved for 3.1.