### PR TITLE
Fixup checkout ref to branch that exists

### DIFF
--- a/buildpipeline/Core-Setup-Linux-Arm-BT.json
+++ b/buildpipeline/Core-Setup-Linux-Arm-BT.json
@@ -487,7 +487,7 @@
     "type": "TfsGit",
     "name": "DotNet-Core-Setup-Trusted",
     "url": "https://devdiv.visualstudio.com/DevDiv/_git/DotNet-Core-Setup-Trusted",
-    "defaultBranch": "refs/heads/buildtools",
+    "defaultBranch": "refs/heads/release/2.1",
     "clean": "false",
     "checkoutSubmodules": false
   },

--- a/buildpipeline/Core-Setup-Linux-BT.json
+++ b/buildpipeline/Core-Setup-Linux-BT.json
@@ -931,7 +931,7 @@
     "type": "TfsGit",
     "name": "DotNet-Core-Setup-Trusted",
     "url": "https://devdiv.visualstudio.com/DevDiv/_git/DotNet-Core-Setup-Trusted",
-    "defaultBranch": "refs/heads/buildtools",
+    "defaultBranch": "refs/heads/release/2.1",
     "clean": "false",
     "checkoutSubmodules": false
   },

--- a/buildpipeline/Core-Setup-OSX-BT.json
+++ b/buildpipeline/Core-Setup-OSX-BT.json
@@ -297,7 +297,7 @@
     "type": "TfsGit",
     "name": "DotNet-Core-Setup-Trusted",
     "url": "https://devdiv.visualstudio.com/DevDiv/_git/DotNet-Core-Setup-Trusted",
-    "defaultBranch": "refs/heads/buildtools",
+    "defaultBranch": "refs/heads/release/2.1",
     "clean": "false",
     "checkoutSubmodules": false
   },


### PR DESCRIPTION
The core-setup legs have a disabled checkout step. The branch that was referenced (buildtools) in some of them is no longer available and thus the build fails to queue. Instead, use release/2.1 (which is used by the other legs).