### PR TITLE
Add servicing configuration (build skips) for targeting packs

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -18,7 +18,30 @@
     <NETCoreAppMaximumVersion>$(MajorVersion).$(MinorVersion)</NETCoreAppMaximumVersion>
     <NETCoreAppFrameworkVersion>$(MajorVersion).$(MinorVersion)</NETCoreAppFrameworkVersion>
     <NETCoreAppFramework>netcoreapp$(NETCoreAppFrameworkVersion)</NETCoreAppFramework>
+    <!--
+      The NETStandard.Library targeting pack does not version along with the runtime. Advance this
+      version if a new NETStandard targeting pack was released in the previous servicing release.
+    -->
+    <NETStandardPatchVersion>1</NETStandardPatchVersion>
   </PropertyGroup>
+  <!--
+    Servicing build settings.
+
+    * To enable a package build for the current patch release, set PatchVersion to match the current
+      patch version of that package. (major.minor.patch)
+
+    * Do not delete these lines to disable the package build. When PatchVersion is incremented at
+      the beginning of the next servicing release, the package automatically stops building because
+      the version no longer matches.
+
+    * These items also keep track of the last time each package was patched, enabling source-build
+      to produce the correct old version number using current sources.
+  -->
+  <ItemGroup Condition="'$(StabilizePackageVersion)' == 'true'">
+    <ProjectServicingConfiguration Include="Microsoft.NETCore.App.Ref" PatchVersion="0" />
+    <ProjectServicingConfiguration Include="NETStandard.Library.Ref" PatchVersion="0" />
+  </ItemGroup>
+
   <!--Package versions-->
   <PropertyGroup>
     <!-- arcade -->

--- a/src/pkg/projects/netstandard/pkg/Directory.Build.props
+++ b/src/pkg/projects/netstandard/pkg/Directory.Build.props
@@ -3,14 +3,14 @@
     <IsFrameworkPackage>true</IsFrameworkPackage>
     <ShortFrameworkName>netstandard</ShortFrameworkName>
     <ProductBrandPrefix>Microsoft .NET Standard</ProductBrandPrefix>
-
-    <ProductBandVersion>2.1</ProductBandVersion>
-    <ProductionVersion>$(ProductBandVersion).0</ProductionVersion>
   </PropertyGroup>
 
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory).., Directory.Build.props))\Directory.Build.props" />
 
   <PropertyGroup>
+    <ProductBandVersion>2.1</ProductBandVersion>
+    <PatchVersion>$(NETStandardPatchVersion)</PatchVersion>
+
     <FrameworkListName>.NET Standard 2.1</FrameworkListName>
     <FrameworkListTargetFrameworkIdentifier>.NETStandard</FrameworkListTargetFrameworkIdentifier>
     <FrameworkListTargetFrameworkVersion>2.1</FrameworkListTargetFrameworkVersion>

--- a/src/test/Microsoft.DotNet.CoreSetup.Packaging.Tests/NETCoreTests.cs
+++ b/src/test/Microsoft.DotNet.CoreSetup.Packaging.Tests/NETCoreTests.cs
@@ -14,10 +14,16 @@ namespace Microsoft.DotNet.CoreSetup.Packaging.Tests
         [Fact]
         public void NETCoreTargetingPackIsValid()
         {
-            using (var tester = NuGetArtifactTester.Open(
+            using (var tester = NuGetArtifactTester.OpenOrNull(
                 dirs,
                 "Microsoft.NETCore.App.Ref"))
             {
+                // Allow no targeting pack for servicing builds.
+                if (tester == null)
+                {
+                    return;
+                }
+
                 tester.IsTargetingPackForPlatform();
                 tester.HasOnlyTheseDataFiles(
                     "data/FrameworkList.xml",

--- a/src/test/Microsoft.DotNet.CoreSetup.Packaging.Tests/NETStandardTests.cs
+++ b/src/test/Microsoft.DotNet.CoreSetup.Packaging.Tests/NETStandardTests.cs
@@ -14,10 +14,16 @@ namespace Microsoft.DotNet.CoreSetup.Packaging.Tests
         [Fact]
         public void NETStandardTargetingPackIsValid()
         {
-            using (var tester = NuGetArtifactTester.Open(
+            using (var tester = NuGetArtifactTester.OpenOrNull(
                 dirs,
                 "NETStandard.Library.Ref"))
             {
+                // Allow no targeting pack for servicing builds.
+                if (tester == null)
+                {
+                    return;
+                }
+
                 tester.HasOnlyTheseDataFiles(
                     "data/FrameworkList.xml",
                     "data/PackageOverrides.txt");


### PR DESCRIPTION
For https://github.com/dotnet/core-setup/issues/8735. Uses https://github.com/dotnet/arcade/pull/4318.

Holding off on merging. Marking post-consolidation to avoid extra migration effort. I'm filing the PR here to keep track of the need to port it over and put it in context. I can't file the PR in the consolidated repo yet because the tooling isn't up to date there. There's no rush: this specific PR has no effect until the stable 5.0.0 build.