### PR TITLE
Fix calling convention of load_in_memory_assembly_fn.

### DIFF
--- a/src/corehost/cli/ijwhost/ijwhost.h
+++ b/src/corehost/cli/ijwhost/ijwhost.h
@@ -14,7 +14,7 @@ bool patch_vtable_entries(PEDecoder& decoder);
 void release_bootstrap_thunks(PEDecoder& decoder);
 bool are_thunks_installed_for_module(HMODULE instance);
 
-using load_in_memory_assembly_fn = void(*)(pal::dll_t handle, const pal::char_t* path);
+using load_in_memory_assembly_fn = void(STDMETHODCALLTYPE*)(pal::dll_t handle, const pal::char_t* path);
 
 pal::hresult_t get_load_in_memory_assembly_delegate(pal::dll_t handle, load_in_memory_assembly_fn* delegate);
 


### PR DESCRIPTION
This fixes a debug assert warning from an unbalanced stack on the first call into an IJW assembly from native code when the IJW assembly has not been previously loaded into the runtime on Windows x86.