### PR TITLE
[release/3.1] Fix build failures with clang 13 rc1

### DIFF
--- a/src/corehost/cli/json/casablanca/include/cpprest/details/SafeInt3.hpp
+++ b/src/corehost/cli/json/casablanca/include/cpprest/details/SafeInt3.hpp
@@ -1317,6 +1317,7 @@ public:
     static void CastThrow( bool b, T& t ) SAFEINT_CPP_THROW
     {
         b = !!t;
+        (void)b;
     }
 };
 


### PR DESCRIPTION
Clang 13 now produces an error in json/casablanca because a function
argument is not used:

    In file included from /core-setup/src/corehost/cli/deps_format.cpp:6:
    In file included from /core-setup/src/corehost/cli/deps_format.h:14:
    In file included from /core-setup/src/corehost/cli/fxr/../json/casablanca/include/cpprest/json.h:36:
    In file included from /core-setup/src/corehost/cli/fxr/../json/casablanca/include/cpprest/details/basic_types.h:41:
    /core-setup/src/corehost/cli/fxr/../json/casablanca/include/cpprest/details/SafeInt3.hpp:1317:33: error: parameter 'b' set but not used [-Werror,-Wunused-but-set-parameter]
        static void CastThrow( bool b, T& t ) SAFEINT_CPP_THROW
                                    ^
    1 error generated.
    gmake[2]: *** [cli/fxr/CMakeFiles/hostfxr.dir/build.make:76: cli/fxr/CMakeFiles/hostfxr.dir/__/deps_format.cpp.o] Error 1

Cast the argument to void to avoid this warning/error.