### PR TITLE
Use PackageLicenseExpression for Setup nupkgs

### DIFF
--- a/src/pkg/Directory.Build.props
+++ b/src/pkg/Directory.Build.props
@@ -9,7 +9,7 @@
   <PropertyGroup>
     <PackageLicenseFile>$(RepoRoot)LICENSE.TXT</PackageLicenseFile>
     <PackageThirdPartyNoticesFile>$(RepoRoot)THIRD-PARTY-NOTICES.TXT</PackageThirdPartyNoticesFile>
-    <LicenseUrl Condition="'$(LicenseUrl)' == ''">https://github.com/dotnet/core-setup/blob/master/LICENSE.TXT</LicenseUrl>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageDescriptionFile>$(InstallerProjectRoot)pkg/projects/descriptions.json</PackageDescriptionFile>
     <!-- This link should be updated for each release milestone, currently this points to 1.0.0 -->
     <ReleaseNotes>https://go.microsoft.com/fwlink/?LinkID=799417</ReleaseNotes>


### PR DESCRIPTION
For https://github.com/dotnet/core-setup/issues/8694. Make the license self-contained by using `PackageLicenseExpression` rather than `LicenseUrl`. Result in nuspec:

```
    <license type="expression">MIT</license>
    <licenseUrl>https://licenses.nuget.org/MIT</licenseUrl>
```