### PR TITLE
[release/3.1] Fix CoreFX compatibility package versions and auto-update

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -41,12 +41,12 @@
     <SystemCodeDomVersion>4.7.0-preview2.19521.18</SystemCodeDomVersion>
     <SystemConfigurationConfigurationManagerVersion>4.7.0-preview2.19521.18</SystemConfigurationConfigurationManagerVersion>
     <SystemDiagnosticsEventLogVersion>4.7.0-preview2.19521.18</SystemDiagnosticsEventLogVersion>
-    <SystemDiagnosticsPerformanceCounter>4.6.0-preview8.19375.15</SystemDiagnosticsPerformanceCounter>
+    <SystemDiagnosticsPerformanceCounterVersion>4.6.0-preview8.19375.15</SystemDiagnosticsPerformanceCounterVersion>
     <SystemDirectoryServicesVersion>4.7.0-preview2.19521.18</SystemDirectoryServicesVersion>
     <SystemDrawingCommonVersion>4.7.0-preview2.19521.18</SystemDrawingCommonVersion>
     <SystemIOFileSystemAccessControlVersion>4.7.0-preview2.19521.18</SystemIOFileSystemAccessControlVersion>
     <SystemIOPackagingVersion>4.7.0-preview2.19521.18</SystemIOPackagingVersion>
-    <SystemIOPipesAccessControl>4.5.1</SystemIOPipesAccessControl>
+    <SystemIOPipesAccessControlVersion>4.5.1</SystemIOPipesAccessControlVersion>
     <SystemResourcesExtensionsPackageVersion>4.7.0-preview2.19521.18</SystemResourcesExtensionsPackageVersion>
     <SystemSecurityAccessControlVersion>4.7.0-preview2.19521.18</SystemSecurityAccessControlVersion>
     <SystemSecurityCryptographyCngVersion>4.7.0-preview2.19521.18</SystemSecurityCryptographyCngVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -41,7 +41,7 @@
     <SystemCodeDomVersion>4.7.0-preview2.19521.18</SystemCodeDomVersion>
     <SystemConfigurationConfigurationManagerVersion>4.7.0-preview2.19521.18</SystemConfigurationConfigurationManagerVersion>
     <SystemDiagnosticsEventLogVersion>4.7.0-preview2.19521.18</SystemDiagnosticsEventLogVersion>
-    <SystemDiagnosticsPerformanceCounterVersion>4.6.0-preview8.19375.15</SystemDiagnosticsPerformanceCounterVersion>
+    <SystemDiagnosticsPerformanceCounterVersion>4.7.0-preview2.19521.18</SystemDiagnosticsPerformanceCounterVersion>
     <SystemDirectoryServicesVersion>4.7.0-preview2.19521.18</SystemDirectoryServicesVersion>
     <SystemDrawingCommonVersion>4.7.0-preview2.19521.18</SystemDrawingCommonVersion>
     <SystemIOFileSystemAccessControlVersion>4.7.0-preview2.19521.18</SystemIOFileSystemAccessControlVersion>

--- a/src/pkg/projects/windowsdesktop/src/windowsdesktop.depproj
+++ b/src/pkg/projects/windowsdesktop/src/windowsdesktop.depproj
@@ -11,12 +11,12 @@
     <PackageReference Include="System.CodeDom" Version="$(SystemCodeDomVersion)" />
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="$(SystemConfigurationConfigurationManagerVersion)" />
     <PackageReference Include="System.Diagnostics.EventLog" Version="$(SystemDiagnosticsEventLogVersion)" />
-    <PackageReference Include="System.Diagnostics.PerformanceCounter" Version="$(SystemDiagnosticsPerformanceCounter)" />
+    <PackageReference Include="System.Diagnostics.PerformanceCounter" Version="$(SystemDiagnosticsPerformanceCounterVersion)" />
     <PackageReference Include="System.DirectoryServices" Version="$(SystemDirectoryServicesVersion)" />
     <PackageReference Include="System.Drawing.Common" Version="$(SystemDrawingCommonVersion)" />
     <PackageReference Include="System.IO.FileSystem.AccessControl" Version="$(SystemIOFileSystemAccessControlVersion)" />
     <PackageReference Include="System.IO.Packaging" Version="$(SystemIOPackagingVersion)" />
-    <PackageReference Include="System.IO.Pipes.AccessControl" Version="$(SystemIOPipesAccessControl)" />
+    <PackageReference Include="System.IO.Pipes.AccessControl" Version="$(SystemIOPipesAccessControlVersion)" />
     <PackageReference Include="System.Resources.Extensions" Version="$(SystemResourcesExtensionsPackageVersion)" />
     <PackageReference Include="System.Security.AccessControl" Version="$(SystemSecurityAccessControlVersion)" />
     <PackageReference Include="System.Security.Cryptography.Cng" Version="$(SystemSecurityCryptographyCngVersion)" />


### PR DESCRIPTION
Ports https://github.com/dotnet/core-setup/pull/8571 from `release/3.0` to `release/3.1`.

Instead of the stable 4.6.0, this PR updates to the 3.1 channel's current version, 4.7.0-preview2.19516.15.

> #### Description
> 
> https://github.com/dotnet/core-setup/issues/8559
> 
> This PR fixes the version of System.Diagnostics.PerformanceCounter included with the WindowsDesktop framework to the released version, 4.6.0. It was previously the unreleased build "4.6.0-preview8.19375.15". This was included with the 3.0.0 and 3.1.0-preview1 WindowsDesktop frameworks.
> 
> This PR also fixes the version property names for System.Diagnostics.PerformanceCounter and System.IO.Pipes.AccessControl so they will be correctly auto-updated in future releases if CoreFX produces a patch.
>
> ...