### PR TITLE
[release/3.1] Set apphost and bundle file permission to 755

### DIFF
--- a/src/managed/Microsoft.NET.HostModel/AppHost/HostWriter.cs
+++ b/src/managed/Microsoft.NET.HostModel/AppHost/HostWriter.cs
@@ -2,8 +2,10 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.ComponentModel;
 using System.IO;
 using System.IO.MemoryMappedFiles;
+using System.Runtime.InteropServices;
 using System.Text;
 using System.Threading;
 
@@ -19,7 +21,7 @@ namespace Microsoft.NET.HostModel.AppHost
         /// hash value embedded in default apphost executable in a place where the path to the app binary should be stored.
         /// </summary>
         private const string AppBinaryPathPlaceholder = "c3ab8ff13720e8ad9047dd39466b3c8974e592c2fa383d4a3960714caef0c4f2";
-        private readonly static byte[] AppBinaryPathPlaceholderSearchValue = Encoding.UTF8.GetBytes(AppBinaryPathPlaceholder);
+        private static readonly byte[] AppBinaryPathPlaceholderSearchValue = Encoding.UTF8.GetBytes(AppBinaryPathPlaceholder);
 
         /// <summary>
         /// Create an AppHost with embedded configuration of app binary location
@@ -43,6 +45,7 @@ namespace Microsoft.NET.HostModel.AppHost
             }
 
             BinaryUtils.CopyFile(appHostSourceFilePath, appHostDestinationFilePath);
+
             bool appHostIsPEImage = false;
 
             void RewriteAppHost()
@@ -70,7 +73,7 @@ namespace Microsoft.NET.HostModel.AppHost
             }
 
             void UpdateResources()
-            { 
+            {
                 if (assemblyToCopyResorcesFrom != null && appHostIsPEImage)
                 {
                     if (ResourceUpdater.IsSupportedOS())
@@ -100,6 +103,24 @@ namespace Microsoft.NET.HostModel.AppHost
 
             try
             {
+                if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                {
+                    var filePermissionOctal = Convert.ToInt32("755", 8); // -rwxr-xr-x
+                    const int EINTR = 4;
+                    int chmodReturnCode = 0;
+
+                    do
+                    {
+                        chmodReturnCode = chmod(appHostDestinationFilePath, filePermissionOctal);
+                    }
+                    while (chmodReturnCode == -1 && Marshal.GetLastWin32Error() == EINTR);
+
+                    if (chmodReturnCode == -1)
+                    {
+                        throw new Win32Exception(Marshal.GetLastWin32Error(), $"Could not set file permission {filePermissionOctal} for {appHostDestinationFilePath}.");
+                    }
+                }
+
                 RetryUtil.RetryOnIOError(RewriteAppHost);
 
                 RetryUtil.RetryOnWin32Error(UpdateResources);
@@ -145,14 +166,14 @@ namespace Microsoft.NET.HostModel.AppHost
             };
 
             // Re-write the destination apphost with the proper contents.
-            RetryUtil.RetryOnIOError(() => 
+            RetryUtil.RetryOnIOError(() =>
                 BinaryUtils.SearchAndReplace(appHostPath,
                                              bundleHeaderPlaceholder,
-                                             BitConverter.GetBytes(bundleHeaderOffset), 
-                                             pad0s:false));
+                                             BitConverter.GetBytes(bundleHeaderOffset),
+                                             pad0s: false));
 
             // Memory-mapped write does not updating last write time
-            RetryUtil.RetryOnIOError(() => 
+            RetryUtil.RetryOnIOError(() =>
                 File.SetLastWriteTimeUtc(appHostPath, DateTime.UtcNow));
         }
 
@@ -195,5 +216,8 @@ namespace Microsoft.NET.HostModel.AppHost
 
             return headerOffset != 0;
         }
+
+        [DllImport("libc", SetLastError = true)]
+        private static extern int chmod(string pathname, int mode);
     }
 }

--- a/src/test/TestUtils/Command.cs
+++ b/src/test/TestUtils/Command.cs
@@ -381,7 +381,8 @@ namespace Microsoft.DotNet.Cli.Build.Framework
                 bool success = exitCode == 0;
                 string msgExpectedToFail = "";
 
-                if (fExpectedToFail) {
+                if (fExpectedToFail)
+                {
                     success = !success;
                     msgExpectedToFail = "failed as expected and ";
                 }


### PR DESCRIPTION
# Unix: Set apphost and bundle file permission to 755

When building a .net core 3 app, the SDK currently simply copies the apphost template (including its permissions) from the install-location.

### Customer Impact

This caused two problems in Unix systems:
* If the dotnet install location is write-protected, the build fails when SDK tries update the apphost (to set the app-path, etc.)  (#8511)
* The built apphost can only be run by the owner (#7062)

### Solution

This change explicitly sets the file permissions of the Apphost in the SDK (via Microsoft.NET.HostModel package) when building on Unix systems to fix the above issues.

### Notes
This fix was contributed by @am11 -- thank you very much.

### Testing 
* Manual testing in 3.1 branch to check that the permissions are set in Unix systems.
* Automated tests are checked into the master branch -- has a dependency on the newer arcade SDK, and hence the test is not ported here.

### Master branch
PR: https://github.com/dotnet/core-setup/pull/8510
Commit: https://github.com/dotnet/core-setup/commit/a6a9202dc186f622f5df7125b12d95d9107c193a
