### PR TITLE
Update version of Newtonsoft.Json used in tests from 9.0.1 to 13.0.1

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -107,6 +107,7 @@
     <MicrosoftDotNetPlatformAbstractionsPackageVersion>1.1.1</MicrosoftDotNetPlatformAbstractionsPackageVersion>
     <MicrosoftTargetingPackPrivateWinRTPackageVersion>1.0.5</MicrosoftTargetingPackPrivateWinRTPackageVersion>
     <MicrosoftDiaSymReaderNativePackageVersion>1.7.0</MicrosoftDiaSymReaderNativePackageVersion>
+    <NewtonsoftJsonVersion>13.0.1</NewtonsoftJsonVersion>
     <!--
       These are used as reference assemblies only, so they must not take a ProdCon/source-build
       version. Insert "RefOnly" to avoid assignment via PVP.

--- a/src/test/Assets/TestProjects/HostApiInvokerApp/HostApiInvokerApp.csproj
+++ b/src/test/Assets/TestProjects/HostApiInvokerApp/HostApiInvokerApp.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersion)" />
   </ItemGroup>
 
 </Project>

--- a/src/test/Assets/TestProjects/LightupLib/LightupLib.csproj
+++ b/src/test/Assets/TestProjects/LightupLib/LightupLib.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersion)" />
   </ItemGroup>
 
 </Project>

--- a/src/test/Assets/TestProjects/PortableApp/PortableApp.csproj
+++ b/src/test/Assets/TestProjects/PortableApp/PortableApp.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersion)" />
   </ItemGroup>
 
   <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />

--- a/src/test/Assets/TestProjects/SharedFxLookupPortableApp/SharedFxLookupPortableApp.csproj
+++ b/src/test/Assets/TestProjects/SharedFxLookupPortableApp/SharedFxLookupPortableApp.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersion)" />
   </ItemGroup>
 
 </Project>

--- a/src/test/Assets/TestProjects/StandaloneApp/StandaloneApp.csproj
+++ b/src/test/Assets/TestProjects/StandaloneApp/StandaloneApp.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersion)" />
   </ItemGroup>
 
 </Project>

--- a/src/test/Assets/TestProjects/StandaloneApp20/StandaloneApp20.csproj
+++ b/src/test/Assets/TestProjects/StandaloneApp20/StandaloneApp20.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersion)" />
   </ItemGroup>
 
 </Project>

--- a/src/test/Assets/TestProjects/StandaloneApp21/StandaloneApp21.csproj
+++ b/src/test/Assets/TestProjects/StandaloneApp21/StandaloneApp21.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersion)" />
   </ItemGroup>
 
 </Project>

--- a/src/test/Assets/TestProjects/StartupHookWithDependency/StartupHookWithDependency.csproj
+++ b/src/test/Assets/TestProjects/StartupHookWithDependency/StartupHookWithDependency.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersion)" />
   </ItemGroup>
 
 </Project>

--- a/src/test/BundleTests/AppHost.Bundle.Tests/AppHost.Bundle.Tests.csproj
+++ b/src/test/BundleTests/AppHost.Bundle.Tests/AppHost.Bundle.Tests.csproj
@@ -17,4 +17,7 @@
     <ProjectReference Include="..\Helpers\BundleHelper.csproj" />
   </ItemGroup>
 
+  <ItemGroup Label="Dependency Resolutions">
+    <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersion)" />
+  </ItemGroup>
 </Project>

--- a/src/test/BundleTests/Microsoft.NET.HostModel.Bundle.Tests/Microsoft.NET.HostModel.Bundle.Tests.csproj
+++ b/src/test/BundleTests/Microsoft.NET.HostModel.Bundle.Tests/Microsoft.NET.HostModel.Bundle.Tests.csproj
@@ -17,4 +17,7 @@
     <ProjectReference Include="..\Helpers\BundleHelper.csproj" />
   </ItemGroup>
 
+  <ItemGroup Label="Dependency Resolutions">
+    <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersion)" />
+  </ItemGroup>
 </Project>

--- a/src/test/HostActivation.Tests/HostActivation.Tests.csproj
+++ b/src/test/HostActivation.Tests/HostActivation.Tests.csproj
@@ -21,7 +21,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersion)" />
     <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="2.1.0" />
     <PackageReference Include="Microsoft.DotNet.PlatformAbstractions" Version="2.1.0" />
     <PackageReference Include="Microsoft.Win32.Registry" Version="4.3.0" />

--- a/src/test/HostActivation.Tests/LightupAppActivation.cs
+++ b/src/test/HostActivation.Tests/LightupAppActivation.cs
@@ -525,7 +525,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
             File.WriteAllText(depsFile, depsjson.ToString());
 
             SharedFramework.AddReferenceToDepsJson(depsFile, "LightupLib/1.0.0", "System.Collections.Immutable", "1.0.0", immutableCollectionVersionInfo);
-            SharedFramework.AddReferenceToDepsJson(depsFile, "LightupLib/1.0.0", "Newtonsoft.Json", "9.0.1");
+            SharedFramework.AddReferenceToDepsJson(depsFile, "LightupLib/1.0.0", "Newtonsoft.Json", "13.0.1");
 
             return depsFile;
         }

--- a/src/test/Microsoft.DotNet.CoreSetup.Packaging.Tests/Microsoft.DotNet.CoreSetup.Packaging.Tests.csproj
+++ b/src/test/Microsoft.DotNet.CoreSetup.Packaging.Tests/Microsoft.DotNet.CoreSetup.Packaging.Tests.csproj
@@ -19,6 +19,10 @@
     <OrderProjectReference Include="@(PkgprojProjectToBuild)" />
   </ItemGroup>
 
+  <ItemGroup Label="Dependency Resolutions">
+    <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersion)" />
+  </ItemGroup>
+  
   <!--
     Ensure the packaging projects build first. Don't do this in VS: the build takes too long and
     isn't incremental.

--- a/src/test/Microsoft.Extensions.DependencyModel.Tests/Microsoft.Extensions.DependencyModel.Tests.csproj
+++ b/src/test/Microsoft.Extensions.DependencyModel.Tests/Microsoft.Extensions.DependencyModel.Tests.csproj
@@ -24,4 +24,8 @@
     <ProjectReference Include="..\..\managed\Microsoft.Extensions.DependencyModel\Microsoft.Extensions.DependencyModel.csproj" />
   </ItemGroup>
 
+  <ItemGroup Label="Dependency Resolutions">
+    <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersion)" />
+  </ItemGroup>
+  
 </Project>


### PR DESCRIPTION
Update version of `Newtonsoft.Json` used in tests to a more secure version.

This is a test-only change.

cc @NikolaMilosavljevic @vitek-karas 