### PR TITLE
[release/3.1] Add dependencies for CPD strict in efcore

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -6,6 +6,18 @@
       <Uri>https://dev.azure.com/dnceng/internal/_git/dotnet-corefx</Uri>
       <Sha>059a4a19e602494bfbed473dbbb18f2dbfbd0878</Sha>
     </Dependency>
+    <Dependency Name="Microsoft.Bcl.AsyncInterfaces" Version="1.1.1">
+      <Uri>https://github.com/dotnet/corefx</Uri>
+      <Sha>059a4a19e602494bfbed473dbbb18f2dbfbd0878</Sha>
+    </Dependency>
+    <Dependency Name="Microsoft.Bcl.HashCode" Version="1.1.0">
+      <Uri>https://github.com/dotnet/corefx</Uri>
+      <Sha>0f7f38c4fd323b26da10cce95f857f77f0f09b48</Sha>
+    </Dependency>
+    <Dependency Name="Microsoft.CSharp" Version="4.7.0">
+      <Uri>https://github.com/dotnet/corefx</Uri>
+      <Sha>0f7f38c4fd323b26da10cce95f857f77f0f09b48</Sha>
+    </Dependency>
     <Dependency Name="Microsoft.NETCore.Platforms" Version="3.1.2">
       <Uri>https://dev.azure.com/dnceng/internal/_git/dotnet-corefx</Uri>
       <Sha>36b8b8e26a8e2e06e000f59e19910d117bf0025b</Sha>
@@ -38,9 +50,21 @@
       <Uri>https://github.com/dotnet/corefx</Uri>
       <Sha>0f7f38c4fd323b26da10cce95f857f77f0f09b48</Sha>
     </Dependency>
+    <Dependency Name="System.Collections.Immutable" Version="1.7.1">
+      <Uri>https://github.com/dotnet/corefx</Uri>
+      <Sha>059a4a19e602494bfbed473dbbb18f2dbfbd0878</Sha>
+    </Dependency>
+    <Dependency Name="System.ComponentModel.Annotations" Version="4.7.0">
+      <Uri>https://github.com/dotnet/corefx</Uri>
+      <Sha>0f7f38c4fd323b26da10cce95f857f77f0f09b48</Sha>
+    </Dependency>
     <Dependency Name="System.Configuration.ConfigurationManager" Version="4.7.0">
       <Uri>https://github.com/dotnet/corefx</Uri>
       <Sha>0f7f38c4fd323b26da10cce95f857f77f0f09b48</Sha>
+    </Dependency>
+    <Dependency Name="System.Diagnostics.DiagnosticSource" Version="4.7.1">
+      <Uri>https://github.com/dotnet/corefx</Uri>
+      <Sha>059a4a19e602494bfbed473dbbb18f2dbfbd0878</Sha>
     </Dependency>
     <Dependency Name="System.Diagnostics.EventLog" Version="4.7.0">
       <Uri>https://github.com/dotnet/corefx</Uri>


### PR DESCRIPTION
/fyi I confirmed the versions match what dotnet/efcore currently has and that they're the latest on NuGet.org