### PR TITLE
Specify sdk version, use nuget cache

### DIFF
--- a/eng/configure-toolset.ps1
+++ b/eng/configure-toolset.ps1
@@ -1,7 +1,3 @@
-# Disable using the globally installed SDK. Using the global install can cause
-# roll-forward to a newer SDK that may not work.
-$script:useInstalledDotNetCli = $false
-
 # Always use the local repo packages directory instead of the user's NuGet cache
 # to keep the same between "ci" and non-"ci" builds. If the efficiency gain is
 # required and it's worth maintaining the different types of build, this can be

--- a/eng/configure-toolset.ps1
+++ b/eng/configure-toolset.ps1
@@ -1,5 +1,0 @@
-# Always use the local repo packages directory instead of the user's NuGet cache
-# to keep the same between "ci" and non-"ci" builds. If the efficiency gain is
-# required and it's worth maintaining the different types of build, this can be
-# removed.
-$script:useGlobalNuGetCache = $false

--- a/eng/configure-toolset.sh
+++ b/eng/configure-toolset.sh
@@ -1,7 +1,3 @@
-# Disable using the globally installed SDK. Using the global install can cause
-# roll-forward to a newer SDK that may not work.
-use_installed_dotnet_cli=false
-
 # Always use the local repo packages directory instead of the user's NuGet cache
 # to keep the same between "ci" and non-"ci" builds. If the efficiency gain is
 # required and it's worth maintaining the different types of build, this can be

--- a/eng/configure-toolset.sh
+++ b/eng/configure-toolset.sh
@@ -1,5 +1,0 @@
-# Always use the local repo packages directory instead of the user's NuGet cache
-# to keep the same between "ci" and non-"ci" builds. If the efficiency gain is
-# required and it's worth maintaining the different types of build, this can be
-# removed.
-use_global_nuget_cache=false

--- a/global.json
+++ b/global.json
@@ -1,4 +1,9 @@
 {
+  "sdk": {
+    "version": "3.0.100",
+    "allowPrerelease": true,
+    "rollForward": "major"
+  },
   "tools": {
     "dotnet": "3.0.100"
   },

--- a/src/test/HostActivation.Tests/MultilevelSDKLookup.cs
+++ b/src/test/HostActivation.Tests/MultilevelSDKLookup.cs
@@ -453,6 +453,8 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
                 return;
             }
 
+            WriteEmptyGlobalJson();
+
             // Add SDK versions
             AddAvailableSdkVersions(_regSdkBaseDir, "9999.0.4");
 
@@ -516,6 +518,8 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
                 return;
             }
 
+            WriteEmptyGlobalJson();
+
             using (var registeredInstallLocationOverride = new RegisteredInstallLocationOverride(DotNet.GreatestVersionHostFxrFilePath))
             {
                 registeredInstallLocationOverride.SetInstallLocation(_regDir, RepoDirectories.BuildArchitecture);
@@ -551,6 +555,8 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
                 // Multi-level lookup is only supported on Windows.
                 return;
             }
+
+            WriteEmptyGlobalJson();
 
             // Add SDK versions
             AddAvailableSdkVersions(_regSdkBaseDir, "9999.0.0", "9999.0.3-dummy");
@@ -730,5 +736,12 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
 
             File.Copy(srcFile, destFile, true);
         }
+
+        private void WriteGlobalJson(string contents)
+        {
+            File.WriteAllText(Path.Combine(_currentWorkingDir, "global.json"), contents);
+        }
+
+        private void WriteEmptyGlobalJson() => WriteGlobalJson("{}");
     }
 }

--- a/src/test/HostActivation.Tests/SDKLookup.cs
+++ b/src/test/HostActivation.Tests/SDKLookup.cs
@@ -62,7 +62,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
             Directory.CreateDirectory(_cwdSdkBaseDir);
             Directory.CreateDirectory(_userSdkBaseDir);
             Directory.CreateDirectory(_exeSdkBaseDir);
-            
+
             // Trace messages used to identify from which folder the SDK was picked
             _exeSelectedMessage = $"Using .NET Core SDK dll=[{_exeSdkBaseDir}";
         }
@@ -370,6 +370,8 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
         [Fact]
         public void SdkLookup_Negative_Version()
         {
+            WriteEmptyGlobalJson();
+
             // Add a negative SDK version
             AddAvailableSdkVersions(_exeSdkBaseDir, "-1.-1.-1");
 
@@ -420,6 +422,8 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
         [Fact]
         public void SdkLookup_Must_Pick_The_Highest_Semantic_Version()
         {
+            WriteEmptyGlobalJson();
+            
             // Add SDK versions
             AddAvailableSdkVersions(_exeSdkBaseDir, "9999.0.0", "9999.0.3-dummy.9", "9999.0.3-dummy.10");
 
@@ -568,6 +572,8 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
         public void It_allows_case_insensitive_roll_forward_policy_names(string rollForward)
         {
             const string Requested = "9999.0.100";
+
+            WriteEmptyGlobalJson();
 
             AddAvailableSdkVersions(_exeSdkBaseDir, Requested);
 
@@ -1285,5 +1291,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
         {
             File.WriteAllText(Path.Combine(_currentWorkingDir, "global.json"), contents);
         }
+        
+        private void WriteEmptyGlobalJson() => WriteGlobalJson("{}");
     }
 }


### PR DESCRIPTION
Submitting targeted PRs to align core-setup, corefx and coreclr.

- Use the user's nuget cache for local builds 
Other dotnet repositories like CoreFx are already using the user's
nuget cache for local builds vs the repo local cache for CI builds
and no problems were reported. Switching to remove differences in builds
- Enforce a minimum dotnet sdk version
Specify a minimum dotnet sdk version in the sdk section global.json
which is honored by the Desktop msbuild as well. Set a roll-forward
policy so that a globally installed sdk with a more recent version can
be used when invoking a project directly.
- Use global dotnet installation if matching
Arcade guarantees that the requested version specified in global.json
is installed.
