### PR TITLE
[release/3.1] Fix servicing project skips: work in unstable mode

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -37,7 +37,7 @@
     * These items also keep track of the last time each package was patched, enabling source-build
       to produce the correct old version number using current sources.
   -->
-  <ItemGroup Condition="'$(StabilizePackageVersion)' == 'true'">
+  <ItemGroup>
     <ProjectServicingConfiguration Include="Microsoft.NETCore.App.Ref" PatchVersion="0" />
     <ProjectServicingConfiguration Include="Microsoft.WindowsDesktop.App.Ref" PatchVersion="0" />
     <ProjectServicingConfiguration Include="NETStandard.Library.Ref" PatchVersion="0" />


### PR DESCRIPTION
#### Description

Ports https://github.com/dotnet/core-setup/pull/8991 from `release/3.0` to `release/3.1`.

For https://github.com/dotnet/runtime/issues/639. Fixes the targeting pack skipping logic so the targeting packs are skipped even when the repo builds in unstable mode.

For example, both 3.1.5 and 3.1.5-servicing-12345 should skip building the netcoreapp targeting packs. If 3.1.5-servicing-12345 included the targeting pack, downstream repos would update to include it, then when we produce a 3.1.5 stable build, we're left with an invalid, stale reference to 3.1.5-servicing-12345 in the downstream repo. So far, this has been solved by pinning the dependency so it isn't updated to the unwanted 3.1.5-servicing-12345 build.

/cc @nguerrera @wtgodbe 

#### Customer Impact

This lets downstream repos unpin their dependencies on the targeting packs, leading to more reliable dependency flow and giving us a more certain release.

#### Regression?

No.

#### Risk

Low. The logic is very simple and only affects unstable mode builds. I can't imagine a way this could negatively impact the build or downstream repos. We have the same implementation merged into dotnet/runtime `master`.