### PR TITLE
Redirect default install location in test to avoid using machine-wide install

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -169,6 +169,6 @@ stages:
         dependsOn: PrepareSignedArtifacts
         pool:
           name: NetCore1ESPool-Svc-Internal
-          demands: ImageOverride -equals build.windows.10.amd64.vs2017
+          demands: ImageOverride -equals Windows.10.vs2019.amd64
 
   - template: /eng/stages/publish.yml

--- a/eng/jobs/prepare-signed-artifacts.yml
+++ b/eng/jobs/prepare-signed-artifacts.yml
@@ -8,7 +8,7 @@ jobs:
   dependsOn: ${{ parameters.dependsOn }}
   pool:
     name: NetCore1ESPool-Svc-Internal
-    demands: ImageOverride -equals build.windows.10.amd64.vs2017
+    demands: ImageOverride -equals Windows.10.vs2019.amd64
   # Double the default timeout.
   timeoutInMinutes: 120
   workspace:

--- a/eng/jobs/windows-build.yml
+++ b/eng/jobs/windows-build.yml
@@ -14,10 +14,10 @@ jobs:
       # Use a hosted pool when possible.
       ${{ if eq(variables['System.TeamProject'], 'public') }}:
         name: NetCore-Svc-Public
-        demands: ImageOverride -equals build.windows.10.amd64.vs2017.open
+        demands: ImageOverride -equals Windows.10.vs2019.amd64.open
       ${{ if ne(variables['System.TeamProject'], 'public') }}:
         name: NetCore1ESPool-Svc-Internal
-        demands: ImageOverride -equals build.windows.10.amd64.vs2017
+        demands: ImageOverride -equals Windows.10.vs2019.amd64
     strategy:
       matrix: 
         debug:

--- a/src/test/HostActivation.Tests/FrameworkResolution/MultipleHives.cs
+++ b/src/test/HostActivation.Tests/FrameworkResolution/MultipleHives.cs
@@ -79,7 +79,10 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.FrameworkResolution
                     SharedState.FrameworkReferenceApp,
                     new TestSettings()
                         .WithRuntimeConfigCustomizer(runtimeConfig)
-                        .WithEnvironment(Constants.TestOnlyEnvironmentVariables.GloballyRegisteredPath, SharedState.DotNetGlobalHive.BinPath),
+                        .WithEnvironment(Constants.TestOnlyEnvironmentVariables.GloballyRegisteredPath, SharedState.DotNetGlobalHive.BinPath)
+                        .WithEnvironment( // Redirect the default install location to an invalid location so that a machine-wide install is not used
+                            Constants.TestOnlyEnvironmentVariables.DefaultInstallPath,
+                            System.IO.Path.Combine(SharedState.DotNetMainHive.BinPath, "invalid")),
                     // Must enable multi-level lookup otherwise multiple hives are not enabled
                     multiLevelLookup: true);
             }


### PR DESCRIPTION
Backport of https://github.com/dotnet/runtime/pull/45500