### PR TITLE
[release/3.1] Add servicing config: project skip infrastructure

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -39,6 +39,7 @@
   -->
   <ItemGroup Condition="'$(StabilizePackageVersion)' == 'true'">
     <ProjectServicingConfiguration Include="Microsoft.NETCore.App.Ref" PatchVersion="0" />
+    <ProjectServicingConfiguration Include="Microsoft.WindowsDesktop.App.Ref" PatchVersion="0" />
     <ProjectServicingConfiguration Include="NETStandard.Library.Ref" PatchVersion="0" />
   </ItemGroup>
 

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -18,7 +18,30 @@
     <NETCoreAppMaximumVersion>$(MajorVersion).$(MinorVersion)</NETCoreAppMaximumVersion>
     <NETCoreAppFrameworkVersion>$(MajorVersion).$(MinorVersion)</NETCoreAppFrameworkVersion>
     <NETCoreAppFramework>netcoreapp$(NETCoreAppFrameworkVersion)</NETCoreAppFramework>
+    <!--
+      The NETStandard.Library targeting pack does not version along with the runtime. Advance this
+      version if a new NETStandard targeting pack was released in the previous servicing release.
+    -->
+    <NETStandardPatchVersion>1</NETStandardPatchVersion>
   </PropertyGroup>
+  <!--
+    Servicing build settings.
+
+    * To enable a package build for the current patch release, set PatchVersion to match the current
+      patch version of that package. (major.minor.patch)
+
+    * Do not delete these lines to disable the package build. When PatchVersion is incremented at
+      the beginning of the next servicing release, the package automatically stops building because
+      the version no longer matches.
+
+    * These items also keep track of the last time each package was patched, enabling source-build
+      to produce the correct old version number using current sources.
+  -->
+  <ItemGroup Condition="'$(StabilizePackageVersion)' == 'true'">
+    <ProjectServicingConfiguration Include="Microsoft.NETCore.App.Ref" PatchVersion="0" />
+    <ProjectServicingConfiguration Include="NETStandard.Library.Ref" PatchVersion="0" />
+  </ItemGroup>
+
   <PropertyGroup>
     <MicrosoftDotNetMaestroTasksVersion>1.0.0-beta.18619.4</MicrosoftDotNetMaestroTasksVersion>
   </PropertyGroup>

--- a/src/pkg/packaging-tools/framework.packaging.targets
+++ b/src/pkg/packaging-tools/framework.packaging.targets
@@ -35,6 +35,17 @@
     </PropertyGroup>
   </Target>
 
+  <Target Name="SkipBuildInstallerProperties"
+          DependsOnTargets="GetSkipBuildProps"
+          BeforeTargets="GetInstallerGenerationFlags">
+    <PropertyGroup Condition="'$(SkipBuild)' == 'true'">
+      <GenerateDeb>false</GenerateDeb>
+      <GenerateRpm>false</GenerateRpm>
+      <GeneratePkg>false</GeneratePkg>
+      <GenerateMSI>false</GenerateMSI>
+    </PropertyGroup>
+  </Target>
+
   <!--
     This targets file is imported for all pkgproj files, but some (like DotNetHostPolicy) don't need
     installers and just use the normal packaging tooling.

--- a/src/pkg/packaging-tools/packaging-tools.targets
+++ b/src/pkg/packaging-tools/packaging-tools.targets
@@ -115,7 +115,54 @@
     </ItemGroup>
   </Target>
 
-  <Target Name="GetSkipBuildProps">
+  <Target Name="GetCurrentProjectServicingConfiguration">
+    <ItemGroup>
+      <CurrentProjectServicingConfiguration
+        Include="@(ProjectServicingConfiguration)"
+        Condition="'%(Identity)' == '$(MSBuildProjectName)'" />
+    </ItemGroup>
+  </Target>
+
+  <!--
+    The Microsoft build's per-package servicing policy conflicts with the source-build restrictions.
+    Targeting packs, for example, are only built/published when there's a known change to release.
+    This is in contrast to runtime packs and the shared framework, which are always built and
+    published. This means it's common in the Microsoft build for downstream repos to depend on two
+    builds' outputs: the current build's runtime assets, and some old build's targeting pack.
+
+    The Microsoft build can simply download the old targeting pack from NuGet.org. Source-build
+    can't do this because the bits on NuGet.org are not built locally. Instead, source-build assumes
+    it's possible to use current sources to build a package with the old version. This target
+    applies the old build's patch version to make that happen.
+
+    This solution has pitfalls. More info at https://github.com/dotnet/core-setup/issues/8735. The
+    target supports SkipSetLastReleasedVersionForSourceBuild (unused as of writing) to allow
+    disabling this workaround if a better way forward is implemented.
+  -->
+  <Target Name="SetLastReleasedVersionForSourceBuild"
+          Condition="
+            '$(DotNetBuildFromSource)' == 'true' and
+            '$(SkipSetLastReleasedVersionForSourceBuild)' != 'true'"
+          BeforeTargets="GetProductVersions"
+          DependsOnTargets="GetCurrentProjectServicingConfiguration">
+    <PropertyGroup>
+      <MostRecentProducedServicingPatchVersion>%(CurrentProjectServicingConfiguration.PatchVersion)</MostRecentProducedServicingPatchVersion>
+      <PatchVersion Condition="'$(MostRecentProducedServicingPatchVersion)' != ''">$(MostRecentProducedServicingPatchVersion)</PatchVersion>
+    </PropertyGroup>
+  </Target>
+
+  <Target Name="GetSkipBuildProps"
+          DependsOnTargets="
+            GetCurrentProjectServicingConfiguration;
+            GetProductVersions">
+    <!--
+      Skip the build if there is an applicable servicing configuration, and the servicing
+      configuration indicates this project shouldn't build for this patch version.
+    -->
+    <PropertyGroup Condition="'@(CurrentProjectServicingConfiguration)' != ''">
+      <SkipBuild Condition="'%(CurrentProjectServicingConfiguration.PatchVersion)' != '$(PatchVersion)'">true</SkipBuild>
+    </PropertyGroup>
+
     <PropertyGroup>
       <!-- Avoid building a project when none of the possible BuildRIDs is the current RID. -->
       <_packageRIDInBuildRIDList Condition="'%(BuildRID.Identity)' == '$(PackageRID)'">true</_packageRIDInBuildRIDList>

--- a/src/pkg/projects/netstandard/pkg/Directory.Build.props
+++ b/src/pkg/projects/netstandard/pkg/Directory.Build.props
@@ -3,14 +3,14 @@
     <IsFrameworkPackage>true</IsFrameworkPackage>
     <ShortFrameworkName>netstandard</ShortFrameworkName>
     <ProductBrandPrefix>Microsoft .NET Standard</ProductBrandPrefix>
-
-    <ProductBandVersion>2.1</ProductBandVersion>
-    <ProductionVersion>$(ProductBandVersion).0</ProductionVersion>
   </PropertyGroup>
 
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory).., Directory.Build.props))\Directory.Build.props" />
 
   <PropertyGroup>
+    <ProductBandVersion>2.1</ProductBandVersion>
+    <PatchVersion>$(NETStandardPatchVersion)</PatchVersion>
+
     <FrameworkListName>.NET Standard 2.1</FrameworkListName>
     <FrameworkListTargetFrameworkIdentifier>.NETStandard</FrameworkListTargetFrameworkIdentifier>
     <FrameworkListTargetFrameworkVersion>2.1</FrameworkListTargetFrameworkVersion>

--- a/src/test/Microsoft.DotNet.CoreSetup.Packaging.Tests/NETCoreTests.cs
+++ b/src/test/Microsoft.DotNet.CoreSetup.Packaging.Tests/NETCoreTests.cs
@@ -14,10 +14,16 @@ namespace Microsoft.DotNet.CoreSetup.Packaging.Tests
         [Fact]
         public void NETCoreTargetingPackIsValid()
         {
-            using (var tester = NuGetArtifactTester.Open(
+            using (var tester = NuGetArtifactTester.OpenOrNull(
                 dirs,
                 "Microsoft.NETCore.App.Ref"))
             {
+                // Allow no targeting pack for servicing builds.
+                if (tester == null)
+                {
+                    return;
+                }
+
                 tester.IsTargetingPackForPlatform();
                 tester.HasOnlyTheseDataFiles(
                     "data/FrameworkList.xml",

--- a/src/test/Microsoft.DotNet.CoreSetup.Packaging.Tests/NETStandardTests.cs
+++ b/src/test/Microsoft.DotNet.CoreSetup.Packaging.Tests/NETStandardTests.cs
@@ -14,10 +14,16 @@ namespace Microsoft.DotNet.CoreSetup.Packaging.Tests
         [Fact]
         public void NETStandardTargetingPackIsValid()
         {
-            using (var tester = NuGetArtifactTester.Open(
+            using (var tester = NuGetArtifactTester.OpenOrNull(
                 dirs,
                 "NETStandard.Library.Ref"))
             {
+                // Allow no targeting pack for servicing builds.
+                if (tester == null)
+                {
+                    return;
+                }
+
                 tester.HasOnlyTheseDataFiles(
                     "data/FrameworkList.xml",
                     "data/PackageOverrides.txt");

--- a/src/test/Microsoft.DotNet.CoreSetup.Packaging.Tests/WindowsDesktopTests.cs
+++ b/src/test/Microsoft.DotNet.CoreSetup.Packaging.Tests/WindowsDesktopTests.cs
@@ -25,7 +25,11 @@ namespace Microsoft.DotNet.CoreSetup.Packaging.Tests
             {
                 if (CurrentRidShouldCreateNupkg)
                 {
-                    Assert.NotNull(tester);
+                    // Allow no targeting pack for servicing builds.
+                    if (tester == null)
+                    {
+                        return;
+                    }
 
                     tester.IsTargetingPackForPlatform();
                     tester.HasOnlyTheseDataFiles(


### PR DESCRIPTION
#### Description

For https://github.com/dotnet/core-setup/issues/8735, *Disable producing targeting packs in servicing builds (unless patching)* and specifically https://github.com/dotnet/core-setup/issues/8507, *Disable producing NETStandard targeting pack in 3.1 branch*.

Ports https://github.com/dotnet/core-setup/pull/8827 from `release/3.0` to `release/3.1`.

This isn't necessary for the 3.1.0 GA build because the `NETStandard.Library.Ref` targeting pack dependency in Core-SDK is already pinned. This should be merged before the 3.1.1 servicing build so the NETCoreApp and WindowsDesktop targeting packs don't also need to be pinned.

#### Customer Impact

The way the build currently works, downstream repos like core-sdk have to manually pin the targeting pack versions so the auto-update PRs don't insert bad targeting packs that we don't plan to ship.

After this PR, dependencies on Core-Setup's targeting packs will no longer need to be pinned because the packs will only be produced when they should be used. This reduces the chance of creating a bad build, reducing maintenance cost of servicing. 

#### Regression?

No.

#### Risk

This may cause build breaks in downstream repos. This would be a good thing from a correctness standpoint, because it reveals bad assumptions that targeting packs are always produced.

To keep this PR simple, targeting pack tests now pass rather than fail if the nupkg isn't found on disk. This allows the tests to pass when the targeting pack isn't being patched. It adds a risk that the tests won't catch a situation where a targeting pack wasn't built but should have been. I believe this risk isn't significant: I've only observed missing nupkgs along with a build failure (so it would get noticed anyway) or major refactoring (which I don't see happening in `release/3.0`). We can backport improvements to these tests in the future.

---

/cc @wtgodbe @mmitche @Anipik @nguerrera 