### PR TITLE
[release/3.1] Fix calling convention of load_in_memory_assembly_fn.

### DIFF
--- a/src/corehost/cli/ijwhost/ijwhost.h
+++ b/src/corehost/cli/ijwhost/ijwhost.h
@@ -14,7 +14,7 @@ bool patch_vtable_entries(PEDecoder& decoder);
 void release_bootstrap_thunks(PEDecoder& decoder);
 bool are_thunks_installed_for_module(HMODULE instance);
 
-using load_in_memory_assembly_fn = void(*)(pal::dll_t handle, const pal::char_t* path);
+using load_in_memory_assembly_fn = void(STDMETHODCALLTYPE*)(pal::dll_t handle, const pal::char_t* path);
 
 pal::hresult_t get_load_in_memory_assembly_delegate(pal::dll_t handle, load_in_memory_assembly_fn* delegate);
 


### PR DESCRIPTION
# Description

This fixes a debug assert warning from an unbalanced stack on the first call into an IJW assembly from native code when the IJW assembly has not been previously loaded into the runtime on Windows x86.

This was initially discovered by a customer.

### Customer Impact

Customers who activate IJW assemblies on x86 via native code in debug will get an assert about an unbalanced stack due to a mismatched calling convention. Additionally, other issues such as double frees or other various issues can happen with mismatched calling conventions.

### Regression

No this is not a regression. This bug has existed in the IJW host since it was added to .NET Core.

### Risk

This change has minimal risk. The current version in release/3.1 is just incorrect and can cause various issues. The fix is known to work as it matches the calling convention.

See #8812 for the equivalent PR into master.