### PR TITLE
[release/3.1] Add automatic SDL validation

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -39,6 +39,8 @@ variables:
   - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
     - name: SignType
       value: $[ coalesce(variables.OfficialSignType, 'real') ]
+    # Values for SDLValidationParameters
+    - group: core-setup-sdl-validation
 
 stages:
 - stage: Build

--- a/eng/stages/publish.yml
+++ b/eng/stages/publish.yml
@@ -16,6 +16,23 @@ stages:
     # quotes inside the string so that it passes through to MSBuild without script interference.
     symbolPublishingAdditionalParameters: "'-warnAsError:$false'"
     publishInstallersAndChecksums: true
+    # Enable SDL validation, passing through values from the 'core-setup-sdl-validation' group.
+    SDLValidationParameters:
+      enable: true
+      artifactNames:
+      - PackageArtifacts
+      - BlobArtifacts
+      params: >-
+        -SourceToolsList @("policheck","credscan")
+        -TsaInstanceURL "$(TsaInstanceURL)"
+        -TsaProjectName "$(TsaProjectName)"
+        -TsaNotificationEmail "$(TsaNotificationEmail)"
+        -TsaCodebaseAdmin "$(TsaCodebaseAdmin)"
+        -TsaBugAreaPath "$(TsaBugAreaPath)"
+        -TsaIterationPath "$(TsaIterationPath)"
+        -TsaRepositoryName "$(TsaRepositoryName)"
+        -TsaCodebaseName "$(TsaCodebaseName)"
+        -TsaPublish $True
 
 # Create extra stage per BAR channel that needs extra publish steps. These run after the Arcade
 # stages because they depend on Arcade's NuGet package publish being complete.


### PR DESCRIPTION
#### Description

Ports SDL validation infrastructure from https://github.com/dotnet/core-setup/pull/8846 to `release/3.1`.

The goal is to get `policheck` and `credscan` integrated for 3.1 to reduce the need for manual runs. (There's still value: https://github.com/dotnet/arcade/issues/4216#issuecomment-553664380.)

For https://github.com/dotnet/core-setup/issues/8669.

I ran a mock build to validate, which passed: https://dev.azure.com/dnceng/internal/_build/results?buildId=496043&view=results

#### Customer Impact

None.

#### Regression?

No.

#### Risk

Very low. The mock build would have caught any reasonable problems. If there are issues once merged, the build will break and we will need to revert this change, but nothing worse than that.

---

/cc @vivmishra @mmitche 