### PR TITLE
[release/3.0] Fix CoreFX compatibility package versions and auto-update

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -40,7 +40,7 @@
     <SystemCodeDomVersion>4.6.0</SystemCodeDomVersion>
     <SystemConfigurationConfigurationManagerVersion>4.6.0</SystemConfigurationConfigurationManagerVersion>
     <SystemDiagnosticsEventLogVersion>4.6.0</SystemDiagnosticsEventLogVersion>
-    <SystemDiagnosticsPerformanceCounterVersion>4.6.0-preview8.19375.15</SystemDiagnosticsPerformanceCounterVersion>
+    <SystemDiagnosticsPerformanceCounterVersion>4.6.0</SystemDiagnosticsPerformanceCounterVersion>
     <SystemDirectoryServicesVersion>4.6.0</SystemDirectoryServicesVersion>
     <SystemDrawingCommonVersion>4.6.1</SystemDrawingCommonVersion>
     <SystemIOFileSystemAccessControlVersion>4.6.0</SystemIOFileSystemAccessControlVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -40,12 +40,12 @@
     <SystemCodeDomVersion>4.6.0</SystemCodeDomVersion>
     <SystemConfigurationConfigurationManagerVersion>4.6.0</SystemConfigurationConfigurationManagerVersion>
     <SystemDiagnosticsEventLogVersion>4.6.0</SystemDiagnosticsEventLogVersion>
-    <SystemDiagnosticsPerformanceCounter>4.6.0-preview8.19375.15</SystemDiagnosticsPerformanceCounter>
+    <SystemDiagnosticsPerformanceCounterVersion>4.6.0-preview8.19375.15</SystemDiagnosticsPerformanceCounterVersion>
     <SystemDirectoryServicesVersion>4.6.0</SystemDirectoryServicesVersion>
     <SystemDrawingCommonVersion>4.6.1</SystemDrawingCommonVersion>
     <SystemIOFileSystemAccessControlVersion>4.6.0</SystemIOFileSystemAccessControlVersion>
     <SystemIOPackagingVersion>4.6.0</SystemIOPackagingVersion>
-    <SystemIOPipesAccessControl>4.5.1</SystemIOPipesAccessControl>
+    <SystemIOPipesAccessControlVersion>4.5.1</SystemIOPipesAccessControlVersion>
     <SystemResourcesExtensionsPackageVersion>4.6.0</SystemResourcesExtensionsPackageVersion>
     <SystemSecurityAccessControlVersion>4.6.0</SystemSecurityAccessControlVersion>
     <SystemSecurityCryptographyCngVersion>4.6.1</SystemSecurityCryptographyCngVersion>

--- a/src/pkg/projects/windowsdesktop/src/windowsdesktop.depproj
+++ b/src/pkg/projects/windowsdesktop/src/windowsdesktop.depproj
@@ -11,12 +11,12 @@
     <PackageReference Include="System.CodeDom" Version="$(SystemCodeDomVersion)" />
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="$(SystemConfigurationConfigurationManagerVersion)" />
     <PackageReference Include="System.Diagnostics.EventLog" Version="$(SystemDiagnosticsEventLogVersion)" />
-    <PackageReference Include="System.Diagnostics.PerformanceCounter" Version="$(SystemDiagnosticsPerformanceCounter)" />
+    <PackageReference Include="System.Diagnostics.PerformanceCounter" Version="$(SystemDiagnosticsPerformanceCounterVersion)" />
     <PackageReference Include="System.DirectoryServices" Version="$(SystemDirectoryServicesVersion)" />
     <PackageReference Include="System.Drawing.Common" Version="$(SystemDrawingCommonVersion)" />
     <PackageReference Include="System.IO.FileSystem.AccessControl" Version="$(SystemIOFileSystemAccessControlVersion)" />
     <PackageReference Include="System.IO.Packaging" Version="$(SystemIOPackagingVersion)" />
-    <PackageReference Include="System.IO.Pipes.AccessControl" Version="$(SystemIOPipesAccessControl)" />
+    <PackageReference Include="System.IO.Pipes.AccessControl" Version="$(SystemIOPipesAccessControlVersion)" />
     <PackageReference Include="System.Resources.Extensions" Version="$(SystemResourcesExtensionsPackageVersion)" />
     <PackageReference Include="System.Security.AccessControl" Version="$(SystemSecurityAccessControlVersion)" />
     <PackageReference Include="System.Security.Cryptography.Cng" Version="$(SystemSecurityCryptographyCngVersion)" />


### PR DESCRIPTION
#### Description

https://github.com/dotnet/core-setup/issues/8559

This PR fixes the version of System.Diagnostics.PerformanceCounter included with the WindowsDesktop framework to the released version, 4.6.0. It was previously the unreleased build "4.6.0-preview8.19375.15". This unreleased version was included with the 3.0.0 and 3.1.0-preview1 WindowsDesktop frameworks.

This PR also fixes the version property names for System.Diagnostics.PerformanceCounter and System.IO.Pipes.AccessControl so they will be correctly auto-updated in future releases if CoreFX produces a patch.

#### Customer Impact

Apps using the 3.0.0 WindowsDesktop shared framework may be using an out of date version of System.Diagnostics.PerformanceCounter. This hasn't caused any failures that I'm aware of.

This can be worked around in a WPF/WinForms project by adding a `ProjectReference` to the proper version of the package. I tried this out with FDD/FDE and SCD, and the right DLL ended up in publish output.

Symbols are not available for the S.D.PerformanceCounter 4.6.0-preview8.**19375.15**, because the build wasn't released. (Preview 8 was **19405.3**.) This makes it more difficult to debug failures involving this DLL.

Fixing auto-update will make sure we deliver the correct version in 3.0.1+.

#### Regression?

No, this bug existed since the dependency was added in 3.0.0-preview8.

#### Risk

If System.Diagnostics.PerformanceCounter behaves differently between 4.6.0-preview8.19375.15 and 4.6.0 stable, these differences will suddenly show up for devs when they upgrade from 3.0.0 to the 3.0.1 release. I don't see any source changes in this library: I believe this is low risk.