### PR TITLE
Enable building for arm64 on arm64

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -94,6 +94,8 @@
   </PropertyGroup>
 
   <PropertyGroup>
+    <BuildArchitecture>$([System.Runtime.InteropServices.RuntimeInformation]::ProcessArchitecture.ToString().ToLowerInvariant())</BuildArchitecture>
+    <TargetArchitecture  Condition="'$(TargetArchitecture)' == '' AND '$(BuildArchitecture)' == 'arm64'">$(BuildArchitecture)</TargetArchitecture>
     <TargetArchitecture  Condition="'$(TargetArchitecture)' == ''">x64</TargetArchitecture>
     <Platform Condition="'$(Platform)'==''">$(TargetArchitecture)</Platform>
   </PropertyGroup>

--- a/src/pkg/packaging-tools/framework.dependency.targets
+++ b/src/pkg/packaging-tools/framework.dependency.targets
@@ -257,7 +257,7 @@
     <PropertyGroup Condition="'$(TargetArchitecture)' == 'arm' AND '$(OS)' != 'Windows_NT'">
       <_crossHostArch>x64</_crossHostArch>
     </PropertyGroup> 
-    <PropertyGroup Condition="'$(TargetArchitecture)' == 'arm64'">
+    <PropertyGroup Condition="'$(TargetArchitecture)' == 'arm64' AND '$(BuildArchitecture)' != 'arm64'">
       <_crossHostArch>x64</_crossHostArch>
     </PropertyGroup> 
     <PropertyGroup>
@@ -279,7 +279,6 @@
       <!-- Find crossgen tool assets in package cache to allow ExcludeAssets=All. -->
       <_runtimeCLR Include="$(_runtimePackageDir)**/$(LibraryFilePrefix)coreclr$(LibraryFileExtension)" />
       <_runtimeCoreLib Include="$(_runtimePackageDir)**/native/System.Private.CoreLib.dll" />
-      <_runtimeJIT Include="$(_jitPackageDir)**/$(LibraryFilePrefix)clrjit$(LibraryFileExtension)" />
       <_fxSystemRuntime Include="$(_corefxPackageDir)**/System.Runtime.dll" />
       <_windowsWinMD Include="$(_winmdPackageDir)**/Windows.winmd" />
       <_diaSymReaderAssembly Include="$(_diaSymReaderPackageDir)**\Microsoft.DiaSymReader.Native.*.dll" />
@@ -294,8 +293,8 @@
       <_coreLibDirectory>%(_runtimeCoreLib.RootDir)%(_runtimeCoreLib.Directory)</_coreLibDirectory>
     </PropertyGroup>
 
-    <PropertyGroup Condition="'@(_runtimeJIT)' != ''">
-      <_jitPath>%(_runtimeJIT.FullPath)</_jitPath>
+    <PropertyGroup>
+      <_jitPath Condition="'$(_crossDir)' == ''">$(_jitPackageDir)runtimes/$(PackageRID)/native/$(LibraryFilePrefix)clrjit$(LibraryFileExtension)</_jitPath>
       <_jitPath Condition="'$(_crossDir)' != ''">$(_jitPackageDir)runtimes$(_crossDir)/native/$(LibraryFilePrefix)clrjit$(LibraryFileExtension)</_jitPath>
     </PropertyGroup>
 


### PR DESCRIPTION
To enable building core-setup on arm64 machines (not cross compiled), we need
to do a few things:

- Set the right TargetArchitecture

  When `TargetArchitecture` is not explicitly specified and when the currently
  running architecture is Arm64, use arm64 as the `TargetArchitecture`. Don't
  always use the currently running architecture as that doesn't play well with
  an x86 Visual Studio trying to create x64 builds.

- Use the right coreclr JIT

  If we are cross-compiling, we need to use the x86_arm64 libclrjit.so. But if
  we are building on an arm64 machine, we need to filter the list of found
  libclrjit.so files to pick the normal-RID (eg, linux-arm64) libclrjit.so from
  the two:

      ./.packages/transport.runtime.linux-arm64.microsoft.netcore.jit/<version>/runtimes/linux-arm64/native/libclrjit.so
      ./.packages/transport.runtime.linux-arm64.microsoft.netcore.jit/<version>/runtimes/x64_arm64/native/libclrjit.so

This is another attempt at https://github.com/dotnet/core-setup/pull/7696. It tries to be more conservative by only modifying `TargetArchitecture`/`Platform` for `arm64`.

cc @dagood @vitek-karas 