### PR TITLE
Allow skipping package build during servicing

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -41,6 +41,9 @@
     <ProjectServicingConfiguration Include="Microsoft.NETCore.App.Ref" PatchVersion="0" />
     <ProjectServicingConfiguration Include="Microsoft.WindowsDesktop.App.Ref" PatchVersion="0" />
     <ProjectServicingConfiguration Include="NETStandard.Library.Ref" PatchVersion="0" />
+    <ProjectServicingConfiguration Include="Microsoft.DotNet.PlatformAbstractions" PatchVersion="6" />
+    <ProjectServicingConfiguration Include="Microsoft.Extensions.DependencyModel" PatchVersion="6" />
+    <ProjectServicingConfiguration Include="Microsoft.NET.HostModel" PatchVersion="6" />
   </ItemGroup>
   <PropertyGroup>
     <MicrosoftDotNetMaestroTasksVersion>1.0.0-beta.18619.4</MicrosoftDotNetMaestroTasksVersion>

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -8,4 +8,31 @@
   <Import Project="packaging.stubs.targets" Condition="'$(MSBuildProjectExtension)' != '.pkgproj'" />
 
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory).., Directory.Build.targets))\Directory.Build.targets" />
+
+  <!--
+    Package build can be skipped by invoking PackIfServiced instead of Pack targets.
+
+    ProjectServicingConfiguration is used to determine if packaging should be skipped. See more in eng/Versions.props.
+  -->
+  <Target Name="GetCurrentProjectServicingConfiguration">
+    <ItemGroup>
+      <CurrentProjectServicingConfiguration
+        Include="@(ProjectServicingConfiguration)"
+        Condition="'%(Identity)' == '$(MSBuildProjectName)'" />
+    </ItemGroup>
+  </Target>
+
+  <Target Name="PackIfServiced"
+        DependsOnTargets="
+          SkipPackIfShouldNotBuild;
+          Pack" />
+
+  <Target Name="SkipPackIfShouldNotBuild"
+        DependsOnTargets="GetCurrentProjectServicingConfiguration">
+    <PropertyGroup>
+      <MostRecentProducedServicingPatchVersion>%(CurrentProjectServicingConfiguration.PatchVersion)</MostRecentProducedServicingPatchVersion>
+      <IsPackable Condition="'$(MostRecentProducedServicingPatchVersion)' != '$(PatchVersion)'">false</IsPackable>
+    </PropertyGroup>
+  </Target>
+
 </Project>

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -14,6 +14,11 @@
 
     ProjectServicingConfiguration is used to determine if packaging should be skipped. See more in eng/Versions.props.
   -->
+  <Target Name="PackIfServiced"
+          DependsOnTargets="
+            SkipPackIfShouldNotBuild;
+            Pack" />
+
   <Target Name="GetCurrentProjectServicingConfiguration">
     <ItemGroup>
       <CurrentProjectServicingConfiguration
@@ -22,13 +27,9 @@
     </ItemGroup>
   </Target>
 
-  <Target Name="PackIfServiced"
-        DependsOnTargets="
-          SkipPackIfShouldNotBuild;
-          Pack" />
-
   <Target Name="SkipPackIfShouldNotBuild"
-        DependsOnTargets="GetCurrentProjectServicingConfiguration">
+          Condition="'$(AlwaysPackEvenIfNotServicing)' != 'true'"
+          DependsOnTargets="GetCurrentProjectServicingConfiguration">
     <PropertyGroup>
       <MostRecentProducedServicingPatchVersion>%(CurrentProjectServicingConfiguration.PatchVersion)</MostRecentProducedServicingPatchVersion>
       <IsPackable Condition="'$(MostRecentProducedServicingPatchVersion)' != '$(PatchVersion)'">false</IsPackable>

--- a/src/pkg/packaging/pack-managed.proj
+++ b/src/pkg/packaging/pack-managed.proj
@@ -11,7 +11,7 @@
       <ManagedProject Include="$(RepoRoot)src\managed\**\*.csproj" />
     </ItemGroup>
 
-    <MSBuild Projects="@(ManagedProject)" Targets="Pack" />
+    <MSBuild Projects="@(ManagedProject)" Targets="PackIfServiced" />
   </Target>
 
   <Target Name="Test" />


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/37661

## Summary

This infra adds the ability to skip package build during servicing, for any package that should not be built and published to NuGet.org.

## Customer Impact

No. This is internal, build infra.

## Regression?

No.

## Testing

Repo build to ensure unchanged packages are not built.

## Risk

None.
