### PR TITLE
[release/3.1] Self contained component fx validation

### DIFF
--- a/src/corehost/cli/fxr/corehost_init.cpp
+++ b/src/corehost/cli/fxr/corehost_init.cpp
@@ -58,6 +58,11 @@ corehost_init_t::corehost_init_t(
         m_clr_values.push_back(kv.second);
     }
 
+    for (const auto& included_framework : get_app(fx_definitions).get_runtime_config().get_included_frameworks())
+    {
+        m_included_frameworks.emplace_back(included_framework);
+    }
+
     make_cstr_arr(m_fx_names, &m_fx_names_cstr);
     make_cstr_arr(m_fx_dirs, &m_fx_dirs_cstr);
     make_cstr_arr(m_fx_requested_versions, &m_fx_requested_versions_cstr);
@@ -130,12 +135,22 @@ const host_interface_t& corehost_init_t::get_host_init_data()
     return hi;
 }
 
-void corehost_init_t::get_found_fx_versions(std::unordered_map<pal::string_t, const fx_ver_t> &out_fx_versions)
+void corehost_init_t::get_found_fx_versions(std::unordered_map<pal::string_t, const fx_ver_t> &out_fx_versions) const
 {
     for (size_t i = 0; i < m_fx_names.size(); ++i)
     {
         fx_ver_t version;
         if (fx_ver_t::parse(m_fx_found_versions[i], &version))
+        {
             out_fx_versions.emplace(m_fx_names[i], version);
+        }
+    }
+}
+
+void corehost_init_t::get_included_frameworks(std::unordered_map<pal::string_t, const fx_ver_t>& out_included_frameworks) const
+{
+    for (const auto& included_framework : m_included_frameworks)
+    {
+        out_included_frameworks.emplace(included_framework.get_fx_name(), included_framework.get_fx_version_number());
     }
 }

--- a/src/corehost/cli/fxr/corehost_init.h
+++ b/src/corehost/cli/fxr/corehost_init.h
@@ -32,6 +32,7 @@ private:
     std::vector<const pal::char_t*> m_fx_requested_versions_cstr;
     std::vector<pal::string_t> m_fx_found_versions;
     std::vector<const pal::char_t*> m_fx_found_versions_cstr;
+    fx_reference_vector_t m_included_frameworks;
     const pal::string_t m_host_command;
     const pal::string_t m_host_info_host_path;
     const pal::string_t m_host_info_dotnet_root;
@@ -48,7 +49,8 @@ public:
 
     const host_interface_t& get_host_init_data();
 
-    void get_found_fx_versions(std::unordered_map<pal::string_t, const fx_ver_t> &out_fx_versions);
+    void get_found_fx_versions(std::unordered_map<pal::string_t, const fx_ver_t> &out_fx_versions) const;
+    void get_included_frameworks(std::unordered_map<pal::string_t, const fx_ver_t>& out_included_frameworks) const;
 };
 
 #endif // __COREHOST_INIT_H__

--- a/src/corehost/cli/fxr/fx_muxer.cpp
+++ b/src/corehost/cli/fxr/fx_muxer.cpp
@@ -131,7 +131,7 @@ static int execute_app(
         std::lock_guard<std::mutex> lock{ g_context_lock };
         assert(g_active_host_context == nullptr);
         g_active_host_context.reset(new host_context_t(host_context_type::empty, hostpolicy_contract, {}));
-        init->get_found_fx_versions(g_active_host_context->fx_versions_by_name);
+        g_active_host_context->initialize_frameworks(*init);
         g_context_initializing.store(false);
     }
 
@@ -602,11 +602,11 @@ namespace
     }
 
     int get_init_info_for_secondary_component(
-        const host_startup_info_t &host_info,
+        const host_startup_info_t& host_info,
         host_mode_t mode,
-        pal::string_t &runtime_config_path,
-        const host_context_t *existing_context,
-        /*out*/ std::unordered_map<pal::string_t, pal::string_t> &config_properties)
+        pal::string_t& runtime_config_path,
+        const host_context_t* existing_context,
+        /*out*/ std::unordered_map<pal::string_t, pal::string_t>& config_properties)
     {
         // Read config
         fx_definition_t app;
@@ -623,16 +623,21 @@ namespace
         }
 
         // Validate the current context is acceptable for this request (frameworks)
-        // Only validate for framework-dependent (i.e. non-empty frameworks)
-        // Self-contained apps don't contain information about frmeworks contained in the app, so there's nothing to validate against.
         if (!existing_context->fx_versions_by_name.empty())
         {
+            // Framework dependent apps always know their frameworks
             if (!fx_resolver_t::is_config_compatible_with_frameworks(app_config, existing_context->fx_versions_by_name))
+                return StatusCode::CoreHostIncompatibleConfig;
+        }
+        else if (!existing_context->included_fx_versions_by_name.empty())
+        {
+            // Self-contained apps can include information about their frameworks in `includedFrameworks` property in runtime config
+            if (!fx_resolver_t::is_config_compatible_with_frameworks(app_config, existing_context->included_fx_versions_by_name))
                 return StatusCode::CoreHostIncompatibleConfig;
         }
         else
         {
-            trace::verbose(_X("Skipped framework validation for loading a component in a self-contained app"));
+            trace::verbose(_X("Skipped framework validation for loading a component in a self-contained app without information about included frameworks"));
         }
 
         app_config.combine_properties(config_properties);

--- a/src/corehost/cli/fxr/host_context.cpp
+++ b/src/corehost/cli/fxr/host_context.cpp
@@ -55,7 +55,7 @@ int host_context_t::create(
     if (rc == StatusCode::Success)
     {
         std::unique_ptr<host_context_t> context_local(new host_context_t(host_context_type::initialized, hostpolicy_contract, hostpolicy_context_contract));
-        init.get_found_fx_versions(context_local->fx_versions_by_name);
+        context_local->initialize_frameworks(init);
         context = std::move(context_local);
     }
 
@@ -131,6 +131,12 @@ host_context_t::host_context_t(
     , hostpolicy_contract { hostpolicy_contract }
     , hostpolicy_context_contract { hostpolicy_context_contract }
 { }
+
+void host_context_t::initialize_frameworks(const corehost_init_t& init)
+{
+    init.get_found_fx_versions(fx_versions_by_name);
+    init.get_included_frameworks(included_fx_versions_by_name);
+}
 
 void host_context_t::close()
 {

--- a/src/corehost/cli/fxr/host_context.h
+++ b/src/corehost/cli/fxr/host_context.h
@@ -50,6 +50,10 @@ public:
     // Frameworks used for active context
     std::unordered_map<pal::string_t, const fx_ver_t> fx_versions_by_name;
 
+    // Included frameworks used for active context - in case this is a self-contained app
+    // this contains a list of frameworks which are part of the app - they are not framework dependencies/refernces.
+    std::unordered_map<pal::string_t, const fx_ver_t> included_fx_versions_by_name;
+
     // Config properties for secondary contexts
     std::unordered_map<pal::string_t, pal::string_t> config_properties;
 
@@ -57,6 +61,8 @@ public:
         host_context_type type,
         const hostpolicy_contract_t &hostpolicy_contract,
         const corehost_context_contract &hostpolicy_context_contract);
+
+    void initialize_frameworks(const corehost_init_t& init);
 
     void close();
 };

--- a/src/corehost/cli/runtime_config.cpp
+++ b/src/corehost/cli/runtime_config.cpp
@@ -167,8 +167,10 @@ bool runtime_config_t::parse_opts(const json_value& opts)
         rc = parse_framework(framework_obj, fx_out);
         if (rc)
         {
-            m_frameworks.push_back(fx_out);
+            return false;
         }
+
+        m_frameworks.push_back(fx_out);
     }
 
     if (rc)
@@ -179,11 +181,26 @@ bool runtime_config_t::parse_opts(const json_value& opts)
             m_is_framework_dependent = true;
 
             const auto& frameworks_obj = iter->second.as_array();
-            rc = read_framework_array(frameworks_obj);
+            rc = read_framework_array(frameworks_obj, m_frameworks);
         }
     }
 
-    return rc;
+    if (rc)
+    {
+        const auto& includedFrameworks = opts_obj.find(_X("includedFrameworks"));
+        if (includedFrameworks != opts_obj.end())
+        {
+            if (m_is_framework_dependent)
+            {
+                trace::error(_X("It's invalid to specify both `framework`/`frameworks` and `includedFrameworks` properties."));
+                return false;
+            }
+
+            rc = read_framework_array(includedFrameworks->second.as_array(), m_included_frameworks, /*name_and_version_only*/ true);
+        }
+    }
+
+    return true;
 }
 
 namespace
@@ -202,9 +219,12 @@ namespace
     }
 }
 
-bool runtime_config_t::parse_framework(const json_object& fx_obj, fx_reference_t& fx_out)
+bool runtime_config_t::parse_framework(const json_object& fx_obj, fx_reference_t& fx_out, bool name_and_version_only)
 {
-    apply_settings_to_fx_reference(m_default_settings, fx_out);
+    if (!name_and_version_only)
+    {
+        apply_settings_to_fx_reference(m_default_settings, fx_out);
+    }
 
     auto fx_name= fx_obj.find(_X("name"));
     if (fx_name != fx_obj.end())
@@ -219,10 +239,15 @@ bool runtime_config_t::parse_framework(const json_object& fx_obj, fx_reference_t
 
         // Release version should prefer release versions, unless the rollForwardToPrerelease is set
         // in which case no preference should be applied.
-        if (!fx_out.get_fx_version_number().is_prerelease() && !m_roll_forward_to_prerelease)
+        if (!name_and_version_only && !fx_out.get_fx_version_number().is_prerelease() && !m_roll_forward_to_prerelease)
         {
             fx_out.set_prefer_release(true);
         }
+    }
+
+    if (name_and_version_only)
+    {
+        return true;
     }
 
     auto roll_forward = fx_obj.find(_X("rollForward"));
@@ -326,7 +351,7 @@ bool runtime_config_t::ensure_dev_config_parsed()
     return true;
 }
 
-bool runtime_config_t::read_framework_array(web::json::array frameworks_json)
+bool runtime_config_t::read_framework_array(const web::json::array frameworks_json, fx_reference_vector_t& frameworks_out, bool name_and_version_only)
 {
     bool rc = true;
 
@@ -335,7 +360,7 @@ bool runtime_config_t::read_framework_array(web::json::array frameworks_json)
         const auto& fx_obj = fx_json.as_object();
 
         fx_reference_t fx_out;
-        rc = parse_framework(fx_obj, fx_out);
+        rc = parse_framework(fx_json, fx_out, name_and_version_only);
         if (!rc)
         {
             break;
@@ -349,17 +374,17 @@ bool runtime_config_t::read_framework_array(web::json::array frameworks_json)
         }
 
         if (std::find_if(
-                m_frameworks.begin(),
-                m_frameworks.end(),
+                frameworks_out.begin(),
+                frameworks_out.end(),
                 [&](const fx_reference_t& item) { return fx_out.get_fx_name() == item.get_fx_name(); })
-            != m_frameworks.end())
+            != frameworks_out.end())
         {
             trace::verbose(_X("Framework %s already specified."), fx_out.get_fx_name().c_str());
             rc = false;
             break;
         }
 
-        m_frameworks.push_back(fx_out);
+        frameworks_out.push_back(fx_out);
     }
 
     return rc;

--- a/src/corehost/cli/runtime_config.cpp
+++ b/src/corehost/cli/runtime_config.cpp
@@ -167,10 +167,8 @@ bool runtime_config_t::parse_opts(const json_value& opts)
         rc = parse_framework(framework_obj, fx_out);
         if (rc)
         {
-            return false;
+            m_frameworks.push_back(fx_out);
         }
-
-        m_frameworks.push_back(fx_out);
     }
 
     if (rc)
@@ -200,7 +198,7 @@ bool runtime_config_t::parse_opts(const json_value& opts)
         }
     }
 
-    return true;
+    return rc;
 }
 
 namespace
@@ -351,7 +349,7 @@ bool runtime_config_t::ensure_dev_config_parsed()
     return true;
 }
 
-bool runtime_config_t::read_framework_array(const web::json::array frameworks_json, fx_reference_vector_t& frameworks_out, bool name_and_version_only)
+bool runtime_config_t::read_framework_array(web::json::array frameworks_json, fx_reference_vector_t& frameworks_out, bool name_and_version_only)
 {
     bool rc = true;
 
@@ -360,7 +358,7 @@ bool runtime_config_t::read_framework_array(const web::json::array frameworks_js
         const auto& fx_obj = fx_json.as_object();
 
         fx_reference_t fx_out;
-        rc = parse_framework(fx_json, fx_out, name_and_version_only);
+        rc = parse_framework(fx_obj, fx_out, name_and_version_only);
         if (!rc)
         {
             break;

--- a/src/corehost/cli/runtime_config.h
+++ b/src/corehost/cli/runtime_config.h
@@ -80,7 +80,7 @@ private:
     bool m_roll_forward_to_prerelease;
 
     bool parse_framework(const json_object& fx_obj, fx_reference_t& fx_out, bool name_and_version_only = false);
-    bool read_framework_array(web::json::array& frameworks, fx_reference_vector_t& frameworks_out, bool name_and_version_only = false);
+    bool read_framework_array(web::json::array frameworks, fx_reference_vector_t& frameworks_out, bool name_and_version_only = false);
 
     bool mark_specified_setting(specified_setting setting);
 };

--- a/src/corehost/cli/runtime_config.h
+++ b/src/corehost/cli/runtime_config.h
@@ -42,6 +42,7 @@ public:
     bool parse_opts(const json_value& opts);
     void combine_properties(std::unordered_map<pal::string_t, pal::string_t>& combined_properties) const;
     const fx_reference_vector_t& get_frameworks() const { return m_frameworks; }
+    const fx_reference_vector_t& get_included_frameworks() const { return m_included_frameworks; }
     void set_fx_version(pal::string_t version);
 
 private:
@@ -50,6 +51,7 @@ private:
 
     std::unordered_map<pal::string_t, pal::string_t> m_properties;
     fx_reference_vector_t m_frameworks;
+    fx_reference_vector_t m_included_frameworks;
     settings_t m_default_settings;   // the default settings (Steps #0 and #1)
     settings_t m_override_settings;  // the settings that can't be changed (Step #5)
     std::vector<std::string> m_prop_keys;
@@ -77,9 +79,9 @@ private:
     // If set to true, all versions (including pre-release) are considered even if starting from a release framework reference.
     bool m_roll_forward_to_prerelease;
 
-    bool parse_framework(const json_object& fx_obj, fx_reference_t& fx_out);
-    bool read_framework_array(web::json::array frameworks);
-    
+    bool parse_framework(const json_object& fx_obj, fx_reference_t& fx_out, bool name_and_version_only = false);
+    bool read_framework_array(web::json::array& frameworks, fx_reference_vector_t& frameworks_out, bool name_and_version_only = false);
+
     bool mark_specified_setting(specified_setting setting);
 };
 #endif // __RUNTIME_CONFIG_H__

--- a/src/test/HostActivation.Tests/FrameworkResolution/FrameworkResolutionBase.cs
+++ b/src/test/HostActivation.Tests/FrameworkResolution/FrameworkResolutionBase.cs
@@ -59,14 +59,42 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.FrameworkResolution
             }
         }
 
+        protected CommandResult RunSelfContainedTest(
+            TestApp app,
+            TestSettings settings)
+        {
+            if (settings.RuntimeConfigCustomizer != null)
+            {
+                settings.RuntimeConfigCustomizer(RuntimeConfig.Path(app.RuntimeConfigJson)).Save();
+            }
+
+            settings.WithCommandLine(app.AppDll);
+
+            Command command = Command.Create(app.AppExe, settings.CommandLine);
+
+            if (settings.WorkingDirectory != null)
+            {
+                command = command.WorkingDirectory(settings.WorkingDirectory);
+            }
+
+            CommandResult result = command
+                .EnableTracingAndCaptureOutputs()
+                .Environment(settings.Environment)
+                .Execute();
+
+            return result;
+        }
+
         public class SharedTestStateBase : IDisposable
         {
             private readonly string _builtDotnet;
+            private readonly RepoDirectoriesProvider _repoDirectories;
             private readonly string _baseDir;
 
             public SharedTestStateBase()
             {
                 _builtDotnet = Path.Combine(TestArtifact.TestArtifactsPath, "sharedFrameworkPublish");
+                _repoDirectories = new RepoDirectoriesProvider();
 
                 string baseDir = Path.Combine(TestArtifact.TestArtifactsPath, "frameworkResolution");
                 _baseDir = SharedFramework.CalculateUniqueTestDirectory(baseDir);
@@ -90,6 +118,43 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.FrameworkResolution
                 File.WriteAllText(Path.Combine(testAppDir, "FrameworkReferenceApp.runtimeconfig.json"), "{}");
 
                 return new TestApp(testAppDir);
+            }
+
+            public TestApp CreateSelfContainedAppWithMockHostPolicy()
+            {
+                string testAppDir = Path.Combine(_baseDir, "SelfContainedApp");
+                Directory.CreateDirectory(testAppDir);
+                TestApp testApp = new TestApp(testAppDir);
+
+                string hostFxrFileName = RuntimeInformationExtensions.GetSharedLibraryFileNameForCurrentPlatform("hostfxr");
+                string hostPolicyFileName = RuntimeInformationExtensions.GetSharedLibraryFileNameForCurrentPlatform("hostpolicy");
+                string mockHostPolicyFileName = RuntimeInformationExtensions.GetSharedLibraryFileNameForCurrentPlatform("mockhostpolicy");
+                string appHostFileName = RuntimeInformationExtensions.GetExeFileNameForCurrentPlatform("apphost");
+
+                DotNetCli builtDotNetCli = new DotNetCli(_builtDotnet);
+
+                // ./hostfxr - the product version
+                File.Copy(builtDotNetCli.GreatestVersionHostFxrFilePath, Path.Combine(testAppDir, hostFxrFileName));
+
+                // ./hostpolicy - the mock
+                File.Copy(
+                    Path.Combine(_repoDirectories.Artifacts, "corehost_test", mockHostPolicyFileName),
+                    Path.Combine(testAppDir, hostPolicyFileName));
+
+                // ./SelfContainedApp.dll
+                File.WriteAllText(Path.Combine(testAppDir, "SelfContainedApp.dll"), string.Empty);
+
+                // ./SelfContainedApp.runtimeconfig.json
+                File.WriteAllText(Path.Combine(testAppDir, "SelfContainedApp.runtimeconfig.json"), "{}");
+
+                // ./SelfContainedApp.exe
+                string selfContainedAppExePath = Path.Combine(testAppDir, RuntimeInformationExtensions.GetExeFileNameForCurrentPlatform("SelfContainedApp"));
+                File.Copy(
+                    Path.Combine(_repoDirectories.HostArtifacts, appHostFileName),
+                    selfContainedAppExePath);
+                AppHostExtensions.BindAppHost(selfContainedAppExePath);
+
+                return testApp;
             }
 
             public void Dispose()

--- a/src/test/HostActivation.Tests/FrameworkResolution/IncludedFrameworksSettings.cs
+++ b/src/test/HostActivation.Tests/FrameworkResolution/IncludedFrameworksSettings.cs
@@ -1,0 +1,95 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.DotNet.Cli.Build;
+using Microsoft.DotNet.Cli.Build.Framework;
+using Xunit;
+
+namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.FrameworkResolution
+{
+    public class IncludedFrameworksSettings :
+        FrameworkResolutionBase,
+        IClassFixture<IncludedFrameworksSettings.SharedTestState>
+    {
+        private SharedTestState SharedState { get; }
+
+        public IncludedFrameworksSettings(SharedTestState sharedState)
+        {
+            SharedState = sharedState;
+        }
+
+        [Fact]
+        public void FrameworkAndIncludedFrameworksIsInvalid()
+        {
+            RunFrameworkDependentTest(
+                new TestSettings()
+                    .WithRuntimeConfigCustomizer(runtimeConfig => runtimeConfig
+                        .WithFramework(MicrosoftNETCoreApp, "5.1.2")
+                        .WithIncludedFramework(MicrosoftNETCoreApp, "5.1.2")))
+                .Should().Fail()
+                .And.HaveStdErrContaining("It's invalid to specify both `framework`/`frameworks` and `includedFrameworks` properties.");
+        }
+
+        [Fact]
+        public void SelfContainedCanHaveIncludedFrameworks()
+        {
+            RunSelfContainedTest(
+                new TestSettings()
+                    .WithRuntimeConfigCustomizer(runtimeConfig => runtimeConfig
+                        .WithIncludedFramework(MicrosoftNETCoreApp, "5.1.2")))
+                .Should().Pass()
+                .And.HaveStdOutContaining("mock is_framework_dependent: 0");
+        }
+
+        [Fact]
+        public void IncludedFrameworkMustSpecifyName()
+        {
+            RunSelfContainedTest(
+                new TestSettings()
+                    .WithRuntimeConfigCustomizer(runtimeConfig => runtimeConfig
+                        .WithIncludedFramework(null, "5.1.2")))
+                .Should().Fail()
+                .And.HaveStdErrContaining("No framework name specified.");
+        }
+
+        [Fact]
+        public void OtherPropertiesAreIgnoredOnIncludedFramework()
+        {
+            RunSelfContainedTest(
+                new TestSettings()
+                    .WithRuntimeConfigCustomizer(runtimeConfig => runtimeConfig
+                        .WithIncludedFramework(new RuntimeConfig.Framework(MicrosoftNETCoreApp, "5.1.2")
+                            .WithApplyPatches(false)    // Properties which are otherwise parsed on frameworks are ignored
+                            .WithRollForward("invalid") // in case of included frameworks. (so invalid values will be accepted)
+                            .WithRollForwardOnNoCandidateFx(42))))
+                .Should().Pass()
+                .And.HaveStdOutContaining("mock is_framework_dependent: 0");
+        }
+
+        private CommandResult RunFrameworkDependentTest(TestSettings testSettings) =>
+            RunTest(SharedState.DotNetWithFrameworks, SharedState.FrameworkReferenceApp, testSettings);
+
+        private CommandResult RunSelfContainedTest(TestSettings testSettings) =>
+            RunSelfContainedTest(SharedState.SelfContainedApp, testSettings);
+
+        public class SharedTestState : SharedTestStateBase
+        {
+            public TestApp FrameworkReferenceApp { get; }
+
+            public TestApp SelfContainedApp { get; }
+
+            public DotNetCli DotNetWithFrameworks { get; }
+
+            public SharedTestState()
+            {
+                DotNetWithFrameworks = DotNet("WithOneFramework")
+                    .AddMicrosoftNETCoreAppFrameworkMockHostPolicy("5.1.2")
+                    .Build();
+
+                FrameworkReferenceApp = CreateFrameworkReferenceApp();
+                SelfContainedApp = CreateSelfContainedAppWithMockHostPolicy();
+            }
+        }
+    }
+}

--- a/src/test/HostActivation.Tests/NativeHosting/HostContext.cs
+++ b/src/test/HostActivation.Tests/NativeHosting/HostContext.cs
@@ -2,10 +2,12 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using Microsoft.DotNet.Cli.Build;
 using Microsoft.DotNet.Cli.Build.Framework;
 using System;
 using System.IO;
 using System.Linq;
+using System.Runtime.InteropServices.ComTypes;
 using Xunit;
 
 namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.NativeHosting
@@ -316,72 +318,98 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.NativeHosting
         }
 
         [Theory]
-        [InlineData(Scenario.ConfigMultiple, false, Constants.MicrosoftNETCoreApp, "1.1.0", Constants.RollForwardSetting.LatestPatch, false)]
-        [InlineData(Scenario.ConfigMultiple, false, Constants.MicrosoftNETCoreApp, "1.1.0", Constants.RollForwardSetting.Minor, false)]
-        [InlineData(Scenario.ConfigMultiple, false, Constants.MicrosoftNETCoreApp, "1.1.0", Constants.RollForwardSetting.LatestMinor, false)]
-        [InlineData(Scenario.ConfigMultiple, false, Constants.MicrosoftNETCoreApp, "1.1.0", Constants.RollForwardSetting.Major, true)]
-        [InlineData(Scenario.ConfigMultiple, false, Constants.MicrosoftNETCoreApp, "1.1.0", Constants.RollForwardSetting.LatestMajor, true)]
-        [InlineData(Scenario.ConfigMultiple, false, Constants.MicrosoftNETCoreApp, "2.1.0", Constants.RollForwardSetting.LatestPatch, false)]
-        [InlineData(Scenario.ConfigMultiple, false, Constants.MicrosoftNETCoreApp, "2.1.0", Constants.RollForwardSetting.Minor, true)]
-        [InlineData(Scenario.ConfigMultiple, false, Constants.MicrosoftNETCoreApp, "2.1.0", Constants.RollForwardSetting.LatestMinor, true)]
-        [InlineData(Scenario.ConfigMultiple, false, Constants.MicrosoftNETCoreApp, "2.1.0", Constants.RollForwardSetting.Major, true)]
-        [InlineData(Scenario.ConfigMultiple, false, Constants.MicrosoftNETCoreApp, "2.1.0", Constants.RollForwardSetting.LatestMajor, true)]
-        [InlineData(Scenario.ConfigMultiple, false, Constants.MicrosoftNETCoreApp, "2.2.0", Constants.RollForwardSetting.Disable, true)]
-        [InlineData(Scenario.ConfigMultiple, false, Constants.MicrosoftNETCoreApp, "3.1.0", Constants.RollForwardSetting.LatestMinor, false)]
-        [InlineData(Scenario.ConfigMultiple, false, "UnknownFramework", "2.2.0", null, null)]
-        [InlineData(Scenario.Mixed, false, Constants.MicrosoftNETCoreApp, "1.1.0", Constants.RollForwardSetting.LatestPatch, false)]
-        [InlineData(Scenario.Mixed, false, Constants.MicrosoftNETCoreApp, "1.1.0", Constants.RollForwardSetting.Minor, false)]
-        [InlineData(Scenario.Mixed, false, Constants.MicrosoftNETCoreApp, "1.1.0", Constants.RollForwardSetting.LatestMinor, false)]
-        [InlineData(Scenario.Mixed, false, Constants.MicrosoftNETCoreApp, "1.1.0", Constants.RollForwardSetting.Major, true)]
-        [InlineData(Scenario.Mixed, false, Constants.MicrosoftNETCoreApp, "1.1.0", Constants.RollForwardSetting.LatestMajor, true)]
-        [InlineData(Scenario.Mixed, false, Constants.MicrosoftNETCoreApp, "2.1.0", Constants.RollForwardSetting.LatestPatch, false)]
-        [InlineData(Scenario.Mixed, false, Constants.MicrosoftNETCoreApp, "2.1.0", Constants.RollForwardSetting.Minor, true)]
-        [InlineData(Scenario.Mixed, false, Constants.MicrosoftNETCoreApp, "2.1.0", Constants.RollForwardSetting.LatestMinor, true)]
-        [InlineData(Scenario.Mixed, false, Constants.MicrosoftNETCoreApp, "2.1.0", Constants.RollForwardSetting.Major, true)]
-        [InlineData(Scenario.Mixed, false, Constants.MicrosoftNETCoreApp, "2.1.0", Constants.RollForwardSetting.LatestMajor, true)]
-        [InlineData(Scenario.Mixed, false, Constants.MicrosoftNETCoreApp, "2.2.0", Constants.RollForwardSetting.Disable, true)]
-        [InlineData(Scenario.Mixed, false, Constants.MicrosoftNETCoreApp, "3.1.0", Constants.RollForwardSetting.LatestMinor, false)]
-        [InlineData(Scenario.Mixed, false, "UnknownFramework", "2.2.0", null, null)]
-        [InlineData(Scenario.Mixed, true, Constants.MicrosoftNETCoreApp, "1.1.0", Constants.RollForwardSetting.LatestPatch, true)]
-        [InlineData(Scenario.Mixed, true, Constants.MicrosoftNETCoreApp, "1.1.0", Constants.RollForwardSetting.Minor, true)]
-        [InlineData(Scenario.Mixed, true, Constants.MicrosoftNETCoreApp, "1.1.0", Constants.RollForwardSetting.LatestMinor, true)]
-        [InlineData(Scenario.Mixed, true, Constants.MicrosoftNETCoreApp, "1.1.0", Constants.RollForwardSetting.Major, true)]
-        [InlineData(Scenario.Mixed, true, Constants.MicrosoftNETCoreApp, "1.1.0", Constants.RollForwardSetting.LatestMajor, true)]
-        [InlineData(Scenario.Mixed, true, Constants.MicrosoftNETCoreApp, "2.1.0", Constants.RollForwardSetting.LatestPatch, true)]
-        [InlineData(Scenario.Mixed, true, Constants.MicrosoftNETCoreApp, "2.1.0", Constants.RollForwardSetting.Minor, true)]
-        [InlineData(Scenario.Mixed, true, Constants.MicrosoftNETCoreApp, "2.1.0", Constants.RollForwardSetting.LatestMinor, true)]
-        [InlineData(Scenario.Mixed, true, Constants.MicrosoftNETCoreApp, "2.1.0", Constants.RollForwardSetting.Major, true)]
-        [InlineData(Scenario.Mixed, true, Constants.MicrosoftNETCoreApp, "2.1.0", Constants.RollForwardSetting.LatestMajor, true)]
-        [InlineData(Scenario.Mixed, true, Constants.MicrosoftNETCoreApp, "2.2.0", Constants.RollForwardSetting.Disable, true)]
-        [InlineData(Scenario.Mixed, true, Constants.MicrosoftNETCoreApp, "3.1.0", Constants.RollForwardSetting.LatestMinor, true)]
-        [InlineData(Scenario.Mixed, true, "UnknownFramework", "2.2.0", null, true)]
-        [InlineData(Scenario.NonContextMixed, false, Constants.MicrosoftNETCoreApp, "1.1.0", Constants.RollForwardSetting.LatestPatch, false)]
-        [InlineData(Scenario.NonContextMixed, false, Constants.MicrosoftNETCoreApp, "1.1.0", Constants.RollForwardSetting.Minor, false)]
-        [InlineData(Scenario.NonContextMixed, false, Constants.MicrosoftNETCoreApp, "1.1.0", Constants.RollForwardSetting.LatestMinor, false)]
-        [InlineData(Scenario.NonContextMixed, false, Constants.MicrosoftNETCoreApp, "1.1.0", Constants.RollForwardSetting.Major, true)]
-        [InlineData(Scenario.NonContextMixed, false, Constants.MicrosoftNETCoreApp, "1.1.0", Constants.RollForwardSetting.LatestMajor, true)]
-        [InlineData(Scenario.NonContextMixed, false, Constants.MicrosoftNETCoreApp, "2.1.0", Constants.RollForwardSetting.LatestPatch, false)]
-        [InlineData(Scenario.NonContextMixed, false, Constants.MicrosoftNETCoreApp, "2.1.0", Constants.RollForwardSetting.Minor, true)]
-        [InlineData(Scenario.NonContextMixed, false, Constants.MicrosoftNETCoreApp, "2.1.0", Constants.RollForwardSetting.LatestMinor, true)]
-        [InlineData(Scenario.NonContextMixed, false, Constants.MicrosoftNETCoreApp, "2.1.0", Constants.RollForwardSetting.Major, true)]
-        [InlineData(Scenario.NonContextMixed, false, Constants.MicrosoftNETCoreApp, "2.1.0", Constants.RollForwardSetting.LatestMajor, true)]
-        [InlineData(Scenario.NonContextMixed, false, Constants.MicrosoftNETCoreApp, "2.2.0", Constants.RollForwardSetting.Disable, true)]
-        [InlineData(Scenario.NonContextMixed, false, Constants.MicrosoftNETCoreApp, "3.1.0", Constants.RollForwardSetting.LatestMinor, false)]
-        [InlineData(Scenario.NonContextMixed, false, "UnknownFramework", "2.2.0", null, null)]
-        [InlineData(Scenario.NonContextMixed, true, Constants.MicrosoftNETCoreApp, "1.1.0", Constants.RollForwardSetting.LatestPatch, true)]
-        [InlineData(Scenario.NonContextMixed, true, Constants.MicrosoftNETCoreApp, "1.1.0", Constants.RollForwardSetting.Minor, true)]
-        [InlineData(Scenario.NonContextMixed, true, Constants.MicrosoftNETCoreApp, "1.1.0", Constants.RollForwardSetting.LatestMinor, true)]
-        [InlineData(Scenario.NonContextMixed, true, Constants.MicrosoftNETCoreApp, "1.1.0", Constants.RollForwardSetting.Major, true)]
-        [InlineData(Scenario.NonContextMixed, true, Constants.MicrosoftNETCoreApp, "1.1.0", Constants.RollForwardSetting.LatestMajor, true)]
-        [InlineData(Scenario.NonContextMixed, true, Constants.MicrosoftNETCoreApp, "2.1.0", Constants.RollForwardSetting.LatestPatch, true)]
-        [InlineData(Scenario.NonContextMixed, true, Constants.MicrosoftNETCoreApp, "2.1.0", Constants.RollForwardSetting.Minor, true)]
-        [InlineData(Scenario.NonContextMixed, true, Constants.MicrosoftNETCoreApp, "2.1.0", Constants.RollForwardSetting.LatestMinor, true)]
-        [InlineData(Scenario.NonContextMixed, true, Constants.MicrosoftNETCoreApp, "2.1.0", Constants.RollForwardSetting.Major, true)]
-        [InlineData(Scenario.NonContextMixed, true, Constants.MicrosoftNETCoreApp, "2.1.0", Constants.RollForwardSetting.LatestMajor, true)]
-        [InlineData(Scenario.NonContextMixed, true, Constants.MicrosoftNETCoreApp, "2.2.0", Constants.RollForwardSetting.Disable, true)]
-        [InlineData(Scenario.NonContextMixed, true, Constants.MicrosoftNETCoreApp, "3.1.0", Constants.RollForwardSetting.LatestMinor, true)]
-        [InlineData(Scenario.NonContextMixed, true, "UnknownFramework", "2.2.0", null, true)]
-        public void CompatibilityCheck_Frameworks(string scenario, bool selfContained, string frameworkName, string version, string rollForward, bool? isCompatibleVersion)
+        [InlineData(Scenario.ConfigMultiple, false, false, Constants.MicrosoftNETCoreApp, "1.1.0", Constants.RollForwardSetting.LatestPatch, false)]
+        [InlineData(Scenario.ConfigMultiple, false, false, Constants.MicrosoftNETCoreApp, "1.1.0", Constants.RollForwardSetting.Minor, false)]
+        [InlineData(Scenario.ConfigMultiple, false, false, Constants.MicrosoftNETCoreApp, "1.1.0", Constants.RollForwardSetting.LatestMinor, false)]
+        [InlineData(Scenario.ConfigMultiple, false, false, Constants.MicrosoftNETCoreApp, "1.1.0", Constants.RollForwardSetting.Major, true)]
+        [InlineData(Scenario.ConfigMultiple, false, false, Constants.MicrosoftNETCoreApp, "1.1.0", Constants.RollForwardSetting.LatestMajor, true)]
+        [InlineData(Scenario.ConfigMultiple, false, false, Constants.MicrosoftNETCoreApp, "2.1.0", Constants.RollForwardSetting.LatestPatch, false)]
+        [InlineData(Scenario.ConfigMultiple, false, false, Constants.MicrosoftNETCoreApp, "2.1.0", Constants.RollForwardSetting.Minor, true)]
+        [InlineData(Scenario.ConfigMultiple, false, false, Constants.MicrosoftNETCoreApp, "2.1.0", Constants.RollForwardSetting.LatestMinor, true)]
+        [InlineData(Scenario.ConfigMultiple, false, false, Constants.MicrosoftNETCoreApp, "2.1.0", Constants.RollForwardSetting.Major, true)]
+        [InlineData(Scenario.ConfigMultiple, false, false, Constants.MicrosoftNETCoreApp, "2.1.0", Constants.RollForwardSetting.LatestMajor, true)]
+        [InlineData(Scenario.ConfigMultiple, false, false, Constants.MicrosoftNETCoreApp, "2.2.0", Constants.RollForwardSetting.Disable, true)]
+        [InlineData(Scenario.ConfigMultiple, false, false, Constants.MicrosoftNETCoreApp, "3.1.0", Constants.RollForwardSetting.LatestMinor, false)]
+        [InlineData(Scenario.ConfigMultiple, false, false, "UnknownFramework", "2.2.0", null, null)]
+        [InlineData(Scenario.Mixed, false, false, Constants.MicrosoftNETCoreApp, "1.1.0", Constants.RollForwardSetting.LatestPatch, false)]
+        [InlineData(Scenario.Mixed, false, false, Constants.MicrosoftNETCoreApp, "1.1.0", Constants.RollForwardSetting.Minor, false)]
+        [InlineData(Scenario.Mixed, false, false, Constants.MicrosoftNETCoreApp, "1.1.0", Constants.RollForwardSetting.LatestMinor, false)]
+        [InlineData(Scenario.Mixed, false, false, Constants.MicrosoftNETCoreApp, "1.1.0", Constants.RollForwardSetting.Major, true)]
+        [InlineData(Scenario.Mixed, false, false, Constants.MicrosoftNETCoreApp, "1.1.0", Constants.RollForwardSetting.LatestMajor, true)]
+        [InlineData(Scenario.Mixed, false, false, Constants.MicrosoftNETCoreApp, "2.1.0", Constants.RollForwardSetting.LatestPatch, false)]
+        [InlineData(Scenario.Mixed, false, false, Constants.MicrosoftNETCoreApp, "2.1.0", Constants.RollForwardSetting.Minor, true)]
+        [InlineData(Scenario.Mixed, false, false, Constants.MicrosoftNETCoreApp, "2.1.0", Constants.RollForwardSetting.LatestMinor, true)]
+        [InlineData(Scenario.Mixed, false, false, Constants.MicrosoftNETCoreApp, "2.1.0", Constants.RollForwardSetting.Major, true)]
+        [InlineData(Scenario.Mixed, false, false, Constants.MicrosoftNETCoreApp, "2.1.0", Constants.RollForwardSetting.LatestMajor, true)]
+        [InlineData(Scenario.Mixed, false, false, Constants.MicrosoftNETCoreApp, "2.2.0", Constants.RollForwardSetting.Disable, true)]
+        [InlineData(Scenario.Mixed, false, false, Constants.MicrosoftNETCoreApp, "3.1.0", Constants.RollForwardSetting.LatestMinor, false)]
+        [InlineData(Scenario.Mixed, false, false, "UnknownFramework", "2.2.0", null, null)]
+        [InlineData(Scenario.Mixed, true, false, Constants.MicrosoftNETCoreApp, "1.1.0", Constants.RollForwardSetting.LatestPatch, true)]
+        [InlineData(Scenario.Mixed, true, false, Constants.MicrosoftNETCoreApp, "1.1.0", Constants.RollForwardSetting.Minor, true)]
+        [InlineData(Scenario.Mixed, true, false, Constants.MicrosoftNETCoreApp, "1.1.0", Constants.RollForwardSetting.LatestMinor, true)]
+        [InlineData(Scenario.Mixed, true, false, Constants.MicrosoftNETCoreApp, "1.1.0", Constants.RollForwardSetting.Major, true)]
+        [InlineData(Scenario.Mixed, true, false, Constants.MicrosoftNETCoreApp, "1.1.0", Constants.RollForwardSetting.LatestMajor, true)]
+        [InlineData(Scenario.Mixed, true, false, Constants.MicrosoftNETCoreApp, "2.1.0", Constants.RollForwardSetting.LatestPatch, true)]
+        [InlineData(Scenario.Mixed, true, false, Constants.MicrosoftNETCoreApp, "2.1.0", Constants.RollForwardSetting.Minor, true)]
+        [InlineData(Scenario.Mixed, true, false, Constants.MicrosoftNETCoreApp, "2.1.0", Constants.RollForwardSetting.LatestMinor, true)]
+        [InlineData(Scenario.Mixed, true, false, Constants.MicrosoftNETCoreApp, "2.1.0", Constants.RollForwardSetting.Major, true)]
+        [InlineData(Scenario.Mixed, true, false, Constants.MicrosoftNETCoreApp, "2.1.0", Constants.RollForwardSetting.LatestMajor, true)]
+        [InlineData(Scenario.Mixed, true, false, Constants.MicrosoftNETCoreApp, "2.2.0", Constants.RollForwardSetting.Disable, true)]
+        [InlineData(Scenario.Mixed, true, false, Constants.MicrosoftNETCoreApp, "3.1.0", Constants.RollForwardSetting.LatestMinor, true)]
+        [InlineData(Scenario.Mixed, true, false, "UnknownFramework", "2.2.0", null, true)]
+        [InlineData(Scenario.Mixed, true, true, Constants.MicrosoftNETCoreApp, "1.1.0", Constants.RollForwardSetting.LatestPatch, false)]
+        [InlineData(Scenario.Mixed, true, true, Constants.MicrosoftNETCoreApp, "1.1.0", Constants.RollForwardSetting.Minor, false)]
+        [InlineData(Scenario.Mixed, true, true, Constants.MicrosoftNETCoreApp, "1.1.0", Constants.RollForwardSetting.LatestMinor, false)]
+        [InlineData(Scenario.Mixed, true, true, Constants.MicrosoftNETCoreApp, "1.1.0", Constants.RollForwardSetting.Major, true)]
+        [InlineData(Scenario.Mixed, true, true, Constants.MicrosoftNETCoreApp, "1.1.0", Constants.RollForwardSetting.LatestMajor, true)]
+        [InlineData(Scenario.Mixed, true, true, Constants.MicrosoftNETCoreApp, "2.1.0", Constants.RollForwardSetting.LatestPatch, false)]
+        [InlineData(Scenario.Mixed, true, true, Constants.MicrosoftNETCoreApp, "2.1.0", Constants.RollForwardSetting.Minor, true)]
+        [InlineData(Scenario.Mixed, true, true, Constants.MicrosoftNETCoreApp, "2.1.0", Constants.RollForwardSetting.LatestMinor, true)]
+        [InlineData(Scenario.Mixed, true, true, Constants.MicrosoftNETCoreApp, "2.1.0", Constants.RollForwardSetting.Major, true)]
+        [InlineData(Scenario.Mixed, true, true, Constants.MicrosoftNETCoreApp, "2.1.0", Constants.RollForwardSetting.LatestMajor, true)]
+        [InlineData(Scenario.Mixed, true, true, Constants.MicrosoftNETCoreApp, "2.2.0", Constants.RollForwardSetting.Disable, true)]
+        [InlineData(Scenario.Mixed, true, true, Constants.MicrosoftNETCoreApp, "3.1.0", Constants.RollForwardSetting.LatestMinor, false)]
+        [InlineData(Scenario.Mixed, true, true, "UnknownFramework", "2.2.0", null, null)]
+        [InlineData(Scenario.NonContextMixed, false, false, Constants.MicrosoftNETCoreApp, "1.1.0", Constants.RollForwardSetting.LatestPatch, false)]
+        [InlineData(Scenario.NonContextMixed, false, false, Constants.MicrosoftNETCoreApp, "1.1.0", Constants.RollForwardSetting.Minor, false)]
+        [InlineData(Scenario.NonContextMixed, false, false, Constants.MicrosoftNETCoreApp, "1.1.0", Constants.RollForwardSetting.LatestMinor, false)]
+        [InlineData(Scenario.NonContextMixed, false, false, Constants.MicrosoftNETCoreApp, "1.1.0", Constants.RollForwardSetting.Major, true)]
+        [InlineData(Scenario.NonContextMixed, false, false, Constants.MicrosoftNETCoreApp, "1.1.0", Constants.RollForwardSetting.LatestMajor, true)]
+        [InlineData(Scenario.NonContextMixed, false, false, Constants.MicrosoftNETCoreApp, "2.1.0", Constants.RollForwardSetting.LatestPatch, false)]
+        [InlineData(Scenario.NonContextMixed, false, false, Constants.MicrosoftNETCoreApp, "2.1.0", Constants.RollForwardSetting.Minor, true)]
+        [InlineData(Scenario.NonContextMixed, false, false, Constants.MicrosoftNETCoreApp, "2.1.0", Constants.RollForwardSetting.LatestMinor, true)]
+        [InlineData(Scenario.NonContextMixed, false, false, Constants.MicrosoftNETCoreApp, "2.1.0", Constants.RollForwardSetting.Major, true)]
+        [InlineData(Scenario.NonContextMixed, false, false, Constants.MicrosoftNETCoreApp, "2.1.0", Constants.RollForwardSetting.LatestMajor, true)]
+        [InlineData(Scenario.NonContextMixed, false, false, Constants.MicrosoftNETCoreApp, "2.2.0", Constants.RollForwardSetting.Disable, true)]
+        [InlineData(Scenario.NonContextMixed, false, false, Constants.MicrosoftNETCoreApp, "3.1.0", Constants.RollForwardSetting.LatestMinor, false)]
+        [InlineData(Scenario.NonContextMixed, false, false, "UnknownFramework", "2.2.0", null, null)]
+        [InlineData(Scenario.NonContextMixed, true, false, Constants.MicrosoftNETCoreApp, "1.1.0", Constants.RollForwardSetting.LatestPatch, true)]
+        [InlineData(Scenario.NonContextMixed, true, false, Constants.MicrosoftNETCoreApp, "1.1.0", Constants.RollForwardSetting.Minor, true)]
+        [InlineData(Scenario.NonContextMixed, true, false, Constants.MicrosoftNETCoreApp, "1.1.0", Constants.RollForwardSetting.LatestMinor, true)]
+        [InlineData(Scenario.NonContextMixed, true, false, Constants.MicrosoftNETCoreApp, "1.1.0", Constants.RollForwardSetting.Major, true)]
+        [InlineData(Scenario.NonContextMixed, true, false, Constants.MicrosoftNETCoreApp, "1.1.0", Constants.RollForwardSetting.LatestMajor, true)]
+        [InlineData(Scenario.NonContextMixed, true, false, Constants.MicrosoftNETCoreApp, "2.1.0", Constants.RollForwardSetting.LatestPatch, true)]
+        [InlineData(Scenario.NonContextMixed, true, false, Constants.MicrosoftNETCoreApp, "2.1.0", Constants.RollForwardSetting.Minor, true)]
+        [InlineData(Scenario.NonContextMixed, true, false, Constants.MicrosoftNETCoreApp, "2.1.0", Constants.RollForwardSetting.LatestMinor, true)]
+        [InlineData(Scenario.NonContextMixed, true, false, Constants.MicrosoftNETCoreApp, "2.1.0", Constants.RollForwardSetting.Major, true)]
+        [InlineData(Scenario.NonContextMixed, true, false, Constants.MicrosoftNETCoreApp, "2.1.0", Constants.RollForwardSetting.LatestMajor, true)]
+        [InlineData(Scenario.NonContextMixed, true, false, Constants.MicrosoftNETCoreApp, "2.2.0", Constants.RollForwardSetting.Disable, true)]
+        [InlineData(Scenario.NonContextMixed, true, false, Constants.MicrosoftNETCoreApp, "3.1.0", Constants.RollForwardSetting.LatestMinor, true)]
+        [InlineData(Scenario.NonContextMixed, true, false, "UnknownFramework", "2.2.0", null, true)]
+        [InlineData(Scenario.NonContextMixed, true, true, Constants.MicrosoftNETCoreApp, "1.1.0", Constants.RollForwardSetting.LatestPatch, false)]
+        [InlineData(Scenario.NonContextMixed, true, true, Constants.MicrosoftNETCoreApp, "1.1.0", Constants.RollForwardSetting.Minor, false)]
+        [InlineData(Scenario.NonContextMixed, true, true, Constants.MicrosoftNETCoreApp, "1.1.0", Constants.RollForwardSetting.LatestMinor, false)]
+        [InlineData(Scenario.NonContextMixed, true, true, Constants.MicrosoftNETCoreApp, "1.1.0", Constants.RollForwardSetting.Major, true)]
+        [InlineData(Scenario.NonContextMixed, true, true, Constants.MicrosoftNETCoreApp, "1.1.0", Constants.RollForwardSetting.LatestMajor, true)]
+        [InlineData(Scenario.NonContextMixed, true, true, Constants.MicrosoftNETCoreApp, "2.1.0", Constants.RollForwardSetting.LatestPatch, false)]
+        [InlineData(Scenario.NonContextMixed, true, true, Constants.MicrosoftNETCoreApp, "2.1.0", Constants.RollForwardSetting.Minor, true)]
+        [InlineData(Scenario.NonContextMixed, true, true, Constants.MicrosoftNETCoreApp, "2.1.0", Constants.RollForwardSetting.LatestMinor, true)]
+        [InlineData(Scenario.NonContextMixed, true, true, Constants.MicrosoftNETCoreApp, "2.1.0", Constants.RollForwardSetting.Major, true)]
+        [InlineData(Scenario.NonContextMixed, true, true, Constants.MicrosoftNETCoreApp, "2.1.0", Constants.RollForwardSetting.LatestMajor, true)]
+        [InlineData(Scenario.NonContextMixed, true, true, Constants.MicrosoftNETCoreApp, "2.2.0", Constants.RollForwardSetting.Disable, true)]
+        [InlineData(Scenario.NonContextMixed, true, true, Constants.MicrosoftNETCoreApp, "3.1.0", Constants.RollForwardSetting.LatestMinor, false)]
+        [InlineData(Scenario.NonContextMixed, true, true, "UnknownFramework", "2.2.0", null, null)]
+        public void CompatibilityCheck_Frameworks(string scenario, bool selfContained, bool useIncludedFrameworks, string frameworkName, string version, string rollForward, bool? isCompatibleVersion)
         {
             if (scenario != Scenario.ConfigMultiple && scenario != Scenario.Mixed && scenario != Scenario.NonContextMixed)
                 throw new Exception($"Unexpected scenario: {scenario}");
@@ -393,13 +421,14 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.NativeHosting
                 .Save();
 
             string appOrConfigPath = scenario == Scenario.ConfigMultiple ? sharedState.RuntimeConfigPath : 
-                (selfContained ? sharedState.SelfContainedAppPath : sharedState.AppPath);
+                (selfContained ? (useIncludedFrameworks ? sharedState.SelfContainedWithIncludedFrameworksAppPath : sharedState.SelfContainedAppPath) : sharedState.AppPath);
+
             string[] args =
             {
                 HostContextArg,
                 scenario,
                 CheckProperties.None,
-                selfContained ? sharedState.SelfContainedHostFxrPath : sharedState.HostFxrPath,
+                selfContained ? (useIncludedFrameworks ? sharedState.SelfContainedWithIncludedFrameworksHostFxrPath : sharedState.SelfContainedHostFxrPath) : sharedState.HostFxrPath,
                 appOrConfigPath,
                 frameworkCompatConfig
             };
@@ -696,6 +725,10 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.NativeHosting
             public string SelfContainedConfigPath { get; }
             public string SelfContainedHostFxrPath { get; }
 
+            public string SelfContainedWithIncludedFrameworksAppPath { get; }
+            public string SelfContainedWithIncludedFrameworksConfigPath { get; }
+            public string SelfContainedWithIncludedFrameworksHostFxrPath { get; }
+
             public string AppPath_MultiProperty { get; }
             public string RuntimeConfigPath_MultiProperty { get; }
 
@@ -746,21 +779,17 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.NativeHosting
                     .WithProperty(AppMultiPropertyName, AppMultiPropertyValue)
                     .Save();
 
-                string selfContainedDir = Path.Combine(BaseDirectory, "selfContained");
-                Directory.CreateDirectory(selfContainedDir);
-                SelfContainedAppPath = Path.Combine(selfContainedDir, "SelfContained.dll");
-                File.WriteAllText(SelfContainedAppPath, string.Empty);
-                var toCopy = Directory.GetFiles(dotNet.GreatestVersionSharedFxPath)
-                    .Concat(Directory.GetFiles(dotNet.GreatestVersionHostFxrPath));
-                foreach (string file in toCopy)
-                {
-                    File.Copy(file, Path.Combine(selfContainedDir, Path.GetFileName(file)));
-                }
+                CreateSelfContainedApp(dotNet, "SelfContained", out string selfContainedAppPath, out string selfContainedHostFxrPath, out string selfContainedConfigPath);
+                SelfContainedAppPath = selfContainedAppPath;
+                SelfContainedHostFxrPath = selfContainedHostFxrPath;
+                SelfContainedConfigPath = selfContainedConfigPath;
 
-                SelfContainedHostFxrPath = Path.Combine(selfContainedDir, Path.GetFileName(dotNet.GreatestVersionHostFxrFilePath));
-                SelfContainedConfigPath = Path.Combine(selfContainedDir, "SelfContained.runtimeconfig.json");
-                RuntimeConfig.FromFile(SelfContainedConfigPath)
-                    .WithProperty(AppPropertyName, AppPropertyValue)
+                CreateSelfContainedApp(dotNet, "SelfContainedWithIncludedFrameworks", out selfContainedAppPath, out selfContainedHostFxrPath, out selfContainedConfigPath);
+                SelfContainedWithIncludedFrameworksAppPath = selfContainedAppPath;
+                SelfContainedWithIncludedFrameworksHostFxrPath = selfContainedHostFxrPath;
+                SelfContainedWithIncludedFrameworksConfigPath = selfContainedConfigPath;
+                RuntimeConfig.FromFile(SelfContainedWithIncludedFrameworksConfigPath)
+                    .WithIncludedFramework(Constants.MicrosoftNETCoreApp, NetCoreAppVersion)
                     .Save();
 
                 string configDir = Path.Combine(BaseDirectory, "config");
@@ -784,6 +813,26 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.NativeHosting
                 RuntimeConfig.FromFile(SecondaryRuntimeConfigPath)
                     .WithFramework(new RuntimeConfig.Framework(Constants.MicrosoftNETCoreApp, NetCoreAppVersion))
                     .WithProperty(SecondaryConfigPropertyName, SecondaryConfigPropertyValue)
+                    .Save();
+            }
+
+            public void CreateSelfContainedApp(DotNetCli dotNet, string name, out string appPath, out string hostFxrPath, out string configPath)
+            {
+                string selfContainedDir = Path.Combine(BaseDirectory, name);
+                Directory.CreateDirectory(selfContainedDir);
+                appPath = Path.Combine(selfContainedDir, name + ".dll");
+                File.WriteAllText(appPath, string.Empty);
+                var toCopy = Directory.GetFiles(dotNet.GreatestVersionSharedFxPath)
+                    .Concat(Directory.GetFiles(dotNet.GreatestVersionHostFxrPath));
+                foreach (string file in toCopy)
+                {
+                    File.Copy(file, Path.Combine(selfContainedDir, Path.GetFileName(file)));
+                }
+
+                hostFxrPath = Path.Combine(selfContainedDir, Path.GetFileName(dotNet.GreatestVersionHostFxrFilePath));
+                configPath = Path.Combine(selfContainedDir, name + ".runtimeconfig.json");
+                RuntimeConfig.FromFile(configPath)
+                    .WithProperty(AppPropertyName, AppPropertyValue)
                     .Save();
             }
         }

--- a/src/test/HostActivation.Tests/RuntimeConfig.cs
+++ b/src/test/HostActivation.Tests/RuntimeConfig.cs
@@ -48,11 +48,17 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
 
             internal JObject ToJson()
             {
-                JObject frameworkReference =
-                    new JObject(
-                        new JProperty("name", Name),
-                        new JProperty("version", Version)
-                        );
+                JObject frameworkReference = new JObject();
+
+                if (Name != null)
+                {
+                    frameworkReference.Add("name", Name);
+                }
+
+                if (Version != null)
+                {
+                    frameworkReference.Add("version", Version);
+                }
 
                 if (RollForward != null)
                 {
@@ -94,6 +100,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
         private bool? _applyPatches;
         private readonly string _path;
         private readonly List<Framework> _frameworks = new List<Framework>();
+        private readonly List<Framework> _includedFrameworks = new List<Framework>();
         private readonly List<Tuple<string, string>> _properties = new List<Tuple<string, string>>();
 
         /// <summary>
@@ -130,6 +137,15 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
                         foreach (JObject framework in frameworks)
                         {
                             runtimeConfig.WithFramework(Framework.FromJson(framework));
+                        }
+                    }
+
+                    var includedFrameworks = runtimeOptions["includedFrameworks"];
+                    if (includedFrameworks != null)
+                    {
+                        foreach (JObject includedFramework in includedFrameworks)
+                        {
+                            runtimeConfig.WithFramework(Framework.FromJson(includedFramework));
                         }
                     }
 
@@ -183,6 +199,17 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
             return this;
         }
 
+        public RuntimeConfig WithIncludedFramework(Framework framework)
+        {
+            _includedFrameworks.Add(framework);
+            return this;
+        }
+
+        public RuntimeConfig WithIncludedFramework(string name, string version)
+        {
+            return WithIncludedFramework(new Framework(name, version));
+        }
+
         public RuntimeConfig WithRollForward(string value)
         {
             _rollForward = value;
@@ -215,6 +242,13 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
                 runtimeOptions.Add(
                     "frameworks",
                     new JArray(_frameworks.Select(f => f.ToJson()).ToArray()));
+            }
+
+            if (_includedFrameworks.Any())
+            {
+                runtimeOptions.Add(
+                    "includedFrameworks",
+                    new JArray(_includedFrameworks.Select(f => f.ToJson()).ToArray()));
             }
 
             if (_rollForward != null)

--- a/src/test/TestUtils/TestUtils.csproj
+++ b/src/test/TestUtils/TestUtils.csproj
@@ -8,6 +8,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\managed\Microsoft.NET.HostModel\Microsoft.NET.HostModel.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="4.19.4" />
     <PackageReference Include="System.Runtime.Serialization.Primitives" Version="4.1.1" />
     <PackageReference Include="xunit" Version="2.2.0" />


### PR DESCRIPTION
#### Issue - #7732
When the native hosting APIs are used to load a managed component into a process which is running a .NET Core app, the hosting layer should validate that the new component framework requirements are met by the frameworks loaded into the process already. This is to allow the new component to communicate with the app (same FX types), but also to overcome the fact that we don't want to load frameworks twice ever.

In order to validate the framework references declared by the new component, the host must know what frameworks are loaded into the process. For framework dependent apps this works fine as the host knows which frameworks it resolved during the app startup. But for self-contained apps, the host doesn't know as everything looks like an app to it.

For example if 3.1 app would try to load a 5.0 component, without this change there would be no validation and it would either fail at runtime during assembly resolution, or worse, later on due to missing methods or other incompatibilities. This really should have been done in 3.0, but we found it too late. Since 3.0 is short lived, fixing this in 3.1 should really solve the problem for most cases.

#### Customer impact
Weird runtime failures where higher version component is loaded into a lower version app (or vice-versa). There's really no workaround other than figuring out the problem manually which can be rather tricky.

#### Fix description
Related change dotnet/sdk#3697 modifies the build of a self-contained app to add `includedFrameworks` property into `.runtimeconfig.json` (in place of the `frameworks` property which is used for framework dependent apps). This property stores the list of frameworks the app was built with.

This change consumes the new property and implements framework validation for native hosting of managed components even in self-contained apps. The new property is parsed using the same code as `frameworks`, just validation is slightly different (`includedFrameworks` doesn't support/recognize properties like `rollForward`). The values are then propagated from the config into the global store.

Validation is performed every time the included framework information is available. This means there's no explicit version check in the hosting layer. (Unlike the SDK which only produces the new property for 3.1 and above). As such it will maintain backward compatibility (3.0 apps will not have the property, and thus FX validation will be skipped). It also means that if somebody adds the new property even to 3.0 apps, it will be picked up and used - potentially allowing a workaround for issues caused by FX validation skipping in 3.0.

#### Risk
Runtime change risk is low, without the new property in `runtimeconfig.json` the hosting layer behaves exactly the same as before. SDK will only add the property for 3.1 apps (and higher), so there will be no backward compat impact either.

#### Additional info
Testing changes:
* Parser validation for the new property
* Refactor helpers to create self-contained apps as this is now needed from more places
* Modify the existing tests to validate the new behavior

#7732 - this is the 3.1 version of the fix.