### PR TITLE
Fix bundle failing to extract empty file.

### DIFF
--- a/src/corehost/cli/apphost/bundle/file_entry.cpp
+++ b/src/corehost/cli/apphost/bundle/file_entry.cpp
@@ -11,7 +11,7 @@ using namespace bundle;
 
 bool file_entry_t::is_valid() const
 {
-    return m_offset > 0 && m_size > 0 &&
+    return m_offset > 0 && m_size >= 0 &&
         static_cast<file_type_t>(m_type) < file_type_t::__last;
 }
 


### PR DESCRIPTION
The file entry validity check marked empty files as invalid. This is wrong, the file size must be non-negative number.

Added a test and fixed the condition.

This is the master version of a fix for #8422. Once merged I will port this to 3.1