### PR TITLE
Update branding to 3.1.16

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <MajorVersion>3</MajorVersion>
     <MinorVersion>1</MinorVersion>
-    <PatchVersion>15</PatchVersion>
+    <PatchVersion>16</PatchVersion>
     <PreReleaseVersionLabel>servicing</PreReleaseVersionLabel>
     <!-- Enable to remove prerelease label. -->
     <StabilizePackageVersion Condition="'$(StabilizePackageVersion)' == ''">true</StabilizePackageVersion>


### PR DESCRIPTION
Prepare branch for 3.1.16 release. After merge, the servising branch is considered open.