### PR TITLE
[release/3.1] Fixes __rid_plat generation on alpine

### DIFF
--- a/src/corehost/build.sh
+++ b/src/corehost/build.sh
@@ -21,14 +21,11 @@ init_rid_plat()
         __rid_plat=""
         if [ -e /etc/os-release ]; then
             source /etc/os-release
-            if [[ "$ID" == "rhel" ]]; then
+            if [ "$ID" == "rhel" ] || [ "$ID" == "alpine" ] ; then
                 # remove the last version number
                 VERSION_ID=${VERSION_ID%.*}
             fi
             __rid_plat="$ID.$VERSION_ID"
-            if [[ "$ID" == "alpine" ]]; then
-                __rid_plat="linux-musl"
-            fi
         elif [ -e /etc/redhat-release ]; then
             local redhatRelease=$(</etc/redhat-release)
             if [[ $redhatRelease == "CentOS release 6."* || $redhatRelease == "Red Hat Enterprise Linux Server release 6."* ]]; then


### PR DESCRIPTION
./src/corehost/build.sh generates wrong plat_rid on Alpine. Generated RID is expected to be alpine.x.xx-xx, while the computed RID is linux-musl-xxx. This patches it by matching what's expected by rest of build system.

Made as part of Alpine Linux dotnet31 / dotnet5 packaging project, see dotnet/source-build#2695