### PR TITLE
Update branding to 2.1.29

### DIFF
--- a/BranchInfo.props
+++ b/BranchInfo.props
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <MajorVersion>2</MajorVersion>
     <MinorVersion>1</MinorVersion>
-    <PatchVersion>28</PatchVersion>
+    <PatchVersion>29</PatchVersion>
 
     <StabilizePackageVersion Condition="'$(StabilizePackageVersion)' == ''">false</StabilizePackageVersion>
 


### PR DESCRIPTION
Prepare branch for 2.1.29 release. After merge, the servising branch is considered open.