### PR TITLE
A couple small source-build fixes

### DIFF
--- a/src/pkg/projects/windowsdesktop/src/windowsdesktop.depproj
+++ b/src/pkg/projects/windowsdesktop/src/windowsdesktop.depproj
@@ -1,4 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <ExcludeFromSourceBuild>true</ExcludeFromSourceBuild>
+  </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.DotNet.Wpf.DncEng" Version="$(MicrosoftDotNetWpfDncEngPackageVersion)" />

--- a/tools-local/tasks/core-setup.tasks.csproj
+++ b/tools-local/tasks/core-setup.tasks.csproj
@@ -15,16 +15,17 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="NuGet.ProjectModel" Version="$(NugetProjectModelPackageVersion)" />
+    <PackageReference Include="NuGet.ProjectModel" Version="4.9.4" />
     <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="2.1.0" />
     <PackageReference Include="Microsoft.DotNet.PlatformAbstractions" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' != 'net46'">
-    <PackageReference Include="Microsoft.Build" Version="$(MicrosoftBuildPackageVersion)" />
-    <PackageReference Include="Microsoft.Build.Framework" Version="$(MicrosoftBuildFrameworkPackageVersion)" />
-    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="$(MicrosoftBuildTasksCorePackageVersion)" />
-    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="$(MicrosoftBuildUtilitiesCorePackageVersion)" />
+    <!-- these are used as reference assemblies only, so they don't need to take a ProdCon/source-build version. -->
+    <PackageReference Include="Microsoft.Build" Version="15.7.179" />
+    <PackageReference Include="Microsoft.Build.Framework" Version="15.7.179" />
+    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="15.7.179" />
+    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="15.7.179" />
 
     <PackageReference Include="System.Diagnostics.FileVersionInfo" Version="4.0.0" />
   </ItemGroup>


### PR DESCRIPTION
- Exclude WindowsDesktop from source-build.
- Pin NuGet and MSBuild packages to reference versions.