### PR TITLE
Set min OS version on macos to 10.13

### DIFF
--- a/eng/jobs/osx-build.yml
+++ b/eng/jobs/osx-build.yml
@@ -4,19 +4,16 @@ parameters:
 jobs:
 - job: ${{ parameters.name }}
   pool:
-    ${{ if eq(variables['System.TeamProject'], 'public') }}:
-      name: Hosted macOS
-    ${{ if ne(variables['System.TeamProject'], 'public') }}:
-      vmImage: macOS-latest
+      vmImage: 'macOS-latest'
   strategy:
-    matrix: 
+    matrix:
       debug:
         _BuildConfig: Debug
       release:
         _BuildConfig: Release
   workspace:
     clean: all
-  variables: 
+  variables:
     CommonMSBuildArgs: >-
       /p:Configuration=$(_BuildConfig)
       /p:PortableBuild=true
@@ -40,7 +37,7 @@ jobs:
       /p:OfficialBuildId=$(OfficialBuildId)
       /p:StripSymbols=true
       $(CommonMSBuildArgs)
-    displayName: Build 
+    displayName: Build
     condition: succeeded()
 
   - template: steps/upload-job-artifacts.yml

--- a/src/settings.cmake
+++ b/src/settings.cmake
@@ -37,6 +37,14 @@ if(CMAKE_SYSTEM_NAME STREQUAL SunOS)
     message("System name SunOS")
 endif(CMAKE_SYSTEM_NAME STREQUAL SunOS)
 
+# Specify the minimum supported version of macOS
+if(CMAKE_SYSTEM_NAME STREQUAL Darwin)
+    set(MACOS_VERSION_MIN_FLAGS "-mmacosx-version-min=10.13")
+    add_compile_options("${MACOS_VERSION_MIN_FLAGS}")
+    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${MACOS_VERSION_MIN_FLAGS}")
+    set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} ${MACOS_VERSION_MIN_FLAGS}")
+endif(CMAKE_SYSTEM_NAME STREQUAL Darwin)
+
 if (NOT WIN32)
     # Try to locate the paxctl tool. Failure to find it is not fatal,
     # but the generated executables won't work on a system where PAX is set


### PR DESCRIPTION
Fixes: https://github.com/dotnet/runtime/issues/61173

## Description

We did not set any particular min OS version in the build so it was using the SDK default and could change when toolset was updated and indeed changed from original 10.13 to 10.15 and then to 11.0

This change puts back 10.13 as min OS version on macos.

## Testing

I have verified locally via `otool -l `that both `apphost` and `dotnet` executables now have:

```
Load command 9
      cmd LC_VERSION_MIN_MACOSX
  cmdsize 16
  version 10.13
      sdk 11.0
```

## Risk

Low, compiler-flag-only change