### PR TITLE
[release/2.1] Add libicu65 to DEB deps package

### DIFF
--- a/src/pkg/packaging/deb/package.targets
+++ b/src/pkg/packaging/deb/package.targets
@@ -348,7 +348,7 @@
         <ReplacementString>libssl1.0.0 | libssl1.0.2 | libssl1.1</ReplacementString>
       </SharedFrameworkTokenValue>
 
-      <KnownLibIcuVersion Include="63;60;57;55;52" />
+      <KnownLibIcuVersion Include="65;63;60;57;55;52" />
       <SharedFrameworkTokenValue Include="%LIBICU_DEPENDENCY_LIST%">
         <ReplacementString>libicu | @(KnownLibIcuVersion -> 'libicu%(Identity)', ' | ')</ReplacementString>
       </SharedFrameworkTokenValue>

--- a/src/pkg/packaging/deb/package.targets
+++ b/src/pkg/packaging/deb/package.targets
@@ -348,7 +348,7 @@
         <ReplacementString>libssl1.0.0 | libssl1.0.2 | libssl1.1</ReplacementString>
       </SharedFrameworkTokenValue>
 
-      <KnownLibIcuVersion Include="65;63;60;57;55;52" />
+      <KnownLibIcuVersion Include="66;65;63;60;57;55;52" />
       <SharedFrameworkTokenValue Include="%LIBICU_DEPENDENCY_LIST%">
         <ReplacementString>libicu | @(KnownLibIcuVersion -> 'libicu%(Identity)', ' | ')</ReplacementString>
       </SharedFrameworkTokenValue>


### PR DESCRIPTION
### Description
Fix for issue dotnet/runtime#32971

Ubuntu Focal (20.04), which is in preview, recently updated to a newer version of libicu - libicu65. The dotnet-runtime-deps deb package needs to be updated appropriately so that the libicu dependency is correctly met/installed.

### Customer Impact
Not being able to install .NET Core on Ubuntu Focal (20.04) release. This is the latest Ubuntu release that goes public in April (in few weeks). We should ensure that .NET works from the very beginning.

### Regression?
No - this was a change in Ubuntu requirements.

### Risk
None

### Packaging changes reviewed?
This PR is for packaging changes - reviewers: @dagood and @MichaelSimons

Fix for issue dotnet/runtime#32971

Ubuntu Focal, which is in preview, recently updated to a newer version of libicu - libicu65. The dotnet-runtime-deps deb package needs to be updated appropriately so that the libicu dependency is correctly met/installed.
