### PR TITLE
Use Version suffix and clean versions

### DIFF
--- a/eng/Tools.props
+++ b/eng/Tools.props
@@ -3,13 +3,13 @@
   <!-- source-built packages -->
   <ItemGroup>
     <!-- arcade -->
-    <PackageReference Include="Microsoft.DotNet.Build.Tasks.Packaging" Version="$(MicrosoftDotNetBuildTasksPackagingPackageVersion)" />
+    <PackageReference Include="Microsoft.DotNet.Build.Tasks.Packaging" Version="$(MicrosoftDotNetBuildTasksPackagingVersion)" />
   </ItemGroup>
 
   <!-- excluded from source build -->
   <ItemGroup Condition="'$(DotNetBuildFromSource)' != 'true'">
-    <PackageReference Include="Microsoft.DotNet.Build.Tasks.Feed" Version="$(MicrosoftDotNetBuildTasksFeedPackageVersion)" />
-    <PackageReference Include="Microsoft.DotNet.VersionTools.Tasks" Version="$(MicrosoftDotNetVersionToolsTasksPackageVersion)" />
+    <PackageReference Include="Microsoft.DotNet.Build.Tasks.Feed" Version="$(MicrosoftDotNetBuildTasksFeedVersion)" />
+    <PackageReference Include="Microsoft.DotNet.VersionTools.Tasks" Version="$(MicrosoftDotNetVersionToolsTasksVersion)" />
 
     <!-- SourceLink -->
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="$(MicrosoftSourceLinkVersion)" PrivateAssets="all" IsImplicitlyDefined="true" />

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -21,7 +21,7 @@
       <Uri>https://github.com/dotnet/corefx</Uri>
       <Sha>dd2ad4367bc4e070f3e8ca81ca6421db5733e731</Sha>
     </Dependency>
-    <Dependency Name="NETStandard.Library" Version="2.2.0-prerelease.19531.1">
+    <Dependency Name="NETStandard.Library" Version="2.2.0-prerelease.19551.1">
       <Uri>https://github.com/dotnet/standard</Uri>
       <Sha>1063b6811691a2e009d7733cbf68f897511f00b2</Sha>
     </Dependency>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -13,91 +13,11 @@
       <Uri>https://github.com/dotnet/corefx</Uri>
       <Sha>a24db0ba5666f46f50649810fe698ad267b60331</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Win32.Registry" Version="5.0.0-alpha.1.19531.13">
-      <Uri>https://github.com/dotnet/corefx</Uri>
-      <Sha>a24db0ba5666f46f50649810fe698ad267b60331</Sha>
-    </Dependency>
-    <Dependency Name="Microsoft.Win32.SystemEvents" Version="5.0.0-alpha.1.19531.13">
-      <Uri>https://github.com/dotnet/corefx</Uri>
-      <Sha>a24db0ba5666f46f50649810fe698ad267b60331</Sha>
-    </Dependency>
-    <Dependency Name="Microsoft.Windows.Compatibility" Version="5.0.0-alpha.1.19531.13">
-      <Uri>https://github.com/dotnet/corefx</Uri>
-      <Sha>a24db0ba5666f46f50649810fe698ad267b60331</Sha>
-    </Dependency>
-    <Dependency Name="System.CodeDom" Version="5.0.0-alpha.1.19531.13">
-      <Uri>https://github.com/dotnet/corefx</Uri>
-      <Sha>a24db0ba5666f46f50649810fe698ad267b60331</Sha>
-    </Dependency>
-    <Dependency Name="System.Configuration.ConfigurationManager" Version="5.0.0-alpha.1.19531.13">
-      <Uri>https://github.com/dotnet/corefx</Uri>
-      <Sha>a24db0ba5666f46f50649810fe698ad267b60331</Sha>
-    </Dependency>
-    <Dependency Name="System.Diagnostics.EventLog" Version="5.0.0-alpha.1.19531.13">
-      <Uri>https://github.com/dotnet/corefx</Uri>
-      <Sha>a24db0ba5666f46f50649810fe698ad267b60331</Sha>
-    </Dependency>
-    <Dependency Name="System.DirectoryServices" Version="5.0.0-alpha.1.19531.13">
-      <Uri>https://github.com/dotnet/corefx</Uri>
-      <Sha>a24db0ba5666f46f50649810fe698ad267b60331</Sha>
-    </Dependency>
-    <Dependency Name="System.Drawing.Common" Version="5.0.0-alpha.1.19531.13">
-      <Uri>https://github.com/dotnet/corefx</Uri>
-      <Sha>a24db0ba5666f46f50649810fe698ad267b60331</Sha>
-    </Dependency>
-    <Dependency Name="System.IO.FileSystem.AccessControl" Version="5.0.0-alpha.1.19531.13">
-      <Uri>https://github.com/dotnet/corefx</Uri>
-      <Sha>a24db0ba5666f46f50649810fe698ad267b60331</Sha>
-    </Dependency>
-    <Dependency Name="System.Resources.Extensions" Version="5.0.0-alpha.1.19531.13">
-      <Uri>https://github.com/dotnet/corefx</Uri>
-      <Sha>a24db0ba5666f46f50649810fe698ad267b60331</Sha>
-    </Dependency>
-    <Dependency Name="System.IO.Packaging" Version="5.0.0-alpha.1.19531.13">
-      <Uri>https://github.com/dotnet/corefx</Uri>
-      <Sha>a24db0ba5666f46f50649810fe698ad267b60331</Sha>
-    </Dependency>
-    <Dependency Name="System.Security.AccessControl" Version="5.0.0-alpha.1.19531.13">
-      <Uri>https://github.com/dotnet/corefx</Uri>
-      <Sha>a24db0ba5666f46f50649810fe698ad267b60331</Sha>
-    </Dependency>
-    <Dependency Name="System.Security.Cryptography.Cng" Version="5.0.0-alpha.1.19531.13">
-      <Uri>https://github.com/dotnet/corefx</Uri>
-      <Sha>a24db0ba5666f46f50649810fe698ad267b60331</Sha>
-    </Dependency>
-    <Dependency Name="System.Security.Cryptography.Pkcs" Version="5.0.0-alpha.1.19531.13">
-      <Uri>https://github.com/dotnet/corefx</Uri>
-      <Sha>a24db0ba5666f46f50649810fe698ad267b60331</Sha>
-    </Dependency>
-    <Dependency Name="System.Security.Cryptography.ProtectedData" Version="5.0.0-alpha.1.19531.13">
-      <Uri>https://github.com/dotnet/corefx</Uri>
-      <Sha>a24db0ba5666f46f50649810fe698ad267b60331</Sha>
-    </Dependency>
-    <Dependency Name="System.Security.Cryptography.Xml" Version="5.0.0-alpha.1.19531.13">
-      <Uri>https://github.com/dotnet/corefx</Uri>
-      <Sha>a24db0ba5666f46f50649810fe698ad267b60331</Sha>
-    </Dependency>
-    <Dependency Name="System.Security.Permissions" Version="5.0.0-alpha.1.19531.13">
-      <Uri>https://github.com/dotnet/corefx</Uri>
-      <Sha>a24db0ba5666f46f50649810fe698ad267b60331</Sha>
-    </Dependency>
-    <Dependency Name="System.Security.Principal.Windows" Version="5.0.0-alpha.1.19531.13">
-      <Uri>https://github.com/dotnet/corefx</Uri>
-      <Sha>a24db0ba5666f46f50649810fe698ad267b60331</Sha>
-    </Dependency>
     <Dependency Name="System.Text.Encodings.Web" Version="5.0.0-alpha.1.19531.13">
       <Uri>https://github.com/dotnet/corefx</Uri>
       <Sha>a24db0ba5666f46f50649810fe698ad267b60331</Sha>
     </Dependency>
     <Dependency Name="System.Text.Json" Version="5.0.0-alpha.1.19531.13">
-      <Uri>https://github.com/dotnet/corefx</Uri>
-      <Sha>a24db0ba5666f46f50649810fe698ad267b60331</Sha>
-    </Dependency>
-    <Dependency Name="System.Threading.AccessControl" Version="5.0.0-alpha.1.19531.13">
-      <Uri>https://github.com/dotnet/corefx</Uri>
-      <Sha>a24db0ba5666f46f50649810fe698ad267b60331</Sha>
-    </Dependency>
-    <Dependency Name="System.Windows.Extensions" Version="5.0.0-alpha.1.19531.13">
       <Uri>https://github.com/dotnet/corefx</Uri>
       <Sha>a24db0ba5666f46f50649810fe698ad267b60331</Sha>
     </Dependency>
@@ -134,11 +54,6 @@
     <Dependency Name="Microsoft.DotNet.XUnitExtensions" Version="5.0.0-beta.19530.15">
       <Uri>https://github.com/dotnet/arcade</Uri>
       <Sha>35c10b82920baacbb3945fd952a0e49c4caec708</Sha>
-    </Dependency>
-    <Dependency Name="Microsoft.SourceLink" Version="1.0.0-beta2-19367-01">
-      <Uri>https://github.com/dotnet/sourcelink</Uri>
-      <Sha>
-      </Sha>
     </Dependency>
   </ToolsetDependencies>
 </Dependencies>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -19,72 +19,41 @@
     <NETCoreAppFrameworkVersion>$(MajorVersion).$(MinorVersion)</NETCoreAppFrameworkVersion>
     <NETCoreAppFramework>netcoreapp$(NETCoreAppFrameworkVersion)</NETCoreAppFramework>
   </PropertyGroup>
-  <PropertyGroup>
-    <MicrosoftDotNetMaestroTasksVersion>1.0.0-beta.18619.4</MicrosoftDotNetMaestroTasksVersion>
-  </PropertyGroup>
   <!--Package versions-->
   <PropertyGroup>
     <!-- arcade -->
-    <MicrosoftDotNetBuildTasksFeedPackageVersion>5.0.0-beta.19530.15</MicrosoftDotNetBuildTasksFeedPackageVersion>
-    <MicrosoftDotNetBuildTasksPackagingPackageVersion>5.0.0-beta.19530.15</MicrosoftDotNetBuildTasksPackagingPackageVersion>
-    <MicrosoftDotNetVersionToolsTasksPackageVersion>5.0.0-beta.19530.15</MicrosoftDotNetVersionToolsTasksPackageVersion>
-    <MicrosoftDotNetXUnitExtensionsPackageVersion>5.0.0-beta.19530.15</MicrosoftDotNetXUnitExtensionsPackageVersion>
+    <MicrosoftDotNetBuildTasksFeedVersion>5.0.0-beta.19530.15</MicrosoftDotNetBuildTasksFeedVersion>
+    <MicrosoftDotNetBuildTasksPackagingVersion>5.0.0-beta.19530.15</MicrosoftDotNetBuildTasksPackagingVersion>
+    <MicrosoftDotNetVersionToolsTasksVersion>5.0.0-beta.19530.15</MicrosoftDotNetVersionToolsTasksVersion>
+    <MicrosoftDotNetXUnitExtensionsVersion>5.0.0-beta.19530.15</MicrosoftDotNetXUnitExtensionsVersion>
     <!-- Testing -->
-    <XUnitPackageVersion>2.4.1</XUnitPackageVersion>
+    <XUnitVersion>2.4.1</XUnitVersion>
     <!-- core-setup -->
-    <MicrosoftExtensionsDependencyModelPackageVersion>2.1.0</MicrosoftExtensionsDependencyModelPackageVersion>
-    <MicrosoftDotNetPlatformAbstractionsPackageVersion>3.0.0</MicrosoftDotNetPlatformAbstractionsPackageVersion>
-    <!-- sourcelink -->
-    <MicrosoftSourceLinkVersion>1.0.0-beta2-19367-01</MicrosoftSourceLinkVersion>
+    <MicrosoftExtensionsDependencyModelVersion>2.1.0</MicrosoftExtensionsDependencyModelVersion>
+    <MicrosoftDotNetPlatformAbstractionsVersion>3.0.0</MicrosoftDotNetPlatformAbstractionsVersion>
     <!-- corefx -->
-    <MicrosoftNETCorePlatformsPackageVersion>5.0.0-alpha.1.19531.13</MicrosoftNETCorePlatformsPackageVersion>
-    <MicrosoftNETCoreTargetsPackageVersion>5.0.0-alpha.1.19531.13</MicrosoftNETCoreTargetsPackageVersion>
-    <MicrosoftPrivateCoreFxNETCoreAppPackageVersion>5.0.0-alpha.1.19531.13</MicrosoftPrivateCoreFxNETCoreAppPackageVersion>
-    <MicrosoftWin32RegistryVersion>5.0.0-alpha.1.19531.13</MicrosoftWin32RegistryVersion>
-    <MicrosoftWin32SystemEventsVersion>5.0.0-alpha.1.19531.13</MicrosoftWin32SystemEventsVersion>
-    <MicrosoftWindowsCompatibilityPackageVersion>5.0.0-alpha.1.19531.13</MicrosoftWindowsCompatibilityPackageVersion>
-    <SystemCodeDomVersion>5.0.0-alpha.1.19531.13</SystemCodeDomVersion>
-    <SystemConfigurationConfigurationManagerVersion>5.0.0-alpha.1.19531.13</SystemConfigurationConfigurationManagerVersion>
-    <SystemDiagnosticsEventLogVersion>5.0.0-alpha.1.19531.13</SystemDiagnosticsEventLogVersion>
-    <SystemDirectoryServicesVersion>5.0.0-alpha.1.19531.13</SystemDirectoryServicesVersion>
-    <SystemDrawingCommonVersion>5.0.0-alpha.1.19531.13</SystemDrawingCommonVersion>
-    <SystemIOFileSystemAccessControlVersion>5.0.0-alpha.1.19531.13</SystemIOFileSystemAccessControlVersion>
-    <SystemIOPackagingVersion>5.0.0-alpha.1.19531.13</SystemIOPackagingVersion>
-    <SystemResourcesExtensionsPackageVersion>5.0.0-alpha.1.19531.13</SystemResourcesExtensionsPackageVersion>
-    <SystemSecurityAccessControlVersion>5.0.0-alpha.1.19531.13</SystemSecurityAccessControlVersion>
-    <SystemSecurityCryptographyCngVersion>5.0.0-alpha.1.19531.13</SystemSecurityCryptographyCngVersion>
-    <SystemSecurityCryptographyPkcsVersion>5.0.0-alpha.1.19531.13</SystemSecurityCryptographyPkcsVersion>
-    <SystemSecurityCryptographyProtectedDataVersion>5.0.0-alpha.1.19531.13</SystemSecurityCryptographyProtectedDataVersion>
-    <SystemSecurityCryptographyXmlVersion>5.0.0-alpha.1.19531.13</SystemSecurityCryptographyXmlVersion>
-    <SystemSecurityPermissionsVersion>5.0.0-alpha.1.19531.13</SystemSecurityPermissionsVersion>
-    <SystemSecurityPrincipalWindowsVersion>5.0.0-alpha.1.19531.13</SystemSecurityPrincipalWindowsVersion>
+    <MicrosoftNETCorePlatformsVersion>5.0.0-alpha.1.19531.13</MicrosoftNETCorePlatformsVersion>
+    <MicrosoftNETCoreTargetsVersion>5.0.0-alpha.1.19531.13</MicrosoftNETCoreTargetsVersion>
+    <MicrosoftPrivateCoreFxNETCoreAppVersion>5.0.0-alpha.1.19531.13</MicrosoftPrivateCoreFxNETCoreAppVersion>
     <SystemTextJsonVersion>5.0.0-alpha.1.19531.13</SystemTextJsonVersion>
     <SystemTextEncodingsWebVersion>5.0.0-alpha.1.19531.13</SystemTextEncodingsWebVersion>
-    <SystemThreadingAccessControlVersion>5.0.0-alpha.1.19531.13</SystemThreadingAccessControlVersion>
-    <SystemWindowsExtensionsPackageVersion>5.0.0-alpha.1.19531.13</SystemWindowsExtensionsPackageVersion>
     <!-- standard -->
-    <NETStandardLibraryPackageVersion>2.2.0-prerelease.19531.1</NETStandardLibraryPackageVersion>
+    <NETStandardLibraryVersion>2.2.0-prerelease.19531.1</NETStandardLibraryVersion>
     <!-- coreclr -->
-    <MicrosoftNETCoreRuntimeCoreCLRPackageVersion>5.0.0-alpha1.19525.1</MicrosoftNETCoreRuntimeCoreCLRPackageVersion>
-    <!-- winforms -->
-    <MicrosoftPrivateWinformsPackageVersion>5.0.0-alpha1.19480.6</MicrosoftPrivateWinformsPackageVersion>
-    <!-- wpf -->
-    <MicrosoftDotNetWpfGitHubPackageVersion>5.0.0-alpha1.19501.4</MicrosoftDotNetWpfGitHubPackageVersion>
-    <!-- wpf-int -->
-    <MicrosoftDotNetWpfDncEngPackageVersion>5.0.0-alpha1.19501.17</MicrosoftDotNetWpfDncEngPackageVersion>
+    <MicrosoftNETCoreRuntimeCoreCLRVersion>5.0.0-alpha1.19525.1</MicrosoftNETCoreRuntimeCoreCLRVersion>
     <!-- Not auto-updated. -->
-    <MicrosoftTargetingPackPrivateWinRTPackageVersion>1.0.5</MicrosoftTargetingPackPrivateWinRTPackageVersion>
-    <MicrosoftDiaSymReaderNativePackageVersion>1.7.0</MicrosoftDiaSymReaderNativePackageVersion>
+    <MicrosoftTargetingPackPrivateWinRTVersion>1.0.5</MicrosoftTargetingPackPrivateWinRTVersion>
+    <MicrosoftDiaSymReaderNativeVersion>1.7.0</MicrosoftDiaSymReaderNativeVersion>
     <!--
       These are used as reference assemblies only, so they must not take a ProdCon/source-build
       version. Insert "RefOnly" to avoid assignment via PVP.
     -->
-    <RefOnlyMicrosoftBuildPackageVersion>15.7.179</RefOnlyMicrosoftBuildPackageVersion>
-    <RefOnlyMicrosoftBuildFrameworkPackageVersion>$(RefOnlyMicrosoftBuildPackageVersion)</RefOnlyMicrosoftBuildFrameworkPackageVersion>
-    <RefOnlyMicrosoftBuildTasksCorePackageVersion>$(RefOnlyMicrosoftBuildPackageVersion)</RefOnlyMicrosoftBuildTasksCorePackageVersion>
-    <RefOnlyMicrosoftBuildUtilitiesCorePackageVersion>$(RefOnlyMicrosoftBuildPackageVersion)</RefOnlyMicrosoftBuildUtilitiesCorePackageVersion>
-    <RefOnlyNugetProjectModelPackageVersion>4.9.4</RefOnlyNugetProjectModelPackageVersion>
-    <RefOnlyNugetPackagingPackageVersion>4.9.4</RefOnlyNugetPackagingPackageVersion>
+    <RefOnlyMicrosoftBuildVersion>15.7.179</RefOnlyMicrosoftBuildVersion>
+    <RefOnlyMicrosoftBuildFrameworkVersion>$(RefOnlyMicrosoftBuildVersion)</RefOnlyMicrosoftBuildFrameworkVersion>
+    <RefOnlyMicrosoftBuildTasksCoreVersion>$(RefOnlyMicrosoftBuildVersion)</RefOnlyMicrosoftBuildTasksCoreVersion>
+    <RefOnlyMicrosoftBuildUtilitiesCoreVersion>$(RefOnlyMicrosoftBuildVersion)</RefOnlyMicrosoftBuildUtilitiesCoreVersion>
+    <RefOnlyNugetProjectModelVersion>4.9.4</RefOnlyNugetProjectModelVersion>
+    <RefOnlyNugetPackagingVersion>4.9.4</RefOnlyNugetPackagingVersion>
   </PropertyGroup>
   <!--Package names-->
   <PropertyGroup>
@@ -92,10 +61,8 @@
     <MicrosoftPrivateCoreFxNETCoreAppPackage>Microsoft.Private.CoreFx.NETCoreApp</MicrosoftPrivateCoreFxNETCoreAppPackage>
     <MicrosoftNETCorePlatformsPackage>Microsoft.NETCore.Platforms</MicrosoftNETCorePlatformsPackage>
     <MicrosoftNETCoreTargetsPackage>Microsoft.NETCore.Targets</MicrosoftNETCoreTargetsPackage>
-    <NETStandardLibraryPackage>NETStandard.Library</NETStandardLibraryPackage>
+    <NETStandardLibraryPackage>netstandard.library</NETStandardLibraryPackage>
     <MicrosoftNETCoreRuntimeCoreCLRPackage>Microsoft.NETCore.Runtime.CoreCLR</MicrosoftNETCoreRuntimeCoreCLRPackage>
-    <MicrosoftBclJsonSourcesPackage>Microsoft.Bcl.Json.Sources</MicrosoftBclJsonSourcesPackage>
     <MicrosoftTargetingPackPrivateWinRTPackage>Microsoft.TargetingPack.Private.WinRT</MicrosoftTargetingPackPrivateWinRTPackage>
-    <MicrosoftSymbolUploaderBuildTaskPackage>Microsoft.SymbolUploader.Build.Task</MicrosoftSymbolUploaderBuildTaskPackage>
   </PropertyGroup>
 </Project>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -22,10 +22,10 @@
   <!--Package versions-->
   <PropertyGroup>
     <!-- arcade -->
-    <MicrosoftDotNetBuildTasksFeedVersion>5.0.0-beta.19531.14</MicrosoftDotNetBuildTasksFeedPackageVersion>
-    <MicrosoftDotNetBuildTasksPackagingVersion>5.0.0-beta.19531.14</MicrosoftDotNetBuildTasksPackagingPackageVersion>
-    <MicrosoftDotNetVersionToolsTasksVersion>5.0.0-beta.19531.14</MicrosoftDotNetVersionToolsTasksPackageVersion>
-    <MicrosoftDotNetXUnitExtensionsVersion>5.0.0-beta.19531.14</MicrosoftDotNetXUnitExtensionsPackageVersion>
+    <MicrosoftDotNetBuildTasksFeedVersion>5.0.0-beta.19531.14</MicrosoftDotNetBuildTasksFeedVersion>
+    <MicrosoftDotNetBuildTasksPackagingVersion>5.0.0-beta.19531.14</MicrosoftDotNetBuildTasksPackagingVersion>
+    <MicrosoftDotNetVersionToolsTasksVersion>5.0.0-beta.19531.14</MicrosoftDotNetVersionToolsTasksVersion>
+    <MicrosoftDotNetXUnitExtensionsVersion>5.0.0-beta.19531.14</MicrosoftDotNetXUnitExtensionsVersion>
     <!-- Testing -->
     <XUnitVersion>2.4.1</XUnitVersion>
     <!-- core-setup -->

--- a/global.json
+++ b/global.json
@@ -9,6 +9,6 @@
   },
   "msbuild-sdks": {
     "Microsoft.DotNet.Arcade.Sdk": "5.0.0-beta.19530.15",
-    "Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk": "5.0.0-beta.19530.15"
+    "Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk": "5.0.0-beta.19551.2"
   }
 }

--- a/global.json
+++ b/global.json
@@ -8,7 +8,7 @@
     "dotnet": "3.0.100"
   },
   "msbuild-sdks": {
-    "Microsoft.DotNet.Arcade.Sdk": "5.0.0-beta.19531.14",
+    "Microsoft.DotNet.Arcade.Sdk": "5.0.0-beta.19551.2",
     "Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk": "5.0.0-beta.19551.2"
   }
 }

--- a/src/pkg/Directory.Build.targets
+++ b/src/pkg/Directory.Build.targets
@@ -2,7 +2,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory).., Directory.Build.targets))\Directory.Build.targets" />
 
   <PropertyGroup>
-    <RuntimeIdGraphDefinitionFile>$(NuGetPackageRoot)$(PlatformPackageId.ToLowerInvariant())\$(MicrosoftNETCorePlatformsPackageVersion)\runtime.json</RuntimeIdGraphDefinitionFile>
+    <RuntimeIdGraphDefinitionFile>$(NuGetPackageRoot)$(PlatformPackageId.ToLowerInvariant())\$(MicrosoftNETCorePlatformsVersion)\runtime.json</RuntimeIdGraphDefinitionFile>
   </PropertyGroup>
 
   <!--

--- a/src/pkg/deps/deps.csproj
+++ b/src/pkg/deps/deps.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NETCore.Platforms" Version="$(MicrosoftNETCorePlatformsPackageVersion)" />
+    <PackageReference Include="$(MicrosoftNETCorePlatformsPackage)" Version="$(MicrosoftNETCorePlatformsVersion)" />
   </ItemGroup>
 
 </Project>

--- a/src/pkg/projects/netcoreapp/pkg/workaround/Microsoft.NETCore.App.pkgproj
+++ b/src/pkg/projects/netcoreapp/pkg/workaround/Microsoft.NETCore.App.pkgproj
@@ -20,7 +20,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Dependency Include="Microsoft.NETCore.Platforms" Version="$(MicrosoftNETCorePlatformsPackageVersion)" />
+    <Dependency Include="$(MicrosoftNETCorePlatformsPackage)" Version="$(MicrosoftNETCorePlatformsVersion)" />
   </ItemGroup>
 
   <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />

--- a/src/pkg/projects/netcoreapp/src/localnetcoreapp.override.targets
+++ b/src/pkg/projects/netcoreapp/src/localnetcoreapp.override.targets
@@ -45,9 +45,9 @@
       <CoreFXSharedFrameworkImplementationPackageSpec Condition="'$(PackageRID)' != ''">$(CoreFXOverridePath)/specs/runtime.$(PackageRID).$(MicrosoftPrivateCoreFxNETCoreAppPackage).nuspec</CoreFXSharedFrameworkImplementationPackageSpec>
     </PropertyGroup>
     
-    <Error Condition="!Exists('$(CoreFXSharedFrameworkPackageSpec)')" Text="The nuspec for the reference Microsoft.Private.CoreFx.NETCoreApp package does not exist." />
+    <Error Condition="!Exists('$(CoreFXSharedFrameworkPackageSpec)')" Text="The nuspec for the reference $(MicrosoftPrivateCoreFxNETCoreAppPackage) package does not exist." />
     <Message Condition="'$(CoreFXSharedFrameworkImplementationPackageSpec)' != '' And !Exists('$(CoreFXSharedFrameworkImplementationPackageSpec)')"
-      Text="The nuspec for the implementation runtime.$(PackageRID).Microsoft.Private.CoreFx.NETCoreApp package does not exist. Falling back to packaged CoreFX." />
+      Text="The nuspec for the implementation runtime.$(PackageRID).$(MicrosoftPrivateCoreFxNETCoreAppPackage) package does not exist. Falling back to packaged CoreFX." />
 
     <XmlPeek
       Namespaces="&lt;Namespace Prefix='nuget' Uri='http://schemas.microsoft.com/packaging/2013/01/nuspec.xsd' /&gt;"
@@ -65,8 +65,8 @@
     </XmlPeek>
     
     <ItemGroup>
-      <CoreFXReferenceItems NuGetPackageId="Microsoft.Private.CoreFx.NETCoreApp" />
-      <CoreFXReferenceCopyLocalItems NuGetPackageId="runtime.$(PackageRID).Microsoft.Private.CoreFx.NETCoreApp" />
+      <CoreFXReferenceItems NuGetPackageId="$(MicrosoftPrivateCoreFxNETCoreAppPackage)" />
+      <CoreFXReferenceCopyLocalItems NuGetPackageId="runtime.$(PackageRID).$(MicrosoftPrivateCoreFxNETCoreAppPackage)" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/pkg/projects/netcoreapp/src/netcoreapp.depproj
+++ b/src/pkg/projects/netcoreapp/src/netcoreapp.depproj
@@ -5,16 +5,16 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Private.CoreFx.NETCoreApp" Version="$(MicrosoftPrivateCoreFxNETCoreAppPackageVersion)" />
-    <PackageReference Include="transport.Microsoft.NETCore.Runtime.CoreCLR" Version="$(MicrosoftNETCoreRuntimeCoreCLRPackageVersion)" />
-    <PackageReference Include="Microsoft.NETCore.Platforms" Version="$(MicrosoftNETCorePlatformsPackageVersion)" />
-    <PackageReference Include="Microsoft.NETCore.Targets" Version="$(MicrosoftNETCoreTargetsPackageVersion)" />
-    <PackageReference Include="NETStandard.Library" Version="$(NETStandardLibraryPackageVersion)" />
+    <PackageReference Include="$(MicrosoftPrivateCoreFxNETCoreAppPackage)" Version="$(MicrosoftPrivateCoreFxNETCoreAppVersion)" />
+    <PackageReference Include="transport.$(MicrosoftNETCoreRuntimeCoreCLRPackage)" Version="$(MicrosoftNETCoreRuntimeCoreCLRVersion)" />
+    <PackageReference Include="$(MicrosoftNETCorePlatformsPackage)" Version="$(MicrosoftNETCorePlatformsVersion)" />
+    <PackageReference Include="$(MicrosoftNETCoreTargetsPackage)" Version="$(MicrosoftNETCoreTargetsVersion)" />
+    <PackageReference Include="$(NETStandardLibraryPackage)" Version="$(NETStandardLibraryVersion)" />
   </ItemGroup>
 
   <!-- This tool is a prebuilt not buildable from source. -->
   <ItemGroup Condition="'$(DotNetBuildFromSource)' != 'true'">
-    <PackageReference Include="Microsoft.DiaSymReader.Native" Version="$(MicrosoftDiaSymReaderNativePackageVersion)" />
+    <PackageReference Include="Microsoft.DiaSymReader.Native" Version="$(MicrosoftDiaSymReaderNativeVersion)" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(PackageTargetRuntime)' == ''">

--- a/src/pkg/projects/netstandard/src/netstandard.depproj
+++ b/src/pkg/projects/netstandard/src/netstandard.depproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="$(NETStandardLibraryPackage)" Version="$(NETStandardLibraryPackageVersion)" />
+    <PackageReference Include="$(NETStandardLibraryPackage)" Version="$(NETStandardLibraryVersion)" />
   </ItemGroup>
 
   <!--
@@ -17,7 +17,7 @@
           BeforeTargets="GetFilesToPackage">
     <ItemGroup>
       <FilesToPackage
-        Include="$(NuGetPackageRoot)$(NETStandardLibraryPackage.ToLowerInvariant())\$(NETStandardLibraryPackageVersion)\build\$(NETStandardTargetFramework)\ref\*"
+        Include="$(NuGetPackageRoot)$(NETStandardLibraryPackage)\$(NETStandardLibraryVersion)\build\$(NETStandardTargetFramework)\ref\*"
         TargetPath="ref/$(NETStandardTargetFramework)" />
     </ItemGroup>
   </Target>

--- a/src/publish/Directory.Build.props
+++ b/src/publish/Directory.Build.props
@@ -24,8 +24,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="$(MicrosoftDotNetBuildTasksFeedPackage)" Version="$(MicrosoftDotNetBuildTasksFeedPackageVersion)" />
-    <PackageReference Include="Microsoft.DotNet.VersionTools.Tasks" Version="$(MicrosoftDotNetVersionToolsTasksPackageVersion)" />
+    <PackageReference Include="$(MicrosoftDotNetBuildTasksFeedPackage)" Version="$(MicrosoftDotNetBuildTasksFeedVersion)" />
+    <PackageReference Include="Microsoft.DotNet.VersionTools.Tasks" Version="$(MicrosoftDotNetVersionToolsTasksVersion)" />
   </ItemGroup>
 
 </Project>

--- a/src/test/HostActivation.Tests/HostActivation.Tests.csproj
+++ b/src/test/HostActivation.Tests/HostActivation.Tests.csproj
@@ -22,7 +22,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="2.1.0" />
-    <PackageReference Include="Microsoft.DotNet.PlatformAbstractions" Version="$(MicrosoftDotNetPlatformAbstractionsPackageVersion)" />
+    <PackageReference Include="Microsoft.DotNet.PlatformAbstractions" Version="$(MicrosoftDotNetPlatformAbstractionsVersion)" />
     <PackageReference Include="Microsoft.Win32.Registry" Version="4.3.0" />
   </ItemGroup>
 

--- a/src/test/Microsoft.DotNet.CoreSetup.Packaging.Tests/Microsoft.DotNet.CoreSetup.Packaging.Tests.csproj
+++ b/src/test/Microsoft.DotNet.CoreSetup.Packaging.Tests/Microsoft.DotNet.CoreSetup.Packaging.Tests.csproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NuGet.Packaging" Version="$(RefOnlyNugetPackagingPackageVersion)" />
+    <PackageReference Include="NuGet.Packaging" Version="$(RefOnlyNugetPackagingVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/test/TestUtils/TestUtils.csproj
+++ b/src/test/TestUtils/TestUtils.csproj
@@ -13,9 +13,9 @@
 
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="4.19.4" />
-    <PackageReference Include="Microsoft.DotNet.PlatformAbstractions" Version="$(MicrosoftDotNetPlatformAbstractionsPackageVersion)" />
-    <PackageReference Include="Microsoft.DotNet.XUnitExtensions" Version="$(MicrosoftDotNetXUnitExtensionsPackageVersion)" />
-    <PackageReference Include="xunit.core" Version="$(XUnitPackageVersion)" ExcludeAssets="build" />
+    <PackageReference Include="Microsoft.DotNet.PlatformAbstractions" Version="$(MicrosoftDotNetPlatformAbstractionsVersion)" />
+    <PackageReference Include="Microsoft.DotNet.XUnitExtensions" Version="$(MicrosoftDotNetXUnitExtensionsVersion)" />
+    <PackageReference Include="xunit.core" Version="$(XUnitVersion)" ExcludeAssets="build" />
   </ItemGroup>
 
 </Project>

--- a/tools-local/tasks/installer.tasks/installer.tasks.csproj
+++ b/tools-local/tasks/installer.tasks/installer.tasks.csproj
@@ -12,17 +12,17 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="NuGet.ProjectModel" Version="$(RefOnlyNugetProjectModelPackageVersion)" />
-    <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="$(MicrosoftExtensionsDependencyModelPackageVersion)" />
+    <PackageReference Include="NuGet.ProjectModel" Version="$(RefOnlyNugetProjectModelVersion)" />
+    <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="$(MicrosoftExtensionsDependencyModelVersion)" />
     <!-- TODO: (Consolidation) Update version when consolidated. -->
     <PackageReference Include="Microsoft.DotNet.PlatformAbstractions" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' != 'net46'">
-    <PackageReference Include="Microsoft.Build" Version="$(RefOnlyMicrosoftBuildPackageVersion)" />
-    <PackageReference Include="Microsoft.Build.Framework" Version="$(RefOnlyMicrosoftBuildFrameworkPackageVersion)" />
-    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="$(RefOnlyMicrosoftBuildTasksCorePackageVersion)" />
-    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="$(RefOnlyMicrosoftBuildUtilitiesCorePackageVersion)" />
+    <PackageReference Include="Microsoft.Build" Version="$(RefOnlyMicrosoftBuildVersion)" />
+    <PackageReference Include="Microsoft.Build.Framework" Version="$(RefOnlyMicrosoftBuildFrameworkVersion)" />
+    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="$(RefOnlyMicrosoftBuildTasksCoreVersion)" />
+    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="$(RefOnlyMicrosoftBuildUtilitiesCoreVersion)" />
 
     <PackageReference Include="System.Diagnostics.FileVersionInfo" Version="4.0.0" />
   </ItemGroup>


### PR DESCRIPTION
Requires https://github.com/dotnet/arcade/pull/4266

I'm consolidating all the version properties to use the `Version` suffix instead of `PackageVersion`. This aligns to Arcade conventions and extension point which also use the `Version` suffix.

- Cleaning the unused dependencies in Version.Details.xml and the sourcelink one as that one is pushed down by arcade.
- Removing the `MicrosoftDotNetMaestroTasksVersion` which is set in Arcade as well.
- Removing unused package names.
- Use package names which are defined in Versions.props in the code.
- Consolidate on using Version suffix everywhere (corefx, coreclr, core-setup, arcade)