### PR TITLE
[release/3.1] Prompt dialog when running GUI app and hostfxr is < 3.*

### DIFF
--- a/src/corehost/cli/apphost/apphost.windows.cpp
+++ b/src/corehost/cli/apphost/apphost.windows.cpp
@@ -76,12 +76,19 @@ namespace
             while (std::getline(ss, line, _X('\n'))){
                 const pal::string_t prefix = _X("The framework '");
                 const pal::string_t suffix = _X("' was not found.");
+				const pal::string_t custom_prefix = _X("  _ ");
                 const pal::string_t url_prefix = _X("  - ") DOTNET_CORE_APPLAUNCH_URL _X("?");
                 if (starts_with(line, prefix, true) && ends_with(line, suffix, true))
                 {
                     dialogMsg.append(line);
                     dialogMsg.append(_X("\n\n"));
                 }
+				else if (starts_with(line, custom_prefix, true))
+				{
+					dialogMsg.erase();
+					dialogMsg.append(line.substr(custom_prefix.length()));
+					dialogMsg.append(_X("\n\n"));
+				}
                 else if (starts_with(line, url_prefix, true))
                 {
                     size_t offset = url_prefix.length() - pal::strlen(DOTNET_CORE_APPLAUNCH_URL) - 1;
@@ -94,6 +101,10 @@ namespace
         dialogMsg.append(_X("Would you like to download it now?"));
 
         assert(url.length() > 0);
+		if (is_gui_application())
+		{
+			url.append(_X("&gui=true"));
+		}
         url.append(_X("&apphost_version="));
         url.append(_STRINGIFY(COMMON_HOST_PKG_VER));
 

--- a/src/corehost/cli/apphost/apphost.windows.cpp
+++ b/src/corehost/cli/apphost/apphost.windows.cpp
@@ -76,19 +76,19 @@ namespace
             while (std::getline(ss, line, _X('\n'))){
                 const pal::string_t prefix = _X("The framework '");
                 const pal::string_t suffix = _X("' was not found.");
-				const pal::string_t custom_prefix = _X("  _ ");
+                const pal::string_t custom_prefix = _X("  _ ");
                 const pal::string_t url_prefix = _X("  - ") DOTNET_CORE_APPLAUNCH_URL _X("?");
                 if (starts_with(line, prefix, true) && ends_with(line, suffix, true))
                 {
                     dialogMsg.append(line);
                     dialogMsg.append(_X("\n\n"));
                 }
-				else if (starts_with(line, custom_prefix, true))
-				{
-					dialogMsg.erase();
-					dialogMsg.append(line.substr(custom_prefix.length()));
-					dialogMsg.append(_X("\n\n"));
-				}
+                else if (starts_with(line, custom_prefix, true))
+                {
+                    dialogMsg.erase();
+                    dialogMsg.append(line.substr(custom_prefix.length()));
+                    dialogMsg.append(_X("\n\n"));
+                }
                 else if (starts_with(line, url_prefix, true))
                 {
                     size_t offset = url_prefix.length() - pal::strlen(DOTNET_CORE_APPLAUNCH_URL) - 1;
@@ -101,10 +101,10 @@ namespace
         dialogMsg.append(_X("Would you like to download it now?"));
 
         assert(url.length() > 0);
-		if (is_gui_application())
-		{
-			url.append(_X("&gui=true"));
-		}
+        if (is_gui_application())
+        {
+            url.append(_X("&gui=true"));
+        }
         url.append(_X("&apphost_version="));
         url.append(_STRINGIFY(COMMON_HOST_PKG_VER));
 

--- a/src/corehost/cli/test/CMakeLists.txt
+++ b/src/corehost/cli/test/CMakeLists.txt
@@ -1,3 +1,4 @@
 add_subdirectory(mockcoreclr)
+add_subdirectory(mockhostfxr)
 add_subdirectory(mockhostpolicy)
 add_subdirectory(nativehost)

--- a/src/corehost/cli/test/mockhostfxr/CMakeLists.txt
+++ b/src/corehost/cli/test/mockhostfxr/CMakeLists.txt
@@ -1,0 +1,17 @@
+# Licensed to the .NET Foundation under one or more agreements.
+# The .NET Foundation licenses this file to you under the MIT license.
+# See the LICENSE file in the project root for more information.
+
+cmake_minimum_required (VERSION 2.6)
+project(mockhostfxr_2_2)
+
+set(DOTNET_PROJECT_NAME "mockhostfxr_2_2")
+
+set(SOURCES
+    ./mockhostfxr.cpp
+)
+
+include(../testlib.cmake)
+
+install(TARGETS mockhostfxr_2_2 DESTINATION corehost_test)
+install_symbols(mockhostfxr_2_2 corehost_test)

--- a/src/corehost/cli/test/mockhostfxr/mockhostfxr.cpp
+++ b/src/corehost/cli/test/mockhostfxr/mockhostfxr.cpp
@@ -7,23 +7,23 @@
 
 namespace
 {
-	void trace_hostfxr_entry_point(const pal::char_t *entry_point)
-	{
-		trace::setup();
-		trace::info(_X("--- Invoked hostfxr mock - %s"), entry_point);
-	}
+    void trace_hostfxr_entry_point(const pal::char_t *entry_point)
+    {
+        trace::setup();
+        trace::info(_X("--- Invoked hostfxr mock - %s"), entry_point);
+    }
 }
 
 SHARED_API int HOSTFXR_CALLTYPE hostfxr_main_startupinfo(const int argc, const pal::char_t* argv[], const pal::char_t* host_path, const pal::char_t* dotnet_root, const pal::char_t* app_path)
 {
-	trace_hostfxr_entry_point(_X("hostfxr_main_startupinfo"));
+    trace_hostfxr_entry_point(_X("hostfxr_main_startupinfo"));
 
-	const pal::string_t dotnet_folder = get_directory(dotnet_root);
+    const pal::string_t dotnet_folder = get_directory(dotnet_root);
 
-	if (pal::strcmp(dotnet_folder.c_str(), _X("hostfxrFrameworkMissingFailure")))
-	{
-		return StatusCode::FrameworkMissingFailure;
-	}
+    if (pal::strcmp(dotnet_folder.c_str(), _X("hostfxrFrameworkMissingFailure")))
+    {
+        return StatusCode::FrameworkMissingFailure;
+    }
 
-	return StatusCode::Success;
+    return StatusCode::Success;
 }

--- a/src/corehost/cli/test/mockhostfxr/mockhostfxr.cpp
+++ b/src/corehost/cli/test/mockhostfxr/mockhostfxr.cpp
@@ -1,0 +1,29 @@
+#include "error_codes.h"
+#include "hostfxr.h"
+#include "host_startup_info.h"
+#include "pal.h"
+#include "trace.h"
+#include "utils.h"
+
+namespace
+{
+	void trace_hostfxr_entry_point(const pal::char_t *entry_point)
+	{
+		trace::setup();
+		trace::info(_X("--- Invoked hostfxr mock - %s"), entry_point);
+	}
+}
+
+SHARED_API int HOSTFXR_CALLTYPE hostfxr_main_startupinfo(const int argc, const pal::char_t* argv[], const pal::char_t* host_path, const pal::char_t* dotnet_root, const pal::char_t* app_path)
+{
+	trace_hostfxr_entry_point(_X("hostfxr_main_startupinfo"));
+
+	const pal::string_t dotnet_folder = get_directory(dotnet_root);
+
+	if (pal::strcmp(dotnet_folder.c_str(), _X("hostfxrFrameworkMissingFailure")))
+	{
+		return StatusCode::FrameworkMissingFailure;
+	}
+
+	return StatusCode::Success;
+}

--- a/src/corehost/corehost.cpp
+++ b/src/corehost/corehost.cpp
@@ -218,6 +218,14 @@ int exe_start(const int argc, const pal::char_t* argv[])
             propagate_error_writer_t propagate_error_writer_to_hostfxr(set_error_writer_fn);
 
             rc = main_fn_v2(argc, argv, host_path_cstr, dotnet_root_cstr, app_path_cstr);
+
+			if (trace::get_error_writer() != nullptr && rc == static_cast<int>(StatusCode::FrameworkMissingFailure) && !set_error_writer_fn)
+			{
+				pal::string_t url = get_download_url();
+				trace::error(_X("  _ To run this application, you need to install a newer version of .NET Core."));
+				trace::error(_X(""));
+				trace::error(_X("  - %s"), url.c_str());
+			}
         }
     }
     else

--- a/src/corehost/corehost.cpp
+++ b/src/corehost/corehost.cpp
@@ -219,13 +219,13 @@ int exe_start(const int argc, const pal::char_t* argv[])
 
             rc = main_fn_v2(argc, argv, host_path_cstr, dotnet_root_cstr, app_path_cstr);
 
-			if (trace::get_error_writer() != nullptr && rc == static_cast<int>(StatusCode::FrameworkMissingFailure) && !set_error_writer_fn)
-			{
-				pal::string_t url = get_download_url();
-				trace::error(_X("  _ To run this application, you need to install a newer version of .NET Core."));
-				trace::error(_X(""));
-				trace::error(_X("  - %s"), url.c_str());
-			}
+            if (trace::get_error_writer() != nullptr && rc == static_cast<int>(StatusCode::FrameworkMissingFailure) && !set_error_writer_fn)
+            {
+                pal::string_t url = get_download_url();
+                trace::error(_X("  _ To run this application, you need to install a newer version of .NET Core."));
+                trace::error(_X(""));
+                trace::error(_X("  - %s"), url.c_str());
+            }
         }
     }
     else

--- a/src/test/HostActivation.Tests/DotNetBuilder.cs
+++ b/src/test/HostActivation.Tests/DotNetBuilder.cs
@@ -66,6 +66,49 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
         }
 
         /// <summary>
+        /// Use a mock version of HostFxr.
+        /// </summary>
+        /// <param name="version">Version to add</param>
+        /// <remarks>
+        /// Currently, the only mock version of HostFxr that we have is mockhostfxr_2_2.
+        /// </remarks>
+        public DotNetBuilder AddMockHostFxr(Version version)
+        {
+            string hostfxrPath = Path.Combine(_path, "host", "fxr", version.ToString());
+            Directory.CreateDirectory(hostfxrPath);
+            bool hasCustomErrorWriter = version.Major >= 3;
+
+            string mockHostFxrFileName = RuntimeInformationExtensions.GetSharedLibraryFileNameForCurrentPlatform(hasCustomErrorWriter ? "mockhostfxr" : "mockhostfxr_2_2");
+            File.Copy(
+                Path.Combine(_repoDirectories.Artifacts, "corehost_test", mockHostFxrFileName),
+                Path.Combine(hostfxrPath, RuntimeInformationExtensions.GetSharedLibraryFileNameForCurrentPlatform("hostfxr")),
+                true);
+
+            return this;
+        }
+
+        /// <summary>
+        /// Removes the specified HostFxr version. If no version is set, it'll delete all versions found.
+        /// </summary>
+        /// <param name="version">Version to remove</param>
+        public DotNetBuilder RemoveHostFxr(Version version = null)
+        {
+            if (version != null)
+            {
+                new DirectoryInfo(Path.Combine(_path, "host", "fxr", version.ToString())).Delete(recursive: true);
+            }
+            else
+            {
+                foreach (var dir in new DirectoryInfo(Path.Combine(_path, "host", "fxr")).GetDirectories())
+                {
+                    dir.Delete(recursive: true);
+                }
+            }
+
+            return this;
+        }
+
+        /// <summary>
         /// Add a mock of the Microsoft.NETCore.App framework with the specified version
         /// </summary>
         /// <param name="version">Version to add</param>

--- a/src/test/HostActivation.Tests/PortableAppActivation.cs
+++ b/src/test/HostActivation.Tests/PortableAppActivation.cs
@@ -407,6 +407,49 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
         }
 
         [Fact]
+        public void AppHost_GUI_NoCustomErrorWriter_FrameworkMissing_ErrorReportedInDialog()
+        {
+            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                return;
+            }
+
+            var fixture = sharedTestState.PortableAppFixture_Built
+                .Copy();
+
+            string appExe = fixture.TestProject.AppExe;
+            File.Copy(sharedTestState.BuiltAppHost, appExe, overwrite: true);
+            AppHostExtensions.BindAppHost(appExe);
+            AppHostExtensions.SetWindowsGraphicalUserInterfaceBit(appExe);
+
+            string dotnetWithMockHostFxr = SharedFramework.CalculateUniqueTestDirectory(Path.Combine(TestArtifact.TestArtifactsPath, "guiErrors"));
+            using (new TestArtifact(dotnetWithMockHostFxr))
+            {
+                Directory.CreateDirectory(dotnetWithMockHostFxr);
+                string expectedErrorCode = Constants.ErrorCode.FrameworkMissingFailure.ToString("x");
+
+                var dotnetBuilder = new DotNetBuilder(dotnetWithMockHostFxr, sharedTestState.RepoDirectories.BuiltDotnet, "hostfxrFrameworkMissingFailure")
+                    .RemoveHostFxr()
+                    .AddMockHostFxr(new Version(2, 2, 0));
+                var dotnet = dotnetBuilder.Build();
+
+                Command command = Command.Create(appExe)
+                    .EnableTracingAndCaptureOutputs()
+                    .DotNetRoot(dotnet.BinPath)
+                    .MultilevelLookup(false)
+                    .Start();
+
+                WaitForPopupFromProcess(command.Process);
+                command.Process.Kill();
+
+                command.WaitForExit(true)
+                    .Should().Fail()
+                    .And.HaveStdErrContaining($"Showing error dialog for application: '{Path.GetFileName(appExe)}' - error code: 0x{expectedErrorCode}")
+                    .And.HaveStdErrContaining("To run this application, you need to install a newer version of .NET Core");
+            }
+        }
+
+        [Fact]
         public void AppHost_GUI_FrameworkDependent_DisabledGUIErrors_DialogNotShown()
         {
             if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))


### PR DESCRIPTION
Issue: [dotnet/runtime#617](https://github.com/dotnet/runtime/issues/617)

Description
---
Since .NET Core 3.1, apphosts have the ability to prompt a dialog whenever a client doesn't have either a runtime or a required framework installed. Currently, clients with an installed version of .NET Core previous to 3.0 that try to run a GUI app will get no error message whatsoever, the application will just silently crash. This fixes the aforementioned scenario by prompting an error dialog that lets the client download a newer version of .NET Core. 

This is because versions of hostfxr previous to 3.0 have no error message propagation, causing the apphost to crash silently.

Customer impact
---

Customers trying to run a GUI apphost with a .NET Core version previous to 3.0 will not get any kind of error message, the apphost will silently crash, not giving any clue of what's wrong.
The error is written into Windows Event Log, but most end users won't go there to check.  
There's no workaround for either the user or the application developer as this happens too early in the host binaries for any application code to run.

Regression?
---

Not a regression - the dialog popup for errors in GUI apps is a new capability in 3.0 (as well as official support for GUI apps as a whole).

Risk
---

Low - the fix is targeted to the very specific case where the bug happens.

----

[Edit] The dialog that we show now:
![image](https://user-images.githubusercontent.com/3836488/72926108-b392da80-3d08-11ea-86a5-bd3d98712b60.png)


cc @vitek-karas @jeffschwMSFT 