### PR TITLE
[release/3.0] Source-build patch: Use RefOnly prefix to pin ref only versions

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -69,15 +69,19 @@
     <!-- wpf-int -->
     <MicrosoftDotNetWpfDncEngPackageVersion>4.8.0-servicing.19510.12</MicrosoftDotNetWpfDncEngPackageVersion>
     <!-- Not auto-updated. -->
-    <MicrosoftBuildPackageVersion>15.7.179</MicrosoftBuildPackageVersion>
-    <MicrosoftBuildFrameworkPackageVersion>$(MicrosoftBuildPackageVersion)</MicrosoftBuildFrameworkPackageVersion>
-    <MicrosoftBuildTasksCorePackageVersion>$(MicrosoftBuildPackageVersion)</MicrosoftBuildTasksCorePackageVersion>
-    <MicrosoftBuildUtilitiesCorePackageVersion>$(MicrosoftBuildPackageVersion)</MicrosoftBuildUtilitiesCorePackageVersion>
     <MicrosoftDotNetPlatformAbstractionsPackageVersion>1.1.1</MicrosoftDotNetPlatformAbstractionsPackageVersion>
-    <NugetProjectModelPackageVersion>4.9.4</NugetProjectModelPackageVersion>
-    <NugetPackagingPackageVersion>4.9.4</NugetPackagingPackageVersion>
     <MicrosoftTargetingPackPrivateWinRTPackageVersion>1.0.5</MicrosoftTargetingPackPrivateWinRTPackageVersion>
     <MicrosoftDiaSymReaderNativePackageVersion>1.7.0</MicrosoftDiaSymReaderNativePackageVersion>
+    <!--
+      These are used as reference assemblies only, so they must not take a ProdCon/source-build
+      version. Insert "RefOnly" to avoid assignment via PVP.
+    -->
+    <RefOnlyMicrosoftBuildPackageVersion>15.7.179</RefOnlyMicrosoftBuildPackageVersion>
+    <RefOnlyMicrosoftBuildFrameworkPackageVersion>$(RefOnlyMicrosoftBuildPackageVersion)</RefOnlyMicrosoftBuildFrameworkPackageVersion>
+    <RefOnlyMicrosoftBuildTasksCorePackageVersion>$(RefOnlyMicrosoftBuildPackageVersion)</RefOnlyMicrosoftBuildTasksCorePackageVersion>
+    <RefOnlyMicrosoftBuildUtilitiesCorePackageVersion>$(RefOnlyMicrosoftBuildPackageVersion)</RefOnlyMicrosoftBuildUtilitiesCorePackageVersion>
+    <RefOnlyNugetProjectModelPackageVersion>4.9.4</RefOnlyNugetProjectModelPackageVersion>
+    <RefOnlyNugetPackagingPackageVersion>4.9.4</RefOnlyNugetPackagingPackageVersion>
   </PropertyGroup>
   <!--Package names-->
   <PropertyGroup>

--- a/src/test/Microsoft.DotNet.CoreSetup.Packaging.Tests/Microsoft.DotNet.CoreSetup.Packaging.Tests.csproj
+++ b/src/test/Microsoft.DotNet.CoreSetup.Packaging.Tests/Microsoft.DotNet.CoreSetup.Packaging.Tests.csproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NuGet.Packaging" Version="$(NugetPackagingPackageVersion)" />
+    <PackageReference Include="NuGet.Packaging" Version="$(RefOnlyNugetPackagingPackageVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tools-local/tasks/core-setup.tasks.csproj
+++ b/tools-local/tasks/core-setup.tasks.csproj
@@ -15,16 +15,16 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="NuGet.ProjectModel" Version="$(NugetProjectModelPackageVersion)" />
+    <PackageReference Include="NuGet.ProjectModel" Version="$(RefOnlyNugetProjectModelPackageVersion)" />
     <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="2.1.0" />
     <PackageReference Include="Microsoft.DotNet.PlatformAbstractions" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' != 'net46'">
-    <PackageReference Include="Microsoft.Build" Version="$(MicrosoftBuildPackageVersion)" />
-    <PackageReference Include="Microsoft.Build.Framework" Version="$(MicrosoftBuildFrameworkPackageVersion)" />
-    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="$(MicrosoftBuildTasksCorePackageVersion)" />
-    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="$(MicrosoftBuildUtilitiesCorePackageVersion)" />
+    <PackageReference Include="Microsoft.Build" Version="$(RefOnlyMicrosoftBuildPackageVersion)" />
+    <PackageReference Include="Microsoft.Build.Framework" Version="$(RefOnlyMicrosoftBuildFrameworkPackageVersion)" />
+    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="$(RefOnlyMicrosoftBuildTasksCorePackageVersion)" />
+    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="$(RefOnlyMicrosoftBuildUtilitiesCorePackageVersion)" />
 
     <PackageReference Include="System.Diagnostics.FileVersionInfo" Version="4.0.0" />
   </ItemGroup>


### PR DESCRIPTION
#### Description

Ports https://github.com/dotnet/core-setup/pull/8693 to `release/3.0`. This incorporates a source-build patch "[0001-Use-pinned-version-of-MSBuild-reference-assemblies.patch](https://github.com/dotnet/source-build/blob/3ecb90b0fcac9c294a22a16fbababe333c06c17b/patches/core-setup/0001-Use-pinned-version-of-MSBuild-reference-assemblies.patch)", reducing maintenance cost.

(Related: the `release/3.1` port, PR https://github.com/dotnet/core-setup/pull/8696.)

#### Customer Impact

Slightly more reliable source-build availability for 3.0 servicing releases due to reduced amount of source-build code requiring manual maintenance.

#### Regression?

No.

#### Risk

Low, the worst case I can imagine is this causing a build break very early in the build while trying to compile the local build tasks. It would be easy to detect and revert. It's also very unlikely: this change has gone through PR validation builds in `master` and been tried out in the context of a full source-build.