### PR TITLE
[release/3.1] Fix bundle failing to extract empty file

### DIFF
--- a/src/corehost/cli/apphost/bundle/file_entry.cpp
+++ b/src/corehost/cli/apphost/bundle/file_entry.cpp
@@ -12,7 +12,7 @@ using namespace bundle;
 
 bool file_entry_t::is_valid()
 {
-    return m_data.offset > 0 && m_data.size > 0 &&
+    return m_data.offset > 0 && m_data.size >= 0 &&
         static_cast<file_type_t>(m_data.type) < file_type_t::__last;
 }
 


### PR DESCRIPTION
This is a port of #8462 to release/3,1

#### Issue description
This is a fix for #8422 - where publishing an app which contains an empty file (file of size 0 bytes) as a single-exe produces an executable which fails to run.

#### Customer impact
The app can't be published as single-exe using .NET Core 3.0 SDK. There's no good workaround, the only possible solution is for the customer to remove the empty file from the app (which might not be possible).

#### Fix
When we extract the bundle onto disk we perform a series of validity checks, one of which is overly aggressive and it only accepts files with positive file size. The correct behavior is to accept all files with non-negative file size.

#### Risk
Very small - we allow slightly more cases to run, we don't disallow more of anything.