### PR TITLE
[release/3.1] BundleExtraction: Improve extraction path computation

### DIFF
--- a/src/corehost/cli/apphost/bundle/bundle_runner.cpp
+++ b/src/corehost/cli/apphost/bundle/bundle_runner.cpp
@@ -179,6 +179,8 @@ void bundle_runner_t::determine_extraction_dir()
         {
             trace::error(_X("Failure processing application bundle."));
             trace::error(_X("Failed to determine location for extracting embedded files"));
+            trace::error(_X("DOTNET_BUNDLE_EXTRACT_BASE_DIR is not set, and temp-directory doesn't exist or is not readable/writable."));
+
             throw StatusCode::BundleExtractionFailure;
         }
 

--- a/src/corehost/common/pal.unix.cpp
+++ b/src/corehost/common/pal.unix.cpp
@@ -265,26 +265,32 @@ bool pal::get_default_servicing_directory(string_t* recv)
     return true;
 }
 
+bool is_read_write_able_directory(pal::string_t& dir)
+{
+    return pal::realpath(&dir) &&
+           (access(dir.c_str(), R_OK | W_OK | X_OK) == 0);
+}
+
 bool pal::get_temp_directory(pal::string_t& tmp_dir)
 {
     // First, check for the POSIX standard environment variable
     if (pal::getenv(_X("TMPDIR"), &tmp_dir))
     {
-        return pal::realpath(&tmp_dir);
+        return is_read_write_able_directory(tmp_dir);
     }
 
     // On non-compliant systems (ex: Ubuntu) try /var/tmp or /tmp directories.
     // /var/tmp is prefered since its contents are expected to survive across
     // machine reboot.
     pal::string_t _var_tmp = _X("/var/tmp/");
-    if (pal::realpath(&_var_tmp))
+    if (is_read_write_able_directory(_var_tmp))
     {
         tmp_dir.assign(_var_tmp);
         return true;
     }
 
     pal::string_t _tmp = _X("/tmp/");
-    if (pal::realpath(&_tmp))
+    if (is_read_write_able_directory(_tmp))
     {
         tmp_dir.assign(_tmp);
         return true;


### PR DESCRIPTION
# HostWriter: BundleExtraction: Improve extraction path computation

### Tracking Issue
Fixes #7940

### Customer Scenario

Single-file apps fail to run on AWS lambda because `/var/tmp` is not writable.

### Problem

On Unix systms where $TMPDIR is not set, temp-directory is currently
determined as:

`/var/tmp/...` (preferred if it exists, because )
`/tmp/...` (if /var/tmp/ is not found)

However, this causes failures on systems where `/var/tmp` exists, but is not writable (as is the case in AWS lambda).

### Fix

This change fixes the problem with a writability check when choosing between `/var/tmp` and '/tmp'

### Testing
* Tested on Ubuntu by turning off write permissions on /var/tmp the app works by extracting to /tmp instead.
* I've requested the developer who filed the issue to verify that the fix solves the problem in his AWS lambda function. 

### Master Branch
Commit: https://github.com/dotnet/core-setup/commit/b2bff948e10f7632a40799808f4d7c74b912df80
PR: https://github.com/dotnet/core-setup/pull/8471
