### PR TITLE
[release/3.1] Include .NET Core Runtime in WindowsDesktop bundle

### DIFF
--- a/src/pkg/projects/windowsdesktop/sfx/Microsoft.WindowsDesktop.App.Bundle.bundleproj
+++ b/src/pkg/projects/windowsdesktop/sfx/Microsoft.WindowsDesktop.App.Bundle.bundleproj
@@ -10,6 +10,11 @@
 
   <ItemGroup>
     <BundleComponentReference Include="Microsoft.WindowsDesktop.App.SharedFx.sfxproj" />
+
+    <!-- Include .NET Core Runtime MSIs. -->
+    <BundleComponentReference Include="..\..\netcoreapp\sfx\Microsoft.NETCore.App.SharedFx.sfxproj" />
+    <BundleComponentReference Include="..\..\Microsoft.NETCore.DotNetHostResolver\Microsoft.NETCore.DotNetHostResolver.pkgproj" />
+    <BundleComponentReference Include="..\..\Microsoft.NETCore.DotNetHost\Microsoft.NETCore.DotNetHost.pkgproj" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
#### Description

https://github.com/dotnet/core-setup/issues/8504: Includes the .NET Core Runtime MSIs inside the .NET Core Desktop Bundle (WindowsDesktop).

#### Customer Impact

The current state of 3.0+ is that you need to install *both* the .NET Core Runtime Bundle and the .NET Core Desktop Bundle in order to run a WinForms or WPF FDE/FDD app. This causes a lot of confusion, because:
1. It seems normal to assume that the Desktop Bundle will give you all you need to run .NET Core Desktop apps, but it doesn't.
2. There is text on the dot.net site that tells you you also need to install .NET Core Runtime, but it is very easy to miss. https://github.com/dotnet/core-setup/issues/8368

These are solved by including .NET Core Runtime inside the .NET Core Desktop Bundle. The user still needs to select the correct architecture(s) to install, but this will be mitigated by creating an improved download page specific to the .NET Core Desktop Runtime Bundle. https://github.com/dotnet/core-setup/issues/7763 tracks also combining the architectures.

3. When you try to launch an FDE WPF/WinForms app without .NET Core Runtime installed, it fails, but doesn't inform the user (only writes to the event log). https://github.com/dotnet/core-setup/issues/8222

This becomes harder to hit because it won't be possible to run the .NET Core Desktop Bundle without also getting the .NET Core Runtime. However, the lack of feedback will still occur if the user tries to launch an FDE app without the prereq runtimes installed, so this is still an important issue.

#### Regression?

No.

#### Risk

Low. We have not fully tested and considered the effects of including the .NET Core Runtime with the .NET Core Desktop Bundle, however this is same approach as the SDK Bundle: the general principle is known and has worked for a long time. (**Edit: The comments explore some interesting scenarios, and they don't raise any concerns.**)

Tested by running `dotnet new winforms` and `dotnet new wpf` FDE apps on a VM with only the .NET Core Desktop Bundle installed, and both worked.

/cc @KathleenDollard @rowanmiller @vatsan-madhavan @richlander 