### PR TITLE
Support for libicu67 and several higher versions - 2.1

### DIFF
--- a/src/pkg/packaging/deb/package.targets
+++ b/src/pkg/packaging/deb/package.targets
@@ -348,7 +348,7 @@
         <ReplacementString>libssl1.0.0 | libssl1.0.2 | libssl1.1</ReplacementString>
       </SharedFrameworkTokenValue>
 
-      <KnownLibIcuVersion Include="66;65;63;60;57;55;52" />
+      <KnownLibIcuVersion Include="72;71;70;69;68;67;66;65;63;60;57;55;52" />
       <SharedFrameworkTokenValue Include="%LIBICU_DEPENDENCY_LIST%">
         <ReplacementString>libicu | @(KnownLibIcuVersion -> 'libicu%(Identity)', ' | ')</ReplacementString>
       </SharedFrameworkTokenValue>


### PR DESCRIPTION
### Description
Backporting the fix: dotnet/runtime#43417

Ubuntu 20.10, which is in preview, recently updated to a newer version of libicu - libicu67. The dotnet-runtime-deps deb package needs to be updated appropriately so that the libicu dependency is correctly met/installed.

### Customer Impact
Not being able to install .NET Core 2.1 on Ubuntu 20.10 release. This is the latest Ubuntu release that goes public in few weeks. We should ensure that .NET Core 2.1 works from the very beginning.

### Regression?
No - this was a change in Ubuntu requirements.

### Risk
Low

### Packaging changes reviewed?
This PR is for packaging changes - reviewers: @dagood