### PR TITLE
[Release/3.1] Update to a new version of Wix toolset

### DIFF
--- a/src/pkg/Directory.Build.props
+++ b/src/pkg/Directory.Build.props
@@ -55,7 +55,7 @@
     -->
     <BuildDistroIndependentInstallers Condition="'$(BuildDistroIndependentInstallers)' == ''">true</BuildDistroIndependentInstallers>
 
-    <WixVersion>3.10.4</WixVersion>
+    <WixVersion>3.14.0.4118</WixVersion>
     <WixToolsDir>$(IntermediateOutputRootPath)WixTools.$(WixVersion)/</WixToolsDir>
     <!-- Used in WiX targets to locate files. -->
     <WixInstallPath>$(WixToolsDir)</WixInstallPath>


### PR DESCRIPTION
Fixes: https://github.com/dotnet/runtime/issues/47814

New Wix toolset includes a signed wixstdba.dll binary that is being flagged by Device Guard on Windows.

This is a Windows specific fix.