### PR TITLE
[release/3.1] Add check for running under translation to mac installers

### DIFF
--- a/src/pkg/packaging/osx/sharedframework/shared-framework-distribution-template.xml
+++ b/src/pkg/packaging/osx/sharedframework/shared-framework-distribution-template.xml
@@ -43,14 +43,18 @@
     var machine = system.sysctl("hw.machine");
     var cputype = system.sysctl("hw.cputype");
     var cpu64 = system.sysctl("hw.cpu64bit_capable");
+    var translated = system.sysctl(""sysctl.proc_translated"");
     system.log("Machine type: " + machine);
     system.log("Cpu type: " + cputype);
     system.log("64-bit: " + cpu64);
+    system.log(""Translated: "" + translated);
 
     // From machine.h
     // CPU_TYPE_X86_64 = CPU_TYPE_X86 | CPU_ARCH_ABI64 = 0x010000007 = 16777223
     // CPU_TYPE_X86 = 7
     var result = machine == "amd64" || machine == "x86_64" || cputype == "16777223" || (cputype == "7" && cpu64 == "1");
+    // We may be running under translation (Rosetta) that makes it seem like system is x64, if so assume machine is not actually x64
+    result = result && (translated != ""1"");
     system.log("IsX64Machine: " + result);
     return result;
 }]]></script>

--- a/src/pkg/packaging/osx/sharedframework/shared-framework-distribution-template.xml
+++ b/src/pkg/packaging/osx/sharedframework/shared-framework-distribution-template.xml
@@ -43,18 +43,18 @@
     var machine = system.sysctl("hw.machine");
     var cputype = system.sysctl("hw.cputype");
     var cpu64 = system.sysctl("hw.cpu64bit_capable");
-    var translated = system.sysctl(""sysctl.proc_translated"");
+    var translated = system.sysctl("sysctl.proc_translated");
     system.log("Machine type: " + machine);
     system.log("Cpu type: " + cputype);
     system.log("64-bit: " + cpu64);
-    system.log(""Translated: "" + translated);
+    system.log("Translated: " + translated);
 
     // From machine.h
     // CPU_TYPE_X86_64 = CPU_TYPE_X86 | CPU_ARCH_ABI64 = 0x010000007 = 16777223
     // CPU_TYPE_X86 = 7
     var result = machine == "amd64" || machine == "x86_64" || cputype == "16777223" || (cputype == "7" && cpu64 == "1");
     // We may be running under translation (Rosetta) that makes it seem like system is x64, if so assume machine is not actually x64
-    result = result && (translated != ""1"");
+    result = result && (translated != "1");
     system.log("IsX64Machine: " + result);
     return result;
 }]]></script>


### PR DESCRIPTION
Backport of dotnet/arcade#8084

## Customer Impact

Installing x64 runtime bundle result in bits being installed to the wrong location.

## Testing

Manual installation on M1 to confirm fix

## Risk

Low.  This change was made and tested in main and has been present there for a month.  I missed it when collecting all the commits for backport.