### PR TITLE
Stabilize upgrade code and provider key

### DIFF
--- a/src/pkg/packaging-tools/windows/variables.wxi
+++ b/src/pkg/packaging-tools/windows/variables.wxi
@@ -23,7 +23,9 @@
     <?error Invalid Platform ($(var.Platform))?>
   <?endif?>
 
-  <?define DependencyKey   = "$(var.DependencyKeyName)_$(var.BuildVersion)_$(var.Platform)$(var.CrossArchContentsPlatformPart)"?>
+  <?ifndef DependencyKey?>
+    <?define DependencyKey = "$(var.DependencyKeyName)_$(var.BuildVersion)_$(var.Platform)$(var.CrossArchContentsPlatformPart)"?>
+  <?endif?>
   <?define DependencyKeyId = "$(var.DependencyKey)" ?>
 
 </Include>

--- a/src/pkg/projects/Microsoft.NETCore.DotNetHost/Microsoft.NETCore.DotNetHost.pkgproj
+++ b/src/pkg/projects/Microsoft.NETCore.DotNetHost/Microsoft.NETCore.DotNetHost.pkgproj
@@ -18,6 +18,11 @@
       <VSInsertionShortComponentName>SharedHost</VSInsertionShortComponentName>
 
       <PublishRootDir>$(IntermediateOutputPath)publishRoot/</PublishRootDir>
+
+      <!-- Stabilizes upgrade codes, using values from 3.1.21 release - do not change -->
+      <UpgradeCode Condition="'$(TargetArchitecture)' == 'arm64'">{3C7E6675-5649-7713-A2D7-5007A43E444D}</UpgradeCode>
+      <UpgradeCode Condition="'$(TargetArchitecture)' == 'x64'">{094423D2-5467-5D7F-13E5-86CC1F9556F5}</UpgradeCode>
+      <UpgradeCode Condition="'$(TargetArchitecture)' == 'x86'">{E41D3D89-5E9D-5F95-0CAE-6ED30E1160EE}</UpgradeCode>
     </PropertyGroup>
 
     <!-- Always clean this up to avoid side-by-side versions in unclean dev builds. -->
@@ -45,6 +50,10 @@
 
       <CandleVariables Include="ExtraPropertyRefIds" Value="ProductCPU;RTM_ProductVersion" />
       <CandleVariables Include="HostSrc" Value="$(PublishRootDir)" />
+      <!-- Stabilizes provider key, using values from 3.1.21 release - do not change -->
+      <CandleVariables Condition="'$(TargetArchitecture)' == 'arm64'" Include="DependencyKey" Value="Dotnet_CLI_SharedHost_24.84.30622_arm64" />
+      <CandleVariables Condition="'$(TargetArchitecture)' == 'x64'" Include="DependencyKey" Value="Dotnet_CLI_SharedHost_24.84.30622_x64" />
+      <CandleVariables Condition="'$(TargetArchitecture)' == 'x86'" Include="DependencyKey" Value="Dotnet_CLI_SharedHost_24.84.30622_x86" />
     </ItemGroup>
   </Target>
 


### PR DESCRIPTION
Stable upgrade codes and dependency key to allow proper msi upgrade experience.

We are using values from latest official release (3.1.21).