### PR TITLE
Remove dependency on core-setup property in task

### DIFF
--- a/tools-local/tasks/installer.tasks/installer.tasks.csproj
+++ b/tools-local/tasks/installer.tasks/installer.tasks.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
-    <TargetFrameworks Condition="'$(RunningOnUnix)' != 'true'">$(TargetFrameworks);net46</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">$(TargetFrameworks);net46</TargetFrameworks>
     <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
   </PropertyGroup>
 


### PR DESCRIPTION
`RunningOnUnix` is currently a custom defined property in core-setup. Removing its usage in installer.tasks to make it work correctly in the runtime repository on Unix.