### PR TITLE
Enable installation on Ubuntu 22.04

### DIFF
--- a/src/pkg/packaging/deb/package.targets
+++ b/src/pkg/packaging/deb/package.targets
@@ -324,7 +324,7 @@
       -->
       <SharedFrameworkTokenValue
         Include="%SSL_DEPENDENCY_LIST%"
-        ReplacementString="libssl1.0.0 | libssl1.0.2 | libssl1.1" />
+        ReplacementString="libssl1.0.0 | libssl1.0.2 | libssl1.1 | libssl3" />
 
       <KnownLibIcuVersion Include="72;71;70;69;68;67;66;65;63;60;57;55;52" />
       <SharedFrameworkTokenValue


### PR DESCRIPTION
Backport of https://github.com/dotnet/runtime/pull/67658 to release/3.1.

Ubuntu 22.04 has libssl3, it does not have libssl1.1 or previous versions - we need to specify a libssl dependency that is present in repo feeds.
