### PR TITLE
Add value of multilevel lookup to log

### DIFF
--- a/src/corehost/common/utils.cpp
+++ b/src/corehost/common/utils.cpp
@@ -272,7 +272,9 @@ bool multilevel_lookup_enabled()
     {
         auto env_val = pal::xtoi(env_lookup.c_str());
         multilevel_lookup = (env_val == 1);
+        trace::verbose(_X("DOTNET_MULTILEVEL_LOOKUP is set to %s"), env_lookup.c_str());
     }
+    trace::info(_X("Multilevel lookup is %s"), multilevel_lookup ? _X("true") : _X("false"));
     return multilevel_lookup;
 }
 


### PR DESCRIPTION
eg
```
--- Resolving FX directory, name 'Microsoft.NETCore.App' version '3.0.0'
DOTNET_MULTILEVEL_LOOKUP is set to 0
Multilevel lookup is false
Searching FX directory in [C:\Program Files\dotnet]
```

I was trying to figure out how to get it to load my private coreclr. Evidently setting this is not enough, but nevertheless, it ought to be logged.