### PR TITLE
[release/3.1] Do not add x86 host to PATH on 64-bit machines

### DIFF
--- a/src/pkg/projects/Microsoft.NETCore.DotNetHost/host.wxs
+++ b/src/pkg/projects/Microsoft.NETCore.DotNetHost/host.wxs
@@ -42,6 +42,9 @@
         <?if $(var.Platform)~=x64 ?>
         <!-- For x64 installer, only add to PATH when actually on native architecture -->
         <Condition>NOT NON_NATIVE_ARCHITECTURE</Condition>
+        <?elseif $(var.Platform)~=x86 ?>
+        <!-- For x86 installer, only add to PATH when not on 64-bit platform -->
+        <Condition>NOT VersionNT64</Condition>
         <?endif?>
 
         <!-- A stable keypath with the right SxS characteristics for our PATH entry-->


### PR DESCRIPTION
Backport of https://github.com/dotnet/runtime/pull/69902 to dotnet/core-setup release/3.1

Fixes: https://github.com/dotnet/runtime/issues/70039

## Customer Impact

This fixes the remaining issue with non-native host paths in machine's environment (PATH).

The fix uses a different model than x64-on-arm64. It is a simpler change as it's easy to determine if machine is 64-bit, using WersionNT64 property. This solution avoids unnecessary changes in arcade infra and adding additional complexity.

## Testing

See main issue: https://github.com/dotnet/runtime/issues/70039#issuecomment-1151412442

## Risk

As with any breaking change, this will affect some users. In this case, anyone that wants 32-bit host (dotnet.exe) to be in PATH on 64-bit machines, will need to add host location to PATH manually.