### PR TITLE
Switch to 1ES servicing pools for release/3.1

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -176,7 +176,7 @@ stages:
         publishUsingPipelines: true
         dependsOn: PrepareSignedArtifacts
         pool:
-          name: NetCoreInternal-Pool
-          queue: buildpool.windows.10.amd64.vs2017
+          name: NetCore1ESPool-Svc-Internal
+          demands: ImageOverride -equals build.windows.10.amd64.vs2017
 
   - template: /eng/stages/publish.yml

--- a/eng/jobs/bash-build.yml
+++ b/eng/jobs/bash-build.yml
@@ -24,11 +24,11 @@ jobs:
         name: dnceng-freebsd-internal
       ${{ if ne(parameters.name, 'FreeBSD_x64') }}:
         ${{ if eq(variables['System.TeamProject'], 'public') }}:
-          name: NetCorePublic-Pool
-          queue: buildpool.ubuntu.1604.amd64.open
+          name: NetCore1ESPool-Svc-Public
+          demands: ImageOverride -equals build.ubuntu.1604.amd64.open
         ${{ if ne(variables['System.TeamProject'], 'public') }}:
-          name: NetCoreInternal-Pool
-          queue: buildpool.ubuntu.1604.amd64
+          name: NetCore1ESPool-Svc-Internal
+          demands: ImageOverride -equals build.ubuntu.1604.amd64
     strategy: ${{ parameters.strategy }}
     variables:
       # Preserve the NuGet authentication env vars into the Docker container.

--- a/eng/jobs/prepare-signed-artifacts.yml
+++ b/eng/jobs/prepare-signed-artifacts.yml
@@ -7,8 +7,8 @@ jobs:
   displayName: Prepare Signed Artifacts
   dependsOn: ${{ parameters.dependsOn }}
   pool:
-    name: NetCoreInternal-Pool
-    queue: buildpool.windows.10.amd64.vs2017
+    name: NetCore1ESPool-Svc-Internal
+    demands: ImageOverride -equals build.windows.10.amd64.vs2017
   # Double the default timeout.
   timeoutInMinutes: 120
   workspace:

--- a/eng/jobs/windows-build.yml
+++ b/eng/jobs/windows-build.yml
@@ -13,11 +13,11 @@ jobs:
     pool:
       # Use a hosted pool when possible.
       ${{ if eq(variables['System.TeamProject'], 'public') }}:
-        name: NetCorePublic-Pool
-        queue: buildpool.windows.10.amd64.vs2017.open
+        name: NetCore1ESPool-Svc-Public
+        demands: ImageOverride -equals build.windows.10.amd64.vs2017.open
       ${{ if ne(variables['System.TeamProject'], 'public') }}:
-        name: NetCoreInternal-Pool
-        queue: buildpool.windows.10.amd64.vs2017
+        name: NetCore1ESPool-Svc-Internal
+        demands: ImageOverride -equals build.windows.10.amd64.vs2017
     strategy:
       matrix: 
         debug:


### PR DESCRIPTION
Tracking issue: https://github.com/dotnet/core-eng/issues/14276