### PR TITLE
Update public pool names

### DIFF
--- a/eng/jobs/bash-build.yml
+++ b/eng/jobs/bash-build.yml
@@ -24,7 +24,7 @@ jobs:
         name: dnceng-freebsd-internal
       ${{ if ne(parameters.name, 'FreeBSD_x64') }}:
         ${{ if eq(variables['System.TeamProject'], 'public') }}:
-          name: NetCore1ESPool-Svc-Public
+          name: NetCore-Svc-Public
           demands: ImageOverride -equals build.ubuntu.1804.amd64.open
         ${{ if ne(variables['System.TeamProject'], 'public') }}:
           name: NetCore1ESPool-Svc-Internal

--- a/eng/jobs/windows-build.yml
+++ b/eng/jobs/windows-build.yml
@@ -13,7 +13,7 @@ jobs:
     pool:
       # Use a hosted pool when possible.
       ${{ if eq(variables['System.TeamProject'], 'public') }}:
-        name: NetCore1ESPool-Svc-Public
+        name: NetCore-Svc-Public
         demands: ImageOverride -equals build.windows.10.amd64.vs2017.open
       ${{ if ne(variables['System.TeamProject'], 'public') }}:
         name: NetCore1ESPool-Svc-Internal


### PR DESCRIPTION
This change is required for builds to continue working in the new org, dev.azure.com/dnceng-public.