### PR TITLE
Fix visibility of ComHost type in HostModel.

### DIFF
--- a/src/managed/Microsoft.NET.HostModel/ComHost/ComHost.cs
+++ b/src/managed/Microsoft.NET.HostModel/ComHost/ComHost.cs
@@ -8,7 +8,7 @@ using System.Text;
 
 namespace Microsoft.NET.HostModel.ComHost
 {
-    class ComHost
+    public class ComHost
     {
         // These need to match RESOURCEID_CLISDMAP and RESOURCETYPE_CLSIDMAP defined in comhost.h.
         private const int ClsidmapResourceId = 64;


### PR DESCRIPTION
I accidentally forgot to make ComHost public when moving it to Microsoft.NET.HostModel. This type needs to be public for the SDK to consume it.