### PR TITLE
[release/3.1] Additional RPMs for CBL-Mariner

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -191,6 +191,13 @@
       <SharedFrameworkInstallerFile>$(SharedFrameworkInstallerStart)$(SharedFrameworkNugetVersion)-$(TargetArchitecture)$(InstallerExtension)</SharedFrameworkInstallerFile>
     </PropertyGroup>
 
+    <PropertyGroup Condition="'$(InstallerExtension)' == '.rpm'">
+      <_CblMarinerVersionSuffix>cm.1</_CblMarinerVersionSuffix>
+      <SharedHostInstallerFileCblMariner>$(SharedHostInstallerStart)$(SharedFrameworkNugetVersion)-$(_CblMarinerVersionSuffix)-$(TargetArchitecture)$(InstallerExtension)</SharedHostInstallerFileCblMariner>
+      <HostFxrInstallerFileCblMariner>$(HostFxrInstallerStart)$(HostResolverVersion)-$(_CblMarinerVersionSuffix)-$(TargetArchitecture)$(InstallerExtension)</HostFxrInstallerFileCblMariner>
+      <SharedFrameworkInstallerFileCblMariner>$(SharedFrameworkInstallerStart)$(SharedFrameworkNugetVersion)-$(_CblMarinerVersionSuffix)-$(TargetArchitecture)$(InstallerExtension)</SharedFrameworkInstallerFileCblMariner>
+    </PropertyGroup>
+
     <!-- Runtime-deps Deb package is distro version agnostic. -->
     <PropertyGroup Condition="'$(InstallerExtension)' == '.deb'">
       <DotnetRuntimeDependenciesPackageInstallerFile>$(DotnetRuntimeDependenciesPackageInstallerStart)$(SharedFrameworkNugetVersion)-$(TargetArchitecture)$(InstallerExtension)</DotnetRuntimeDependenciesPackageInstallerFile>

--- a/src/pkg/packaging-tools/installer.targets
+++ b/src/pkg/packaging-tools/installer.targets
@@ -140,6 +140,15 @@
           UseHardlinksIfPossible="False" />
 
     <Message Text="$(MSBuildProjectName) -> $(InstallerFile)" Importance="high" />
+
+    <Copy Condition="'$(CreateRPMForCblMariner)' == 'true'"
+          SourceFiles="@(GeneratedRpmFiles)"
+          DestinationFiles="$(_InstallerFileCblMariner)"
+          OverwriteReadOnlyFiles="True"
+          SkipUnchangedFiles="False"
+          UseHardlinksIfPossible="False" />
+
+    <Message Text="$(MSBuildProjectName) -> $(_InstallerFileCblMariner)" Importance="high" />
   </Target>
 
   <Target Name="GetRpmInstallerJsonProperties"

--- a/src/pkg/packaging-tools/packaging-tools.targets
+++ b/src/pkg/packaging-tools/packaging-tools.targets
@@ -100,6 +100,14 @@
       <CompressedArchiveFile>$(AssetOutputPath)$(InstallerFileNameWithoutExtension)$(CompressedFileExtension)</CompressedArchiveFile>
     </PropertyGroup>
 
+    <PropertyGroup Condition="'$(InstallerExtension)' == '.rpm'">
+      <CreateRPMForCblMariner>true</CreateRPMForCblMariner>
+      <_CblMarinerVersionSuffix>cm.1</_CblMarinerVersionSuffix>
+      <_InstallerBuildPartCblMariner>$(ProductVersion)-$(_CblMarinerVersionSuffix)-$(TargetArchitecture)</_InstallerBuildPartCblMariner>
+      <_InstallerFileNameWithoutExtensionCblMariner>$(InstallerName)-$(_InstallerBuildPartCblMariner)$(CrossArchContentsBuildPart)</_InstallerFileNameWithoutExtensionCblMariner>
+      <_InstallerFileCblMariner Condition="'$(_InstallerFileCblMariner)' == ''">$(AssetOutputPath)$(_InstallerFileNameWithoutExtensionCblMariner)$(InstallerExtension)</_InstallerFileCblMariner>
+    </PropertyGroup>
+
     <!--
       Set the directory containing contents to include in the archive (zip/tarball). This default
       means the "shared" dir is inside the archive and it can be extracted directly into the dotnet

--- a/src/pkg/packaging/rpm/package.targets
+++ b/src/pkg/packaging/rpm/package.targets
@@ -27,6 +27,7 @@
       <RpmPackageVersion>$(HostPackageVersion)</RpmPackageVersion>
       <InputRoot>$(SharedHostPublishRoot)</InputRoot>
       <RpmFile>$(SharedHostInstallerFile)</RpmFile>
+      <RpmFileCblMariner>$(SharedHostInstallerFileCblMariner)</RpmFileCblMariner>
       <ManPagesDir>$(ProjectDir)Documentation/manpages</ManPagesDir>
       <ConfigJsonName>dotnet-sharedhost-rpm_config.json</ConfigJsonName>
       <ConfigJsonFile>$(rpmPackagingConfigPath)$(ConfigJsonName)</ConfigJsonFile>
@@ -111,6 +112,12 @@
           SkipUnchangedFiles="False"
           UseHardlinksIfPossible="False" />
 
+    <Copy SourceFiles="@(GeneratedRpmFiles)"
+          DestinationFiles="$(RpmFileCblMariner)"
+          OverwriteReadOnlyFiles="True"
+          SkipUnchangedFiles="False"
+          UseHardlinksIfPossible="False" />
+
     <!--
       Clean up dotnet symlink. Later build steps are confused and fail because the symlink points to
       a path that doesn't exist on the build machine.
@@ -124,6 +131,7 @@
       <RpmPackageVersion>$(HostResolverPackageVersion)</RpmPackageVersion>
       <InputRoot>$(HostFxrPublishRoot)</InputRoot>
       <RpmFile>$(HostFxrInstallerFile)</RpmFile>
+      <RpmFileCblMariner>$(HostFxrInstallerFileCblMariner)</RpmFileCblMariner>
       <ConfigJsonName>dotnet-hostfxr-rpm_config.json</ConfigJsonName>
       <ConfigJsonFile>$(rpmPackagingConfigPath)$(ConfigJsonName)</ConfigJsonFile>
       <RpmIntermediatesDir>$(PackagesIntermediateDir)$(RpmPackageName)/$(RpmPackageVersion)</RpmIntermediatesDir>
@@ -203,6 +211,12 @@
           SkipUnchangedFiles="False"
           UseHardlinksIfPossible="False" />
 
+    <Copy SourceFiles="@(GeneratedRpmFiles)"
+          DestinationFiles="$(RpmFileCblMariner)"
+          OverwriteReadOnlyFiles="True"
+          SkipUnchangedFiles="False"
+          UseHardlinksIfPossible="False" />
+
   </Target>
 
   <Target Name="GenerateSharedFrameworkRpm">
@@ -211,6 +225,7 @@
       <RpmPackageVersion>$(RuntimePackageVersion)</RpmPackageVersion>
       <InputRoot>$(SharedFrameworkPublishRoot)</InputRoot>
       <RpmFile>$(SharedFrameworkInstallerFile)</RpmFile>
+      <RpmFileCblMariner>$(SharedFrameworkInstallerFileCblMariner)</RpmFileCblMariner>
       <ConfigJsonName>dotnet-sharedframework-rpm_config.json</ConfigJsonName>
       <ConfigJsonFile>$(rpmPackagingConfigPath)$(ConfigJsonName)</ConfigJsonFile>
       <RpmIntermediatesDir>$(PackagesIntermediateDir)$(RpmPackageName)/$(RpmPackageVersion)</RpmIntermediatesDir>
@@ -298,6 +313,12 @@
 
     <Copy SourceFiles="@(GeneratedRpmFiles)"
           DestinationFiles="$(RpmFile)"
+          OverwriteReadOnlyFiles="True"
+          SkipUnchangedFiles="False"
+          UseHardlinksIfPossible="False" />
+
+    <Copy SourceFiles="@(GeneratedRpmFiles)"
+          DestinationFiles="$(RpmFileCblMariner)"
           OverwriteReadOnlyFiles="True"
           SkipUnchangedFiles="False"
           UseHardlinksIfPossible="False" />


### PR DESCRIPTION
Backport of https://github.com/dotnet/runtime/pull/59548

Implementation is based on https://github.com/dotnet/arcade/pull/7812, but is more closely related to the changes in PR listed above.

