### PR TITLE
Backport ARM64 IJW host fix to 3.1

### DIFF
--- a/src/corehost/cli/ijwhost/arm64/bootstrap_thunk.cpp
+++ b/src/corehost/cli/ijwhost/arm64/bootstrap_thunk.cpp
@@ -10,21 +10,19 @@
 // Get thunk from the address that the thunk code provided
 bootstrap_thunk *bootstrap_thunk::get_thunk_from_cookie(std::uintptr_t cookie)
 {
-    
+
     // Cookie is generated via the first thunk instruction:
-    //  mov r12, pc
-    // The pc is returned from the hardware as the pc at the start of the instruction (i.e. the thunk address)
-    // + 4. So we can recover the thunk address simply by subtracting 4 from the cookie.
-    return (bootstrap_thunk *)(cookie - 4);
+    //  adr x16, #0
+    // The pc is returned from the hardware as the pc at the start of the instruction (i.e. the thunk address).
+    return (bootstrap_thunk *)cookie;
 }
 
 //=================================================================================
 // Get thunk from the thunk code entry point address
 bootstrap_thunk *bootstrap_thunk::get_thunk_from_entrypoint(std::uintptr_t entryAddr)
 {
-        // The entry point is at the start of the thunk but the code address will have the low-order bit set to
-    // indicate Thumb code and we need to mask that out.
-    return (bootstrap_thunk *)(entryAddr & ~1);
+    // The entry point is at the start of the thunk
+    return (bootstrap_thunk*)entryAddr;
 }
 
 //=================================================================================
@@ -51,8 +49,7 @@ std::uint32_t bootstrap_thunk::get_token()
 //=================================================================================
 std::uintptr_t bootstrap_thunk::get_entrypoint()
 {
-    // Set the low-order bit of the address returned to indicate to the hardware that it's Thumb code.
-    return (std::uintptr_t)this | 1;
+    return (std::uintptr_t)this;
 }
 
 //=================================================================================
@@ -65,10 +62,11 @@ void bootstrap_thunk::initialize(std::uintptr_t pThunkInitFcn,
                                           std::uintptr_t *pSlot)
 {
     // Initialize code section of the thunk:
-    WORD rgCode[] = {
-        0x46fc,             // mov r12, pc
-        0xf8df, 0xf004,     // ldr pc, [pc, #4]
-        0x0000              // padding for 4-byte alignment of target address that follows
+    std::uint32_t rgCode[] = {
+        0x10000010,        // adr x16, #0
+        0xF9400A11,        // ldr x17, [x16, #16]
+        0xD61F0220,        // br x17
+        0x00000000,        // padding for 64-bit alignment
     };
     BYTE *pCode = (BYTE*)this;
     memcpy(pCode, rgCode, sizeof(rgCode));

--- a/src/corehost/cli/ijwhost/arm64/bootstrap_thunk.h
+++ b/src/corehost/cli/ijwhost/arm64/bootstrap_thunk.h
@@ -19,7 +19,7 @@ extern "C" void start_runtime_thunk_stub();
 class bootstrap_thunk
 {
 private:
-    DWORD           m_rgCode[4];
+    std::uint32_t         m_rgCode[4];
     std::uintptr_t        m_pBootstrapCode;
 
     pal::dll_t       m_dll;            // pal::dll_t of this module


### PR DESCRIPTION
Backport of dotnet/runtime#46933 to release/3.1

Today, activating the runtime through the IJW host on ARM64 crashes due to an invalid address and invalid instructions. This PR fixes the ARM64 bootstrapping stub so we can don't crash when the first call into the runtime is through a native export of a managed function via C++/CLI.

## Customer Impact

This fix allows users to call into managed code from native code in C++/CLI. This is one of the fundamental C++/CLI scenarios, which is not currently officially supported on ARM64 on .NET Core 3.1, but has been talked about for the future. Given that the most common C++/CLI scenario is the opposite, I would guess this would be at most 1 in 4 C++/CLI scenarios overall, but I don't have usage data to back that number up. The issue was reported internally by the C++ team.

## Testing

This fix has been verified offline with the people that reported the issue (C++ team).

## Risk

Minimal risk. Without this fix, this path crashes hard with an "unaligned address" failure. With the fix, the runtime successfully starts and the managed code is successfully called.