### PR TITLE
Switch core-setup to use VS2019.

### DIFF
--- a/eng/jobs/windows-build.yml
+++ b/eng/jobs/windows-build.yml
@@ -14,10 +14,10 @@ jobs:
       # Use a hosted pool when possible.
       ${{ if eq(variables['System.TeamProject'], 'public') }}:
         name: NetCorePublic-Pool
-        queue: buildpool.windows.10.amd64.vs2017.open
+        queue: buildpool.windows.10.amd64.vs2019.open
       ${{ if ne(variables['System.TeamProject'], 'public') }}:
         name: NetCoreInternal-Pool
-        queue: buildpool.windows.10.amd64.vs2017
+        queue: buildpool.windows.10.amd64.vs2019
     strategy:
       matrix: 
         debug:


### PR DESCRIPTION
As discussed today, we want to switch the repos to use VS2019 now. We aren't going to actively break using VS2017, but we want to have our CI use VS2019.