### PR TITLE
Fix the validation channel's variable name

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -266,6 +266,6 @@ stages:
       - dependsOn: PVR_Publish
         channel:
           name: .NET Tools - Validation
-          bar: PublicValidationRelease_30_Channel_Id
+          bar: NetCore_Tools_Validation_Channel_Id
           storage: dev/validation
           public: true


### PR DESCRIPTION
The BAR channel ID variable mapping is currently wrong, causing all custom branch builds with no channel mapping to run the validation custom stages.

The cause is this name change in the Arcade channel templates: https://github.com/dotnet/arcade/pull/3991/files#diff-629d95ccfc208972db366150653accfaL19

```diff
   # .NET Tools - Validation
-  - name: PublicValidationRelease_30_Channel_Id
+  - name: NetCore_Tools_Validation_Channel_Id
     value: 9
```

I'd put in a check that ensures the variable name matches up, but with the custom stages hopefully going away soon (in 3.1/3.0 too?) it may not be worthwhile.