### PR TITLE
Move to 3.1.100 sdk to build 3.1

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "tools": {
-    "dotnet": "3.0.101"
+    "dotnet": "3.1.100"
   },
   "msbuild-sdks": {
     "Microsoft.DotNet.Arcade.Sdk": "1.0.0-beta.19577.5"


### PR DESCRIPTION
For consistency with upstack components which require the 3.1.100 SDK