### PR TITLE
[release/3.1] Make upgrade install new host first, then uninstall old

### DIFF
--- a/src/pkg/packaging-tools/windows/product/product.common.wxi
+++ b/src/pkg/packaging-tools/windows/product/product.common.wxi
@@ -3,7 +3,11 @@
 
   <Package Compressed="yes" InstallScope="perMachine" InstallerVersion="$(var.InstallerVersion)" />
 
-  <MajorUpgrade DowngradeErrorMessage="$(var.DowngradeErrorMessage)" Schedule="afterInstallInitialize"/>
+  <?ifndef MajorUpgradeSchedule?>
+    <?define MajorUpgradeSchedule = afterInstallInitialize?>
+  <?endif?>
+
+  <MajorUpgrade DowngradeErrorMessage="$(var.DowngradeErrorMessage)" Schedule="$(var.MajorUpgradeSchedule)"/>
 
   <MediaTemplate CompressionLevel="high" EmbedCab="yes"/>
 

--- a/src/pkg/packaging-tools/windows/wix.targets
+++ b/src/pkg/packaging-tools/windows/wix.targets
@@ -247,6 +247,7 @@
       <CandleVariables Include="NugetVersion" Value="$(ProductVersion)" />
       <CandleVariables Include="TargetArchitectureDescription" Value="$(TargetArchitecture)$(CrossArchContentsBuildPart)" />
       <CandleVariables Include="UpgradeCode" Value="$(UpgradeCode)" />
+      <CandleVariables Include="MajorUpgradeSchedule" Value="$(MajorUpgradeSchedule)" Condition="'$(MajorUpgradeSchedule)' != ''" />
 
       <!-- If this is a cross-arch MSI, add target arch to the dependency key for uniqueness. -->
       <CandleVariables Include="CrossArchContentsPlatformPart" Value="$(CrossArchContentsBuildPart.Replace('-', '_'))" />

--- a/src/pkg/projects/Microsoft.NETCore.DotNetHost/Microsoft.NETCore.DotNetHost.pkgproj
+++ b/src/pkg/projects/Microsoft.NETCore.DotNetHost/Microsoft.NETCore.DotNetHost.pkgproj
@@ -14,6 +14,7 @@
       <WixProductMoniker>$(SharedHostBrandName)</WixProductMoniker>
       <RegKeyProductName>sharedhost</RegKeyProductName>
       <WixDependencyKeyName>Dotnet_CLI_SharedHost</WixDependencyKeyName>
+      <MajorUpgradeSchedule>afterInstallExecute</MajorUpgradeSchedule>
       <VSInsertionShortComponentName>SharedHost</VSInsertionShortComponentName>
 
       <PublishRootDir>$(IntermediateOutputPath)publishRoot/</PublishRootDir>


### PR DESCRIPTION
Backport of https://github.com/dotnet/runtime/pull/60307 and https://github.com/dotnet/arcade/pull/8025 to core-setup/release/3.1

## Customer Impact

Customers installing upgrades of .NET 3.1 observe the entry for dotnet will move to the end of the PATH variable, often resulting in x86 dotnet being first and winning.

## Testing

Manual build of host and upgrade testing.  I've tested upgrade scenarios where 5.0 x86 + x64 is installed.  Upgrade to 6.0 x64 without the fix will move x64 PATH to end.  Once fix is in place we don't move PATH entry.

## Risk

Low.  This doesn't change installer behavior like some of the other options we considered.  The change is scoped to only the host MSI