### PR TITLE
BundleExtraction: Determine extraction path based on writability.

### DIFF
--- a/src/corehost/cli/apphost/bundle/extractor.cpp
+++ b/src/corehost/cli/apphost/bundle/extractor.cpp
@@ -23,6 +23,7 @@ void extractor_t::determine_extraction_dir()
         {
             trace::error(_X("Failure processing application bundle."));
             trace::error(_X("Failed to determine location for extracting embedded files."));
+            trace::error(_X("DOTNET_BUNDLE_EXTRACT_BASE_DIR is not set, and temp-directory doesn't exist or is not readable/writable."));
             throw StatusCode::BundleExtractionFailure;
         }
 

--- a/src/corehost/common/pal.unix.cpp
+++ b/src/corehost/common/pal.unix.cpp
@@ -297,26 +297,32 @@ bool pal::get_default_servicing_directory(string_t* recv)
     return true;
 }
 
+bool is_read_write_able_directory(pal::string_t& dir)
+{
+    return pal::realpath(&dir) &&
+           (access(dir.c_str(), R_OK | W_OK | X_OK) == 0);
+}
+
 bool pal::get_temp_directory(pal::string_t& tmp_dir)
 {
     // First, check for the POSIX standard environment variable
     if (pal::getenv(_X("TMPDIR"), &tmp_dir))
     {
-        return pal::realpath(&tmp_dir);
+        return is_read_write_able_directory(tmp_dir);
     }
 
     // On non-compliant systems (ex: Ubuntu) try /var/tmp or /tmp directories.
     // /var/tmp is prefered since its contents are expected to survive across
     // machine reboot.
     pal::string_t _var_tmp = _X("/var/tmp/");
-    if (pal::realpath(&_var_tmp))
+    if (is_read_write_able_directory(_var_tmp))
     {
         tmp_dir.assign(_var_tmp);
         return true;
     }
 
     pal::string_t _tmp = _X("/tmp/");
-    if (pal::realpath(&_tmp))
+    if (is_read_write_able_directory(_tmp))
     {
         tmp_dir.assign(_tmp);
         return true;


### PR DESCRIPTION
## Summary 
On Unix systms where $TMPDIR is not set, temp-directory is currently
determined as:

/var/tmp/... (if it exists)
/tmp (if not)

However, this causes failures on systems where /var/tmp exists, but is not
writable (as is the case in AWS lambda).

This change fixes the issue by adding a writability check.

## Testing
* Tested on Ubuntu by turning off write permissions on `/var/tmp` the app works by extracting to `/tmp` instead,
* Once the change is checked in, and an SDK is built with it, I'll request @stevemk14ebr to verify that the fix solves the problem in executing hos AWS lambda function.

## Further considerations
* Once the fix is verified, I intent to port the change to 3.1 branch.
* A further consideration was to add the current directory (or the directory where the single-file app resides) to the list of candidate directories where extraction is performed. 
    * However this change was deemed significantly depart from 3.0 behavior (ex: directory containing extracted files shows up on desktop), and not a suitable in 3.1 (bugfix) release.
    * This change can be considered for .net 5, if extraction is still necessary at that point.

## Tracking
Fixes #7940


