### PR TITLE
Build DependencyModel in May

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -50,7 +50,7 @@
     <ProjectServicingConfiguration Include="Microsoft.WindowsDesktop.App.Ref" PatchVersion="0" />
     <ProjectServicingConfiguration Include="NETStandard.Library.Ref" PatchVersion="0" />
     <ProjectServicingConfiguration Include="Microsoft.DotNet.PlatformAbstractions" PatchVersion="6" />
-    <ProjectServicingConfiguration Include="Microsoft.Extensions.DependencyModel" PatchVersion="6" />
+    <ProjectServicingConfiguration Include="Microsoft.Extensions.DependencyModel" PatchVersion="25" />
     <ProjectServicingConfiguration Include="Microsoft.NET.HostModel" PatchVersion="16" />
   </ItemGroup>
   <PropertyGroup>


### PR DESCRIPTION
This project was updated to fix a Component Governance bug in January: https://github.com/dotnet/core-setup/pull/9198. However, it hasn't been serviced since then, which means downstream repos that depend on it (like dotnet/efcore) still have active CompGov bugs. Servicing it in May should fix that.

CC @dcwhittaker @Pilchie - the SLA for this is April 1, but the alert won't be fixed by this until mid-April - is that alright? Can we extend it? I could also add an explicit `PackageReference` to System.Text.Encodings.Web to the relevant project in EFCore, but again, we wouldn't be able to check that in until after April 1, so I think this is a better long-term fix.