### PR TITLE
[release/2.1] Always build VS insertion packages as prerelease

### DIFF
--- a/src/pkg/packaging/dir.proj
+++ b/src/pkg/packaging/dir.proj
@@ -210,25 +210,31 @@
         <NuSpecFile>$(MSBuildThisFileDirectory)windows/vscomponents/VS.Redist.Common.Component.nuspec</NuSpecFile>
         <GenerateNupkgPowershellScript>$(MSBuildThisFileDirectory)windows/vscomponents/generatenupkg.ps1</GenerateNupkgPowershellScript>
         <ProjectUrl>https://github.com/dotnet/core-setup</ProjectUrl>
+        <!--
+          Always build VS insertion packages with non-stable version. Ensures uniqueness for each
+          build, even if building stable multiple times in a row. Necessary because these are
+          published to an immutable feed before release day.
+        -->
+        <VSInsertionVersionSuffix>$(ProductionVersion)-$(PreReleaseLabel)-$(BuildNumberMajor)-$(BuildNumberMinor)</VSInsertionVersionSuffix>
       </PropertyGroup>
 
       <ItemGroup>
         <SdkMsiComponent Include="HostFxrMsiNupkg">
           <MsiInstallerFile>$(HostFxrInstallerFile)</MsiInstallerFile>
           <ComponentId>VS.Redist.Common.NetCore.HostFXR.$(TargetArchitecture).$(NETCoreAppFrameworkVersion)</ComponentId>
-          <ComponentVersion>$(SharedFrameworkNugetVersion)</ComponentVersion>
+          <ComponentVersion>$(VSInsertionVersionSuffix)</ComponentVersion>
           <ComponentFriendlyName>$(NETCoreAppFrameworkVersion) .NET Core HostFX Resolver</ComponentFriendlyName>
         </SdkMsiComponent>
         <SdkMsiComponent Include="SharedFrameworkMsiNupkg">
           <MsiInstallerFile>$(SharedFrameworkInstallerFile)</MsiInstallerFile>
           <ComponentId>VS.Redist.Common.NetCore.SharedFramework.$(TargetArchitecture).$(NETCoreAppFrameworkVersion)</ComponentId>
-          <ComponentVersion>$(SharedFrameworkNugetVersion)</ComponentVersion>
+          <ComponentVersion>$(VSInsertionVersionSuffix)</ComponentVersion>
           <ComponentFriendlyName>$(NETCoreAppFrameworkVersion) .NET Core SharedFramework</ComponentFriendlyName>
         </SdkMsiComponent>
         <SdkMsiComponent Include="SharedHostMsiNupkg">
           <MsiInstallerFile>$(SharedHostInstallerFile)</MsiInstallerFile>
           <ComponentId>VS.Redist.Common.NetCore.SharedHost.$(TargetArchitecture).$(NETCoreAppFrameworkVersion)</ComponentId>
-          <ComponentVersion>$(SharedFrameworkNugetVersion)</ComponentVersion>
+          <ComponentVersion>$(VSInsertionVersionSuffix)</ComponentVersion>
           <ComponentFriendlyName>$(NETCoreAppFrameworkVersion) .NET Core SharedHost</ComponentFriendlyName>
         </SdkMsiComponent>
       </ItemGroup>

--- a/src/pkg/packaging/dir.proj
+++ b/src/pkg/packaging/dir.proj
@@ -215,26 +215,26 @@
           build, even if building stable multiple times in a row. Necessary because these are
           published to an immutable feed before release day.
         -->
-        <VSInsertionVersionSuffix>$(ProductionVersion)-$(PreReleaseLabel)-$(BuildNumberMajor)-$(BuildNumberMinor)</VSInsertionVersionSuffix>
+        <VSInsertionVersion>$(ProductionVersion)-$(PreReleaseLabel)-$(BuildNumberMajor)-$(BuildNumberMinor)</VSInsertionVersion>
       </PropertyGroup>
 
       <ItemGroup>
         <SdkMsiComponent Include="HostFxrMsiNupkg">
           <MsiInstallerFile>$(HostFxrInstallerFile)</MsiInstallerFile>
           <ComponentId>VS.Redist.Common.NetCore.HostFXR.$(TargetArchitecture).$(NETCoreAppFrameworkVersion)</ComponentId>
-          <ComponentVersion>$(VSInsertionVersionSuffix)</ComponentVersion>
+          <ComponentVersion>$(VSInsertionVersion)</ComponentVersion>
           <ComponentFriendlyName>$(NETCoreAppFrameworkVersion) .NET Core HostFX Resolver</ComponentFriendlyName>
         </SdkMsiComponent>
         <SdkMsiComponent Include="SharedFrameworkMsiNupkg">
           <MsiInstallerFile>$(SharedFrameworkInstallerFile)</MsiInstallerFile>
           <ComponentId>VS.Redist.Common.NetCore.SharedFramework.$(TargetArchitecture).$(NETCoreAppFrameworkVersion)</ComponentId>
-          <ComponentVersion>$(VSInsertionVersionSuffix)</ComponentVersion>
+          <ComponentVersion>$(VSInsertionVersion)</ComponentVersion>
           <ComponentFriendlyName>$(NETCoreAppFrameworkVersion) .NET Core SharedFramework</ComponentFriendlyName>
         </SdkMsiComponent>
         <SdkMsiComponent Include="SharedHostMsiNupkg">
           <MsiInstallerFile>$(SharedHostInstallerFile)</MsiInstallerFile>
           <ComponentId>VS.Redist.Common.NetCore.SharedHost.$(TargetArchitecture).$(NETCoreAppFrameworkVersion)</ComponentId>
-          <ComponentVersion>$(VSInsertionVersionSuffix)</ComponentVersion>
+          <ComponentVersion>$(VSInsertionVersion)</ComponentVersion>
           <ComponentFriendlyName>$(NETCoreAppFrameworkVersion) .NET Core SharedHost</ComponentFriendlyName>
         </SdkMsiComponent>
       </ItemGroup>


### PR DESCRIPTION
#### Description
Always build VS insertion packages with non-stable version. Ensures uniqueness for each build, even if building stable multiple times in a row. Necessary because these are published to an immutable feed before release day.

Fixes https://github.com/dotnet/runtime/issues/514

#### Customer Impact
Without this, we need manual effort per extra build to modify the nupkgs to be unstable before they can be pushed to the immutable feed.

#### Regression?
No.

#### Risk
This may break the build in an unknown way, in which case we can revert the PR and continue.

Tested with `.\build.cmd -- /p:StabilizePackageVersion=true`, which produced `VS.Redist.Common.NetCore.HostFXR.x64.2.1.2.1.16-servicing-28514-0.nupkg`, but stable versions for other nupkgs. This is a pretty simple change so I think this is enough to be pretty confident in it.

`SdkMsiComponent`'s `ComponentVersion` metadata is only used for package version (based on global find on the repo). Its contents are still stable as expected, e.g. `dotnet-hostfxr-2.1.16-win-x64.msi`.
