### PR TITLE
Avoid importing an Arcade extension point

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -20,7 +20,7 @@
     Get ProjectToBuild and '<subset>ProjectToBuild' items. Using the items lets projects handle
     $(Subset) automatically when creating project-to-project dependencies.
   -->
-  <Import Project="$(RepositoryEngineeringDir)Build.props" />
+  <Import Project="$(RepositoryEngineeringDir)Subsets.props" />
 
   <!--
     Before Microsoft.Common.targets, set the extensions path to match the restore dir as Arcade


### PR DESCRIPTION
Importing Subsets.props instead of Build.props allows to avoid duplicate Imports in the runtime repository without any project renames or other condition hacks. Also in general we should avoid importing an Arcade extension point.