### PR TITLE
HostModel: Bundler: Use invariant culture when normalizing file ext

### DIFF
--- a/src/managed/Microsoft.NET.HostModel/Bundle/Bundler.cs
+++ b/src/managed/Microsoft.NET.HostModel/Bundle/Bundler.cs
@@ -92,7 +92,7 @@ namespace Microsoft.NET.HostModel.Bundle
                 return false;
             }
 
-            if (Path.GetExtension(fileRelativePath).ToLower().Equals(".pdb"))
+            if (Path.GetExtension(fileRelativePath).ToLowerInvariant().Equals(".pdb"))
             {
                 return EmbedPDBs;
             }


### PR DESCRIPTION
The Bundler excludes PDB files by default. When looking for PDB files,
the extension is normalized by using ToLower().
This change fixes the issue to use invariant culture instead.
