### PR TITLE
[release/3.0] Fixup corefx versions

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Dependencies>
   <ProductDependencies>
-    <Dependency Name="Microsoft.NETCore.Platforms" Version="3.0.1-servicing.19501.4">
+    <Dependency Name="Microsoft.NETCore.Platforms" Version="3.0.0">
       <Uri>https://github.com/dotnet/corefx</Uri>
-      <Sha>54d63c3e283e0c3937a35ab4e99f391c84ff119e</Sha>
+      <Sha>4ac4c0367003fe3973a3648eb0715ddb0e3bbcea</Sha>
     </Dependency>
     <Dependency Name="Microsoft.NETCore.Targets" Version="3.0.0">
       <Uri>https://github.com/dotnet/corefx</Uri>
-      <Sha>bedb348c4d93b6172967df6cdeea0272c81eb752</Sha>
+      <Sha>4ac4c0367003fe3973a3648eb0715ddb0e3bbcea</Sha>
     </Dependency>
     <Dependency Name="Microsoft.Private.CoreFx.NETCoreApp" Version="4.6.0-servicing.19502.4">
       <Uri>https://github.com/dotnet/corefx</Uri>
@@ -15,55 +15,55 @@
     </Dependency>
     <Dependency Name="Microsoft.Win32.Registry.AccessControl" Version="4.6.0">
       <Uri>https://github.com/dotnet/corefx</Uri>
-      <Sha>bedb348c4d93b6172967df6cdeea0272c81eb752</Sha>
+      <Sha>4ac4c0367003fe3973a3648eb0715ddb0e3bbcea</Sha>
     </Dependency>
     <Dependency Name="Microsoft.Win32.Registry" Version="4.6.0">
       <Uri>https://github.com/dotnet/corefx</Uri>
-      <Sha>bedb348c4d93b6172967df6cdeea0272c81eb752</Sha>
+      <Sha>4ac4c0367003fe3973a3648eb0715ddb0e3bbcea</Sha>
     </Dependency>
     <Dependency Name="Microsoft.Win32.SystemEvents" Version="4.6.0">
       <Uri>https://github.com/dotnet/corefx</Uri>
-      <Sha>bedb348c4d93b6172967df6cdeea0272c81eb752</Sha>
+      <Sha>4ac4c0367003fe3973a3648eb0715ddb0e3bbcea</Sha>
     </Dependency>
     <Dependency Name="Microsoft.Windows.Compatibility" Version="3.0.0">
       <Uri>https://github.com/dotnet/corefx</Uri>
-      <Sha>bedb348c4d93b6172967df6cdeea0272c81eb752</Sha>
+      <Sha>4ac4c0367003fe3973a3648eb0715ddb0e3bbcea</Sha>
     </Dependency>
     <Dependency Name="System.CodeDom" Version="4.6.0">
       <Uri>https://github.com/dotnet/corefx</Uri>
-      <Sha>bedb348c4d93b6172967df6cdeea0272c81eb752</Sha>
+      <Sha>4ac4c0367003fe3973a3648eb0715ddb0e3bbcea</Sha>
     </Dependency>
     <Dependency Name="System.Configuration.ConfigurationManager" Version="4.6.0">
       <Uri>https://github.com/dotnet/corefx</Uri>
-      <Sha>bedb348c4d93b6172967df6cdeea0272c81eb752</Sha>
+      <Sha>4ac4c0367003fe3973a3648eb0715ddb0e3bbcea</Sha>
     </Dependency>
     <Dependency Name="System.Diagnostics.EventLog" Version="4.6.0">
       <Uri>https://github.com/dotnet/corefx</Uri>
-      <Sha>bedb348c4d93b6172967df6cdeea0272c81eb752</Sha>
+      <Sha>4ac4c0367003fe3973a3648eb0715ddb0e3bbcea</Sha>
     </Dependency>
     <Dependency Name="System.Diagnostics.PerformanceCounter" Version="4.6.0">
       <Uri>https://github.com/dotnet/corefx</Uri>
-      <Sha>bedb348c4d93b6172967df6cdeea0272c81eb752</Sha>
+      <Sha>4ac4c0367003fe3973a3648eb0715ddb0e3bbcea</Sha>
     </Dependency>
     <Dependency Name="System.DirectoryServices" Version="4.6.0">
       <Uri>https://github.com/dotnet/corefx</Uri>
-      <Sha>bedb348c4d93b6172967df6cdeea0272c81eb752</Sha>
+      <Sha>4ac4c0367003fe3973a3648eb0715ddb0e3bbcea</Sha>
     </Dependency>
     <Dependency Name="System.Drawing.Common" Version="4.6.0">
       <Uri>https://github.com/dotnet/corefx</Uri>
-      <Sha>bedb348c4d93b6172967df6cdeea0272c81eb752</Sha>
+      <Sha>4ac4c0367003fe3973a3648eb0715ddb0e3bbcea</Sha>
     </Dependency>
     <Dependency Name="System.IO.FileSystem.AccessControl" Version="4.6.0">
       <Uri>https://github.com/dotnet/corefx</Uri>
-      <Sha>bedb348c4d93b6172967df6cdeea0272c81eb752</Sha>
+      <Sha>4ac4c0367003fe3973a3648eb0715ddb0e3bbcea</Sha>
     </Dependency>
     <Dependency Name="System.Resources.Extensions" Version="4.6.0">
       <Uri>https://github.com/dotnet/corefx</Uri>
-      <Sha>bedb348c4d93b6172967df6cdeea0272c81eb752</Sha>
+      <Sha>4ac4c0367003fe3973a3648eb0715ddb0e3bbcea</Sha>
     </Dependency>
     <Dependency Name="System.IO.Packaging" Version="4.6.0">
       <Uri>https://github.com/dotnet/corefx</Uri>
-      <Sha>bedb348c4d93b6172967df6cdeea0272c81eb752</Sha>
+      <Sha>4ac4c0367003fe3973a3648eb0715ddb0e3bbcea</Sha>
     </Dependency>
     <Dependency Name="System.IO.Pipes.AccessControl" Version="4.5.1">
       <Uri>https://github.com/dotnet/corefx</Uri>
@@ -71,47 +71,47 @@
     </Dependency>
     <Dependency Name="System.Security.AccessControl" Version="4.6.0">
       <Uri>https://github.com/dotnet/corefx</Uri>
-      <Sha>bedb348c4d93b6172967df6cdeea0272c81eb752</Sha>
+      <Sha>4ac4c0367003fe3973a3648eb0715ddb0e3bbcea</Sha>
     </Dependency>
     <Dependency Name="System.Security.Cryptography.Cng" Version="4.6.0">
       <Uri>https://github.com/dotnet/corefx</Uri>
-      <Sha>bedb348c4d93b6172967df6cdeea0272c81eb752</Sha>
+      <Sha>4ac4c0367003fe3973a3648eb0715ddb0e3bbcea</Sha>
     </Dependency>
     <Dependency Name="System.Security.Cryptography.Pkcs" Version="4.6.0">
       <Uri>https://github.com/dotnet/corefx</Uri>
-      <Sha>bedb348c4d93b6172967df6cdeea0272c81eb752</Sha>
+      <Sha>4ac4c0367003fe3973a3648eb0715ddb0e3bbcea</Sha>
     </Dependency>
     <Dependency Name="System.Security.Cryptography.ProtectedData" Version="4.6.0">
       <Uri>https://github.com/dotnet/corefx</Uri>
-      <Sha>bedb348c4d93b6172967df6cdeea0272c81eb752</Sha>
+      <Sha>4ac4c0367003fe3973a3648eb0715ddb0e3bbcea</Sha>
     </Dependency>
     <Dependency Name="System.Security.Cryptography.Xml" Version="4.6.0">
       <Uri>https://github.com/dotnet/corefx</Uri>
-      <Sha>bedb348c4d93b6172967df6cdeea0272c81eb752</Sha>
+      <Sha>4ac4c0367003fe3973a3648eb0715ddb0e3bbcea</Sha>
     </Dependency>
     <Dependency Name="System.Security.Permissions" Version="4.6.0">
       <Uri>https://github.com/dotnet/corefx</Uri>
-      <Sha>bedb348c4d93b6172967df6cdeea0272c81eb752</Sha>
+      <Sha>4ac4c0367003fe3973a3648eb0715ddb0e3bbcea</Sha>
     </Dependency>
     <Dependency Name="System.Security.Principal.Windows" Version="4.6.0">
       <Uri>https://github.com/dotnet/corefx</Uri>
-      <Sha>bedb348c4d93b6172967df6cdeea0272c81eb752</Sha>
+      <Sha>4ac4c0367003fe3973a3648eb0715ddb0e3bbcea</Sha>
     </Dependency>
     <Dependency Name="System.Text.Encodings.Web" Version="4.6.0">
       <Uri>https://github.com/dotnet/corefx</Uri>
-      <Sha>bedb348c4d93b6172967df6cdeea0272c81eb752</Sha>
+      <Sha>4ac4c0367003fe3973a3648eb0715ddb0e3bbcea</Sha>
     </Dependency>
     <Dependency Name="System.Text.Json" Version="4.6.0">
       <Uri>https://github.com/dotnet/corefx</Uri>
-      <Sha>bedb348c4d93b6172967df6cdeea0272c81eb752</Sha>
+      <Sha>4ac4c0367003fe3973a3648eb0715ddb0e3bbcea</Sha>
     </Dependency>
     <Dependency Name="System.Threading.AccessControl" Version="4.6.0">
       <Uri>https://github.com/dotnet/corefx</Uri>
-      <Sha>bedb348c4d93b6172967df6cdeea0272c81eb752</Sha>
+      <Sha>4ac4c0367003fe3973a3648eb0715ddb0e3bbcea</Sha>
     </Dependency>
     <Dependency Name="System.Windows.Extensions" Version="4.6.0">
       <Uri>https://github.com/dotnet/corefx</Uri>
-      <Sha>bedb348c4d93b6172967df6cdeea0272c81eb752</Sha>
+      <Sha>4ac4c0367003fe3973a3648eb0715ddb0e3bbcea</Sha>
     </Dependency>
     <Dependency Name="NETStandard.Library" Version="2.1.0">
       <Uri>https://github.com/dotnet/standard</Uri>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -30,7 +30,7 @@
     <!-- sourcelink -->
     <MicrosoftSourceLinkVersion>1.0.0-beta2-19367-01</MicrosoftSourceLinkVersion>
     <!-- corefx -->
-    <MicrosoftNETCorePlatformsPackageVersion>3.0.1-servicing.19501.4</MicrosoftNETCorePlatformsPackageVersion>
+    <MicrosoftNETCorePlatformsPackageVersion>3.0.0</MicrosoftNETCorePlatformsPackageVersion>
     <MicrosoftNETCoreTargetsPackageVersion>3.0.0</MicrosoftNETCoreTargetsPackageVersion>
     <MicrosoftPrivateCoreFxNETCoreAppPackageVersion>4.6.0-servicing.19502.4</MicrosoftPrivateCoreFxNETCoreAppPackageVersion>
     <MicrosoftWin32RegistryAccessControlVersion>4.6.0</MicrosoftWin32RegistryAccessControlVersion>


### PR DESCRIPTION
Corefx branding was updated after 3.0 GA after a few commits went in. We also stopped producing Microsoft.NETCore.Platforms after a few commits went in.
These versions had already flowed, which meant that the shas for OOB packages were not the GA shas, and netcore platforms was reed to 3.0.1-servicing incorrectly.
Revert these changes.