### PR TITLE
[release/3.1] Set InitialAssetsLocation as well as location

### DIFF
--- a/publish/prepare-artifacts.proj
+++ b/publish/prepare-artifacts.proj
@@ -135,13 +135,17 @@
         <RelativeBlobPath>$(InstallersRelativePath)%(Filename)%(Extension)</RelativeBlobPath>
         <ManifestArtifactData>NonShipping=true</ManifestArtifactData>
       </ItemsToPush>
+    </ItemGroup>
 
+    <ItemGroup>
+        <ManifestBuildData Include="InitialAssetsLocation=$(SYSTEM_TEAMFOUNDATIONCOLLECTIONURI)$(SYSTEM_TEAMPROJECT)/_apis/build/builds/$(BUILD_BUILDID)/artifacts" />
+        <ManifestBuildData Include="Location=$(AzureFeedUrl)" />
     </ItemGroup>
 
     <!-- Push items to AzDO as build artifacts, generating the asset manifest as a side effect. -->
     <PushToAzureDevOpsArtifacts
       ItemsToPush="@(ItemsToPush)"
-      ManifestBuildData="Location=$(ExpectedFeedUrl)"
+      ManifestBuildData="@(ManifestBuildData)" />
       ManifestRepoUri="$(BUILD_REPOSITORY_URI)"
       ManifestBranch="$(BUILD_SOURCEBRANCH)"
       ManifestBuildId="$(BUILD_BUILDNUMBER)"


### PR DESCRIPTION
This repo was only setting Location. This setting is being deprecated for InitialAssetsLocation. Without setting InitialAssetsLocation, the Location parameter is used to populate the initial locations of each asset. This means that Maestro was thinking that all assets in core-setup, coming out of the build, were sitting in the dotnet-core feed, which is not true.