### PR TITLE
[Release/2.1] Update to a new version of Wix toolset

### DIFF
--- a/src/pkg/packaging/windows/package.props
+++ b/src/pkg/packaging/windows/package.props
@@ -2,7 +2,7 @@
 <Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <WindowsScriptRoot>$(PackagingRoot)windows\</WindowsScriptRoot>
-    <WixVersion>3.10.4</WixVersion>
+    <WixVersion>3.14.0.4118</WixVersion>
     <GetWixScript>$(WindowsScriptRoot)GetWix.ps1</GetWixScript>
     <WixToolsDir>$(IntermediateOutputRootPath)WixTools.$(WixVersion)</WixToolsDir>
     <WixObjRoot>$(IntermediateOutputRootPath)wix/</WixObjRoot>


### PR DESCRIPTION
Fixes: https://github.com/dotnet/runtime/issues/47877

New Wix toolset includes a signed wixstdba.dll binary that is being flagged by Device Guard on Windows.

This is a Windows specific fix.
