### PR TITLE
Switch to label.N form for pre-release label

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -4,7 +4,8 @@
     <MajorVersion>5</MajorVersion>
     <MinorVersion>0</MinorVersion>
     <PatchVersion>0</PatchVersion>
-    <PreReleaseVersionLabel>alpha1</PreReleaseVersionLabel>
+    <PreReleaseVersionLabel>alpha</PreReleaseVersionLabel>
+    <PreReleaseVersionIteration>1</PreReleaseVersionIteration>
     <ReleaseBrandSuffix>Alpha 1</ReleaseBrandSuffix>
     <!-- Enable to remove prerelease label. -->
     <StabilizePackageVersion Condition="'$(StabilizePackageVersion)' == ''">false</StabilizePackageVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -6,7 +6,6 @@
     <PatchVersion>0</PatchVersion>
     <PreReleaseVersionLabel>alpha</PreReleaseVersionLabel>
     <PreReleaseVersionIteration>1</PreReleaseVersionIteration>
-    <ReleaseBrandSuffix>Alpha 1</ReleaseBrandSuffix>
     <!-- Enable to remove prerelease label. -->
     <StabilizePackageVersion Condition="'$(StabilizePackageVersion)' == ''">false</StabilizePackageVersion>
     <DotNetFinalVersionKind Condition="'$(StabilizePackageVersion)' == 'true'">release</DotNetFinalVersionKind>

--- a/src/pkg/Directory.Build.targets
+++ b/src/pkg/Directory.Build.targets
@@ -14,11 +14,13 @@
       Condition="
         '$(ReleaseBrandSuffix)' == '' and
         '$(PreReleaseVersionLabel)' != '' and
-        $(PreReleaseVersionLabel.StartsWith('preview'))">
-      <!-- Convert 'preview7' to 'Preview 7'. -->
+        '$(PreReleaseVersionIteration)' != ''">
+      <!-- Convert 'preview.7' to 'Preview 7'.
+          'preview' will come from the pre-release version iteration and the numeric value
+          will be the PreReleaseVersionIteration. -->
+
       <ReleaseBrandSuffix>$(PreReleaseVersionLabel.Substring(0,1).ToUpperInvariant())</ReleaseBrandSuffix>
-      <ReleaseBrandSuffix>$(ReleaseBrandSuffix)$(PreReleaseVersionLabel.Substring(1,6))</ReleaseBrandSuffix>
-      <ReleaseBrandSuffix>$(ReleaseBrandSuffix) $(PreReleaseVersionLabel.Substring(7))</ReleaseBrandSuffix>
+      <ReleaseBrandSuffix>$(ReleaseBrandSuffix) $(PreReleaseVersionIteration)</ReleaseBrandSuffix>
     </PropertyGroup>
 
     <PropertyGroup>

--- a/src/pkg/Directory.Build.targets
+++ b/src/pkg/Directory.Build.targets
@@ -20,6 +20,7 @@
           will be the PreReleaseVersionIteration. -->
 
       <ReleaseBrandSuffix>$(PreReleaseVersionLabel.Substring(0,1).ToUpperInvariant())</ReleaseBrandSuffix>
+      <ReleaseBrandSuffix>$(ReleaseBrandSuffix)$(PreReleaseVersionLabel.Substring(1))</ReleaseBrandSuffix>
       <ReleaseBrandSuffix>$(ReleaseBrandSuffix) $(PreReleaseVersionIteration)</ReleaseBrandSuffix>
     </PropertyGroup>
 


### PR DESCRIPTION
In order to facilitate better preview sorting, switch to label.N form for the pre-release label.