### PR TITLE
Fix repo urls

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -7,7 +7,7 @@
       <Sha>059a4a19e602494bfbed473dbbb18f2dbfbd0878</Sha>
     </Dependency>
     <Dependency Name="Microsoft.Bcl.AsyncInterfaces" Version="1.1.1">
-      <Uri>https://github.com/dotnet/corefx</Uri>
+      <Uri>https://dev.azure.com/dnceng/internal/_git/dotnet-corefx</Uri>
       <Sha>059a4a19e602494bfbed473dbbb18f2dbfbd0878</Sha>
     </Dependency>
     <Dependency Name="Microsoft.Bcl.HashCode" Version="1.1.0">
@@ -55,7 +55,7 @@
       <Sha>8a3ffed558ddf943c1efa87d693227722d6af094</Sha>
     </Dependency>
     <Dependency Name="System.Collections.Immutable" Version="1.7.1">
-      <Uri>https://github.com/dotnet/corefx</Uri>
+      <Uri>https://dev.azure.com/dnceng/internal/_git/dotnet-corefx</Uri>
       <Sha>059a4a19e602494bfbed473dbbb18f2dbfbd0878</Sha>
     </Dependency>
     <Dependency Name="System.ComponentModel.Annotations" Version="4.7.0">
@@ -71,7 +71,7 @@
       <Sha>36b8b8e26a8e2e06e000f59e19910d117bf0025b</Sha>
     </Dependency>
     <Dependency Name="System.Diagnostics.DiagnosticSource" Version="4.7.1">
-      <Uri>https://github.com/dotnet/corefx</Uri>
+      <Uri>https://dev.azure.com/dnceng/internal/_git/dotnet-corefx</Uri>
       <Sha>059a4a19e602494bfbed473dbbb18f2dbfbd0878</Sha>
     </Dependency>
     <Dependency Name="System.Diagnostics.EventLog" Version="4.7.0">
@@ -107,7 +107,7 @@
       <Sha>059a4a19e602494bfbed473dbbb18f2dbfbd0878</Sha>
     </Dependency>
     <Dependency Name="System.Reflection.MetadataLoadContext" Version="4.7.2">
-      <Uri>https://github.com/dotnet/corefx</Uri>
+      <Uri>https://dev.azure.com/dnceng/internal/_git/dotnet-corefx</Uri>
       <Sha>c4164928b270ee2369808ab347d33423ef765216</Sha>
     </Dependency>
     <Dependency Name="System.Reflection.Emit" Version="4.7.0">
@@ -119,7 +119,7 @@
       <Sha>0f7f38c4fd323b26da10cce95f857f77f0f09b48</Sha>
     </Dependency>
     <Dependency Name="System.IO.Pipelines" Version="4.7.2">
-      <Uri>https://github.com/dotnet/corefx</Uri>
+      <Uri>https://dev.azure.com/dnceng/internal/_git/dotnet-corefx</Uri>
       <Sha>059a4a19e602494bfbed473dbbb18f2dbfbd0878</Sha>
     </Dependency>
     <Dependency Name="System.IO.Pipes.AccessControl" Version="4.5.1">
@@ -127,11 +127,11 @@
       <Sha>7ee84596d92e178bce54c986df31ccc52479e772 </Sha>
     </Dependency>
     <Dependency Name="System.Net.Http.WinHttpHandler" Version="4.7.2">
-      <Uri>https://github.com/dotnet/corefx</Uri>
+      <Uri>https://dev.azure.com/dnceng/internal/_git/dotnet-corefx</Uri>
       <Sha>620cea9ccf0359993e803c900059932966399584</Sha>
     </Dependency>
     <Dependency Name="System.Net.WebSockets.WebSocketProtocol" Version="4.7.1">
-      <Uri>https://github.com/dotnet/corefx</Uri>
+      <Uri>https://dev.azure.com/dnceng/internal/_git/dotnet-corefx</Uri>
       <Sha>059a4a19e602494bfbed473dbbb18f2dbfbd0878 </Sha>
     </Dependency>
     <Dependency Name="System.Security.AccessControl" Version="4.7.0">
@@ -175,7 +175,7 @@
       <Sha>0f7f38c4fd323b26da10cce95f857f77f0f09b48</Sha>
     </Dependency>
     <Dependency Name="System.Threading.Channels" Version="4.7.1">
-      <Uri>https://github.com/dotnet/corefx</Uri>
+      <Uri>https://dev.azure.com/dnceng/internal/_git/dotnet-corefx</Uri>
       <Sha>059a4a19e602494bfbed473dbbb18f2dbfbd0878</Sha>
     </Dependency>
     <Dependency Name="System.Windows.Extensions" Version="4.7.0">


### PR DESCRIPTION
Legacy coherency models look up the build by repo+sha. So when the repo url
is wrong, the build can't be found, and coherent dependencies could
potentially be downgraded.