### PR TITLE
[release/2.2] Generate VS insertion MSI nupkgs

### DIFF
--- a/BranchInfo.props
+++ b/BranchInfo.props
@@ -18,5 +18,6 @@
     <ContainerName>dotnet</ContainerName>
     <ChecksumContainerName>$(ContainerName)</ChecksumContainerName>
     <NETCoreAppMaximumVersion>$(MajorVersion).$(MinorVersion)</NETCoreAppMaximumVersion>
+    <NETCoreAppFrameworkVersion>$(MajorVersion).$(MinorVersion)</NETCoreAppFrameworkVersion>
   </PropertyGroup>
 </Project>

--- a/publish/dir.props
+++ b/publish/dir.props
@@ -28,7 +28,10 @@
     <CompressedFile Include="$(AssetOutputPath)**/*$(CompressedFileExtension)">
       <RelativeBlobPath>$(BinariesRelativePath)</RelativeBlobPath>
     </CompressedFile>
-    <RuntimePackageFile Include="$(PackageOutputPath)**/runtime.*.nupkg" >
+    <RuntimePackageFile
+      Include="
+        $(PackageOutputPath)**/runtime.*.nupkg;
+        $(PackageOutputPath)**/VS.Redist.Common.*.nupkg" >
       <RelativeBlobPath>$(BinariesRelativePath)</RelativeBlobPath>
     </RuntimePackageFile>
     <RidAgnosticPackageFile Include="$(PackageOutputPath)**/*.nupkg" Exclude="@(RuntimePackageFile)" >

--- a/publish/publish.proj
+++ b/publish/publish.proj
@@ -46,8 +46,11 @@
 
   <Target Name="ExcludeSymbolsPackagesFromPublishedVersions">
     <ItemGroup>
-      <PackagesToShip Include="$(DownloadDirectory)*.nupkg" Exclude="$(DownloadDirectory)*.symbols.nupkg" />
-      <PackagesToShip Remove="%(PackagesToShip.Identity)" Condition="$([System.String]::Copy('%(PackagesToShip.Identity)').Contains('latest'))" />
+      <PackagesToShip Include="$(DownloadDirectory)*.nupkg"
+                      Exclude="$(DownloadDirectory)*.symbols.nupkg;
+                               $(DownloadDirectory)VS.Redist.Common.*.nupkg" />
+      <PackagesToShip Remove="%(PackagesToShip.Identity)"
+                      Condition="$([System.String]::Copy('%(PackagesToShip.Identity)').Contains('latest'))" />
       <ShippedNuGetPackage Include="@(PackagesToShip)" />
     </ItemGroup>
   </Target>

--- a/src/pkg/packaging/dir.proj
+++ b/src/pkg/packaging/dir.proj
@@ -14,7 +14,7 @@
 
   <Target Name="Build" DependsOnTargets="BuildInstallers;BuildCombinedInstallers" Condition="'$(DOTNET_BUILD_SKIP_PACKAGING)' != 'true'" />
   <Target Name="BuildInstallers" DependsOnTargets="$(PackageTargets)" Condition="'$(DOTNET_BUILD_SKIP_PACKAGING)' != 'true'" />
-  <Target Name="BuildCombinedInstallers" DependsOnTargets="GenerateCombinedInstallers" Condition="'$(DOTNET_BUILD_SKIP_PACKAGING)' != 'true'" />
+  <Target Name="BuildCombinedInstallers" DependsOnTargets="GenerateCombinedInstallers;GenerateVSNugetPackages" Condition="'$(DOTNET_BUILD_SKIP_PACKAGING)' != 'true'" />
 
   <Target Name="InitPackage">
     <ItemGroup>
@@ -185,4 +185,83 @@
           Condition="'@(PackageProjects)' != ''" />
   </Target>
 
-</Project>
+  <Target Name="GenerateVSNugetPackages"
+          Condition="'$(OS)' == 'Windows_NT' AND '$(TargetArchitecture)' != 'arm' AND '$(TargetArchitecture)' != 'arm64'"
+          DependsOnTargets="SetupVSNugetPackages;GenerateInstallers;GenerateProjectInstallers;GenerateCombinedInstallers"
+          Inputs="@(SdkMsiComponent->'%(MsiInstallerFile)');
+                    $(NuSpecFile);
+                    $(GenerateNupkgPowershellScript)"
+          Outputs="@(SdkMsiComponent->'$(PackageOutputPath)%(ComponentId).%(ComponentVersion).nupkg')">
+
+    <Exec Command="powershell -NoProfile -NoLogo $(GenerateNupkgPowershellScript) ^
+                      '%(SdkMsiComponent.MsiInstallerFile)' ^
+                      '@(SdkMsiComponent->'%(ComponentVersion)')' ^
+                      '$(NuSpecFile)' ^
+                      '@(SdkMsiComponent->'$(PackageOutputPath)%(ComponentId).%(ComponentVersion).nupkg')' ^
+                      '$(TargetArchitecture)' ^
+                      '@(SdkMsiComponent->'%(ComponentId)')' ^
+                      '@(SdkMsiComponent->'%(ComponentFriendlyName)')' ^
+                      '$(ProjectUrl)' ^
+                      '$(BinDir)'" />
+  </Target>
+  
+  <Target Name="SetupVSNugetPackages">
+      <PropertyGroup>
+        <NuSpecFile>$(MSBuildThisFileDirectory)windows/vscomponents/VS.Redist.Common.Component.nuspec</NuSpecFile>
+        <GenerateNupkgPowershellScript>$(MSBuildThisFileDirectory)windows/vscomponents/generatenupkg.ps1</GenerateNupkgPowershellScript>
+        <ProjectUrl>https://github.com/dotnet/core-setup</ProjectUrl>
+      </PropertyGroup>
+
+      <ItemGroup>
+        <SdkMsiComponent Include="HostFxrMsiNupkg">
+          <MsiInstallerFile>$(HostFxrInstallerFile)</MsiInstallerFile>
+          <ComponentId>VS.Redist.Common.NetCore.HostFXR.$(TargetArchitecture).$(NETCoreAppFrameworkVersion)</ComponentId>
+          <ComponentVersion>$(SharedFrameworkNugetVersion)</ComponentVersion>
+          <ComponentFriendlyName>$(NETCoreAppFrameworkVersion) .NET Core HostFX Resolver</ComponentFriendlyName>
+        </SdkMsiComponent>
+        <SdkMsiComponent Include="AppHostPackMsiNupkg">
+          <MsiInstallerFile>$(AppHostPackInstallerFile)</MsiInstallerFile>
+          <ComponentId>VS.Redist.Common.NetCore.AppHostPack.$(TargetArchitecture).$(NETCoreAppFrameworkVersion)</ComponentId>
+          <ComponentVersion>$(SharedFrameworkNugetVersion)</ComponentVersion>
+          <ComponentFriendlyName>$(NETCoreAppFrameworkVersion) .NET Core AppHost Pack</ComponentFriendlyName>
+        </SdkMsiComponent>
+        <SdkMsiComponent Include="SharedFrameworkMsiNupkg">
+          <MsiInstallerFile>$(SharedFrameworkInstallerFile)</MsiInstallerFile>
+          <ComponentId>VS.Redist.Common.NetCore.SharedFramework.$(TargetArchitecture).$(NETCoreAppFrameworkVersion)</ComponentId>
+          <ComponentVersion>$(SharedFrameworkNugetVersion)</ComponentVersion>
+          <ComponentFriendlyName>$(NETCoreAppFrameworkVersion) .NET Core SharedFramework</ComponentFriendlyName>
+        </SdkMsiComponent>
+        <SdkMsiComponent Include="SharedHostMsiNupkg">
+          <MsiInstallerFile>$(SharedHostInstallerFile)</MsiInstallerFile>
+          <ComponentId>VS.Redist.Common.NetCore.SharedHost.$(TargetArchitecture).$(NETCoreAppFrameworkVersion)</ComponentId>
+          <ComponentVersion>$(SharedFrameworkNugetVersion)</ComponentVersion>
+          <ComponentFriendlyName>$(NETCoreAppFrameworkVersion) .NET Core SharedHost</ComponentFriendlyName>
+        </SdkMsiComponent>
+        <SdkMsiComponent Include="NetStandardTargetingPackMsiNupkg">
+          <MsiInstallerFile>$(NetStandardTargetingPackInstallerFile)</MsiInstallerFile>
+          <ComponentId>VS.Redist.Common.NetStandard.TargetingPack.$(TargetArchitecture).$(NetStandardProductBandVersion)</ComponentId>
+          <ComponentVersion>$(NetStandardProductBandVersion).$(PatchVersion)$(ProductVersionSuffix)</ComponentVersion>
+          <ComponentFriendlyName>$(NetStandardProductBandVersion) .NET Standard TargetingPack</ComponentFriendlyName>
+        </SdkMsiComponent>
+        <SdkMsiComponent Include="NetCoreTargetingPackMsiNupkg">
+          <MsiInstallerFile>$(TargetingPackInstallerFile)</MsiInstallerFile>
+          <ComponentId>VS.Redist.Common.NetCore.TargetingPack.$(TargetArchitecture).$(NETCoreAppFrameworkVersion)</ComponentId>
+          <ComponentVersion>$(SharedFrameworkNugetVersion)</ComponentVersion>
+          <ComponentFriendlyName>$(NETCoreAppFrameworkVersion) .NET Core TargetingPack</ComponentFriendlyName>
+        </SdkMsiComponent>
+        <SdkMsiComponent Include="WindowsDesktopMsiNupkg">
+          <MsiInstallerFile>$(WindowsDesktopSharedFrameworkInstallerFile)</MsiInstallerFile>
+          <ComponentId>VS.Redist.Common.WindowsDesktop.SharedFramework.$(TargetArchitecture).$(NETCoreAppFrameworkVersion)</ComponentId>
+          <ComponentVersion>$(SharedFrameworkNugetVersion)</ComponentVersion>
+          <ComponentFriendlyName>$(NETCoreAppFrameworkVersion) WindowsDesktop SharedFramework</ComponentFriendlyName>
+        </SdkMsiComponent>
+        <SdkMsiComponent Include="WindowsDesktopTargetingPackMsiNupkg">
+          <MsiInstallerFile>$(WindowsDesktopTargetingPackInstallerFile)</MsiInstallerFile>
+          <ComponentId>VS.Redist.Common.WindowsDesktop.TargetingPack.$(TargetArchitecture).$(NETCoreAppFrameworkVersion)</ComponentId>
+          <ComponentVersion>$(SharedFrameworkNugetVersion)</ComponentVersion>
+          <ComponentFriendlyName>$(NETCoreAppFrameworkVersion) WindowsDesktop TargetingPack</ComponentFriendlyName>
+        </SdkMsiComponent>
+      </ItemGroup>
+    </Target>
+
+  </Project>

--- a/src/pkg/packaging/dir.proj
+++ b/src/pkg/packaging/dir.proj
@@ -187,7 +187,7 @@
 
   <Target Name="GenerateVSNugetPackages"
           Condition="'$(OS)' == 'Windows_NT' AND '$(TargetArchitecture)' != 'arm' AND '$(TargetArchitecture)' != 'arm64'"
-          DependsOnTargets="SetupVSNugetPackages;GenerateInstallers;GenerateProjectInstallers;GenerateCombinedInstallers"
+          DependsOnTargets="SetupVSNugetPackages"
           Inputs="@(SdkMsiComponent->'%(MsiInstallerFile)');
                     $(NuSpecFile);
                     $(GenerateNupkgPowershellScript)"

--- a/src/pkg/packaging/dir.proj
+++ b/src/pkg/packaging/dir.proj
@@ -219,12 +219,6 @@
           <ComponentVersion>$(SharedFrameworkNugetVersion)</ComponentVersion>
           <ComponentFriendlyName>$(NETCoreAppFrameworkVersion) .NET Core HostFX Resolver</ComponentFriendlyName>
         </SdkMsiComponent>
-        <SdkMsiComponent Include="AppHostPackMsiNupkg">
-          <MsiInstallerFile>$(AppHostPackInstallerFile)</MsiInstallerFile>
-          <ComponentId>VS.Redist.Common.NetCore.AppHostPack.$(TargetArchitecture).$(NETCoreAppFrameworkVersion)</ComponentId>
-          <ComponentVersion>$(SharedFrameworkNugetVersion)</ComponentVersion>
-          <ComponentFriendlyName>$(NETCoreAppFrameworkVersion) .NET Core AppHost Pack</ComponentFriendlyName>
-        </SdkMsiComponent>
         <SdkMsiComponent Include="SharedFrameworkMsiNupkg">
           <MsiInstallerFile>$(SharedFrameworkInstallerFile)</MsiInstallerFile>
           <ComponentId>VS.Redist.Common.NetCore.SharedFramework.$(TargetArchitecture).$(NETCoreAppFrameworkVersion)</ComponentId>
@@ -236,30 +230,6 @@
           <ComponentId>VS.Redist.Common.NetCore.SharedHost.$(TargetArchitecture).$(NETCoreAppFrameworkVersion)</ComponentId>
           <ComponentVersion>$(SharedFrameworkNugetVersion)</ComponentVersion>
           <ComponentFriendlyName>$(NETCoreAppFrameworkVersion) .NET Core SharedHost</ComponentFriendlyName>
-        </SdkMsiComponent>
-        <SdkMsiComponent Include="NetStandardTargetingPackMsiNupkg">
-          <MsiInstallerFile>$(NetStandardTargetingPackInstallerFile)</MsiInstallerFile>
-          <ComponentId>VS.Redist.Common.NetStandard.TargetingPack.$(TargetArchitecture).$(NetStandardProductBandVersion)</ComponentId>
-          <ComponentVersion>$(NetStandardProductBandVersion).$(PatchVersion)$(ProductVersionSuffix)</ComponentVersion>
-          <ComponentFriendlyName>$(NetStandardProductBandVersion) .NET Standard TargetingPack</ComponentFriendlyName>
-        </SdkMsiComponent>
-        <SdkMsiComponent Include="NetCoreTargetingPackMsiNupkg">
-          <MsiInstallerFile>$(TargetingPackInstallerFile)</MsiInstallerFile>
-          <ComponentId>VS.Redist.Common.NetCore.TargetingPack.$(TargetArchitecture).$(NETCoreAppFrameworkVersion)</ComponentId>
-          <ComponentVersion>$(SharedFrameworkNugetVersion)</ComponentVersion>
-          <ComponentFriendlyName>$(NETCoreAppFrameworkVersion) .NET Core TargetingPack</ComponentFriendlyName>
-        </SdkMsiComponent>
-        <SdkMsiComponent Include="WindowsDesktopMsiNupkg">
-          <MsiInstallerFile>$(WindowsDesktopSharedFrameworkInstallerFile)</MsiInstallerFile>
-          <ComponentId>VS.Redist.Common.WindowsDesktop.SharedFramework.$(TargetArchitecture).$(NETCoreAppFrameworkVersion)</ComponentId>
-          <ComponentVersion>$(SharedFrameworkNugetVersion)</ComponentVersion>
-          <ComponentFriendlyName>$(NETCoreAppFrameworkVersion) WindowsDesktop SharedFramework</ComponentFriendlyName>
-        </SdkMsiComponent>
-        <SdkMsiComponent Include="WindowsDesktopTargetingPackMsiNupkg">
-          <MsiInstallerFile>$(WindowsDesktopTargetingPackInstallerFile)</MsiInstallerFile>
-          <ComponentId>VS.Redist.Common.WindowsDesktop.TargetingPack.$(TargetArchitecture).$(NETCoreAppFrameworkVersion)</ComponentId>
-          <ComponentVersion>$(SharedFrameworkNugetVersion)</ComponentVersion>
-          <ComponentFriendlyName>$(NETCoreAppFrameworkVersion) WindowsDesktop TargetingPack</ComponentFriendlyName>
         </SdkMsiComponent>
       </ItemGroup>
     </Target>

--- a/src/pkg/packaging/dir.props
+++ b/src/pkg/packaging/dir.props
@@ -30,13 +30,4 @@
     <HostFxrBrandName>$(ProductBrandPrefix) Host FX Resolver - $(ProductBrandSuffix)</HostFxrBrandName>
     <SharedFrameworkBrandName>$(ProductBrandPrefix) Runtime - $(ProductBrandSuffix)</SharedFrameworkBrandName>
   </PropertyGroup>
-  <PropertyGroup>
-    <TargetingPackInstallerFile>$(AssetOutputPath)dotnet-targeting-pack-$(ProductMoniker)$(InstallerExtension)</TargetingPackInstallerFile>
-    <AppHostPackInstallerFile>$(AssetOutputPath)dotnet-apphost-pack-$(ProductMoniker)$(InstallerExtension)</AppHostPackInstallerFile>
-    <NetStandardProductBandVersion>2.1</NetStandardProductBandVersion>
-    <NetStandardProductMoniker>$(NetStandardProductBandVersion).$(PatchVersion)$(ProductVersionSuffix)-$(PackageTargetRid)</NetStandardProductMoniker>
-    <NetStandardTargetingPackInstallerFile>$(AssetOutputPath)netstandard-targeting-pack-$(NetStandardProductMoniker)$(InstallerExtension)</NetStandardTargetingPackInstallerFile>
-    <WindowsDesktopSharedFrameworkInstallerFile>$(AssetOutputPath)windowsdesktop-runtime-$(ProductMoniker)$(InstallerExtension)</WindowsDesktopSharedFrameworkInstallerFile>
-    <WindowsDesktopTargetingPackInstallerFile>$(AssetOutputPath)windowsdesktop-targeting-pack-$(ProductMoniker)$(InstallerExtension)</WindowsDesktopTargetingPackInstallerFile>
-  </PropertyGroup>
 </Project>

--- a/src/pkg/packaging/dir.props
+++ b/src/pkg/packaging/dir.props
@@ -30,4 +30,13 @@
     <HostFxrBrandName>$(ProductBrandPrefix) Host FX Resolver - $(ProductBrandSuffix)</HostFxrBrandName>
     <SharedFrameworkBrandName>$(ProductBrandPrefix) Runtime - $(ProductBrandSuffix)</SharedFrameworkBrandName>
   </PropertyGroup>
+  <PropertyGroup>
+    <TargetingPackInstallerFile>$(AssetOutputPath)dotnet-targeting-pack-$(ProductMoniker)$(InstallerExtension)</TargetingPackInstallerFile>
+    <AppHostPackInstallerFile>$(AssetOutputPath)dotnet-apphost-pack-$(ProductMoniker)$(InstallerExtension)</AppHostPackInstallerFile>
+    <NetStandardProductBandVersion>2.1</NetStandardProductBandVersion>
+    <NetStandardProductMoniker>$(NetStandardProductBandVersion).$(PatchVersion)$(ProductVersionSuffix)-$(PackageTargetRid)</NetStandardProductMoniker>
+    <NetStandardTargetingPackInstallerFile>$(AssetOutputPath)netstandard-targeting-pack-$(NetStandardProductMoniker)$(InstallerExtension)</NetStandardTargetingPackInstallerFile>
+    <WindowsDesktopSharedFrameworkInstallerFile>$(AssetOutputPath)windowsdesktop-runtime-$(ProductMoniker)$(InstallerExtension)</WindowsDesktopSharedFrameworkInstallerFile>
+    <WindowsDesktopTargetingPackInstallerFile>$(AssetOutputPath)windowsdesktop-targeting-pack-$(ProductMoniker)$(InstallerExtension)</WindowsDesktopTargetingPackInstallerFile>
+  </PropertyGroup>
 </Project>

--- a/src/pkg/packaging/windows/vscomponents/VS.Redist.Common.Component.nuspec
+++ b/src/pkg/packaging/windows/vscomponents/VS.Redist.Common.Component.nuspec
@@ -1,0 +1,18 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
+  <metadata>
+    <id>$COMPONENT_NAME$</id>
+    <version>1.0.0</version>
+    <title>$COMPONENT_NAME$</title>
+    <authors>Microsoft</authors>
+    <owners>Microsoft</owners>
+    <licenseUrl>https://www.microsoft.com/net/dotnet_library_license.htm</licenseUrl>
+    <projectUrl>$PROJECT_URL$</projectUrl>
+    <requireLicenseAcceptance>true</requireLicenseAcceptance>
+    <description>$FRIENDLY_NAME$ ($ARCH$) Windows Installer MSI as a .nupkg for internal Visual Studio build consumption</description>
+    <copyright>© Microsoft Corporation. All rights reserved.</copyright>
+  </metadata>
+  <files>
+    <file src="$COMPONENT_MSI$" />
+  </files>
+</package>

--- a/src/pkg/packaging/windows/vscomponents/generatenupkg.ps1
+++ b/src/pkg/packaging/windows/vscomponents/generatenupkg.ps1
@@ -1,0 +1,35 @@
+# Copyright (c) .NET Foundation and contributors. All rights reserved.
+# Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+param(
+    [Parameter(Mandatory=$true)][string]$MsiPath,
+    [Parameter(Mandatory=$true)][string]$MsiVersion,
+    [Parameter(Mandatory=$true)][string]$NuspecFile,
+    [Parameter(Mandatory=$true)][string]$NupkgFile,
+    [Parameter(Mandatory=$true)][string]$Architecture,
+    [Parameter(Mandatory=$true)][string]$ComponentName,
+    [Parameter(Mandatory=$true)][string]$ComponentFriendlyName,
+    [Parameter(Mandatory=$true)][string]$ProjectUrl,
+    [Parameter(Mandatory=$true)][string]$BinDir
+)
+
+$NuGetDir = Join-Path $BinDir  "nuget"
+$NuGetExe = Join-Path $NuGetDir "nuget.exe"
+$OutputDirectory = [System.IO.Path]::GetDirectoryName($NupkgFile)
+
+if (-not (Test-Path $NuGetDir)) {
+    New-Item -ItemType Directory -Force -Path $NuGetDir | Out-Null
+}
+
+if (-not (Test-Path $NuGetExe)) {
+    # Using 3.5.0 to workaround https://github.com/NuGet/Home/issues/5016
+    Write-Output "Downloading nuget.exe to $NuGetExe"
+    wget https://dist.nuget.org/win-x86-commandline/v3.5.0/nuget.exe -OutFile $NuGetExe
+}
+
+if (Test-Path $NupkgFile) {
+    Remove-Item -Force $NupkgFile
+}
+
+& $NuGetExe pack $NuspecFile -Version $MsiVersion -OutputDirectory $OutputDirectory -NoDefaultExcludes -NoPackageAnalysis -Properties COMPONENT_MSI=$MsiPath`;ARCH=$Architecture`;COMPONENT_NAME=$ComponentName`;FRIENDLY_NAME=$ComponentFriendlyName`;PROJECT_URL=$ProjectUrl
+Exit $LastExitCode


### PR DESCRIPTION
Ports https://github.com/dotnet/core-setup/pull/7968 to `release/2.2` for https://github.com/dotnet/core-setup/issues/7730:

> Note that this PR only generates the VS insertion nupkgs: publishing these will be done by adding a ProdCon v1 infra feature.
> 
> #### Description
> 
> Ports https://github.com/dotnet/core-setup/pull/6913 to `release/2.1` for the basic infra that produces a nupkg for each MSI. This nupkg is used in VS insertions to reduce maintenance cost. This is part of the effort to simplify SDK servicing.
> 
> Ports https://github.com/dotnet/core-setup/pull/7032 on top to fix a signing bug the initial implementation had.
> 
> Also includes some new changes to work in `release/2.1`. This branch only builds 3 MSIs (per arch) compared to the many produced in 3.0, so most configurations are removed.
> 
> #### Customer Impact
> 
> Nothing noticeable. This allows the build to generate the VS insertion packages automatically. Without this, I have to generate the VS insertion package manually.
> 
> #### Regression?
> 
> No.
> 
> #### Risk
> 
> Minimal. The same infra has worked to release from `release/3.0`, where the signing issue was worked out, and the changes are fairly small to get it ported to `release/2.1`.