### PR TITLE
[release/3.1] Use PackageLicenseExpression for Setup nupkgs

### DIFF
--- a/src/pkg/Directory.Build.props
+++ b/src/pkg/Directory.Build.props
@@ -9,7 +9,7 @@
   <PropertyGroup>
     <PackageLicenseFile>$(ProjectDir)LICENSE.TXT</PackageLicenseFile>
     <PackageThirdPartyNoticesFile>$(ProjectDir)THIRD-PARTY-NOTICES.TXT</PackageThirdPartyNoticesFile>
-    <LicenseUrl>https://github.com/dotnet/core-setup/blob/master/LICENSE.TXT</LicenseUrl>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageDescriptionFile>$(ProjectDir)src/pkg/projects/descriptions.json</PackageDescriptionFile>
     <!-- This link should be updated for each release milestone, currently this points to 1.0.0 -->
     <ReleaseNotes>https://go.microsoft.com/fwlink/?LinkID=799417</ReleaseNotes>


### PR DESCRIPTION
#### Description

For https://github.com/dotnet/core-setup/issues/8694. Makes the license in the Core-Setup NuGet packages self-contained by using `PackageLicenseExpression` rather than `LicenseUrl`.

The same change is in PR for Core-Setup 3.1 here: https://github.com/dotnet/corefx/pull/42277. Customer impact and risk are the same, copied below.

#### Customer Impact

> NuGet doesn't classify our license as MIT, URL may be disrupted by repo-consolidation resulting in broken links resulting in 404's in the future.

#### Regression?

No.

#### Risk

> Low. This is a build/package-metadata-only change. If it builds it should be good, other parts of the stack have been using this feature without issue.