### PR TITLE
Update CoreCLR override to use the sharedFramework output folder instead of comparing with packages

### DIFF
--- a/src/pkg/projects/netcoreapp/src/localnetcoreapp.override.targets
+++ b/src/pkg/projects/netcoreapp/src/localnetcoreapp.override.targets
@@ -4,40 +4,43 @@
   <Target Name="OverrideRuntimeFilesFromPackageResolve" Condition="'$(CoreCLROverridePath)' != ''" BeforeTargets="GetFilesFromPackageResolve">
     <Error Condition="!Exists('$(CoreCLROverridePath)')" Text="The path provided to CoreCLROverridePath ($(CoreCLROverridePath)) does not exist." />
     <PropertyGroup>
-      <CoreCLRCrossTargetComponentFolderName Condition="'$(TargetArchitecture)' == 'arm64' and '$(BuildArchitecture)' != 'arm64'">x64</CoreCLRCrossTargetComponentFolderName>
-      <CoreCLRCrossTargetComponentFolderName Condition="'$(TargetArchitecture)' == 'arm' and '$(BuildArchitecture)' != 'arm' and '$(TargetsWindows)' == 'true'">x86</CoreCLRCrossTargetComponentFolderName>
-      <CoreCLRCrossTargetComponentFolderName Condition="'$(TargetArchitecture)' == 'arm' and '$(BuildArchitecture)' != 'arm' and '$(TargetsLinux)' == 'true'">x64</CoreCLRCrossTargetComponentFolderName>
-      <CoreCLRSharedFrameworkFolder>$([MSBuild]::NormalizePath($(CoreCLROverridePath),'sharedFramework'))</CoreCLRSharedFrameworkFolder>
-      <CoreCLRCrossTargetComponentFolder
-        Condition="'$(CoreCLRCrossTargetComponentFolderName)' != ''">$([MSBuild]::NormalizePath($(CoreCLROverridePath),$(CoreCLRCrossTargetComponentFolder),'sharedFramework'))</CoreCLRCrossTargetComponentFolder>
+      <CoreCLROverridePath>$([MSBuild]::NormalizeDirectory('$(CoreCLROverridePath)'))</CoreCLROverridePath>
+    </PropertyGroup>
+    <PropertyGroup>
+      <CoreCLRCrossTargetComponentDirName Condition="'$(TargetArchitecture)' == 'arm64' and '$(BuildArchitecture)' != 'arm64'">x64</CoreCLRCrossTargetComponentDirName>
+      <CoreCLRCrossTargetComponentDirName Condition="'$(TargetArchitecture)' == 'arm' and '$(BuildArchitecture)' != 'arm' and '$(TargetsWindows)' == 'true'">x86</CoreCLRCrossTargetComponentDirName>
+      <CoreCLRCrossTargetComponentDirName Condition="'$(TargetArchitecture)' == 'arm' and '$(BuildArchitecture)' != 'arm' and '$(TargetsLinux)' == 'true'">x64</CoreCLRCrossTargetComponentDirName>
+      <CoreCLRSharedFrameworkDir>$([MSBuild]::NormalizeDirectory('$(CoreCLROverridePath)','sharedFramework'))</CoreCLRSharedFrameworkDir>
+      <CoreCLRCrossTargetComponentDir
+        Condition="'$(CoreCLRCrossTargetComponentDirName)' != ''">$([MSBuild]::NormalizeDirectory('$(CoreCLROverridePath)','$(CoreCLRCrossTargetComponentDir)','sharedFramework'))</CoreCLRCrossTargetComponentDir>
     </PropertyGroup>
     <ItemGroup>
-      <CoreCLRFiles Include="$(CoreCLRSharedFrameworkFolder)/*.*" />
-      <CoreCLRCrossTargetFiles Condition="'$(CoreCLRCrossTargetComponentFolder)' != ''" Include="$(CoreCLRCrossTargetComponentFolder)/*.*" />
-      <CoreCLRFiles Include="$(CoreCLROverridePath)/Redist/**/*.dll" />
+      <CoreCLRFiles Include="$(CoreCLRSharedFrameworkDir)*.*" />
+      <CoreCLRCrossTargetFiles Condition="'$(CoreCLRCrossTargetComponentDir)' != ''" Include="$(CoreCLRCrossTargetComponentDir)*.*" />
+      <CoreCLRFiles Include="$(CoreCLROverridePath)Redist/**/*.dll" />
       <CoreCLRFiles>
         <IsNative>true</IsNative>
       </CoreCLRFiles>
-      <CoreCLRFiles Include="$(CoreCLROverridePath)/System.Private.CoreLib.dll" />
+      <CoreCLRFiles Include="$(CoreCLROverridePath)System.Private.CoreLib.dll" />
       <CoreCLRFiles
         Include="
-          $(CoreCLRSharedFrameworkFolder)/PDB/*.pdb;
-          $(CoreCLRSharedFrameworkFolder)/PDB/*.dbg;
-          $(CoreCLRSharedFrameworkFolder)/PDB/*.dwarf" />
+          $(CoreCLRSharedFrameworkDir)PDB/*.pdb;
+          $(CoreCLRSharedFrameworkDir)PDB/*.dbg;
+          $(CoreCLRSharedFrameworkDir)PDB/*.dwarf" />
       <CoreCLRFiles
-        Include="$(CoreCLROverridePath)/PDB/System.Private.CoreLib.pdb;$(CoreCLROverridePath)/PDB/System.Private.CoreLib.ni.pdb" />
-      <CoreCLRCrossTargetFiles Condition="'$(CoreCLRCrossTargetComponentFolder)' != ''"
+        Include="$(CoreCLROverridePath)PDB/System.Private.CoreLib.pdb;$(CoreCLROverridePath)PDB/System.Private.CoreLib.ni.pdb" />
+      <CoreCLRCrossTargetFiles Condition="'$(CoreCLRCrossTargetComponentDir)' != ''"
         Include="
-          $(CoreCLRCrossTargetComponentFolder)/PDB/*.pdb;
-          $(CoreCLRCrossTargetComponentFolder)/PDB/*.dbg;
-          $(CoreCLRCrossTargetComponentFolder)/PDB/*.dwarf" />
+          $(CoreCLRCrossTargetComponentDir)PDB/*.pdb;
+          $(CoreCLRCrossTargetComponentDir)PDB/*.dbg;
+          $(CoreCLRCrossTargetComponentDir)PDB/*.dwarf" />
 
       <CoreCLRFiles>
         <TargetPath>runtime/$(RuntimeIdentifier)/native</TargetPath>
       </CoreCLRFiles>
 
       <CoreCLRCrossTargetFiles>
-        <TargetPath>runtime/$(CoreCLRCrossTargetComponentFolderName)_$(TargetArchitecture)/native</TargetPath>
+        <TargetPath>runtime/$(CoreCLRCrossTargetComponentDirName)_$(TargetArchitecture)/native</TargetPath>
       </CoreCLRCrossTargetFiles>
 
       <CoreCLRFiles Include="@(CoreCLRCrossTargetFiles)" />

--- a/src/pkg/projects/netcoreapp/src/localnetcoreapp.override.targets
+++ b/src/pkg/projects/netcoreapp/src/localnetcoreapp.override.targets
@@ -4,25 +4,36 @@
   <Target Name="OverrideRuntimeFilesFromPackageResolve" Condition="'$(CoreCLROverridePath)' != ''" BeforeTargets="GetFilesFromPackageResolve">
     <Error Condition="!Exists('$(CoreCLROverridePath)')" Text="The path provided to CoreCLROverridePath ($(CoreCLROverridePath)) does not exist." />
     <PropertyGroup>
-      <CoreCLRPDBOverridePath Condition="'$(CoreCLRPDBOverridePath)' == '' and Exists('$(CoreCLROverridePath)/PDB')">$(CoreCLROverridePath)/PDB</CoreCLRPDBOverridePath>
       <CoreCLRCrossTargetComponentFolder Condition="'$(TargetArchitecture)' == 'arm64'">x64</CoreCLRCrossTargetComponentFolder>
       <CoreCLRCrossTargetComponentFolder Condition="'$(TargetArchitecture)' == 'arm' and '$(TargetsWindows)' == 'true'">x86</CoreCLRCrossTargetComponentFolder>
       <CoreCLRCrossTargetComponentFolder Condition="'$(TargetArchitecture)' == 'arm' and '$(TargetsLinux)' == 'true'">x64</CoreCLRCrossTargetComponentFolder>
     </PropertyGroup>
     <ItemGroup>
       <CoreCLRFiles Include="$(CoreCLROverridePath)/sharedFramework/*.*" />
-      <CoreCLRFiles Condition="'$(CoreCLRCrossTargetComponentFolder)' != ''" Include="$(CoreCLROverridePath)/$(CoreCLRCrossTargetComponentFolder)/sharedFramework/*.*" />
+      <CoreCLRCrossTargetFiles Condition="'$(CoreCLRCrossTargetComponentFolder)' != ''" Include="$(CoreCLROverridePath)/$(CoreCLRCrossTargetComponentFolder)/sharedFramework/*.*" />
       <CoreCLRFiles Include="$(CoreCLROverridePath)/Redist/**/*.dll" />
       <CoreCLRFiles>
         <IsNative>true</IsNative>
       </CoreCLRFiles>
       <CoreCLRFiles Include="$(CoreCLROverridePath)/System.Private.CoreLib.dll" />
-      <CoreCLRFiles Condition="'$(CoreCLRPDBOverridePath)' != ''"
-        Include="$(CoreCLRPDBOverridePath)/*.pdb;$(CoreCLRPDBOverridePath)/*.dbg;$(CoreCLRPDBOverridePath)/*.dwarf" />
+      <CoreCLRFiles
+        Include="$(CoreCLROverridePath)/sharedFramework/PDB/*.pdb;$(CoreCLROverridePath)/sharedFramework/PDB/*.dbg;$(CoreCLROverridePath)/sharedFramework/PDB/*.dwarf" />
+      <CoreCLRFiles
+        Include="$(CoreCLROverridePath)/PDB/System.Private.CoreLib.pdb;$(CoreCLROverridePath)/PDB/System.Private.CoreLib.ni.pdb" />
+      <CoreCLRCrossTargetFiles Condition="'$(CoreCLRCrossTargetComponentFolder)' != ''"
+        Include="$(CoreCLROverridePath)/$(CoreCLRCrossTargetComponentFolder)/sharedFramework/PDB/*.pdb;
+        $(CoreCLROverridePath)/$(CoreCLRCrossTargetComponentFolder)/sharedFramework/PDB/*.dbg;
+        $(CoreCLROverridePath)/$(CoreCLRCrossTargetComponentFolder)/sharedFramework/PDB/*.dwarf" />
 
       <CoreCLRFiles>
         <TargetPath>runtime/$(RuntimeIdentifier)/native</TargetPath>
       </CoreCLRFiles>
+
+      <CoreCLRCrossTargetFiles>
+        <TargetPath>runtime/$(CoreCLRCrossTargetComponentFolder)_$(TargetArchitecture)/native</TargetPath>
+      </CoreCLRCrossTargetFiles>
+
+      <CoreCLRFiles Include="@(CoreCLRCrossTargetFiles)" />
 
       <ReferenceCopyLocalPaths Remove="@(ReferenceCopyLocalPaths)" Condition="'@(CoreCLRFiles->'%(FileName)%(Extension)')' == '%(FileName)%(Extension)'"/>
       <ReferenceCopyLocalPaths Remove="@(ReferenceCopyLocalPaths)" Condition="$([System.String]::Copy('%(FileName)').StartsWith('mscordaccore_'))" />

--- a/src/pkg/projects/netcoreapp/src/localnetcoreapp.override.targets
+++ b/src/pkg/projects/netcoreapp/src/localnetcoreapp.override.targets
@@ -5,38 +5,33 @@
     <Error Condition="!Exists('$(CoreCLROverridePath)')" Text="The path provided to CoreCLROverridePath ($(CoreCLROverridePath)) does not exist." />
     <PropertyGroup>
       <CoreCLRPDBOverridePath Condition="'$(CoreCLRPDBOverridePath)' == '' and Exists('$(CoreCLROverridePath)/PDB')">$(CoreCLROverridePath)/PDB</CoreCLRPDBOverridePath>
+      <CoreCLRCrossTargetComponentFolder Condition="'$(TargetArchitecture)' == 'arm64'">x64</CoreCLRCrossTargetComponentFolder>
+      <CoreCLRCrossTargetComponentFolder Condition="'$(TargetArchitecture)' == 'arm' and '$(TargetsWindows)' == 'true'">x86</CoreCLRCrossTargetComponentFolder>
+      <CoreCLRCrossTargetComponentFolder Condition="'$(TargetArchitecture)' == 'arm' and '$(TargetsLinux)' == 'true'">x64</CoreCLRCrossTargetComponentFolder>
     </PropertyGroup>
     <ItemGroup>
-      <CoreCLRFiles Include="$(CoreCLROverridePath)/*.*" />
+      <CoreCLRFiles Include="$(CoreCLROverridePath)/sharedFramework/*.*" />
+      <CoreCLRFiles Condition="'$(CoreCLRCrossTargetComponentFolder)' != ''" Include="$(CoreCLROverridePath)/$(CoreCLRCrossTargetComponentFolder)/sharedFramework/*.*" />
       <CoreCLRFiles Include="$(CoreCLROverridePath)/Redist/**/*.dll" />
+      <CoreCLRFiles>
+        <IsNative>true</IsNative>
+      </CoreCLRFiles>
+      <CoreCLRFiles Include="$(CoreCLROverridePath)/System.Private.CoreLib.dll" />
       <CoreCLRFiles Condition="'$(CoreCLRPDBOverridePath)' != ''"
         Include="$(CoreCLRPDBOverridePath)/*.pdb;$(CoreCLRPDBOverridePath)/*.dbg;$(CoreCLRPDBOverridePath)/*.dwarf" />
 
-      <OverriddenRuntimeFiles Include="@(ReferenceCopyLocalPaths)" Condition="'@(CoreCLRFiles->'%(FileName)%(Extension)')' == '%(FileName)%(Extension)'">
-        <CoreCLRFile>@(CoreCLRFiles)</CoreCLRFile>
-      </OverriddenRuntimeFiles>
+      <CoreCLRFiles>
+        <TargetPath>runtime/$(RuntimeIdentifier)/native</TargetPath>
+      </CoreCLRFiles>
 
-      <LongNameDacFile Include="@(ReferenceCopyLocalPaths)" Condition="$([System.String]::Copy('%(FileName)').StartsWith('mscordaccore_'))">
-        <TargetPath>%(PathInPackage)</TargetPath>
-      </LongNameDacFile>
-
-      <ShortNameDacFileOverride Include="@(CoreCLRFiles)" Condition="'%(FileName)%(Extension)' == 'mscordaccore.dll'" />
-
-      <OverriddenRuntimeFiles Include="@(LongNameDacFile)">
-        <CoreCLRFile>@(ShortNameDacFileOverride)</CoreCLRFile>
-      </OverriddenRuntimeFiles>
-
-      <OverriddenRuntimeFiles>
-        <IsNative Condition="$([System.String]::new('%(Identity)').ToLowerInvariant().Replace('\', '/').Contains('/native/'))">true</IsNative>
-      </OverriddenRuntimeFiles>
-
-      <ReferenceCopyLocalPaths Remove="@(OverriddenRuntimeFiles)" />
-      <ReferenceCopyLocalPaths Include="@(OverriddenRuntimeFiles->Metadata('CoreCLRFile'))" />
+      <ReferenceCopyLocalPaths Remove="@(ReferenceCopyLocalPaths)" Condition="'@(CoreCLRFiles->'%(FileName)%(Extension)')' == '%(FileName)%(Extension)'"/>
+      <ReferenceCopyLocalPaths Remove="@(ReferenceCopyLocalPaths)" Condition="$([System.String]::Copy('%(FileName)').StartsWith('mscordaccore_'))" />
+      <ReferenceCopyLocalPaths Include="@(CoreCLRFiles)" />
     </ItemGroup>
 
     <Error Condition="'@(CoreCLRFiles)' == ''" Text="The path provided to CoreCLROverridePath ($(CoreCLROverridePath)) does not contain any files." />
   </Target>
-
+ 
   <Target Name="OverrideFrameworkFilesFromPackageResolve" Condition="'$(CoreFXOverridePath)' != ''" BeforeTargets="GetFilesFromPackageResolve">
     <Error Condition="!Exists('$(CoreFXOverridePath)')" Text="The path provided to CoreFXOverridePath ($(CoreFXOverridePath)) does not exist." />
 

--- a/src/pkg/projects/netcoreapp/src/localnetcoreapp.override.targets
+++ b/src/pkg/projects/netcoreapp/src/localnetcoreapp.override.targets
@@ -4,26 +4,33 @@
   <Target Name="OverrideRuntimeFilesFromPackageResolve" Condition="'$(CoreCLROverridePath)' != ''" BeforeTargets="GetFilesFromPackageResolve">
     <Error Condition="!Exists('$(CoreCLROverridePath)')" Text="The path provided to CoreCLROverridePath ($(CoreCLROverridePath)) does not exist." />
     <PropertyGroup>
-      <CoreCLRCrossTargetComponentFolder Condition="'$(TargetArchitecture)' == 'arm64'">x64</CoreCLRCrossTargetComponentFolder>
-      <CoreCLRCrossTargetComponentFolder Condition="'$(TargetArchitecture)' == 'arm' and '$(TargetsWindows)' == 'true'">x86</CoreCLRCrossTargetComponentFolder>
-      <CoreCLRCrossTargetComponentFolder Condition="'$(TargetArchitecture)' == 'arm' and '$(TargetsLinux)' == 'true'">x64</CoreCLRCrossTargetComponentFolder>
+      <CoreCLRCrossTargetComponentFolderName Condition="'$(TargetArchitecture)' == 'arm64' and '$(BuildArchitecture)' != 'arm64'">x64</CoreCLRCrossTargetComponentFolderName>
+      <CoreCLRCrossTargetComponentFolderName Condition="'$(TargetArchitecture)' == 'arm' and '$(BuildArchitecture)' != 'arm' and '$(TargetsWindows)' == 'true'">x86</CoreCLRCrossTargetComponentFolderName>
+      <CoreCLRCrossTargetComponentFolderName Condition="'$(TargetArchitecture)' == 'arm' and '$(BuildArchitecture)' != 'arm' and '$(TargetsLinux)' == 'true'">x64</CoreCLRCrossTargetComponentFolderName>
+      <CoreCLRSharedFrameworkFolder>$([MSBuild]::NormalizePath($(CoreCLROverridePath),'sharedFramework'))</CoreCLRSharedFrameworkFolder>
+      <CoreCLRCrossTargetComponentFolder
+        Condition="'$(CoreCLRCrossTargetComponentFolderName)' != ''">$([MSBuild]::NormalizePath($(CoreCLROverridePath),$(CoreCLRCrossTargetComponentFolder),'sharedFramework'))</CoreCLRCrossTargetComponentFolder>
     </PropertyGroup>
     <ItemGroup>
-      <CoreCLRFiles Include="$(CoreCLROverridePath)/sharedFramework/*.*" />
-      <CoreCLRCrossTargetFiles Condition="'$(CoreCLRCrossTargetComponentFolder)' != ''" Include="$(CoreCLROverridePath)/$(CoreCLRCrossTargetComponentFolder)/sharedFramework/*.*" />
+      <CoreCLRFiles Include="$(CoreCLRSharedFrameworkFolder)/*.*" />
+      <CoreCLRCrossTargetFiles Condition="'$(CoreCLRCrossTargetComponentFolder)' != ''" Include="$(CoreCLRCrossTargetComponentFolder)/*.*" />
       <CoreCLRFiles Include="$(CoreCLROverridePath)/Redist/**/*.dll" />
       <CoreCLRFiles>
         <IsNative>true</IsNative>
       </CoreCLRFiles>
       <CoreCLRFiles Include="$(CoreCLROverridePath)/System.Private.CoreLib.dll" />
       <CoreCLRFiles
-        Include="$(CoreCLROverridePath)/sharedFramework/PDB/*.pdb;$(CoreCLROverridePath)/sharedFramework/PDB/*.dbg;$(CoreCLROverridePath)/sharedFramework/PDB/*.dwarf" />
+        Include="
+          $(CoreCLRSharedFrameworkFolder)/PDB/*.pdb;
+          $(CoreCLRSharedFrameworkFolder)/PDB/*.dbg;
+          $(CoreCLRSharedFrameworkFolder)/PDB/*.dwarf" />
       <CoreCLRFiles
         Include="$(CoreCLROverridePath)/PDB/System.Private.CoreLib.pdb;$(CoreCLROverridePath)/PDB/System.Private.CoreLib.ni.pdb" />
       <CoreCLRCrossTargetFiles Condition="'$(CoreCLRCrossTargetComponentFolder)' != ''"
-        Include="$(CoreCLROverridePath)/$(CoreCLRCrossTargetComponentFolder)/sharedFramework/PDB/*.pdb;
-        $(CoreCLROverridePath)/$(CoreCLRCrossTargetComponentFolder)/sharedFramework/PDB/*.dbg;
-        $(CoreCLROverridePath)/$(CoreCLRCrossTargetComponentFolder)/sharedFramework/PDB/*.dwarf" />
+        Include="
+          $(CoreCLRCrossTargetComponentFolder)/PDB/*.pdb;
+          $(CoreCLRCrossTargetComponentFolder)/PDB/*.dbg;
+          $(CoreCLRCrossTargetComponentFolder)/PDB/*.dwarf" />
 
       <CoreCLRFiles>
         <TargetPath>runtime/$(RuntimeIdentifier)/native</TargetPath>
@@ -42,7 +49,7 @@
 
     <Error Condition="'@(CoreCLRFiles)' == ''" Text="The path provided to CoreCLROverridePath ($(CoreCLROverridePath)) does not contain any files." />
   </Target>
- 
+
   <Target Name="OverrideFrameworkFilesFromPackageResolve" Condition="'$(CoreFXOverridePath)' != ''" BeforeTargets="GetFilesFromPackageResolve">
     <Error Condition="!Exists('$(CoreFXOverridePath)')" Text="The path provided to CoreFXOverridePath ($(CoreFXOverridePath)) does not exist." />
 

--- a/src/pkg/projects/netcoreapp/src/localnetcoreapp.override.targets
+++ b/src/pkg/projects/netcoreapp/src/localnetcoreapp.override.targets
@@ -37,7 +37,7 @@
       </CoreCLRFiles>
 
       <CoreCLRCrossTargetFiles>
-        <TargetPath>runtime/$(CoreCLRCrossTargetComponentFolder)_$(TargetArchitecture)/native</TargetPath>
+        <TargetPath>runtime/$(CoreCLRCrossTargetComponentFolderName)_$(TargetArchitecture)/native</TargetPath>
       </CoreCLRCrossTargetFiles>
 
       <CoreCLRFiles Include="@(CoreCLRCrossTargetFiles)" />

--- a/src/pkg/projects/netcoreapp/src/netcoreapp.depproj
+++ b/src/pkg/projects/netcoreapp/src/netcoreapp.depproj
@@ -56,7 +56,8 @@
   <!-- Fetches all the runtime items from the packages that we want to redist -->
   <Target Name="GetRuntimeFilesFromPackages"
           BeforeTargets="GetRuntimeFilesToPackage"
-          DependsOnTargets="GetCorePackagePaths">
+          DependsOnTargets="GetCorePackagePaths"
+          Condition="'$(CoreCLROverridePath)' == ''">
     <ItemGroup Condition="'$(PackageTargetRuntime)' != ''">
       <_ToolsToPackage Include="$(_runtimePackageDir)tools/**/*.*"/>
       <FilesToPackage Include="@(_ToolsToPackage)">


### PR DESCRIPTION
Currently, the core-setup scripting to use a local CoreCLR build depends on the CoreCLR packages. With dotnet/coreclr#27841, we will be able to determine what files are part of the shared framework based on if they are in the sharedFramework folder.

This PR updates the CoreCLR override mechanism to use the sharedFramework folder instead of comparing files against the packages.