### PR TITLE
[release/3.0] Double publish artifacts in cases of stable builds

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -28,10 +28,6 @@
       <IncludePreReleaseLabelInPackageVersion Condition="'$(SuppressFinalPackageVersion)' == 'true'">true</IncludePreReleaseLabelInPackageVersion>
       <IncludePreReleaseLabelInPackageVersion Condition="'$(IsShipping)' != 'true'">true</IncludePreReleaseLabelInPackageVersion>
 
-      <IncludeBuildNumberInPackageVersion Condition="'$(StabilizePackageVersion)' != 'true'">true</IncludeBuildNumberInPackageVersion>
-      <IncludeBuildNumberInPackageVersion Condition="'$(SuppressFinalPackageVersion)' == 'true'">true</IncludeBuildNumberInPackageVersion>
-      <IncludeBuildNumberInPackageVersion Condition="'$(IsShipping)' != 'true'">true</IncludeBuildNumberInPackageVersion>
-
       <ProductVersionSuffix Condition="'$(IncludePreReleaseLabelInPackageVersion)' == 'true'">-$(VersionSuffix)</ProductVersionSuffix>
       <ProductBandVersion Condition="'$(ProductBandVersion)' == ''">$(MajorVersion).$(MinorVersion)</ProductBandVersion>
       <ProductionVersion Condition="'$(ProductionVersion)' == ''">$(ProductBandVersion).$(PatchVersion)</ProductionVersion>

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -221,6 +221,6 @@ stages:
       - dependsOn: PVR_Publish
         channel:
           name: .NET Tools - Validation
-          bar: PublicValidationRelease_30_Channel_Id
+          bar: NetCore_Tools_Validation_Channel_Id
           storage: dev/validation
           public: true

--- a/eng/jobs/run-publish-project.yml
+++ b/eng/jobs/run-publish-project.yml
@@ -110,9 +110,15 @@ jobs:
     - task: NuGetAuthenticate@0
 
   - task: DownloadBuildArtifacts@0
-    displayName: Download Artifacts
+    displayName: Download Package Artifacts
     inputs:
-      artifactName: PreparedArtifacts
+      artifactName: PackageArtifacts
+      downloadPath: $(Build.SourcesDirectory)\artifacts\PackageDownload
+
+  - task: DownloadBuildArtifacts@0
+    displayName: Download Blob Artifacts
+    inputs:
+      artifactName: BlobArtifacts
       downloadPath: $(Build.SourcesDirectory)\artifacts\PackageDownload
 
   - powershell: |

--- a/publish/Directory.Build.targets
+++ b/publish/Directory.Build.targets
@@ -65,10 +65,6 @@
 
       <UploadToBlobStorageFile Include="@(SymbolNupkgToPublishFile)" />
     </ItemGroup>
-
-    <Error
-      Condition="'@(SymbolNupkgToPublishFile)' == ''"
-      Text="No symbol packages found." />
   </Target>
 
   <Import Project="..\Directory.Build.targets" />

--- a/publish/prepare-artifacts.proj
+++ b/publish/prepare-artifacts.proj
@@ -2,7 +2,7 @@
   <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
 
   <UsingTask TaskName="GenerateChecksums" AssemblyFile="$(LocalBuildToolsTaskFile)" />
-
+  
   <PropertyGroup>
     <SuppressFinalPackageVersion>true</SuppressFinalPackageVersion>
   </PropertyGroup>
@@ -28,31 +28,10 @@
       Properties="DownloadDirectory=$(DownloadDirectory)" />
   </Target>
 
-  <Target Name="UploadPreparedArtifactsToPipeline"
-          DependsOnTargets="
-            FindDownloadedArtifacts;
-            SignPackages;
-            CreateChecksums">
-    <PropertyGroup>
-      <PreparedFileUploadDir>$(ArtifactsObjDir)PreparedFileUpload\</PreparedFileUploadDir>
-    </PropertyGroup>
-    
-    <ItemGroup>
-      <AllFilesToBlobStorage Include="@(UploadToBlobStorageFile);@(UploadToBlobStorageFile)" />
-    </ItemGroup>
-    
-    <Copy SourceFiles="@(AllFilesToBlobStorage)" DestinationFolder="$(PreparedFileUploadDir)">
-      <Output TaskParameter="CopiedFiles" ItemName="CopiedUploadToBlobStorageFile" />
-    </Copy>
-
-    <Message Importance="High" Text="Uploading PreparedArtifacts to pipeline" />
-    <Message
-      Text="##vso[artifact.upload containerfolder=PreparedArtifacts;artifactname=PreparedArtifacts]%(CopiedUploadToBlobStorageFile.Identity)"
-      Importance="High" />
-  </Target>
-
   <Target Name="PreparePublishToAzureBlobFeed">
     <Error Condition="'$(PackagesUrl)'==''" Text="Missing property PackagesUrl" />
+    <Error Condition="'@(NupkgToPublishFile)' == ''" Text="No nupkgs found." />
+    <Error Condition="'@(SymbolNupkgToPublishFile)' == ''" Text="No symbol packages found." />
 
     <PropertyGroup>
       <ExpectedFeedUrl>$(PackagesUrl)</ExpectedFeedUrl>
@@ -113,20 +92,50 @@
       <!-- Create temp dir to store generated asset manifest, per Arcade guidance. -->
       <TempWorkingDir>$(ArtifactsObjDir)TempWorkingDir\$([System.Guid]::NewGuid())\</TempWorkingDir>
     </PropertyGroup>
+    
+    <!-- If this is a stabilized build, then we'll be pushing these stable blobs into
+           a non-stable directory name, as intended. But this presents a problem. Some downstream repos will
+           attempt to install this runtime using the dotnet-install script. As it is currently written, the dotnet
+           install script excepts that a runtime with version X will appear in a directory named X, which wouldn't be the
+           case. To avoid this issue, create another copy of the file with suffixed branding
+
+           Example: If 3.0.1 is the actual runtime version, and 3.0.1-servicing-19502-23 is the
+           suffixed version, blobs will look like:
+           - Runtime/3.0.1-servicing-19502-23/dotnet-host-3.0.1-x64.rpm
+           - Runtime/3.0.1-servicing-19502-23/dotnet-host-3.0.1-servicing-19502-23-x64.rpm
+
+           These files are the same file, just with different names.
+
+           Lastly, mark the suffixed versions as non-shipping so that we don't end with double the files in the file
+           shipping drop.
+      -->
+    <ItemGroup Condition="'$(DotNetFinalVersionKind)' == 'release'">
+        <ItemsToCopyWithSuffix Include="@(UploadToBlobStorageFile);@(GeneratedChecksumFile)" Exclude="@(NupkgToPublishFile);@(SymbolNupkgToPublishFile)"
+            Condition="'$([System.String]::Copy(`%(Filename)`).Contains(`$(ProductionVersion)`))' == 'true' AND '$([System.String]::Copy(`%(Filename)`).Contains(`$(ProductVersion)`))' != 'true'">
+          <SuffixedPath>%(Directory)/$([System.String]::Copy('%(Filename)%(Extension)').Replace('$(ProductionVersion)' ,'$(ProductVersion)'))</SuffixedPath>
+        </ItemsToCopyWithSuffix>
+    </ItemGroup>
+    
+    <Copy
+      SourceFiles="@(ItemsToCopyWithSuffix -> '%(Identity)')"
+      DestinationFiles="@(ItemsToCopyWithSuffix -> '%(SuffixedPath)')">
+      <Output TaskParameter="CopiedFiles" ItemName="ItemsToPushWithSuffix" />
+    </Copy>
 
     <ItemGroup>
       <ItemsToPush Remove="@(ItemsToPush)" />
 
       <ItemsToPush
-        Include="@(UploadToBlobStorageFile)"
+        Include="@(UploadToBlobStorageFile);@(GeneratedChecksumFile)"
         Exclude="@(NupkgToPublishFile);@(SymbolNupkgToPublishFile)">
         <RelativeBlobPath>$(InstallersRelativePath)%(Filename)%(Extension)</RelativeBlobPath>
       </ItemsToPush>
       
-      <ItemsToPush Include="@(GeneratedChecksumFile)">
+      <ItemsToPush Include="@(ItemsToPushWithSuffix)">
         <RelativeBlobPath>$(InstallersRelativePath)%(Filename)%(Extension)</RelativeBlobPath>
-        <Category>Checksum</Category>
+        <ManifestArtifactData>NonShipping=true</ManifestArtifactData>
       </ItemsToPush>
+
     </ItemGroup>
 
     <!-- Push items to AzDO as build artifacts, generating the asset manifest as a side effect. -->
@@ -159,7 +168,9 @@
   -->
   <Target Name="Build"
           DependsOnTargets="
-            UploadPreparedArtifactsToPipeline;
+            FindDownloadedArtifacts;
+            SignPackages;
+            CreateChecksums;
             PreparePublishToAzureBlobFeed;
             PreparePublishFilesToAzureBlobFeed">
     <Message Importance="High" Text="Complete!" />

--- a/publish/publish-final.proj
+++ b/publish/publish-final.proj
@@ -16,6 +16,9 @@
 
   <Target Name="GetShippedNuGetPackages"
           DependsOnTargets="FindDownloadedArtifacts">
+
+    <Error Condition="'@(NupkgToPublishFile)' == ''" Text="No packages found." />
+
     <ItemGroup>
       <!-- Nupkgs to include in dotnet/versions update. -->
       <ShippedNuGetPackage Include="@(NupkgToPublishFile)" />


### PR DESCRIPTION
Stable assets do not publish to stable directories to avoid overwrite issues. But, the dotnet-install script expects the runtime version and directory to match, which they wouldn't. To deal with this, in cases of stable builds, copy all the stable branded bits to files with non-stable names.  Thus, the suffixed directory will contain the stable file names (e.g. 3.0.1) as well as suffixed file names that work prior to release day. On release day, the directory is copied or renamed and the dotnet-install script will work with the official versions.