### PR TITLE
[release/3.1] Fix build errors using GCC 11 (#46334)

### DIFF
--- a/src/corehost/cli/test/nativehost/host_context_test.cpp
+++ b/src/corehost/cli/test/nativehost/host_context_test.cpp
@@ -11,6 +11,7 @@
 #include <corehost_context_contract.h>
 #include "host_context_test.h"
 #include <utils.h>
+#include <thread>
 
 namespace
 {


### PR DESCRIPTION
This is a backport of https://github.com/dotnet/runtime/pull/46334

Building runtime with GCC 11 (actually the C++ Standard Library, which is also used by Clang on some platforms) leads to some new errors. The errors are consistent with the "Header dependency changes" section documented at https://gcc.gnu.org/gcc-11/porting_to.html

The core-setup error looks like this

    src/corehost/cli/test/nativehost/host_context_test.cpp:436:31: error: no member named 'sleep_for' in namespace 'std::this_thread'
                std::this_thread::sleep_for(std::chrono::milliseconds(100));
                ~~~~~~~~~~~~~~~~~~^
    1 error generated.

Fix that by including `<thread>`.

GCC 11 is being used by some upcoming distributions, such as Fedora 34.