### PR TITLE
[release/3.1] Single-File: Close AppHost stream when reusing extraction

### DIFF
--- a/src/corehost/cli/apphost/bundle/bundle_runner.cpp
+++ b/src/corehost/cli/apphost/bundle/bundle_runner.cpp
@@ -285,6 +285,7 @@ StatusCode bundle_runner_t::extract()
         determine_extraction_dir();
         if (can_reuse_extraction())
         {
+            fclose(m_bundle_stream);
             return StatusCode::Success;
         }
 

--- a/src/test/Assets/TestProjects/AppWithWait/AppWithWait.csproj
+++ b/src/test/Assets/TestProjects/AppWithWait/AppWithWait.csproj
@@ -1,0 +1,10 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>$(NETCoreAppFramework)</TargetFramework>
+    <OutputType>Exe</OutputType>
+    <RuntimeIdentifier>$(TestTargetRid)</RuntimeIdentifier>
+    <RuntimeFrameworkVersion>$(MNAVersion)</RuntimeFrameworkVersion>
+  </PropertyGroup>
+
+</Project>

--- a/src/test/Assets/TestProjects/AppWithWait/Program.cs
+++ b/src/test/Assets/TestProjects/AppWithWait/Program.cs
@@ -1,0 +1,33 @@
+using System;
+using System.IO;
+using System.Threading;
+
+namespace AppWithSubDirs
+{
+    public static class Program
+    {
+        public static void Main(string[] args)
+        {
+            Console.Write("Hello ");
+
+            // If the caller wants the app to start and wait, it provides the names of two files.
+            // In this case, this test app creates the waitFile, and waits until resumeFile is created
+            if (args.Length == 2)
+            {
+                string waitFile = args[0];
+                string resumeFile = args[1];
+
+                File.Create(waitFile).Close();
+
+                Thread.Sleep(200);
+
+                while (!File.Exists(resumeFile))
+                {
+                    Thread.Sleep(100);
+                }
+            }
+
+            Console.WriteLine("World!");
+        }
+    }
+}

--- a/src/test/BundleTests/Helpers/BundleHelper.cs
+++ b/src/test/BundleTests/Helpers/BundleHelper.cs
@@ -21,6 +21,11 @@ namespace BundleTests.Helpers
             return Path.Combine(GetPublishPath(fixture), GetAppName(fixture));
         }
 
+        public static string GetPublishedSingleFilePath(TestProjectFixture fixture)
+        {
+            return GetHostPath(fixture);
+        }
+
         public static string GetHostName(TestProjectFixture fixture)
         {
             return Path.GetFileName(fixture.TestProject.AppExe);

--- a/src/test/BundleTests/Microsoft.NET.HostModel.Bundle.Tests/BundleRename.cs
+++ b/src/test/BundleTests/Microsoft.NET.HostModel.Bundle.Tests/BundleRename.cs
@@ -1,0 +1,92 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.IO;
+using Xunit;
+using Microsoft.DotNet.Cli.Build.Framework;
+using Microsoft.DotNet.CoreSetup.Test;
+using BundleTests.Helpers;
+using System.Threading;
+
+namespace AppHost.Bundle.Tests
+{
+    public class BundleRename : IClassFixture<BundleRename.SharedTestState>
+    {
+        private SharedTestState sharedTestState;
+
+        public BundleRename(SharedTestState fixture)
+        {
+            sharedTestState = fixture;
+        }
+
+        [Theory]
+        [InlineData(true)]  // Test renaming the single-exe during the initial run, when contents are extracted
+        [InlineData(false)] // Test renaming the single-exe during subsequent runs, when contents are reused
+        private void Bundle_can_be_renamed_while_running(bool renameFirstRun)
+        {
+            var fixture = sharedTestState.TestFixture.Copy();
+            string singleFile = BundleHelper.GetPublishedSingleFilePath(fixture);
+            string renameFile = Path.Combine(BundleHelper.GetPublishPath(fixture), Path.GetRandomFileName());
+            string waitFile = Path.Combine(BundleHelper.GetPublishPath(fixture), "wait");
+            string resumeFile = Path.Combine(BundleHelper.GetPublishPath(fixture), "resume");
+
+            if (!renameFirstRun)
+            {
+                Command.Create(singleFile)
+                    .CaptureStdErr()
+                    .CaptureStdOut()
+                    .Execute()
+                    .Should()
+                    .Pass()
+                    .And
+                    .HaveStdOutContaining("Hello World!");
+            }
+
+            // Once the App starts running, it creates the waitFile, and waits until resumeFile file is created.
+            var singleExe = Command.Create(singleFile, waitFile, resumeFile)
+                .CaptureStdErr()
+                .CaptureStdOut()
+                .Start();
+
+            while (!File.Exists(waitFile))
+            {
+                Thread.Sleep(100);
+            }
+
+            File.Move(singleFile, renameFile);
+            File.Create(resumeFile).Close();
+
+            var result = singleExe.WaitForExit(fExpectedToFail: false);
+
+            result
+                .Should()
+                .Pass()
+                .And
+                .HaveStdOutContaining("Hello World!");
+        }
+
+        public class SharedTestState : IDisposable
+        {
+            public TestProjectFixture TestFixture { get; set; }
+            public RepoDirectoriesProvider RepoDirectories { get; set; }
+
+            public SharedTestState()
+            {
+                RepoDirectories = new RepoDirectoriesProvider();
+                TestFixture = new TestProjectFixture("AppWithWait", RepoDirectories);
+                TestFixture
+                    .EnsureRestoredForRid(TestFixture.CurrentRid, RepoDirectories.CorehostPackages)
+                    .PublishProject(runtime: TestFixture.CurrentRid,
+                                    singleFile: true,
+                                    outputDirectory: BundleHelper.GetPublishPath(TestFixture));
+            }
+
+            public void Dispose()
+            {
+                TestFixture.Dispose();
+            }
+        }
+    }
+}

--- a/src/test/TestUtils/TestProjectFixture.cs
+++ b/src/test/TestUtils/TestProjectFixture.cs
@@ -252,7 +252,8 @@ namespace Microsoft.DotNet.CoreSetup.Test
             string runtime = null,
             string framework = null,
             string selfContained = null,
-            string outputDirectory = null)
+            string outputDirectory = null,
+            bool singleFile = false)
         {
             dotnet = dotnet ?? SdkDotnet;
             outputDirectory = outputDirectory ?? TestProject.OutputDirectory;
@@ -289,6 +290,11 @@ namespace Microsoft.DotNet.CoreSetup.Test
             {
                 publishArgs.Add("-o");
                 publishArgs.Add(outputDirectory);
+            }
+
+            if (singleFile)
+            {
+                publishArgs.Add("/p:PublishSingleFile=true");
             }
 
             publishArgs.Add($"/p:TestTargetRid={RepoDirProvider.TargetRID}");


### PR DESCRIPTION
## Issue
https://github.com/dotnet/runtime/issues/1260

## Customer Scenario
A single-file app cannot be renamed while running -- an idiom used while updating the app in-place.

## Problem
When running a single-file app, the AppHost reads itself in order to extract the embedded contents.
The Apphost must always read its contents in order to read the headers, but doesn't always extract the contents, because previously extracted files are re-used when available.

In the case where apphost doesn't extract, currently, the file stream isn't immediately closed on Windows. This prevents the app from being renamed while running.

## Solution
This change fixes the problem by closing the open stream in all cases.

## Risk
Very Low

## Master Branch
https://github.com/dotnet/runtime/pull/2272